### PR TITLE
Use d.Try less granularly

### DIFF
--- a/d/check.go
+++ b/d/check.go
@@ -23,5 +23,5 @@ type recoverablePanicker struct {
 }
 
 func (s recoverablePanicker) Errorf(format string, args ...interface{}) {
-	panic(nomsError{fmt.Sprintf(format, args...)})
+	panic(UsageError{fmt.Sprintf(format, args...)})
 }

--- a/d/try.go
+++ b/d/try.go
@@ -7,18 +7,17 @@ func Try(f func()) (err error) {
 	return
 }
 
-// TODO: I think a better name for this might be like UsageError. That's really what it's intended for: telling the caller "you're holding it wrong".
-type nomsError struct {
+type UsageError struct {
 	msg string
 }
 
-func (e nomsError) Error() string {
+func (e UsageError) Error() string {
 	return e.msg
 }
 
 func nomsRecover(errp *error) {
 	if r := recover(); r != nil {
-		if _, ok := r.(nomsError); !ok {
+		if _, ok := r.(UsageError); !ok {
 			panic(r)
 		}
 		*errp = r.(error)

--- a/d/try_test.go
+++ b/d/try_test.go
@@ -10,7 +10,7 @@ func TestTry(t *testing.T) {
 	assert := assert.New(t)
 
 	e := Try(func() { Exp.Fail("hey-o") })
-	assert.IsType(nomsError{}, e)
+	assert.IsType(UsageError{}, e)
 
 	assert.Panics(func() {
 		Try(func() { Chk.Fail("hey-o") })


### PR DESCRIPTION
We can still get useful error messages out of d.Try without
specifically wrapping every single thing that might throw a
noms UsageError, so do so. The code is cleaner.

Towards issue #176
