### PR TITLE
Add hacky types.Type

### DIFF
--- a/clients/type_sample/.gitignore
+++ b/clients/type_sample/.gitignore
@@ -1,0 +1,1 @@
+type_sample

--- a/clients/type_sample/type_sample.go
+++ b/clients/type_sample/type_sample.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/d"
+	"github.com/attic-labs/noms/ref"
+	"github.com/attic-labs/noms/types"
+)
+
+func main() {
+	cs := &chunks.MemoryStore{}
+
+	boolType := types.MakePrimitiveType("Bool", types.BoolKind)
+	uint8Type := types.MakePrimitiveType("UInt8", types.UInt8Kind)
+	stringType := types.MakePrimitiveType("String", types.StringKind)
+	mapType := types.MakeMapType(types.NewString("MapOfStringToUInt8"), stringType, uint8Type)
+	setType := types.MakeSetType(types.NewString("SetOfString"), stringType)
+	mahType := types.MakeStructType(types.NewString("MahStruct"), types.NewMap(
+		types.NewString("Field1"), stringType,
+		types.NewString("Field2"), boolType))
+	otherType := types.MakeStructType(types.NewString("MahOtherStruct"), types.NewMap(
+		types.NewString("StructField"), mahType,
+		types.NewString("StringField"), stringType))
+
+	mRef := types.WriteValue(mapType, cs)
+	setRef := types.WriteValue(setType, cs)
+	otherRef := types.WriteValue(otherType, cs)
+	mahRef := types.WriteValue(mahType, cs)
+
+	printTypeRef := func(r ref.Ref) {
+		b, err := ioutil.ReadAll(cs.Get(r))
+		d.Chk.NoError(err)
+		out := &bytes.Buffer{}
+		d.Chk.NoError(json.Indent(out, b[1:], "", "  "))
+		fmt.Printf("%s:\n%s\n", r.String(), out.Bytes())
+	}
+
+	printTypeRef(boolType.Ref())
+	printTypeRef(uint8Type.Ref())
+	printTypeRef(stringType.Ref())
+	printTypeRef(mRef)
+	printTypeRef(setRef)
+	printTypeRef(mahRef)
+	printTypeRef(otherRef)
+}

--- a/enc/json_decode.go
+++ b/enc/json_decode.go
@@ -93,6 +93,16 @@ func jsonDecodeTaggedValue(m map[string]interface{}) interface{} {
 			if v, ok := v.([]interface{}); ok {
 				return jsonDecodeSet(v)
 			}
+		case "type":
+			if v, ok := v.(map[string]interface{}); ok {
+				name, ok := v["name"].(string)
+				d.Exp.True(ok, "Name field of type must be string, not %+v", v["name"])
+				kindEnc, ok := v["kind"]
+				d.Exp.True(ok, "Kind field of type must be uint8, not %+v", v["kind"])
+				kind := jsonDecodeValue(kindEnc).(uint8)
+				desc := jsonDecodeValue(v["desc"]).(Map)
+				return Type{name, kind, desc}
+			}
 		}
 		break
 	}

--- a/enc/json_encode.go
+++ b/enc/json_encode.go
@@ -41,6 +41,12 @@ type Map []interface{}
 
 type Set []interface{}
 
+type Type struct {
+	Name string
+	Kind uint8
+	Desc Map
+}
+
 func jsonEncode(dst io.Writer, v interface{}) {
 	var j interface{}
 	j = getJSON(v)
@@ -64,6 +70,8 @@ func getJSON(v interface{}) interface{} {
 		return getJSONMap(v)
 	case Set:
 		return getJSONSet(v)
+	case Type:
+		return getJSONType(v)
 	default:
 		return getJSONPrimitive(v)
 	}
@@ -163,6 +171,16 @@ func getJSONMap(m Map) interface{} {
 
 func getJSONSet(s Set) interface{} {
 	return getJSONIterable("set", s)
+}
+
+func getJSONType(t Type) interface{} {
+	return map[string]interface{}{
+		"type": map[string]interface{}{
+			"name": getJSONPrimitive(t.Name),
+			"kind": getJSONPrimitive(t.Kind),
+			"desc": getJSONMap(t.Desc),
+		},
+	}
 }
 
 func getJSONIterable(tag string, items []interface{}) interface{} {

--- a/enc/json_encode_test.go
+++ b/enc/json_encode_test.go
@@ -79,6 +79,14 @@ func TestJsonEncode(t *testing.T) {
 `, ref2, ref1)
 	testEncode(expected, SetFromItems("foo", true, uint16(42), ref2, ref1))
 
+	// Types
+	expected = `j {"type":{"desc":{"map":[]},"kind":{"uint8":0},"name":""}}
+`
+	testEncode(expected, Type{"", 0, Map{}})
+	expected = fmt.Sprintf(`j {"type":{"desc":{"map":["key",{"ref":"%s"},"value",{"ref":"%s"}]},"kind":{"uint8":13},"name":""}}
+`, ref1, ref2)
+	testEncode(expected, Type{"", 13, MapFromItems("key", ref1, "value", ref2)})
+
 	// Blob (compound)
 	testEncode(fmt.Sprintf(`j {"cb":["%s",2]}
 `, ref2), CompoundBlob{[]uint64{2}, []ref.Ref{ref2}})

--- a/types/read_value.go
+++ b/types/read_value.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -63,6 +62,8 @@ func fromEncodeable(i interface{}, cs chunks.ChunkSource) Future {
 		return futureMapFromIterable(i, cs)
 	case enc.Set:
 		return futureSetFromIterable(i, cs)
+	case enc.Type:
+		return futureFromValue(makeType(NewString(i.Name), Kind(i.Kind), mapFromFutures(futuresFromIterable(i.Desc, cs), cs)))
 	case enc.CompoundBlob:
 		blobs := make([]Future, len(i.Blobs))
 		for idx, blobRef := range i.Blobs {
@@ -78,7 +79,7 @@ func fromEncodeable(i interface{}, cs chunks.ChunkSource) Future {
 		cl := compoundList{i.Offsets, lists, &ref.Ref{}, cs}
 		return futureFromValue(cl)
 	default:
-		d.Exp.Fail(fmt.Sprintf("Unknown encodeable", "%+v", i))
+		d.Exp.Fail("Unknown encodeable", "%+v", i)
 	}
 
 	return nil

--- a/types/type.go
+++ b/types/type.go
@@ -1,0 +1,88 @@
+package types
+
+import (
+	"github.com/attic-labs/noms/d"
+	"github.com/attic-labs/noms/ref"
+)
+
+// Type structs define and describe Noms types, both custom and built-in.
+// Name is optional.
+// Kind and Desc collectively describe any legal Noms type. Kind captures what kind of type the instance describes, e.g. Set, Bool, Map, Struct, etc. Desc captures further information needed to flesh out the definition, such as the type of the elements in a List, or the field names and types of a Struct.
+// If Kind refers to a primitive, then Desc is empty.
+// If Kind refers to Set or List, then Desc is a map[String]Type{"elem": elementType}
+// If Kind refers to Map, then Desc is a map[String]Type{"key": keyType, "value": valueType}
+// If Kind refers to Struct, then Desc is a map[String]Type{"fieldName1": field1Type, "fieldName2": field2Type}
+// TODO: Replace Kind and Desc with a Union that can hold this kind of type description information in a less ad-hoc kind of way. Also, TODO...make Unions a thing.
+type Type struct {
+	Name String
+	Kind UInt8
+	Desc Map
+	ref  ref.Ref
+}
+
+func MakePrimitiveType(n string, k Kind) Type {
+	return makeType(NewString(n), k, NewMap())
+}
+
+func MakeMapType(name String, keyType, valueType Type) Type {
+	return makeType(name, MapKind, NewMap(NewString("key"), keyType, NewString("value"), valueType))
+}
+
+func MakeListType(name String, valueType Type) Type {
+	return makeType(name, ListKind, NewMap(NewString("elem"), valueType))
+}
+
+func MakeSetType(name String, valueType Type) Type {
+	return makeType(name, SetKind, NewMap(NewString("elem"), valueType))
+}
+
+func MakeStructType(name String, fields Map) Type {
+	return makeType(name, StructKind, fields)
+}
+
+func makeType(name String, kind Kind, desc Map) Type {
+	switch kind {
+	case BoolKind, Int8Kind, Int16Kind, Int32Kind, Int64Kind, Float32Kind, Float64Kind, UInt8Kind, UInt16Kind, UInt32Kind, UInt64Kind, StringKind, ListKind, MapKind, SetKind, StructKind:
+		return Type{Name: name, Kind: UInt8(kind), Desc: desc}
+	default:
+		d.Exp.Fail("Unrecognized Kind:", "%v", kind)
+		panic("unreachable")
+	}
+}
+
+func (t Type) Ref() ref.Ref {
+	return ensureRef(&t.ref, t)
+}
+
+func (t Type) Equals(other Value) (res bool) {
+	if other == nil {
+		return false
+	} else {
+		return t.Ref() == other.Ref()
+	}
+}
+
+func (t Type) Chunks() []Future {
+	return t.Desc.Chunks()
+}
+
+type Kind uint8
+
+const (
+	BoolKind Kind = iota
+	Int8Kind
+	Int16Kind
+	Int32Kind
+	Int64Kind
+	Float32Kind
+	Float64Kind
+	UInt8Kind
+	UInt16Kind
+	UInt32Kind
+	UInt64Kind
+	StringKind
+	ListKind
+	MapKind
+	SetKind
+	StructKind
+)

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/attic-labs/noms/chunks"
+)
+
+func TestTypes(t *testing.T) {
+	assert := assert.New(t)
+	cs := &chunks.MemoryStore{}
+
+	boolType := MakePrimitiveType("Bool", BoolKind)
+	uint8Type := MakePrimitiveType("UInt8", UInt8Kind)
+	stringType := MakePrimitiveType("String", StringKind)
+	mapType := MakeMapType(NewString("MapOfStringToUInt8"), stringType, uint8Type)
+	setType := MakeSetType(NewString("SetOfString"), stringType)
+	mahType := MakeStructType(NewString("MahStruct"), NewMap(
+		NewString("Field1"), stringType,
+		NewString("Field2"), boolType))
+	otherType := MakeStructType(NewString("MahOtherStruct"), NewMap(
+		NewString("StructField"), mahType,
+		NewString("StringField"), stringType))
+
+	mRef := WriteValue(mapType, cs)
+	setRef := WriteValue(setType, cs)
+	otherRef := WriteValue(otherType, cs)
+	mahRef := WriteValue(mahType, cs)
+
+	assert.True(otherType.Equals(ReadValue(otherRef, cs)))
+	assert.True(mapType.Equals(ReadValue(mRef, cs)))
+	assert.True(setType.Equals(ReadValue(setRef, cs)))
+	assert.True(mahType.Equals(ReadValue(mahRef, cs)))
+}

--- a/types/write_value_test.go
+++ b/types/write_value_test.go
@@ -30,7 +30,6 @@ func TestWriteValue(t *testing.T) {
 	assert.NoError(err)
 	testEncode(string([]byte{'b', ' ', 0x00, 0x01, 0x02}), b)
 	testEncode(string("j \"foo\"\n"), NewString("foo"))
-
 }
 
 func TestWriteBlobLeaf(t *testing.T) {


### PR DESCRIPTION
We want to explore encoding type information about Noms data in
the Noms database. So, we need some way to describe types. This
takes the shortest path to making a Noms type called "Type" that
is a peer of Set, Map et al and can describe all the types we currently
use -- except types.Value, which we want to replace in the type system
with Unions (a TODO).
