### PR TITLE
Performance improvements, given the xml_importer workload

### DIFF
--- a/chunks/file_store_test.go
+++ b/chunks/file_store_test.go
@@ -142,10 +142,10 @@ func (suite *FileStoreTestSuite) TestFileStoreRoot() {
 func (suite *FileStoreTestSuite) TestFileStorePutExisting() {
 	input := "abc"
 
-	renameCount := 0
-	suite.store.rename = func(oldPath, newPath string) error {
-		renameCount++
-		return os.Rename(oldPath, newPath)
+	mkdirCount := 0
+	suite.store.mkdirAll = func(path string, perm os.FileMode) error {
+		mkdirCount++
+		return os.MkdirAll(path, perm)
 	}
 
 	write := func() {
@@ -158,10 +158,10 @@ func (suite *FileStoreTestSuite) TestFileStorePutExisting() {
 
 	write()
 
-	suite.Equal(1, renameCount)
+	suite.Equal(1, mkdirCount)
 
 	write()
 
 	// Shouldn't have written the second time.
-	suite.Equal(1, renameCount)
+	suite.Equal(1, mkdirCount)
 }

--- a/ref/ref.go
+++ b/ref/ref.go
@@ -22,7 +22,7 @@ type Ref struct {
 	digest Sha1Digest
 }
 
-// Returns a *copy* of the digest.
+// Digest returns a *copy* of the digest that backs Ref.
 func (r Ref) Digest() Sha1Digest {
 	return r.digest
 }
@@ -35,7 +35,7 @@ func New(digest Sha1Digest) Ref {
 	return Ref{digest}
 }
 
-// Creates a new instance of the hash we use for refs.
+// NewHash creates a new instance of the hash we use for refs.
 func NewHash() hash.Hash {
 	return sha1.New()
 }
@@ -70,9 +70,12 @@ func MustParse(s string) Ref {
 	return r
 }
 
+// Less compares two Refs, returning true if the first is less than the second.
+// This can be called a lot, so performance and avoiding creating garbage may be important.
+// Particularly, Chk.Equals{Value} does reflection, and this can be expensive, so avoid it here.
 func Less(r1, r2 Ref) bool {
 	d1, d2 := r1.digest, r2.digest
-	Chk.Equal(len(d1), len(d2))
+	Chk.True(len(d1) == len(d2))
 	for k := 0; k < len(d1); k++ {
 		b1, b2 := d1[k], d2[k]
 		if b1 < b2 {

--- a/types/map.go
+++ b/types/map.go
@@ -99,7 +99,8 @@ func copyMapData(m mapData) mapData {
 }
 
 func buildMapData(oldData mapData, futures []future) mapData {
-	Chk.Equal(0, len(futures)%2, "Must specify even number of key/value pairs")
+	// Sadly, Chk.Equals() costs too much.
+	Chk.True(0 == len(futures)%2, "Must specify even number of key/value pairs")
 
 	m := copyMapData(oldData)
 	for i := 0; i < len(futures); i += 2 {


### PR DESCRIPTION
1) Get rid of temp file usage in FileStore. Instead, write to a buffer and then
   dump to disk on Close().
2) Chk.Equals() uses reflection even if you call it on primitive types, which
   can be surprisingly costly. Switch to a Chk.True() in a couple of hot paths.
