### PR TITLE
Rename package 'store' to 'chunks'.

### DIFF
--- a/chunks/chunk_store.go
+++ b/chunks/chunk_store.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"io"
@@ -6,7 +6,13 @@ import (
 	"github.com/attic-labs/noms/ref"
 )
 
-type RootStore interface {
+type ChunkStore interface {
+	RootTracker
+	ChunkSource
+	ChunkSink
+}
+
+type RootTracker interface {
 	Root() ref.Ref
 	UpdateRoot(current, last ref.Ref) bool
 }

--- a/chunks/file_store.go
+++ b/chunks/file_store.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"flag"

--- a/chunks/file_store_test.go
+++ b/chunks/file_store_test.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"io/ioutil"

--- a/chunks/memory_store.go
+++ b/chunks/memory_store.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"bytes"

--- a/chunks/memory_store_test.go
+++ b/chunks/memory_store_test.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"io/ioutil"

--- a/chunks/nop_sink.go
+++ b/chunks/nop_sink.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"hash"

--- a/chunks/nop_sink_test.go
+++ b/chunks/nop_sink_test.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"testing"

--- a/chunks/s3_store.go
+++ b/chunks/s3_store.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"flag"

--- a/chunks/s3_store_test.go
+++ b/chunks/s3_store_test.go
@@ -1,4 +1,4 @@
-package store
+package chunks
 
 import (
 	"bytes"

--- a/commit/commit.go
+++ b/commit/commit.go
@@ -1,10 +1,10 @@
 package commit
 
 import (
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/enc"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
@@ -13,9 +13,9 @@ type Reachable interface {
 }
 
 type Commit struct {
-	root      store.RootStore
-	source    store.ChunkSource
-	sink      store.ChunkSink
+	root      chunks.RootTracker
+	source    chunks.ChunkSource
+	sink      chunks.ChunkSink
 	reachable Reachable
 }
 

--- a/commit/commit_test.go
+++ b/commit/commit_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/enc"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +17,7 @@ func TestCommit(t *testing.T) {
 	defer os.Remove(dir)
 	assert.NoError(err)
 
-	store := store.NewFileStore(dir, "root")
+	store := chunks.NewFileStore(dir, "root")
 	commit := &Commit{
 		store,
 		store,

--- a/commit/memcache_reachable.go
+++ b/commit/memcache_reachable.go
@@ -1,16 +1,16 @@
 package commit
 
 import (
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/enc"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
 // TODO(rafael):
 type memcacheReachable struct {
-	source store.ChunkSource
+	source chunks.ChunkSource
 	refs   map[string]bool
 }
 
@@ -54,7 +54,7 @@ func (cache *memcacheReachable) IsSupercededFrom(candidate, root ref.Ref) bool {
 	return ok
 }
 
-func NewMemCacheReachable(source store.ChunkSource) Reachable {
+func NewMemCacheReachable(source chunks.ChunkSource) Reachable {
 	return &memcacheReachable{
 		source,
 		make(map[string]bool),

--- a/enc/blob_codec.go
+++ b/enc/blob_codec.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
@@ -14,7 +14,7 @@ var (
 	blobTag = []byte("b ")
 )
 
-func blobEncode(b types.Blob, s store.ChunkSink) (r ref.Ref, err error) {
+func blobEncode(b types.Blob, s chunks.ChunkSink) (r ref.Ref, err error) {
 	w := s.Put()
 	if _, err = w.Write(blobTag); err != nil {
 		return
@@ -25,7 +25,7 @@ func blobEncode(b types.Blob, s store.ChunkSink) (r ref.Ref, err error) {
 	return w.Ref()
 }
 
-func blobDecode(r io.Reader, s store.ChunkSource) (types.Value, error) {
+func blobDecode(r io.Reader, s chunks.ChunkSource) (types.Value, error) {
 	buf := &bytes.Buffer{}
 	_, err := io.CopyN(buf, r, int64(len(blobTag)))
 	if err != nil {

--- a/enc/blob_codec_test.go
+++ b/enc/blob_codec_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/attic-labs/noms/store"
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,7 +16,7 @@ func TestBlobCodec(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	defer os.Remove(dir)
 	assert.NoError(err)
-	fs := store.NewFileStore(dir, "root")
+	fs := chunks.NewFileStore(dir, "root")
 	b1 := types.NewBlob([]byte{})
 	r1, err := blobEncode(b1, fs)
 	// echo -n 'b ' | sha1sum

--- a/enc/json_decode.go
+++ b/enc/json_decode.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
-func jsonDecode(reader io.Reader, s store.ChunkSource) (types.Value, error) {
+func jsonDecode(reader io.Reader, s chunks.ChunkSource) (types.Value, error) {
 	prefix := make([]byte, len(jsonTag))
 	_, err := io.ReadFull(reader, prefix)
 	if err != nil {
@@ -30,7 +30,7 @@ func jsonDecode(reader io.Reader, s store.ChunkSource) (types.Value, error) {
 	return jsonDecodeValue(v, s)
 }
 
-func jsonDecodeValue(v interface{}, s store.ChunkSource) (types.Value, error) {
+func jsonDecodeValue(v interface{}, s chunks.ChunkSource) (types.Value, error) {
 	switch v := v.(type) {
 	case bool:
 		return types.Bool(v), nil
@@ -43,7 +43,7 @@ func jsonDecodeValue(v interface{}, s store.ChunkSource) (types.Value, error) {
 	}
 }
 
-func jsonDecodeTaggedValue(m map[string]interface{}, s store.ChunkSource) (types.Value, error) {
+func jsonDecodeTaggedValue(m map[string]interface{}, s chunks.ChunkSource) (types.Value, error) {
 	Chk.Equal(1, len(m))
 	for k, v := range m {
 		switch k {
@@ -91,7 +91,7 @@ func jsonDecodeTaggedValue(m map[string]interface{}, s store.ChunkSource) (types
 	return nil, fmt.Errorf("Cannot decode tagged json value: %+v", m)
 }
 
-func jsonDecodeList(input []interface{}, s store.ChunkSource) (types.Value, error) {
+func jsonDecodeList(input []interface{}, s chunks.ChunkSource) (types.Value, error) {
 	output := types.NewList()
 	for _, inVal := range input {
 		outVal, err := jsonDecodeValue(inVal, s)
@@ -103,7 +103,7 @@ func jsonDecodeList(input []interface{}, s store.ChunkSource) (types.Value, erro
 	return output, nil
 }
 
-func jsonDecodeSet(input []interface{}, s store.ChunkSource) (types.Value, error) {
+func jsonDecodeSet(input []interface{}, s chunks.ChunkSource) (types.Value, error) {
 	vals := []types.Value{}
 	for _, inVal := range input {
 		outVal, err := jsonDecodeValue(inVal, s)
@@ -115,7 +115,7 @@ func jsonDecodeSet(input []interface{}, s store.ChunkSource) (types.Value, error
 	return types.NewSet(vals...), nil
 }
 
-func jsonDecodeMap(input []interface{}, s store.ChunkSource) (types.Value, error) {
+func jsonDecodeMap(input []interface{}, s chunks.ChunkSource) (types.Value, error) {
 	output := types.NewMap()
 	Chk.Equal(0, len(input)%2, "Length on input array must be multiple of 2")
 	for i := 0; i < len(input); i += 2 {
@@ -135,7 +135,7 @@ func jsonDecodeMap(input []interface{}, s store.ChunkSource) (types.Value, error
 	return output, nil
 }
 
-func jsonDecodeRef(refStr string, s store.ChunkSource) (types.Value, error) {
+func jsonDecodeRef(refStr string, s chunks.ChunkSource) (types.Value, error) {
 	ref, err := ref.Parse(refStr)
 	if err != nil {
 		return nil, err

--- a/enc/json_decode_test.go
+++ b/enc/json_decode_test.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/attic-labs/noms/store"
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestJSONDecode(t *testing.T) {
 	assert := assert.New(t)
-	cs := store.MemoryStore{}
+	cs := chunks.MemoryStore{}
 
 	put := func(s string) {
 		s += "\n"

--- a/enc/json_encode.go
+++ b/enc/json_encode.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
@@ -15,7 +15,7 @@ var (
 	jsonTag = []byte("j ")
 )
 
-func jsonEncode(v types.Value, s store.ChunkSink) (r ref.Ref, err error) {
+func jsonEncode(v types.Value, s chunks.ChunkSink) (r ref.Ref, err error) {
 	var j interface{}
 	j, err = getJSON(v, s)
 	if err != nil {
@@ -32,7 +32,7 @@ func jsonEncode(v types.Value, s store.ChunkSink) (r ref.Ref, err error) {
 	return w.Ref()
 }
 
-func getJSON(v types.Value, s store.ChunkSink) (interface{}, error) {
+func getJSON(v types.Value, s chunks.ChunkSink) (interface{}, error) {
 	switch v := v.(type) {
 	case types.Blob:
 		Chk.Fail(fmt.Sprintf("jsonEncode doesn't support encoding blobs - didn't expect to get here: %+v", v))
@@ -83,7 +83,7 @@ func getJSON(v types.Value, s store.ChunkSink) (interface{}, error) {
 	}
 	return nil, nil
 }
-func getJSONList(l types.List, s store.ChunkSink) (r interface{}, err error) {
+func getJSONList(l types.List, s chunks.ChunkSink) (r interface{}, err error) {
 	j := []interface{}{}
 	for i := uint64(0); i < l.Len(); i++ {
 		var cj interface{}
@@ -99,7 +99,7 @@ func getJSONList(l types.List, s store.ChunkSink) (r interface{}, err error) {
 	return
 }
 
-func getJSONMap(m types.Map, s store.ChunkSink) (r interface{}, err error) {
+func getJSONMap(m types.Map, s chunks.ChunkSink) (r interface{}, err error) {
 	// Iteration through Set is random, but we need a deterministic order for serialization. Let's order using the refs of the values in the set.
 	order := types.MapEntrySlice{}
 	m.Iter(func(entry types.MapEntry) (stop bool) {
@@ -128,7 +128,7 @@ func getJSONMap(m types.Map, s store.ChunkSink) (r interface{}, err error) {
 	return
 }
 
-func getJSONSet(set types.Set, s store.ChunkSink) (r interface{}, err error) {
+func getJSONSet(set types.Set, s chunks.ChunkSink) (r interface{}, err error) {
 	// Iteration through Set is random, but we need a deterministic order for serialization. Let's order using the refs of the values in the set.
 	lookup := map[ref.Ref]types.Value{}
 	order := ref.RefSlice{}
@@ -156,7 +156,7 @@ func getJSONSet(set types.Set, s store.ChunkSink) (r interface{}, err error) {
 	return
 }
 
-func getChildJSON(v types.Value, s store.ChunkSink) (interface{}, error) {
+func getChildJSON(v types.Value, s chunks.ChunkSink) (interface{}, error) {
 	var r ref.Ref
 	var err error
 	switch v := v.(type) {

--- a/enc/json_encode_test.go
+++ b/enc/json_encode_test.go
@@ -4,18 +4,18 @@ import (
 	"crypto/sha1"
 	"testing"
 
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonEncode(t *testing.T) {
 	assert := assert.New(t)
-	var s *store.MemoryStore
+	var s *chunks.MemoryStore
 
 	testEncode := func(expected string, v types.Value) ref.Ref {
-		s = &store.MemoryStore{}
+		s = &chunks.MemoryStore{}
 		r, err := jsonEncode(v, s)
 		assert.NoError(err)
 

--- a/enc/read_value.go
+++ b/enc/read_value.go
@@ -5,14 +5,14 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
 // Reads and decodes a value from a chunk source.
-func ReadValue(ref ref.Ref, cs store.ChunkSource) (types.Value, error) {
+func ReadValue(ref ref.Ref, cs chunks.ChunkSource) (types.Value, error) {
 	reader, err := cs.Get(ref)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func ReadValue(ref ref.Ref, cs store.ChunkSource) (types.Value, error) {
 	return nil, fmt.Errorf("Unsupported chunk tag: %+v", prefix)
 }
 
-func MustReadValue(ref ref.Ref, cs store.ChunkSource) types.Value {
+func MustReadValue(ref ref.Ref, cs chunks.ChunkSource) types.Value {
 	val, err := ReadValue(ref, cs)
 	Chk.NoError(err)
 	return val

--- a/enc/reffer_impl.go
+++ b/enc/reffer_impl.go
@@ -1,9 +1,9 @@
 package enc
 
 import (
+	"github.com/attic-labs/noms/chunks"
 	. "github.com/attic-labs/noms/dbg"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
@@ -12,7 +12,7 @@ func init() {
 }
 
 func refferImpl(v types.Value) ref.Ref {
-	r, err := WriteValue(v, store.NopSink{})
+	r, err := WriteValue(v, chunks.NopSink{})
 	// This can never fail because NopSink doesn't write anywhere.
 	Chk.Nil(err)
 	return r

--- a/enc/write_value.go
+++ b/enc/write_value.go
@@ -1,12 +1,12 @@
 package enc
 
 import (
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 )
 
-func WriteValue(v types.Value, cs store.ChunkSink) (ref.Ref, error) {
+func WriteValue(v types.Value, cs chunks.ChunkSink) (ref.Ref, error) {
 	switch v := v.(type) {
 	case types.Blob:
 		return blobEncode(v, cs)

--- a/enc/write_value_test.go
+++ b/enc/write_value_test.go
@@ -4,8 +4,8 @@ import (
 	"crypto/sha1"
 	"testing"
 
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/store"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,10 +13,10 @@ import (
 func TestWriteValue(t *testing.T) {
 	assert := assert.New(t)
 
-	var s *store.MemoryStore
+	var s *chunks.MemoryStore
 
 	testEncode := func(expected string, v types.Value) ref.Ref {
-		s = &store.MemoryStore{}
+		s = &chunks.MemoryStore{}
 		r, err := WriteValue(v, s)
 		assert.NoError(err)
 


### PR DESCRIPTION
This is in preparation for renaming the 'Commit' abstraction to
DataStore. So we will essentially have a 'chunkstore' abstraction
and a 'datastore' abstraction.
