### PR TITLE
Introduce a list iterator to get rid of O(log n) lookups in loops

### DIFF
--- a/types/list_iterator.go
+++ b/types/list_iterator.go
@@ -1,0 +1,64 @@
+package types
+
+// listIterator allows iterating over a List from a given index.
+type listIterator interface {
+	next() (f Future, done bool)
+}
+
+func newListIterator(l List) listIterator {
+	switch l := l.(type) {
+	case listLeaf:
+		return &listLeafIterator{l, 0}
+	case compoundList:
+		return &compoundListIterator{l, newListIterator(l.lists[0].Deref(l.cs).(List)), 0}
+	}
+	panic("Unreachable")
+}
+
+func newListIteratorAt(l List, idx uint64) listIterator {
+	switch l := l.(type) {
+	case listLeaf:
+		return &listLeafIterator{l, idx}
+	case compoundList:
+		si := findSubIndex(idx, l.offsets)
+		if si > 0 {
+			idx -= l.offsets[si-1]
+		}
+		return &compoundListIterator{l, newListIteratorAt(l.lists[si].Deref(l.cs).(List), idx), uint64(si)}
+	}
+	panic("Unreachable")
+}
+
+// listLeafIterator implements listIterator
+type listLeafIterator struct {
+	list listLeaf
+	i    uint64
+}
+
+func (it *listLeafIterator) next() (f Future, done bool) {
+	if it.i >= it.list.Len() {
+		done = true
+		return
+	}
+	f = it.list.getFuture(it.i)
+	done = false
+	it.i++
+	return
+}
+
+// compoundListIterator implements listIterator
+type compoundListIterator struct {
+	list compoundList
+	it   listIterator
+	si   uint64
+}
+
+func (it *compoundListIterator) next() (f Future, done bool) {
+	f, done = it.it.next()
+	if done && it.si < uint64(len(it.list.lists))-1 {
+		it.si++
+		it.it = newListIterator(it.list.lists[it.si].Deref(it.list.cs).(List))
+		f, done = it.it.next()
+	}
+	return
+}

--- a/types/list_iterator_test.go
+++ b/types/list_iterator_test.go
@@ -1,0 +1,71 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+)
+
+func TestListLeafIterator(t *testing.T) {
+	assert := assert.New(t)
+
+	l := NewList(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4))
+	l2 := NewList()
+	it := newListIterator(l)
+	i := 0
+	for f, done := it.next(); !done; f, done = it.next() {
+		l2 = l2.Append(f.Deref(nil))
+		assert.True(Int32(i).Equals(f.Deref(nil)))
+		i++
+	}
+	assert.Equal(5, i)
+	assert.True(l.Equals(l2))
+}
+
+func TestListLeafIteratorAt(t *testing.T) {
+	assert := assert.New(t)
+
+	l := NewList(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4))
+	l2 := NewList()
+	it := newListIteratorAt(l, 2)
+	i := 2
+	for f, done := it.next(); !done; f, done = it.next() {
+		l2 = l2.Append(f.Deref(nil))
+		assert.True(Int32(i).Equals(f.Deref(nil)))
+		i++
+	}
+	assert.Equal(5, i)
+	assert.True(l.Slice(2, l.Len()).Equals(l2))
+}
+
+func TestCompoundListIterator(t *testing.T) {
+	assert := assert.New(t)
+
+	l := getTestCompoundList(t)
+	l2 := NewList()
+	it := newListIterator(l)
+	i := 0
+	for f, done := it.next(); !done; f, done = it.next() {
+		l2 = l2.Append(f.Deref(nil))
+		assert.True(UInt8(i).Equals(f.Deref(nil)))
+		i++
+	}
+	assert.Equal(255, i)
+	assert.True(l.Equals(l2))
+}
+
+func TestCompoundListIteratorAt(t *testing.T) {
+	assert := assert.New(t)
+
+	l := getTestCompoundList(t)
+	l2 := NewList()
+	it := newListIteratorAt(l, 100)
+	i := 100
+	for f, done := it.next(); !done; f, done = it.next() {
+		l2 = l2.Append(f.Deref(nil))
+		assert.True(UInt8(i).Equals(f.Deref(nil)))
+		i++
+	}
+	assert.Equal(255, i)
+	assert.True(l.Slice(100, l.Len()).Equals(l2))
+}


### PR DESCRIPTION
When we are building the chunked lists we had a lot of loops that did
O(log n) Get operations. Since we are just getting consecutive elements
from the list we can make getting the next one O(1) making these loop
go from O(n*log(n)) to O(n)

Issue #215
