### PR TITLE
Add custom name for all generated types

### DIFF
--- a/nomgen/nomgen.go
+++ b/nomgen/nomgen.go
@@ -206,11 +206,17 @@ func getGoStructName(typeDef types.Value) string {
 	case types.String:
 		name := typeDef.String()
 		switch name {
-		case "bool", "int16", "int32", "int64", "uint16", "uint32", "uint64", "float32", "float64", "blob", "string", "set", "map", "value":
+		case "bool", "int16", "int32", "int64", "float32", "float64", "blob", "string", "set", "map", "value":
 			return strings.Title(typeDef.String())
+		case "uint16", "uint32", "uint64":
+			return strings.ToUpper(typeDef.String()[:2]) + typeDef.String()[2:]
 		}
+
 		Chk.Fail("unexpected noms type name: %s", name)
 	case types.Map:
+		if typeDef.Has(types.NewString("$name")) {
+			return typeDef.Get(types.NewString("$name")).(types.String).String()
+		}
 		typ := typeDef.Get(types.NewString("$type")).(types.String).String()
 		switch typ {
 		case "noms.ListDef":
@@ -222,7 +228,7 @@ func getGoStructName(typeDef types.Value) string {
 		case "noms.SetDef":
 			return fmt.Sprintf("%sSet", getGoStructName(typeDef.Get(types.NewString("elem"))))
 		case "noms.StructDef":
-			return typeDef.Get(types.NewString("$name")).(types.String).String()
+			Chk.Fail("noms.StructDef must have a $name filed: %+v", typeDef)
 		}
 	}
 	Chk.Fail("Unexpected typeDef struct: %+v", typeDef)

--- a/nomgen/test/gen/types.go
+++ b/nomgen/test/gen/types.go
@@ -45,5 +45,10 @@ func main() {
 		types.NewString("key"), testStruct,
 		types.NewString("value"), testSet))
 
+	ng.AddType(types.NewMap(
+		types.NewString("$type"), types.NewString("noms.SetDef"),
+		types.NewString("$name"), types.NewString("MyTestSet"),
+		types.NewString("elem"), types.NewString("uint32")))
+
 	ng.WriteGo("main")
 }

--- a/nomgen/test/test.go
+++ b/nomgen/test/test.go
@@ -63,6 +63,15 @@ func TestCompound(t *testingT) {
 	assert.Equal(m.Get(k), v)
 }
 
+func TestCustomName(t *testingT) {
+	assert := assert.New(t)
+
+	s := NewMyTestSet()
+	assert.True(s.Empty())
+	s = s.Insert(types.UInt32(32))
+	assert.Equal(uint64(1), s.Len())
+}
+
 type testingT struct {
 	testing.T
 	errors int
@@ -80,5 +89,6 @@ func main() {
 	TestSet(t)
 	TestStructTest(t)
 	TestCompound(t)
+	TestCustomName(t)
 	os.Exit(t.errors)
 }

--- a/nomgen/test/types.go
+++ b/nomgen/test/types.go
@@ -8,6 +8,88 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+// MyTestSet
+
+type MyTestSet struct {
+	s types.Set
+}
+
+type MyTestSetIterCallback (func(p types.UInt32) (stop bool))
+
+func NewMyTestSet() MyTestSet {
+	return MyTestSet{types.NewSet()}
+}
+
+func MyTestSetFromVal(p types.Value) MyTestSet {
+	return MyTestSet{p.(types.Set)}
+}
+
+func (s MyTestSet) NomsValue() types.Set {
+	return s.s
+}
+
+func (s MyTestSet) Equals(p MyTestSet) bool {
+	return s.s.Equals(p.s)
+}
+
+func (s MyTestSet) Ref() ref.Ref {
+	return s.s.Ref()
+}
+
+func (s MyTestSet) Empty() bool {
+	return s.s.Empty()
+}
+
+func (s MyTestSet) Len() uint64 {
+	return s.s.Len()
+}
+
+func (s MyTestSet) Has(p types.UInt32) bool {
+	return s.s.Has(p)
+}
+
+func (s MyTestSet) Iter(cb MyTestSetIterCallback) {
+	s.s.Iter(func(v types.Value) bool {
+		return cb(types.UInt32FromVal(v))
+	})
+}
+
+func (s MyTestSet) Insert(p ...types.UInt32) MyTestSet {
+	return MyTestSet{s.s.Insert(s.fromElemSlice(p)...)}
+}
+
+func (s MyTestSet) Remove(p ...types.UInt32) MyTestSet {
+	return MyTestSet{s.s.Remove(s.fromElemSlice(p)...)}
+}
+
+func (s MyTestSet) Union(others ...MyTestSet) MyTestSet {
+	return MyTestSet{s.s.Union(s.fromStructSlice(others)...)}
+}
+
+func (s MyTestSet) Subtract(others ...MyTestSet) MyTestSet {
+	return MyTestSet{s.s.Subtract(s.fromStructSlice(others)...)}
+}
+
+func (s MyTestSet) Any() types.UInt32 {
+	return types.UInt32FromVal(s.s.Any())
+}
+
+func (s MyTestSet) fromStructSlice(p []MyTestSet) []types.Set {
+	r := make([]types.Set, len(p))
+	for i, v := range p {
+		r[i] = v.s
+	}
+	return r
+}
+
+func (s MyTestSet) fromElemSlice(p []types.UInt32) []types.Value {
+	r := make([]types.Value, len(p))
+	for i, v := range p {
+		r[i] = v
+	}
+	return r
+}
+
 // TestStructBoolSetMap
 
 type TestStructBoolSetMap struct {


### PR DESCRIPTION
Map, Set and List can now also define their name using $name.

Issue #108
