### PR TITLE
ReadValue() should return early if it can't Get() a Ref

### DIFF
--- a/types/read_value.go
+++ b/types/read_value.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/attic-labs/noms/chunks"
@@ -14,7 +15,10 @@ import (
 func ReadValue(ref ref.Ref, cs chunks.ChunkSource) (Value, error) {
 	Chk.NotNil(cs)
 	reader, err := cs.Get(ref)
-	if reader == nil || err != nil {
+	if reader == nil {
+		return nil, errors.New("Chunk not present")
+	}
+	if err != nil {
 		return nil, err
 	}
 	defer reader.Close()

--- a/types/read_value_test.go
+++ b/types/read_value_test.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/ref"
+	"github.com/stretchr/testify/assert"
+)
+
+type ErrorSource struct {
+	chunks.ChunkSource
+}
+
+func (e ErrorSource) Get(r ref.Ref) (io.ReadCloser, error) {
+	return nil, errors.New("Good golly Miss Molly!")
+}
+
+func TestTolerateUngettableRefs(t *testing.T) {
+	assert := assert.New(t)
+	v, err := ReadValue(ref.Ref{}, &chunks.TestStore{})
+	assert.Nil(v)
+	assert.NotNil(err)
+
+	v, err = ReadValue(ref.Ref{}, &ErrorSource{})
+	assert.Nil(v)
+	assert.NotNil(err)
+}


### PR DESCRIPTION
ReadValue() tries to Get() the ref it's given from the ChunkSource it's given.
We recently changed ChunkSource to return nil with no error if the ref is not
in the ChunkSource. ReadValue, though, soldiers on in the case of a nil
return value from Get, calling Close() on it and other things. This is, I
think, bad.
