### PR TITLE
flickr: slurp in geotags

### DIFF
--- a/clients/flickr/types.go
+++ b/clients/flickr/types.go
@@ -204,6 +204,14 @@ func (s RemotePhoto) SetTags(p SetOfString) RemotePhoto {
 	return RemotePhotoFromVal(s.m.Set(types.NewString("tags"), p.NomsValue()))
 }
 
+func (s RemotePhoto) Geoposition() Geoposition {
+	return GeopositionFromVal(s.m.Get(types.NewString("geoposition")))
+}
+
+func (s RemotePhoto) SetGeoposition(p Geoposition) RemotePhoto {
+	return RemotePhotoFromVal(s.m.Set(types.NewString("geoposition"), p.NomsValue()))
+}
+
 func (s RemotePhoto) Url() types.String {
 	return types.StringFromVal(s.m.Get(types.NewString("url")))
 }
@@ -292,6 +300,51 @@ func (s SetOfString) fromElemSlice(p []types.String) []types.Value {
 		r[i] = v
 	}
 	return r
+}
+
+// Geoposition
+
+type Geoposition struct {
+	m types.Map
+}
+
+func NewGeoposition() Geoposition {
+	return Geoposition{
+		types.NewMap(types.NewString("$name"), types.NewString("Geoposition")),
+	}
+}
+
+func GeopositionFromVal(v types.Value) Geoposition {
+	return Geoposition{v.(types.Map)}
+}
+
+// TODO: This was going to be called Value() but it collides with root.value. We need some other place to put the built-in fields like Value() and Equals().
+func (s Geoposition) NomsValue() types.Map {
+	return s.m
+}
+
+func (s Geoposition) Equals(p Geoposition) bool {
+	return s.m.Equals(p.m)
+}
+
+func (s Geoposition) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Geoposition) Longitude() types.Float32 {
+	return types.Float32FromVal(s.m.Get(types.NewString("longitude")))
+}
+
+func (s Geoposition) SetLongitude(p types.Float32) Geoposition {
+	return GeopositionFromVal(s.m.Set(types.NewString("longitude"), p))
+}
+
+func (s Geoposition) Latitude() types.Float32 {
+	return types.Float32FromVal(s.m.Get(types.NewString("latitude")))
+}
+
+func (s Geoposition) SetLatitude(p types.Float32) Geoposition {
+	return GeopositionFromVal(s.m.Set(types.NewString("latitude"), p))
 }
 
 // User

--- a/clients/util/types.go
+++ b/clients/util/types.go
@@ -3,6 +3,7 @@ package util
 import "github.com/attic-labs/noms/types"
 
 var (
+	Geoposition           types.Map
 	PhotoTypeDef          types.Map
 	PhotoSetTypeDef       types.Map
 	RemotePhotoTypeDef    types.Map
@@ -10,6 +11,13 @@ var (
 )
 
 func init() {
+	Geoposition = types.NewMap(
+		types.NewString("$type"), types.NewString("noms.StructDef"),
+		types.NewString("$name"), types.NewString("Geoposition"),
+		types.NewString("latitude"), types.NewString("float32"),
+		types.NewString("longitude"), types.NewString("float32"),
+	)
+
 	stringSet := types.NewMap(
 		types.NewString("$type"), types.NewString("noms.SetDef"),
 		types.NewString("elem"), types.NewString("string"))
@@ -18,6 +26,7 @@ func init() {
 		types.NewString("$type"), types.NewString("noms.StructDef"),
 		types.NewString("$name"), types.NewString("Photo"),
 		types.NewString("height"), types.NewString("uint32"),
+		types.NewString("geoposition"), Geoposition,
 		types.NewString("id"), types.NewString("string"),
 		types.NewString("image"), types.NewString("blob"),
 		types.NewString("tags"), stringSet,


### PR DESCRIPTION
@willhite: added geo slurping to Flickr the way we talked about.

After coding this up, I think it's a little odd this way too. Here are some problems that I see:
1. An image schema does seem like it would naturally compose a geotag field, because EXIF includes this.
2. If you're looking at a photo, you don't see its geotag right there ... you have to go look for the geotag that points to this photo.
3. Because a geotag points at a photo, there is the opportunity to have conflicting information.

That all said, the thing you mentioned about another application being able to do the geotagging after the fact is also appealing.

Let's talk about it tomorrow.
