### PR TITLE
Change Dataset 'Root' field to be called 'Heads'

### DIFF
--- a/clients/server/server.go
+++ b/clients/server/server.go
@@ -70,7 +70,7 @@ func (s server) handleGetRef(w http.ResponseWriter, hashString string) {
 
 func (s server) handleGetDataset(w http.ResponseWriter, id string) {
 	dataStore := datas.NewDataStore(s.cs, s.cs.(chunks.RootTracker))
-	dataset := mgmt.GetDatasetRoot(mgmt.GetDatasets(dataStore), id)
+	dataset := mgmt.GetDatasetHeads(mgmt.GetDatasets(dataStore), id)
 	if dataset == nil {
 		http.Error(w, fmt.Sprintf("Dataset not found: %s", id), http.StatusNotFound)
 		return

--- a/clients/server/server_test.go
+++ b/clients/server/server_test.go
@@ -62,7 +62,7 @@ func TestGetRef(t *testing.T) {
 	s := server{ms}
 	s.handle(w, req)
 	assert.Equal(w.Code, http.StatusOK)
-	assert.Equal(`j {"set":[{"ref":"sha1-8cd398c860f50a43898e3f95b266b5fdecb4e1e6"}]}
+	assert.Equal(`j {"set":[{"ref":"sha1-643bfe5cc64aca9536d90e2682984c33241acbbe"}]}
 `, w.Body.String())
 }
 

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -58,7 +58,7 @@ type datasetRootTracker struct {
 }
 
 func (rt *datasetRootTracker) Root() ref.Ref {
-	dataset := mgmt.GetDatasetRoot(mgmt.GetDatasets(rt.parentStore), rt.datasetID)
+	dataset := mgmt.GetDatasetHeads(mgmt.GetDatasets(rt.parentStore), rt.datasetID)
 	if dataset == nil {
 		return ref.Ref{}
 	} else {
@@ -72,6 +72,6 @@ func (rt *datasetRootTracker) UpdateRoot(current, last ref.Ref) bool {
 	}
 
 	datasetCommit := types.MustReadValue(current, rt.parentStore)
-	rt.parentStore = mgmt.CommitDatasets(rt.parentStore, mgmt.SetDatasetRoot(mgmt.GetDatasets(rt.parentStore), rt.datasetID, datasetCommit))
+	rt.parentStore = mgmt.CommitDatasets(rt.parentStore, mgmt.SetDatasetHeads(mgmt.GetDatasets(rt.parentStore), rt.datasetID, datasetCommit))
 	return true
 }

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -34,5 +34,5 @@ func TestDatasetCommitTracker(t *testing.T) {
 	assert.False(datasetDs2.Heads().Any().Value().Equals(datasetCommit1))
 	assert.False(datasetDs1.Heads().Any().Value().Equals(datasetCommit2))
 
-	assert.Equal("sha1-9b9fcfcd7e41ff727e6bea0edfa26f71def178a5", ms.Root().String())
+	assert.Equal("sha1-20ddbcdce78e73801dfdf863ff73a6f95425b55d", ms.Root().String())
 }

--- a/dataset/mgmt/gen/types.go
+++ b/dataset/mgmt/gen/types.go
@@ -26,7 +26,7 @@ func main() {
 		types.NewString("$type"), types.NewString("noms.StructDef"),
 		types.NewString("$name"), types.NewString("Dataset"),
 		types.NewString("id"), types.NewString("string"),
-		types.NewString("root"), types.NewString("value")))
+		types.NewString("heads"), types.NewString("value")))
 
 	ng.AddType(types.NewMap(
 		types.NewString("$type"), types.NewString("noms.SetDef"),

--- a/dataset/mgmt/mgmt.go
+++ b/dataset/mgmt/mgmt.go
@@ -35,16 +35,16 @@ func getDataset(datasets SetOfDataset, datasetID string) (r *Dataset) {
 	return
 }
 
-func GetDatasetRoot(datasets SetOfDataset, datasetID string) types.Value {
+func GetDatasetHeads(datasets SetOfDataset, datasetID string) types.Value {
 	dataset := getDataset(datasets, datasetID)
 	if dataset == nil {
 		return nil
 	}
-	return dataset.Root()
+	return dataset.Heads()
 }
 
-func SetDatasetRoot(datasets SetOfDataset, datasetID string, val types.Value) SetOfDataset {
-	newDataset := NewDataset().SetId(types.NewString(datasetID)).SetRoot(val)
+func SetDatasetHeads(datasets SetOfDataset, datasetID string, val types.Value) SetOfDataset {
+	newDataset := NewDataset().SetId(types.NewString(datasetID)).SetHeads(val)
 	dataset := getDataset(datasets, datasetID)
 	if dataset == nil {
 		return datasets.Insert(newDataset)

--- a/dataset/mgmt/mgmt_test.go
+++ b/dataset/mgmt/mgmt_test.go
@@ -16,15 +16,15 @@ func TestGetDataset(t *testing.T) {
 	datasets := GetDatasets(ds)
 	dataset := getDataset(datasets, "testdataset")
 	assert.Nil(dataset)
-	datasets = SetDatasetRoot(datasets, "testdataset", types.Int32(42))
+	datasets = SetDatasetHeads(datasets, "testdataset", types.Int32(42))
 	dataset = getDataset(datasets, "testdataset")
 	assert.Equal("testdataset", dataset.Id().String())
 }
 
 func TestSetDatasetRoot(t *testing.T) {
 	assert := assert.New(t)
-	datasets := SetDatasetRoot(NewSetOfDataset(), "testdataset", types.Int32(42))
+	datasets := SetDatasetHeads(NewSetOfDataset(), "testdataset", types.Int32(42))
 	assert.EqualValues(1, datasets.Len())
-	assert.True(types.Int32(42).Equals(datasets.Any().Root()))
-	assert.True(types.Int32(42).Equals(GetDatasetRoot(datasets, "testdataset")))
+	assert.True(types.Int32(42).Equals(datasets.Any().Heads()))
+	assert.True(types.Int32(42).Equals(GetDatasetHeads(datasets, "testdataset")))
 }

--- a/dataset/mgmt/types.go
+++ b/dataset/mgmt/types.go
@@ -8,6 +8,49 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+// Dataset
+
+type Dataset struct {
+	m types.Map
+}
+
+func NewDataset() Dataset {
+	return Dataset{types.NewMap()}
+}
+
+func DatasetFromVal(v types.Value) Dataset {
+	return Dataset{v.(types.Map)}
+}
+
+// TODO: This was going to be called Value() but it collides with root.value. We need some other place to put the built-in fields like Value() and Equals().
+func (s Dataset) NomsValue() types.Map {
+	return s.m
+}
+
+func (s Dataset) Equals(p Dataset) bool {
+	return s.m.Equals(p.m)
+}
+
+func (s Dataset) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Dataset) Id() types.String {
+	return types.StringFromVal(s.m.Get(types.NewString("id")))
+}
+
+func (s Dataset) SetId(p types.String) Dataset {
+	return DatasetFromVal(s.m.Set(types.NewString("id"), p))
+}
+
+func (s Dataset) Heads() types.Value {
+	return (s.m.Get(types.NewString("heads")))
+}
+
+func (s Dataset) SetHeads(p types.Value) Dataset {
+	return DatasetFromVal(s.m.Set(types.NewString("heads"), p))
+}
+
 // SetOfDataset
 
 type SetOfDataset struct {
@@ -88,48 +131,5 @@ func (s SetOfDataset) fromElemSlice(p []Dataset) []types.Value {
 		r[i] = v.NomsValue()
 	}
 	return r
-}
-
-// Dataset
-
-type Dataset struct {
-	m types.Map
-}
-
-func NewDataset() Dataset {
-	return Dataset{types.NewMap()}
-}
-
-func DatasetFromVal(v types.Value) Dataset {
-	return Dataset{v.(types.Map)}
-}
-
-// TODO: This was going to be called Value() but it collides with root.value. We need some other place to put the built-in fields like Value() and Equals().
-func (s Dataset) NomsValue() types.Map {
-	return s.m
-}
-
-func (s Dataset) Equals(p Dataset) bool {
-	return s.m.Equals(p.m)
-}
-
-func (s Dataset) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s Dataset) Id() types.String {
-	return types.StringFromVal(s.m.Get(types.NewString("id")))
-}
-
-func (s Dataset) SetId(p types.String) Dataset {
-	return DatasetFromVal(s.m.Set(types.NewString("id"), p))
-}
-
-func (s Dataset) Root() types.Value {
-	return (s.m.Get(types.NewString("root")))
-}
-
-func (s Dataset) SetRoot(p types.Value) Dataset {
-	return DatasetFromVal(s.m.Set(types.NewString("root"), p))
 }
 


### PR DESCRIPTION
Since the Value stored in Dataset.Root is always a CommitSet, 'Heads'
is a more accurate and useful name for this field than 'Root'.
