### PR TITLE
Add xml2noms, which nomifies XML files and dumps them to stdout

### DIFF
--- a/clients/go/stdout_writer.go
+++ b/clients/go/stdout_writer.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"hash"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/dbg"
+	"github.com/attic-labs/noms/ref"
+)
+
+type StdoutChunkSink struct {
+	chunks.ChunkSink
+}
+
+func (f StdoutChunkSink) Put() chunks.ChunkWriter {
+	h := ref.NewHash()
+	return &stdoutChunkWriter{
+		ioutil.NopCloser(nil),
+		os.Stdout,
+		io.MultiWriter(os.Stdout, h),
+		h,
+	}
+}
+
+type stdoutChunkWriter struct {
+	io.Closer
+	file   *os.File
+	writer io.Writer
+	hash   hash.Hash
+}
+
+func (w *stdoutChunkWriter) Write(data []byte) (int, error) {
+	dbg.Chk.NotNil(w.file, "Write() cannot be called after Ref() or Close().")
+	return w.writer.Write(data)
+}
+
+func (w *stdoutChunkWriter) Ref() (ref.Ref, error) {
+	w.file = nil
+	return ref.FromHash(w.hash), nil
+}

--- a/clients/go/util.go
+++ b/clients/go/util.go
@@ -39,6 +39,15 @@ func NomsValueFromDecodedJSON(o interface{}) types.Value {
 			}
 		}
 		return out
+	case []map[string]interface{}:
+		out := types.NewList()
+		for _, v := range o {
+			nv := NomsValueFromDecodedJSON(v)
+			if nv != nil {
+				out = out.Append(nv)
+			}
+		}
+		return out
 	case map[string]interface{}:
 		out := types.NewMap()
 		for k, v := range o {

--- a/clients/xml_importer/xml_importer.go
+++ b/clients/xml_importer/xml_importer.go
@@ -8,18 +8,8 @@ import (
 	"github.com/attic-labs/noms/clients/go"
 	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/dataset"
-	"github.com/attic-labs/noms/types"
 	"github.com/clbanning/mxj"
 )
-
-func nomsValueFromDecodedJSON(o interface{}) types.Value {
-	switch o := o.(type) {
-	case mxj.Map:
-		return util.NomsValueFromDecodedJSON(o.Old())
-	default:
-		return util.NomsValueFromDecodedJSON(o)
-	}
-}
 
 func main() {
 	datasetDataStoreFlags := dataset.DatasetDataFlags()
@@ -46,7 +36,7 @@ func main() {
 
 	roots := ds.Roots()
 
-	value := nomsValueFromDecodedJSON(xmlObject)
+	value := util.NomsValueFromDecodedJSON(xmlObject.Old())
 
 	ds.Commit(datas.NewRootSet().Insert(
 		datas.NewRoot().SetParents(


### PR DESCRIPTION
Given a directory, xml2noms will walk it to find XML files, convert
them into a list of loosely-typed noms values, and then encode them
and dump them to stdout.

Addresses issue #30
