### PR TITLE
Tighten up compound blob encoding

### DIFF
--- a/enc/json_decode.go
+++ b/enc/json_decode.go
@@ -108,7 +108,7 @@ func toUint64(v interface{}) (uint64, error) {
 	return i, nil
 }
 
-// [{"ref":"sha1-0"}, length0, ... {"ref":"sha1-N"},lengthN]
+// ["sha1-0", length0, ... "sha1-N",lengthN]
 func jsonDecodeCompoundBlob(input []interface{}) interface{} {
 	if len(input)%2 != 0 || len(input) < 2 {
 		d.Exp.NoError(errInvalidEncoding)
@@ -120,16 +120,15 @@ func jsonDecodeCompoundBlob(input []interface{}) interface{} {
 	blobs := make([]ref.Ref, numBlobs)
 
 	ensureRef := func(v interface{}) ref.Ref {
-		// Consider rejiggering this error handling with BUG #176.
-		if v, ok := v.(ref.Ref); !ok {
-			d.Exp.Fail(fmt.Sprintf("CompoundBlob children must be ref.Refs; got %+v", v))
-			return ref.Ref{}
+		if v, ok := v.(string); ok {
+			return ref.Parse(v)
 		}
-		return v.(ref.Ref)
+		d.Exp.Fail(fmt.Sprintf("CompoundBlob children must be ref.Refs; got %+v", v))
+		return ref.Ref{}
 	}
 
 	for i := 0; i < len(input); i += 2 {
-		blobs[i/2] = ensureRef(jsonDecodeValue(input[i]))
+		blobs[i/2] = ensureRef(input[i])
 		length, err := toUint64(input[i+1])
 		d.Exp.NoError(err)
 		offset += length

--- a/enc/json_decode_test.go
+++ b/enc/json_decode_test.go
@@ -84,14 +84,14 @@ func TestJSONDecode(t *testing.T) {
 	// echo -n 'b Hello' | sha1sum
 	blr := ref.Parse("sha1-c35018551e725bd2ab45166b69d15fda00b161c1")
 	cb := CompoundBlob{[]uint64{2}, []ref.Ref{blr}}
-	testDecode(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"},2]}
+	testDecode(`j {"cb":["sha1-c35018551e725bd2ab45166b69d15fda00b161c1",2]}
 `, cb)
 	// echo -n 'b  ' | sha1sum
 	blr2 := ref.Parse("sha1-641283a12b475ed58ba510517c1224a912e934a6")
 	// echo -n 'b World!' | sha1sum
 	blr3 := ref.Parse("sha1-8169c017ce2779f3f66bfe27ee2313d71f7698b9")
 	cb2 := CompoundBlob{[]uint64{5, 6, 12}, []ref.Ref{blr, blr2, blr3}}
-	testDecode(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"},5,{"ref":"sha1-641283a12b475ed58ba510517c1224a912e934a6"},1,{"ref":"sha1-8169c017ce2779f3f66bfe27ee2313d71f7698b9"},6]}
+	testDecode(`j {"cb":["sha1-c35018551e725bd2ab45166b69d15fda00b161c1",5,"sha1-641283a12b475ed58ba510517c1224a912e934a6",1,"sha1-8169c017ce2779f3f66bfe27ee2313d71f7698b9",6]}
 `, cb2)
 }
 
@@ -115,17 +115,17 @@ func TestCompoundBlobJSONDecodeInvalidFormat(t *testing.T) {
 	})
 
 	d.IsUsageError(assert, func() {
-		jsonDecode(strings.NewReader(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"},2.5]}
+		jsonDecode(strings.NewReader(`j {"cb":["sha1-c35018551e725bd2ab45166b69d15fda00b161c1",2.5]}
 `))
 	})
 
 	d.IsUsageError(assert, func() {
-		jsonDecode(strings.NewReader(`j {"cb":[{"ref":"sha1-c35018551e725bd2ab45166b69d15fda00b161c1"}]}
+		jsonDecode(strings.NewReader(`j {"cb":["sha1-c35018551e725bd2ab45166b69d15fda00b161c1"]}
 `))
 	})
 
 	d.IsUsageError(assert, func() {
-		jsonDecode(strings.NewReader(`j {"cb":[{"ref":"invalid ref"},2]}
+		jsonDecode(strings.NewReader(`j {"cb":["invalid ref",2]}
 `))
 	})
 }

--- a/enc/json_encode.go
+++ b/enc/json_encode.go
@@ -121,13 +121,12 @@ func getJSONPrimitive(v interface{}) interface{} {
 }
 
 func getJSONCompoundBlob(cb CompoundBlob) interface{} {
-	// Perhaps tighten this up: BUG #170
-	// {"cb":[{"ref":"sha1-x"},length]}
-	// {"cb":[{"ref":"sha1-x"},lengthX,{"ref":"sha1-y"},lengthY]}
+	// {"cb":["sha1-x",length]}
+	// {"cb":["sha1-x",lengthX,"sha1-y",lengthY]}
 	offset := uint64(0)
 	l := make([]interface{}, 0, len(cb.Blobs)*2)
 	for i, f := range cb.Blobs {
-		l = append(l, getJSONPrimitive(f))
+		l = append(l, f.String())
 		l = append(l, cb.Offsets[i]-offset)
 		offset = cb.Offsets[i]
 	}

--- a/enc/json_encode_test.go
+++ b/enc/json_encode_test.go
@@ -80,6 +80,6 @@ func TestJsonEncode(t *testing.T) {
 	testEncode(expected, SetFromItems("foo", true, uint16(42), ref2, ref1))
 
 	// Blob (compound)
-	testEncode(fmt.Sprintf(`j {"cb":[{"ref":"%s"},2]}
+	testEncode(fmt.Sprintf(`j {"cb":["%s",2]}
 `, ref2), CompoundBlob{[]uint64{2}, []ref.Ref{ref2}})
 }


### PR DESCRIPTION
Before:

``` json
{"cb":[{"ref":"sha1-x"},lengthX,{"ref":"sha1-y"},lengthY]}
```

After:

``` json
{"cb":["sha1-x",lengthX,"sha1-y",lengthY]}
```

Fixes #170
