### PR TITLE
Use io.Copy in fileChunkWriter rather than Bytes()

### DIFF
--- a/chunks/file_store.go
+++ b/chunks/file_store.go
@@ -131,9 +131,9 @@ func (w *fileChunkWriter) Close() error {
 	}
 
 	totalBytes := w.buffer.Len()
-	written, err := file.Write(w.buffer.Bytes())
+	written, err := io.Copy(file, w.buffer)
 	Chk.NoError(err)
-	Chk.True(totalBytes == written, "Too few bytes written.") // BUG #83
+	Chk.True(int64(totalBytes) == written, "Too few bytes written.") // BUG #83
 
 	w.buffer = nil
 	return nil


### PR DESCRIPTION
Fixes #145.

I looked for other occurences via `git grep Bytes()`. Only other
suspicious cases I found were related to types.Blob, which doesn't
deal in io.Reader yet, and memoryChunkWriter. In memoryChunkWriter
we're copying from a buffer, so I don't think there's any win, so
left that one.
