### PR TITLE
Remove extraneous type asserts from ChunkStore to RootTracker

### DIFF
--- a/clients/pitchmap/index/index.go
+++ b/clients/pitchmap/index/index.go
@@ -164,7 +164,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	dataStore := datas.NewDataStore(cs, cs.(chunks.RootTracker))
+	dataStore := datas.NewDataStore(cs)
 	inputDataset := dataset.NewDataset(dataStore, *inputID)
 	outputDataset := dataset.NewDataset(dataStore, *outputID)
 

--- a/clients/server/server.go
+++ b/clients/server/server.go
@@ -69,7 +69,7 @@ func (s server) handleGetRef(w http.ResponseWriter, hashString string) {
 }
 
 func (s server) handleGetDataset(w http.ResponseWriter, id string) {
-	dataStore := datas.NewDataStore(s.cs, s.cs.(chunks.RootTracker))
+	dataStore := datas.NewDataStore(s.cs)
 	dataset := mgmt.GetDatasetHeads(mgmt.GetDatasets(dataStore), id)
 	if dataset == nil {
 		http.Error(w, fmt.Sprintf("Dataset not found: %s", id), http.StatusNotFound)

--- a/clients/server/server_test.go
+++ b/clients/server/server_test.go
@@ -17,7 +17,7 @@ var datasetID = "testdataset"
 
 func createTestStore() chunks.ChunkStore {
 	ms := &chunks.MemoryStore{}
-	datasetDs := dataset.NewDataset(datas.NewDataStore(ms, ms), datasetID)
+	datasetDs := dataset.NewDataset(datas.NewDataStore(ms), datasetID)
 	datasetValue := types.NewString("Value for " + datasetID)
 	datasetDs = datasetDs.Commit(datas.NewSetOfCommit().Insert(
 		datas.NewCommit().SetParents(

--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -16,8 +16,12 @@ type DataStore struct {
 	heads SetOfCommit
 }
 
+func NewDataStore(cs chunks.ChunkStore) DataStore {
+	return NewDataStoreWithRootTracker(cs, cs)
+}
+
 // NewDataStore() creates a new DataStore with a specified ChunkStore and RootTracker. Typically these two values will be the same, but it is sometimes useful to have a separate RootTracker (e.g., see DataSet).
-func NewDataStore(cs chunks.ChunkStore, rt chunks.RootTracker) DataStore {
+func NewDataStoreWithRootTracker(cs chunks.ChunkStore, rt chunks.RootTracker) DataStore {
 	return newDataStoreInternal(cs, rt, newCommitCache(cs))
 }
 

--- a/datas/datastore_test.go
+++ b/datas/datastore_test.go
@@ -17,7 +17,7 @@ func TestDataStoreCommit(t *testing.T) {
 	assert.NoError(err)
 
 	chunks := chunks.NewFileStore(dir, "root")
-	ds := NewDataStore(chunks, chunks)
+	ds := NewDataStore(chunks)
 
 	commits := ds.Heads()
 	assert.Equal(uint64(0), commits.Len())
@@ -117,7 +117,7 @@ func TestDataStoreConcurrency(t *testing.T) {
 	assert.NoError(err)
 
 	chunks := chunks.NewFileStore(dir, "commit")
-	ds := NewDataStore(chunks, chunks)
+	ds := NewDataStore(chunks)
 
 	// Setup:
 	// |a| <- |b|
@@ -134,7 +134,7 @@ func TestDataStoreConcurrency(t *testing.T) {
 	bcSet := bSet.Insert(c)
 
 	// Important to create this here.
-	ds2 := NewDataStore(chunks, chunks)
+	ds2 := NewDataStore(chunks)
 
 	// Change 1:
 	// |a| <- |b| <- |d|

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -16,7 +16,7 @@ type Dataset struct {
 }
 
 func NewDataset(parentStore datas.DataStore, datasetID string) Dataset {
-	return Dataset{datas.NewDataStore(parentStore, &datasetRootTracker{parentStore, datasetID})}
+	return Dataset{datas.NewDataStoreWithRootTracker(parentStore, &datasetRootTracker{parentStore, datasetID})}
 }
 
 func (ds *Dataset) Commit(newCommits datas.SetOfCommit) Dataset {
@@ -48,10 +48,8 @@ func (f datasetFlags) CreateDataset() *Dataset {
 		return nil
 	}
 
-	// Blech, kinda sucks to typecast to RootTracker, but we know that all the implementations of ChunkStore implement it.
-	commitDataStore := datas.NewDataStore(cs, cs.(chunks.RootTracker))
-
-	ds := NewDataset(commitDataStore, *f.datasetID)
+	rootDS := datas.NewDataStore(cs)
+	ds := NewDataset(rootDS, *f.datasetID)
 	return &ds
 }
 

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -15,13 +15,13 @@ func TestDatasetCommitTracker(t *testing.T) {
 	datasetId2 := "othertestdataset"
 	ms := &chunks.MemoryStore{}
 
-	datasetDs1 := NewDataset(datas.NewDataStore(ms, ms), datasetId1)
+	datasetDs1 := NewDataset(datas.NewDataStore(ms), datasetId1)
 	datasetCommit1 := types.NewString("Commit value for " + datasetId1)
 	datasetDs1 = datasetDs1.Commit(datas.NewSetOfCommit().Insert(
 		datas.NewCommit().SetParents(
 			types.NewSet()).SetValue(datasetCommit1)))
 
-	datasetDs2 := NewDataset(datas.NewDataStore(ms, ms), datasetId2)
+	datasetDs2 := NewDataset(datas.NewDataStore(ms), datasetId2)
 	datasetCommit2 := types.NewString("Commit value for " + datasetId2)
 	datasetDs2 = datasetDs2.Commit(datas.NewSetOfCommit().Insert(
 		datas.NewCommit().SetParents(

--- a/dataset/mgmt/mgmt_test.go
+++ b/dataset/mgmt/mgmt_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetDataset(t *testing.T) {
 	assert := assert.New(t)
 	ms := &chunks.MemoryStore{}
-	ds := datas.NewDataStore(ms, ms)
+	ds := datas.NewDataStore(ms)
 	datasets := GetDatasets(ds)
 	dataset := getDataset(datasets, "testdataset")
 	assert.Nil(dataset)

--- a/sync/pull_test.go
+++ b/sync/pull_test.go
@@ -12,7 +12,7 @@ import (
 
 func createTestDataset(name string) dataset.Dataset {
 	t := &chunks.TestStore{}
-	return dataset.NewDataset(datas.NewDataStore(t, t), name)
+	return dataset.NewDataset(datas.NewDataStore(t), name)
 
 }
 


### PR DESCRIPTION
Also, factor out a separate NewDataStoreWithRootTracker() since
the common case is to use the same value for both the ChunkStore
and the RootTracker.

Fixes #134
