### PR TITLE
Slight modification to compound blob encoding

### DIFF
--- a/enc/json_decode_test.go
+++ b/enc/json_decode_test.go
@@ -80,15 +80,15 @@ func TestJSONDecode(t *testing.T) {
 	// Blob (compound)
 	// echo -n 'b Hello' | sha1sum
 	blr := ref.MustParse("sha1-c35018551e725bd2ab45166b69d15fda00b161c1")
-	cb := CompoundBlob{uint64(2), []uint64{0}, []ref.Ref{blr}}
+	cb := CompoundBlob{[]uint64{2}, []ref.Ref{blr}}
 	testDecode(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"},2]}
 `, cb)
 	// echo -n 'b  ' | sha1sum
 	blr2 := ref.MustParse("sha1-641283a12b475ed58ba510517c1224a912e934a6")
 	// echo -n 'b World!' | sha1sum
 	blr3 := ref.MustParse("sha1-8169c017ce2779f3f66bfe27ee2313d71f7698b9")
-	cb2 := CompoundBlob{uint64(12), []uint64{0, 5, 6}, []ref.Ref{blr, blr2, blr3}}
-	testDecode(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"},5,{"ref":"sha1-641283a12b475ed58ba510517c1224a912e934a6"},6,{"ref":"sha1-8169c017ce2779f3f66bfe27ee2313d71f7698b9"},12]}
+	cb2 := CompoundBlob{[]uint64{5, 6, 12}, []ref.Ref{blr, blr2, blr3}}
+	testDecode(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"},5,{"ref":"sha1-641283a12b475ed58ba510517c1224a912e934a6"},1,{"ref":"sha1-8169c017ce2779f3f66bfe27ee2313d71f7698b9"},6]}
 `, cb2)
 }
 

--- a/enc/json_encode_test.go
+++ b/enc/json_encode_test.go
@@ -87,5 +87,5 @@ func TestJsonEncode(t *testing.T) {
 
 	// Blob (compound)
 	testEncode(fmt.Sprintf(`j {"cb":[{"ref":"%s"},2]}
-`, ref2), CompoundBlob{uint64(2), []uint64{0}, []ref.Ref{ref2}})
+`, ref2), CompoundBlob{[]uint64{2}, []ref.Ref{ref2}})
 }

--- a/types/blob.go
+++ b/types/blob.go
@@ -42,10 +42,10 @@ func NewBlob(r io.Reader) (Blob, error) {
 			break
 		}
 
-		blob = newBlobLeaf(buf.Bytes())
-		offsets = append(offsets, length)
-		blobs = append(blobs, futureFromValue(blob))
 		length += n
+		offsets = append(offsets, length)
+		blob = newBlobLeaf(buf.Bytes())
+		blobs = append(blobs, futureFromValue(blob))
 	}
 
 	if length == 0 {
@@ -55,7 +55,7 @@ func NewBlob(r io.Reader) (Blob, error) {
 	if len(blobs) == 1 {
 		return blob, nil
 	}
-	return compoundBlob{length, offsets, blobs, &ref.Ref{}, nil}, nil
+	return compoundBlob{offsets, blobs, &ref.Ref{}, nil}, nil
 }
 
 func BlobFromVal(v Value) Blob {

--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -19,10 +19,10 @@ func getTestCompoundBlob(datas ...string) compoundBlob {
 	for i, s := range datas {
 		b, _ := NewBlob(bytes.NewBufferString(s))
 		blobs[i] = futureFromValue(b)
-		offsets[i] = length
 		length += uint64(len(s))
+		offsets[i] = length
 	}
-	return compoundBlob{length, offsets, blobs, &ref.Ref{}, nil}
+	return compoundBlob{offsets, blobs, &ref.Ref{}, nil}
 }
 
 func getAliceBlob(t *testing.T) compoundBlob {
@@ -86,7 +86,7 @@ func TestCompoundBlobReaderLazy(t *testing.T) {
 	b2 := newBlobLeaf([]byte("bye"))
 	tb2 := &testBlob{b2, &readCount2}
 
-	cb := compoundBlob{uint64(5), []uint64{0, 2}, []Future{futureFromValue(tb1), futureFromValue(tb2)}, &ref.Ref{}, nil}
+	cb := compoundBlob{[]uint64{2, 5}, []Future{futureFromValue(tb1), futureFromValue(tb2)}, &ref.Ref{}, nil}
 
 	r := cb.Reader()
 	assert.Equal(0, readCount1)
@@ -129,7 +129,7 @@ func TestCompoundBlobReaderLazySeek(t *testing.T) {
 	b2 := newBlobLeaf([]byte("bye"))
 	tb2 := &testBlob{b2, &readCount2}
 
-	cb := compoundBlob{uint64(5), []uint64{0, 2}, []Future{futureFromValue(tb1), futureFromValue(tb2)}, &ref.Ref{}, nil}
+	cb := compoundBlob{[]uint64{2, 5}, []Future{futureFromValue(tb1), futureFromValue(tb2)}, &ref.Ref{}, nil}
 
 	r := cb.Reader()
 
@@ -232,7 +232,7 @@ func TestCompoundBlobChunks(t *testing.T) {
 	bl1 := newBlobLeaf([]byte("hello"))
 	blr1 := bl1.Ref()
 	bl2 := newBlobLeaf([]byte("world"))
-	cb = compoundBlob{uint64(10), []uint64{0, 5}, []Future{futureFromRef(blr1), futureFromValue(bl2)}, &ref.Ref{}, cs}
+	cb = compoundBlob{[]uint64{5, 10}, []Future{futureFromRef(blr1), futureFromValue(bl2)}, &ref.Ref{}, cs}
 	assert.Equal(1, len(cb.Chunks()))
 }
 

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -54,7 +54,7 @@ func TestPrimitiveEquals(t *testing.T) {
 		func() Value {
 			b1, _ := NewBlob(bytes.NewBufferString("hi"))
 			b2, _ := NewBlob(bytes.NewBufferString("bye"))
-			return compoundBlob{uint64(5), []uint64{0, 2}, []Future{futureFromValue(b1), futureFromValue(b2)}, &ref.Ref{}, nil}
+			return compoundBlob{[]uint64{2, 5}, []Future{futureFromValue(b1), futureFromValue(b2)}, &ref.Ref{}, nil}
 		},
 		func() Value { return NewList() },
 		func() Value { return NewList(NewString("foo")) },

--- a/types/get_ref_test.go
+++ b/types/get_ref_test.go
@@ -42,7 +42,7 @@ func TestEnsureRef(t *testing.T) {
 	}()
 
 	bl := newBlobLeaf([]byte("hi"))
-	cb := compoundBlob{uint64(2), []uint64{0}, []Future{futureFromValue(bl)}, &ref.Ref{}, cs}
+	cb := compoundBlob{[]uint64{2}, []Future{futureFromValue(bl)}, &ref.Ref{}, cs}
 
 	values := []Value{
 		newBlobLeaf([]byte{}),

--- a/types/read_value.go
+++ b/types/read_value.go
@@ -86,7 +86,7 @@ func fromEncodeable(i interface{}, cs chunks.ChunkSource) (Future, error) {
 			}
 			blobs[idx] = f
 		}
-		cb := compoundBlob{i.Length, i.Offsets, blobs, &ref.Ref{}, cs}
+		cb := compoundBlob{i.Offsets, blobs, &ref.Ref{}, cs}
 		return futureFromValue(cb), nil
 	default:
 		dbg.Chk.Fail("Unknown encodeable", "%+v", i)

--- a/types/write_value.go
+++ b/types/write_value.go
@@ -76,7 +76,7 @@ func encCompoundBlobFromCompoundBlob(cb compoundBlob, cs chunks.ChunkSink) (inte
 		// All children of compoundBlob must be Blobs, which get encoded and reffed by processChild.
 		refs[idx] = i.(ref.Ref)
 	}
-	return enc.CompoundBlob{Length: cb.length, Offsets: cb.offsets, Blobs: refs}, nil
+	return enc.CompoundBlob{Offsets: cb.offsets, Blobs: refs}, nil
 }
 
 func makeListEncodeable(l List, cs chunks.ChunkSink) (interface{}, error) {


### PR DESCRIPTION
The json serialization now only contains the length of each individual
blob child.

The go representation of this still uses offsets but the offsets are
for the end delimiter.

For "hi" "bye" we get

{"cb", [{"ref": "sha1-hi"}, 2, {"ref": "sha1-bye"}, 3]}

compoundBlob{[2, 5], [sha1-hi, ,sha1-bye]}

Keeping the length in the serialization leads to smaller serializations

Using the end offset leads to simpler binary search and allows us to
use the last entry as the length.

Issue #17
