### PR TITLE
NomDL CodeGen: Struct should use Map for now

### DIFF
--- a/nomdl/codegen/codegen.go
+++ b/nomdl/codegen/codegen.go
@@ -40,12 +40,12 @@ func main() {
 	gen := NewCodeGen(&buf, pkg)
 	gen.WritePackage(*packageFlag)
 
+	bs, err := imports.Process(*outFlag, buf.Bytes(), nil)
+	d.Chk.NoError(err)
+
 	outFile, err := os.OpenFile(*outFlag, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	d.Chk.NoError(err)
 	defer outFile.Close()
-
-	bs, err := imports.Process(*outFlag, buf.Bytes(), nil)
-	d.Chk.NoError(err)
 
 	io.Copy(outFile, bytes.NewBuffer(bs))
 }
@@ -76,9 +76,6 @@ func (gen *codeGen) readTemplates() *template.Template {
 			"valueToUser": gen.valueToUser,
 			"userZero":    gen.userZero,
 			"valueZero":   gen.valueZero,
-			"add": func(a, b int) int {
-				return a + b
-			},
 		}).ParseGlob(glob))
 }
 
@@ -422,14 +419,12 @@ func (gen *codeGen) writeStruct(t parse.TypeRef) {
 		Name          string
 		Fields        []parse.Field
 		Choices       []parse.Field
-		UnionOffset   int
 		HasUnion      bool
 		UnionZeroType parse.TypeRef
 	}{
 		gen.userName(t),
 		desc.Fields,
 		nil,
-		len(desc.Fields),
 		desc.Union != nil,
 		parse.TypeRef{Desc: parse.PrimitiveDesc(parse.UInt32Kind)},
 	}

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -7,33 +7,33 @@ type {{.Name}}Def struct {
 {{end}}}
 
 type {{.Name}} struct {
-	l types.List
+	m types.Map
 }
 
 func New{{.Name}}() {{.Name}} {
-	return {{.Name}}{types.NewList(
-			{{range .Fields}}{{valueZero .T}},
-			{{end}}{{if .HasUnion}}types.UInt32(0),
-			{{valueZero .UnionZeroType}},{{end}}
+	return {{.Name}}{types.NewMap(
+			types.NewString("$name"), types.NewString("{{.Name}}"),
+			{{range .Fields}}types.NewString("{{.Name}}"), {{valueZero .T}},
+			{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(0),
+			types.NewString("$unionValue"), {{valueZero .UnionZeroType}},{{end}}
 		)}
 }
 
 func (def {{.Name}}Def) New() {{.Name}} {
 	return {{.Name}}{
-		types.NewList(
-		{{range .Fields}}{{defToValue (print "def." .Name) .T}},
-		{{end}}{{if .HasUnion}}types.UInt32(def.__unionIndex),
-		def.__unionDefToValue(),
-	{{end}}
+		types.NewMap(
+			types.NewString("$name"), types.NewString("{{.Name}}"),
+			{{range .Fields}}types.NewString("{{.Name}}"), {{defToValue (print "def." .Name) .T}},
+			{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
+			types.NewString("$unionValue"), def.__unionDefToValue(),
+		{{end}}
 	)}
 }
 
-{{$unionOffset := .UnionOffset}}
-
 func (self {{.Name}}) Def() {{.Name}}Def {
 	return {{.Name}}Def{
-		{{range $index, $field := .Fields}}{{valueToDef (print "self.l.Get(" $index ")") .T}},
-		{{end}}{{if .HasUnion}}uint32(self.l.Get({{$unionOffset}}).(types.UInt32)),
+		{{range .Fields}}{{valueToDef (printf `self.m.Get(types.NewString("%s"))` .Name) .T}},
+		{{end}}{{if .HasUnion}}uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
 		self.__unionValueToDef(),{{end}}
 	}
 }
@@ -48,9 +48,9 @@ func (def {{.Name}}Def) __unionDefToValue() types.Value {
 }
 
 func (self {{.Name}}) __unionValueToDef() interface{} {
-	switch uint32(self.l.Get({{$unionOffset}}).(types.UInt32)) {
+	switch uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
 	{{range $index, $field := .Choices}}case {{$index}}:
-		return {{valueToDef (printf "self.l.Get(%d)" (add $unionOffset 1)) .T}}
+		return {{valueToDef `self.m.Get(types.NewString("$unionValue"))` .T}}
 	{{end}}}
 	panic("unreachable")
 }
@@ -58,42 +58,42 @@ func (self {{.Name}}) __unionValueToDef() interface{} {
 
 func {{.Name}}FromVal(val types.Value) {{.Name}} {
 	// TODO: Validate here
-	return {{.Name}}{val.(types.List)}
+	return {{.Name}}{val.(types.Map)}
 }
 
 func (self {{.Name}}) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self {{.Name}}) Equals(p {{.Name}}) bool {
-	return self.l.Equals(p.l)
+func (self {{.Name}}) Equals(other {{.Name}}) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self {{.Name}}) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 {{$name := .Name}}
 {{range $index, $field := .Fields}}
 func (self {{$name}}) {{.Name}}() {{userType .T}} {
-	return {{valueToUser (printf "self.l.Get(%d)" $index) .T}}
+	return {{valueToUser (printf `self.m.Get(types.NewString("%s"))` .Name) .T}}
 }
 
 func (self {{$name}}) Set{{.Name}}(val {{userType .T}}) {{$name}} {
-	return {{$name}}{self.l.Set({{$index}}, {{userToValue "val" .T}})}
+	return {{$name}}{self.m.Set(types.NewString("{{.Name}}"), {{userToValue "val" .T}})}
 }
 {{end}}
 
 {{range $index, $field := .Choices}}
 func (self {{$name}}) {{.Name}}() (val {{userType .T}}, ok bool) {
-	if self.l.Get({{$unionOffset}}).(types.UInt32) != {{$index}} {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != {{$index}} {
 		return
 	}
-	return {{valueToUser (printf "self.l.Get(%d)" (add $unionOffset 1)) .T}}, true
+	return {{valueToUser `self.m.Get(types.NewString("$unionValue"))` .T}}, true
 }
 
 func (self {{$name}}) Set{{.Name}}(val {{userType .T}}) {{$name}} {
-	return {{$name}}{self.l.Set({{$unionOffset}}, types.UInt32({{$index}})).Set({{add $unionOffset 1}}, {{userToValue "val" .T}})}
+	return {{$name}}{self.m.Set(types.NewString("$unionIndex"), types.UInt32({{$index}})).Set(types.NewString("$unionValue"), {{userToValue "val" .T}})}
 }
 
 func (def {{$name}}Def) {{.Name}}() (val {{defType .T}}, ok bool) {

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -14,51 +14,53 @@ type EnumStructDef struct {
 }
 
 type EnumStruct struct {
-	l types.List
+	m types.Map
 }
 
 func NewEnumStruct() EnumStruct {
-	return EnumStruct{types.NewList(
-		types.Int32(0),
+	return EnumStruct{types.NewMap(
+		types.NewString("$name"), types.NewString("EnumStruct"),
+		types.NewString("Hand"), types.Int32(0),
 	)}
 }
 
 func (def EnumStructDef) New() EnumStruct {
 	return EnumStruct{
-		types.NewList(
-			types.Int32(def.Hand),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("EnumStruct"),
+			types.NewString("Hand"), types.Int32(def.Hand),
 		)}
 }
 
 func (self EnumStruct) Def() EnumStructDef {
 	return EnumStructDef{
-		Handedness(self.l.Get(0).(types.Int32)),
+		Handedness(self.m.Get(types.NewString("Hand")).(types.Int32)),
 	}
 }
 
 func EnumStructFromVal(val types.Value) EnumStruct {
 	// TODO: Validate here
-	return EnumStruct{val.(types.List)}
+	return EnumStruct{val.(types.Map)}
 }
 
 func (self EnumStruct) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self EnumStruct) Equals(p EnumStruct) bool {
-	return self.l.Equals(p.l)
+func (self EnumStruct) Equals(other EnumStruct) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self EnumStruct) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self EnumStruct) Hand() Handedness {
-	return Handedness(self.l.Get(0).(types.Int32))
+	return Handedness(self.m.Get(types.NewString("Hand")).(types.Int32))
 }
 
 func (self EnumStruct) SetHand(val Handedness) EnumStruct {
-	return EnumStruct{self.l.Set(0, types.Int32(val))}
+	return EnumStruct{self.m.Set(types.NewString("Hand"), types.Int32(val))}
 }
 
 // Handedness

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -15,60 +15,62 @@ type StructDef struct {
 }
 
 type Struct struct {
-	l types.List
+	m types.Map
 }
 
 func NewStruct() Struct {
-	return Struct{types.NewList(
-		types.NewString(""),
-		types.Bool(false),
+	return Struct{types.NewMap(
+		types.NewString("$name"), types.NewString("Struct"),
+		types.NewString("S"), types.NewString(""),
+		types.NewString("B"), types.Bool(false),
 	)}
 }
 
 func (def StructDef) New() Struct {
 	return Struct{
-		types.NewList(
-			types.NewString(def.S),
-			types.Bool(def.B),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("Struct"),
+			types.NewString("S"), types.NewString(def.S),
+			types.NewString("B"), types.Bool(def.B),
 		)}
 }
 
 func (self Struct) Def() StructDef {
 	return StructDef{
-		self.l.Get(0).(types.String).String(),
-		bool(self.l.Get(1).(types.Bool)),
+		self.m.Get(types.NewString("S")).(types.String).String(),
+		bool(self.m.Get(types.NewString("B")).(types.Bool)),
 	}
 }
 
 func StructFromVal(val types.Value) Struct {
 	// TODO: Validate here
-	return Struct{val.(types.List)}
+	return Struct{val.(types.Map)}
 }
 
 func (self Struct) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self Struct) Equals(p Struct) bool {
-	return self.l.Equals(p.l)
+func (self Struct) Equals(other Struct) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self Struct) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self Struct) S() string {
-	return self.l.Get(0).(types.String).String()
+	return self.m.Get(types.NewString("S")).(types.String).String()
 }
 
 func (self Struct) SetS(val string) Struct {
-	return Struct{self.l.Set(0, types.NewString(val))}
+	return Struct{self.m.Set(types.NewString("S"), types.NewString(val))}
 }
 
 func (self Struct) B() bool {
-	return bool(self.l.Get(1).(types.Bool))
+	return bool(self.m.Get(types.NewString("B")).(types.Bool))
 }
 
 func (self Struct) SetB(val bool) Struct {
-	return Struct{self.l.Set(1, types.Bool(val))}
+	return Struct{self.m.Set(types.NewString("B"), types.Bool(val))}
 }

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -27,192 +27,194 @@ type StructPrimitivesDef struct {
 }
 
 type StructPrimitives struct {
-	l types.List
+	m types.Map
 }
 
 func NewStructPrimitives() StructPrimitives {
-	return StructPrimitives{types.NewList(
-		types.UInt64(0),
-		types.UInt32(0),
-		types.UInt16(0),
-		types.UInt8(0),
-		types.Int64(0),
-		types.Int32(0),
-		types.Int16(0),
-		types.Int8(0),
-		types.Float64(0),
-		types.Float32(0),
-		types.Bool(false),
-		types.NewString(""),
-		types.NewEmptyBlob(),
-		types.Bool(false),
+	return StructPrimitives{types.NewMap(
+		types.NewString("$name"), types.NewString("StructPrimitives"),
+		types.NewString("UInt64"), types.UInt64(0),
+		types.NewString("UInt32"), types.UInt32(0),
+		types.NewString("UInt16"), types.UInt16(0),
+		types.NewString("UInt8"), types.UInt8(0),
+		types.NewString("Int64"), types.Int64(0),
+		types.NewString("Int32"), types.Int32(0),
+		types.NewString("Int16"), types.Int16(0),
+		types.NewString("Int8"), types.Int8(0),
+		types.NewString("Float64"), types.Float64(0),
+		types.NewString("Float32"), types.Float32(0),
+		types.NewString("Bool"), types.Bool(false),
+		types.NewString("String"), types.NewString(""),
+		types.NewString("Blob"), types.NewEmptyBlob(),
+		types.NewString("Value"), types.Bool(false),
 	)}
 }
 
 func (def StructPrimitivesDef) New() StructPrimitives {
 	return StructPrimitives{
-		types.NewList(
-			types.UInt64(def.UInt64),
-			types.UInt32(def.UInt32),
-			types.UInt16(def.UInt16),
-			types.UInt8(def.UInt8),
-			types.Int64(def.Int64),
-			types.Int32(def.Int32),
-			types.Int16(def.Int16),
-			types.Int8(def.Int8),
-			types.Float64(def.Float64),
-			types.Float32(def.Float32),
-			types.Bool(def.Bool),
-			types.NewString(def.String),
-			def.Blob,
-			def.Value,
+		types.NewMap(
+			types.NewString("$name"), types.NewString("StructPrimitives"),
+			types.NewString("UInt64"), types.UInt64(def.UInt64),
+			types.NewString("UInt32"), types.UInt32(def.UInt32),
+			types.NewString("UInt16"), types.UInt16(def.UInt16),
+			types.NewString("UInt8"), types.UInt8(def.UInt8),
+			types.NewString("Int64"), types.Int64(def.Int64),
+			types.NewString("Int32"), types.Int32(def.Int32),
+			types.NewString("Int16"), types.Int16(def.Int16),
+			types.NewString("Int8"), types.Int8(def.Int8),
+			types.NewString("Float64"), types.Float64(def.Float64),
+			types.NewString("Float32"), types.Float32(def.Float32),
+			types.NewString("Bool"), types.Bool(def.Bool),
+			types.NewString("String"), types.NewString(def.String),
+			types.NewString("Blob"), def.Blob,
+			types.NewString("Value"), def.Value,
 		)}
 }
 
 func (self StructPrimitives) Def() StructPrimitivesDef {
 	return StructPrimitivesDef{
-		uint64(self.l.Get(0).(types.UInt64)),
-		uint32(self.l.Get(1).(types.UInt32)),
-		uint16(self.l.Get(2).(types.UInt16)),
-		uint8(self.l.Get(3).(types.UInt8)),
-		int64(self.l.Get(4).(types.Int64)),
-		int32(self.l.Get(5).(types.Int32)),
-		int16(self.l.Get(6).(types.Int16)),
-		int8(self.l.Get(7).(types.Int8)),
-		float64(self.l.Get(8).(types.Float64)),
-		float32(self.l.Get(9).(types.Float32)),
-		bool(self.l.Get(10).(types.Bool)),
-		self.l.Get(11).(types.String).String(),
-		self.l.Get(12).(types.Blob),
-		self.l.Get(13),
+		uint64(self.m.Get(types.NewString("UInt64")).(types.UInt64)),
+		uint32(self.m.Get(types.NewString("UInt32")).(types.UInt32)),
+		uint16(self.m.Get(types.NewString("UInt16")).(types.UInt16)),
+		uint8(self.m.Get(types.NewString("UInt8")).(types.UInt8)),
+		int64(self.m.Get(types.NewString("Int64")).(types.Int64)),
+		int32(self.m.Get(types.NewString("Int32")).(types.Int32)),
+		int16(self.m.Get(types.NewString("Int16")).(types.Int16)),
+		int8(self.m.Get(types.NewString("Int8")).(types.Int8)),
+		float64(self.m.Get(types.NewString("Float64")).(types.Float64)),
+		float32(self.m.Get(types.NewString("Float32")).(types.Float32)),
+		bool(self.m.Get(types.NewString("Bool")).(types.Bool)),
+		self.m.Get(types.NewString("String")).(types.String).String(),
+		self.m.Get(types.NewString("Blob")).(types.Blob),
+		self.m.Get(types.NewString("Value")),
 	}
 }
 
 func StructPrimitivesFromVal(val types.Value) StructPrimitives {
 	// TODO: Validate here
-	return StructPrimitives{val.(types.List)}
+	return StructPrimitives{val.(types.Map)}
 }
 
 func (self StructPrimitives) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self StructPrimitives) Equals(p StructPrimitives) bool {
-	return self.l.Equals(p.l)
+func (self StructPrimitives) Equals(other StructPrimitives) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self StructPrimitives) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self StructPrimitives) UInt64() uint64 {
-	return uint64(self.l.Get(0).(types.UInt64))
+	return uint64(self.m.Get(types.NewString("UInt64")).(types.UInt64))
 }
 
 func (self StructPrimitives) SetUInt64(val uint64) StructPrimitives {
-	return StructPrimitives{self.l.Set(0, types.UInt64(val))}
+	return StructPrimitives{self.m.Set(types.NewString("UInt64"), types.UInt64(val))}
 }
 
 func (self StructPrimitives) UInt32() uint32 {
-	return uint32(self.l.Get(1).(types.UInt32))
+	return uint32(self.m.Get(types.NewString("UInt32")).(types.UInt32))
 }
 
 func (self StructPrimitives) SetUInt32(val uint32) StructPrimitives {
-	return StructPrimitives{self.l.Set(1, types.UInt32(val))}
+	return StructPrimitives{self.m.Set(types.NewString("UInt32"), types.UInt32(val))}
 }
 
 func (self StructPrimitives) UInt16() uint16 {
-	return uint16(self.l.Get(2).(types.UInt16))
+	return uint16(self.m.Get(types.NewString("UInt16")).(types.UInt16))
 }
 
 func (self StructPrimitives) SetUInt16(val uint16) StructPrimitives {
-	return StructPrimitives{self.l.Set(2, types.UInt16(val))}
+	return StructPrimitives{self.m.Set(types.NewString("UInt16"), types.UInt16(val))}
 }
 
 func (self StructPrimitives) UInt8() uint8 {
-	return uint8(self.l.Get(3).(types.UInt8))
+	return uint8(self.m.Get(types.NewString("UInt8")).(types.UInt8))
 }
 
 func (self StructPrimitives) SetUInt8(val uint8) StructPrimitives {
-	return StructPrimitives{self.l.Set(3, types.UInt8(val))}
+	return StructPrimitives{self.m.Set(types.NewString("UInt8"), types.UInt8(val))}
 }
 
 func (self StructPrimitives) Int64() int64 {
-	return int64(self.l.Get(4).(types.Int64))
+	return int64(self.m.Get(types.NewString("Int64")).(types.Int64))
 }
 
 func (self StructPrimitives) SetInt64(val int64) StructPrimitives {
-	return StructPrimitives{self.l.Set(4, types.Int64(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Int64"), types.Int64(val))}
 }
 
 func (self StructPrimitives) Int32() int32 {
-	return int32(self.l.Get(5).(types.Int32))
+	return int32(self.m.Get(types.NewString("Int32")).(types.Int32))
 }
 
 func (self StructPrimitives) SetInt32(val int32) StructPrimitives {
-	return StructPrimitives{self.l.Set(5, types.Int32(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Int32"), types.Int32(val))}
 }
 
 func (self StructPrimitives) Int16() int16 {
-	return int16(self.l.Get(6).(types.Int16))
+	return int16(self.m.Get(types.NewString("Int16")).(types.Int16))
 }
 
 func (self StructPrimitives) SetInt16(val int16) StructPrimitives {
-	return StructPrimitives{self.l.Set(6, types.Int16(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Int16"), types.Int16(val))}
 }
 
 func (self StructPrimitives) Int8() int8 {
-	return int8(self.l.Get(7).(types.Int8))
+	return int8(self.m.Get(types.NewString("Int8")).(types.Int8))
 }
 
 func (self StructPrimitives) SetInt8(val int8) StructPrimitives {
-	return StructPrimitives{self.l.Set(7, types.Int8(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Int8"), types.Int8(val))}
 }
 
 func (self StructPrimitives) Float64() float64 {
-	return float64(self.l.Get(8).(types.Float64))
+	return float64(self.m.Get(types.NewString("Float64")).(types.Float64))
 }
 
 func (self StructPrimitives) SetFloat64(val float64) StructPrimitives {
-	return StructPrimitives{self.l.Set(8, types.Float64(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Float64"), types.Float64(val))}
 }
 
 func (self StructPrimitives) Float32() float32 {
-	return float32(self.l.Get(9).(types.Float32))
+	return float32(self.m.Get(types.NewString("Float32")).(types.Float32))
 }
 
 func (self StructPrimitives) SetFloat32(val float32) StructPrimitives {
-	return StructPrimitives{self.l.Set(9, types.Float32(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Float32"), types.Float32(val))}
 }
 
 func (self StructPrimitives) Bool() bool {
-	return bool(self.l.Get(10).(types.Bool))
+	return bool(self.m.Get(types.NewString("Bool")).(types.Bool))
 }
 
 func (self StructPrimitives) SetBool(val bool) StructPrimitives {
-	return StructPrimitives{self.l.Set(10, types.Bool(val))}
+	return StructPrimitives{self.m.Set(types.NewString("Bool"), types.Bool(val))}
 }
 
 func (self StructPrimitives) String() string {
-	return self.l.Get(11).(types.String).String()
+	return self.m.Get(types.NewString("String")).(types.String).String()
 }
 
 func (self StructPrimitives) SetString(val string) StructPrimitives {
-	return StructPrimitives{self.l.Set(11, types.NewString(val))}
+	return StructPrimitives{self.m.Set(types.NewString("String"), types.NewString(val))}
 }
 
 func (self StructPrimitives) Blob() types.Blob {
-	return self.l.Get(12).(types.Blob)
+	return self.m.Get(types.NewString("Blob")).(types.Blob)
 }
 
 func (self StructPrimitives) SetBlob(val types.Blob) StructPrimitives {
-	return StructPrimitives{self.l.Set(12, val)}
+	return StructPrimitives{self.m.Set(types.NewString("Blob"), val)}
 }
 
 func (self StructPrimitives) Value() types.Value {
-	return self.l.Get(13)
+	return self.m.Get(types.NewString("Value"))
 }
 
 func (self StructPrimitives) SetValue(val types.Value) StructPrimitives {
-	return StructPrimitives{self.l.Set(13, val)}
+	return StructPrimitives{self.m.Set(types.NewString("Value"), val)}
 }

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -17,84 +17,86 @@ type StructWithListDef struct {
 }
 
 type StructWithList struct {
-	l types.List
+	m types.Map
 }
 
 func NewStructWithList() StructWithList {
-	return StructWithList{types.NewList(
-		types.NewList(),
-		types.Bool(false),
-		types.NewString(""),
-		types.Int64(0),
+	return StructWithList{types.NewMap(
+		types.NewString("$name"), types.NewString("StructWithList"),
+		types.NewString("L"), types.NewList(),
+		types.NewString("B"), types.Bool(false),
+		types.NewString("S"), types.NewString(""),
+		types.NewString("I"), types.Int64(0),
 	)}
 }
 
 func (def StructWithListDef) New() StructWithList {
 	return StructWithList{
-		types.NewList(
-			def.L.New().NomsValue(),
-			types.Bool(def.B),
-			types.NewString(def.S),
-			types.Int64(def.I),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("StructWithList"),
+			types.NewString("L"), def.L.New().NomsValue(),
+			types.NewString("B"), types.Bool(def.B),
+			types.NewString("S"), types.NewString(def.S),
+			types.NewString("I"), types.Int64(def.I),
 		)}
 }
 
 func (self StructWithList) Def() StructWithListDef {
 	return StructWithListDef{
-		ListOfUInt8FromVal(self.l.Get(0)).Def(),
-		bool(self.l.Get(1).(types.Bool)),
-		self.l.Get(2).(types.String).String(),
-		int64(self.l.Get(3).(types.Int64)),
+		ListOfUInt8FromVal(self.m.Get(types.NewString("L"))).Def(),
+		bool(self.m.Get(types.NewString("B")).(types.Bool)),
+		self.m.Get(types.NewString("S")).(types.String).String(),
+		int64(self.m.Get(types.NewString("I")).(types.Int64)),
 	}
 }
 
 func StructWithListFromVal(val types.Value) StructWithList {
 	// TODO: Validate here
-	return StructWithList{val.(types.List)}
+	return StructWithList{val.(types.Map)}
 }
 
 func (self StructWithList) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self StructWithList) Equals(p StructWithList) bool {
-	return self.l.Equals(p.l)
+func (self StructWithList) Equals(other StructWithList) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self StructWithList) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self StructWithList) L() ListOfUInt8 {
-	return ListOfUInt8FromVal(self.l.Get(0))
+	return ListOfUInt8FromVal(self.m.Get(types.NewString("L")))
 }
 
 func (self StructWithList) SetL(val ListOfUInt8) StructWithList {
-	return StructWithList{self.l.Set(0, val.NomsValue())}
+	return StructWithList{self.m.Set(types.NewString("L"), val.NomsValue())}
 }
 
 func (self StructWithList) B() bool {
-	return bool(self.l.Get(1).(types.Bool))
+	return bool(self.m.Get(types.NewString("B")).(types.Bool))
 }
 
 func (self StructWithList) SetB(val bool) StructWithList {
-	return StructWithList{self.l.Set(1, types.Bool(val))}
+	return StructWithList{self.m.Set(types.NewString("B"), types.Bool(val))}
 }
 
 func (self StructWithList) S() string {
-	return self.l.Get(2).(types.String).String()
+	return self.m.Get(types.NewString("S")).(types.String).String()
 }
 
 func (self StructWithList) SetS(val string) StructWithList {
-	return StructWithList{self.l.Set(2, types.NewString(val))}
+	return StructWithList{self.m.Set(types.NewString("S"), types.NewString(val))}
 }
 
 func (self StructWithList) I() int64 {
-	return int64(self.l.Get(3).(types.Int64))
+	return int64(self.m.Get(types.NewString("I")).(types.Int64))
 }
 
 func (self StructWithList) SetI(val int64) StructWithList {
-	return StructWithList{self.l.Set(3, types.Int64(val))}
+	return StructWithList{self.m.Set(types.NewString("I"), types.Int64(val))}
 }
 
 // ListOfUInt8

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -16,30 +16,32 @@ type StructWithUnionFieldDef struct {
 }
 
 type StructWithUnionField struct {
-	l types.List
+	m types.Map
 }
 
 func NewStructWithUnionField() StructWithUnionField {
-	return StructWithUnionField{types.NewList(
-		types.Float32(0),
-		types.UInt32(0),
-		types.Float64(0),
+	return StructWithUnionField{types.NewMap(
+		types.NewString("$name"), types.NewString("StructWithUnionField"),
+		types.NewString("A"), types.Float32(0),
+		types.NewString("$unionIndex"), types.UInt32(0),
+		types.NewString("$unionValue"), types.Float64(0),
 	)}
 }
 
 func (def StructWithUnionFieldDef) New() StructWithUnionField {
 	return StructWithUnionField{
-		types.NewList(
-			types.Float32(def.A),
-			types.UInt32(def.__unionIndex),
-			def.__unionDefToValue(),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("StructWithUnionField"),
+			types.NewString("A"), types.Float32(def.A),
+			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
+			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
 }
 
 func (self StructWithUnionField) Def() StructWithUnionFieldDef {
 	return StructWithUnionFieldDef{
-		float32(self.l.Get(0).(types.Float32)),
-		uint32(self.l.Get(1).(types.UInt32)),
+		float32(self.m.Get(types.NewString("A")).(types.Float32)),
+		uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
 		self.__unionValueToDef(),
 	}
 }
@@ -61,55 +63,55 @@ func (def StructWithUnionFieldDef) __unionDefToValue() types.Value {
 }
 
 func (self StructWithUnionField) __unionValueToDef() interface{} {
-	switch uint32(self.l.Get(1).(types.UInt32)) {
+	switch uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
 	case 0:
-		return float64(self.l.Get(2).(types.Float64))
+		return float64(self.m.Get(types.NewString("$unionValue")).(types.Float64))
 	case 1:
-		return self.l.Get(2).(types.String).String()
+		return self.m.Get(types.NewString("$unionValue")).(types.String).String()
 	case 2:
-		return self.l.Get(2).(types.Blob)
+		return self.m.Get(types.NewString("$unionValue")).(types.Blob)
 	case 3:
-		return self.l.Get(2)
+		return self.m.Get(types.NewString("$unionValue"))
 	case 4:
-		return SetOfUInt8FromVal(self.l.Get(2)).Def()
+		return SetOfUInt8FromVal(self.m.Get(types.NewString("$unionValue"))).Def()
 	}
 	panic("unreachable")
 }
 
 func StructWithUnionFieldFromVal(val types.Value) StructWithUnionField {
 	// TODO: Validate here
-	return StructWithUnionField{val.(types.List)}
+	return StructWithUnionField{val.(types.Map)}
 }
 
 func (self StructWithUnionField) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self StructWithUnionField) Equals(p StructWithUnionField) bool {
-	return self.l.Equals(p.l)
+func (self StructWithUnionField) Equals(other StructWithUnionField) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self StructWithUnionField) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self StructWithUnionField) A() float32 {
-	return float32(self.l.Get(0).(types.Float32))
+	return float32(self.m.Get(types.NewString("A")).(types.Float32))
 }
 
 func (self StructWithUnionField) SetA(val float32) StructWithUnionField {
-	return StructWithUnionField{self.l.Set(0, types.Float32(val))}
+	return StructWithUnionField{self.m.Set(types.NewString("A"), types.Float32(val))}
 }
 
 func (self StructWithUnionField) B() (val float64, ok bool) {
-	if self.l.Get(1).(types.UInt32) != 0 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 0 {
 		return
 	}
-	return float64(self.l.Get(2).(types.Float64)), true
+	return float64(self.m.Get(types.NewString("$unionValue")).(types.Float64)), true
 }
 
 func (self StructWithUnionField) SetB(val float64) StructWithUnionField {
-	return StructWithUnionField{self.l.Set(1, types.UInt32(0)).Set(2, types.Float64(val))}
+	return StructWithUnionField{self.m.Set(types.NewString("$unionIndex"), types.UInt32(0)).Set(types.NewString("$unionValue"), types.Float64(val))}
 }
 
 func (def StructWithUnionFieldDef) B() (val float64, ok bool) {
@@ -126,14 +128,14 @@ func (def StructWithUnionFieldDef) SetB(val float64) StructWithUnionFieldDef {
 }
 
 func (self StructWithUnionField) C() (val string, ok bool) {
-	if self.l.Get(1).(types.UInt32) != 1 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 1 {
 		return
 	}
-	return self.l.Get(2).(types.String).String(), true
+	return self.m.Get(types.NewString("$unionValue")).(types.String).String(), true
 }
 
 func (self StructWithUnionField) SetC(val string) StructWithUnionField {
-	return StructWithUnionField{self.l.Set(1, types.UInt32(1)).Set(2, types.NewString(val))}
+	return StructWithUnionField{self.m.Set(types.NewString("$unionIndex"), types.UInt32(1)).Set(types.NewString("$unionValue"), types.NewString(val))}
 }
 
 func (def StructWithUnionFieldDef) C() (val string, ok bool) {
@@ -150,14 +152,14 @@ func (def StructWithUnionFieldDef) SetC(val string) StructWithUnionFieldDef {
 }
 
 func (self StructWithUnionField) D() (val types.Blob, ok bool) {
-	if self.l.Get(1).(types.UInt32) != 2 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 2 {
 		return
 	}
-	return self.l.Get(2).(types.Blob), true
+	return self.m.Get(types.NewString("$unionValue")).(types.Blob), true
 }
 
 func (self StructWithUnionField) SetD(val types.Blob) StructWithUnionField {
-	return StructWithUnionField{self.l.Set(1, types.UInt32(2)).Set(2, val)}
+	return StructWithUnionField{self.m.Set(types.NewString("$unionIndex"), types.UInt32(2)).Set(types.NewString("$unionValue"), val)}
 }
 
 func (def StructWithUnionFieldDef) D() (val types.Blob, ok bool) {
@@ -174,14 +176,14 @@ func (def StructWithUnionFieldDef) SetD(val types.Blob) StructWithUnionFieldDef 
 }
 
 func (self StructWithUnionField) E() (val types.Value, ok bool) {
-	if self.l.Get(1).(types.UInt32) != 3 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 3 {
 		return
 	}
-	return self.l.Get(2), true
+	return self.m.Get(types.NewString("$unionValue")), true
 }
 
 func (self StructWithUnionField) SetE(val types.Value) StructWithUnionField {
-	return StructWithUnionField{self.l.Set(1, types.UInt32(3)).Set(2, val)}
+	return StructWithUnionField{self.m.Set(types.NewString("$unionIndex"), types.UInt32(3)).Set(types.NewString("$unionValue"), val)}
 }
 
 func (def StructWithUnionFieldDef) E() (val types.Value, ok bool) {
@@ -198,14 +200,14 @@ func (def StructWithUnionFieldDef) SetE(val types.Value) StructWithUnionFieldDef
 }
 
 func (self StructWithUnionField) F() (val SetOfUInt8, ok bool) {
-	if self.l.Get(1).(types.UInt32) != 4 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 4 {
 		return
 	}
-	return SetOfUInt8FromVal(self.l.Get(2)), true
+	return SetOfUInt8FromVal(self.m.Get(types.NewString("$unionValue"))), true
 }
 
 func (self StructWithUnionField) SetF(val SetOfUInt8) StructWithUnionField {
-	return StructWithUnionField{self.l.Set(1, types.UInt32(4)).Set(2, val.NomsValue())}
+	return StructWithUnionField{self.m.Set(types.NewString("$unionIndex"), types.UInt32(4)).Set(types.NewString("$unionValue"), val.NomsValue())}
 }
 
 func (def StructWithUnionFieldDef) F() (val SetOfUInt8Def, ok bool) {

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -15,62 +15,64 @@ type StructWithUnionsDef struct {
 }
 
 type StructWithUnions struct {
-	l types.List
+	m types.Map
 }
 
 func NewStructWithUnions() StructWithUnions {
-	return StructWithUnions{types.NewList(
-		New__unionOfBOfFloat64AndCOfString().NomsValue(),
-		New__unionOfEOfFloat64AndFOfString().NomsValue(),
+	return StructWithUnions{types.NewMap(
+		types.NewString("$name"), types.NewString("StructWithUnions"),
+		types.NewString("A"), New__unionOfBOfFloat64AndCOfString().NomsValue(),
+		types.NewString("D"), New__unionOfEOfFloat64AndFOfString().NomsValue(),
 	)}
 }
 
 func (def StructWithUnionsDef) New() StructWithUnions {
 	return StructWithUnions{
-		types.NewList(
-			def.A.New().NomsValue(),
-			def.D.New().NomsValue(),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("StructWithUnions"),
+			types.NewString("A"), def.A.New().NomsValue(),
+			types.NewString("D"), def.D.New().NomsValue(),
 		)}
 }
 
 func (self StructWithUnions) Def() StructWithUnionsDef {
 	return StructWithUnionsDef{
-		__unionOfBOfFloat64AndCOfStringFromVal(self.l.Get(0)).Def(),
-		__unionOfEOfFloat64AndFOfStringFromVal(self.l.Get(1)).Def(),
+		__unionOfBOfFloat64AndCOfStringFromVal(self.m.Get(types.NewString("A"))).Def(),
+		__unionOfEOfFloat64AndFOfStringFromVal(self.m.Get(types.NewString("D"))).Def(),
 	}
 }
 
 func StructWithUnionsFromVal(val types.Value) StructWithUnions {
 	// TODO: Validate here
-	return StructWithUnions{val.(types.List)}
+	return StructWithUnions{val.(types.Map)}
 }
 
 func (self StructWithUnions) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self StructWithUnions) Equals(p StructWithUnions) bool {
-	return self.l.Equals(p.l)
+func (self StructWithUnions) Equals(other StructWithUnions) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self StructWithUnions) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self StructWithUnions) A() __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfStringFromVal(self.l.Get(0))
+	return __unionOfBOfFloat64AndCOfStringFromVal(self.m.Get(types.NewString("A")))
 }
 
 func (self StructWithUnions) SetA(val __unionOfBOfFloat64AndCOfString) StructWithUnions {
-	return StructWithUnions{self.l.Set(0, val.NomsValue())}
+	return StructWithUnions{self.m.Set(types.NewString("A"), val.NomsValue())}
 }
 
 func (self StructWithUnions) D() __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfStringFromVal(self.l.Get(1))
+	return __unionOfEOfFloat64AndFOfStringFromVal(self.m.Get(types.NewString("D")))
 }
 
 func (self StructWithUnions) SetD(val __unionOfEOfFloat64AndFOfString) StructWithUnions {
-	return StructWithUnions{self.l.Set(1, val.NomsValue())}
+	return StructWithUnions{self.m.Set(types.NewString("D"), val.NomsValue())}
 }
 
 // __unionOfBOfFloat64AndCOfString
@@ -81,27 +83,29 @@ type __unionOfBOfFloat64AndCOfStringDef struct {
 }
 
 type __unionOfBOfFloat64AndCOfString struct {
-	l types.List
+	m types.Map
 }
 
 func New__unionOfBOfFloat64AndCOfString() __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfString{types.NewList(
-		types.UInt32(0),
-		types.Float64(0),
+	return __unionOfBOfFloat64AndCOfString{types.NewMap(
+		types.NewString("$name"), types.NewString("__unionOfBOfFloat64AndCOfString"),
+		types.NewString("$unionIndex"), types.UInt32(0),
+		types.NewString("$unionValue"), types.Float64(0),
 	)}
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) New() __unionOfBOfFloat64AndCOfString {
 	return __unionOfBOfFloat64AndCOfString{
-		types.NewList(
-			types.UInt32(def.__unionIndex),
-			def.__unionDefToValue(),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("__unionOfBOfFloat64AndCOfString"),
+			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
+			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
 }
 
 func (self __unionOfBOfFloat64AndCOfString) Def() __unionOfBOfFloat64AndCOfStringDef {
 	return __unionOfBOfFloat64AndCOfStringDef{
-		uint32(self.l.Get(0).(types.UInt32)),
+		uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
 		self.__unionValueToDef(),
 	}
 }
@@ -117,41 +121,41 @@ func (def __unionOfBOfFloat64AndCOfStringDef) __unionDefToValue() types.Value {
 }
 
 func (self __unionOfBOfFloat64AndCOfString) __unionValueToDef() interface{} {
-	switch uint32(self.l.Get(0).(types.UInt32)) {
+	switch uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
 	case 0:
-		return float64(self.l.Get(1).(types.Float64))
+		return float64(self.m.Get(types.NewString("$unionValue")).(types.Float64))
 	case 1:
-		return self.l.Get(1).(types.String).String()
+		return self.m.Get(types.NewString("$unionValue")).(types.String).String()
 	}
 	panic("unreachable")
 }
 
 func __unionOfBOfFloat64AndCOfStringFromVal(val types.Value) __unionOfBOfFloat64AndCOfString {
 	// TODO: Validate here
-	return __unionOfBOfFloat64AndCOfString{val.(types.List)}
+	return __unionOfBOfFloat64AndCOfString{val.(types.Map)}
 }
 
 func (self __unionOfBOfFloat64AndCOfString) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self __unionOfBOfFloat64AndCOfString) Equals(p __unionOfBOfFloat64AndCOfString) bool {
-	return self.l.Equals(p.l)
+func (self __unionOfBOfFloat64AndCOfString) Equals(other __unionOfBOfFloat64AndCOfString) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self __unionOfBOfFloat64AndCOfString) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self __unionOfBOfFloat64AndCOfString) B() (val float64, ok bool) {
-	if self.l.Get(0).(types.UInt32) != 0 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 0 {
 		return
 	}
-	return float64(self.l.Get(1).(types.Float64)), true
+	return float64(self.m.Get(types.NewString("$unionValue")).(types.Float64)), true
 }
 
 func (self __unionOfBOfFloat64AndCOfString) SetB(val float64) __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfString{self.l.Set(0, types.UInt32(0)).Set(1, types.Float64(val))}
+	return __unionOfBOfFloat64AndCOfString{self.m.Set(types.NewString("$unionIndex"), types.UInt32(0)).Set(types.NewString("$unionValue"), types.Float64(val))}
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) B() (val float64, ok bool) {
@@ -168,14 +172,14 @@ func (def __unionOfBOfFloat64AndCOfStringDef) SetB(val float64) __unionOfBOfFloa
 }
 
 func (self __unionOfBOfFloat64AndCOfString) C() (val string, ok bool) {
-	if self.l.Get(0).(types.UInt32) != 1 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 1 {
 		return
 	}
-	return self.l.Get(1).(types.String).String(), true
+	return self.m.Get(types.NewString("$unionValue")).(types.String).String(), true
 }
 
 func (self __unionOfBOfFloat64AndCOfString) SetC(val string) __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfString{self.l.Set(0, types.UInt32(1)).Set(1, types.NewString(val))}
+	return __unionOfBOfFloat64AndCOfString{self.m.Set(types.NewString("$unionIndex"), types.UInt32(1)).Set(types.NewString("$unionValue"), types.NewString(val))}
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) C() (val string, ok bool) {
@@ -199,27 +203,29 @@ type __unionOfEOfFloat64AndFOfStringDef struct {
 }
 
 type __unionOfEOfFloat64AndFOfString struct {
-	l types.List
+	m types.Map
 }
 
 func New__unionOfEOfFloat64AndFOfString() __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfString{types.NewList(
-		types.UInt32(0),
-		types.Float64(0),
+	return __unionOfEOfFloat64AndFOfString{types.NewMap(
+		types.NewString("$name"), types.NewString("__unionOfEOfFloat64AndFOfString"),
+		types.NewString("$unionIndex"), types.UInt32(0),
+		types.NewString("$unionValue"), types.Float64(0),
 	)}
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) New() __unionOfEOfFloat64AndFOfString {
 	return __unionOfEOfFloat64AndFOfString{
-		types.NewList(
-			types.UInt32(def.__unionIndex),
-			def.__unionDefToValue(),
+		types.NewMap(
+			types.NewString("$name"), types.NewString("__unionOfEOfFloat64AndFOfString"),
+			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
+			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
 }
 
 func (self __unionOfEOfFloat64AndFOfString) Def() __unionOfEOfFloat64AndFOfStringDef {
 	return __unionOfEOfFloat64AndFOfStringDef{
-		uint32(self.l.Get(0).(types.UInt32)),
+		uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
 		self.__unionValueToDef(),
 	}
 }
@@ -235,41 +241,41 @@ func (def __unionOfEOfFloat64AndFOfStringDef) __unionDefToValue() types.Value {
 }
 
 func (self __unionOfEOfFloat64AndFOfString) __unionValueToDef() interface{} {
-	switch uint32(self.l.Get(0).(types.UInt32)) {
+	switch uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
 	case 0:
-		return float64(self.l.Get(1).(types.Float64))
+		return float64(self.m.Get(types.NewString("$unionValue")).(types.Float64))
 	case 1:
-		return self.l.Get(1).(types.String).String()
+		return self.m.Get(types.NewString("$unionValue")).(types.String).String()
 	}
 	panic("unreachable")
 }
 
 func __unionOfEOfFloat64AndFOfStringFromVal(val types.Value) __unionOfEOfFloat64AndFOfString {
 	// TODO: Validate here
-	return __unionOfEOfFloat64AndFOfString{val.(types.List)}
+	return __unionOfEOfFloat64AndFOfString{val.(types.Map)}
 }
 
 func (self __unionOfEOfFloat64AndFOfString) NomsValue() types.Value {
-	return self.l
+	return self.m
 }
 
-func (self __unionOfEOfFloat64AndFOfString) Equals(p __unionOfEOfFloat64AndFOfString) bool {
-	return self.l.Equals(p.l)
+func (self __unionOfEOfFloat64AndFOfString) Equals(other __unionOfEOfFloat64AndFOfString) bool {
+	return self.m.Equals(other.m)
 }
 
 func (self __unionOfEOfFloat64AndFOfString) Ref() ref.Ref {
-	return self.l.Ref()
+	return self.m.Ref()
 }
 
 func (self __unionOfEOfFloat64AndFOfString) E() (val float64, ok bool) {
-	if self.l.Get(0).(types.UInt32) != 0 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 0 {
 		return
 	}
-	return float64(self.l.Get(1).(types.Float64)), true
+	return float64(self.m.Get(types.NewString("$unionValue")).(types.Float64)), true
 }
 
 func (self __unionOfEOfFloat64AndFOfString) SetE(val float64) __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfString{self.l.Set(0, types.UInt32(0)).Set(1, types.Float64(val))}
+	return __unionOfEOfFloat64AndFOfString{self.m.Set(types.NewString("$unionIndex"), types.UInt32(0)).Set(types.NewString("$unionValue"), types.Float64(val))}
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) E() (val float64, ok bool) {
@@ -286,14 +292,14 @@ func (def __unionOfEOfFloat64AndFOfStringDef) SetE(val float64) __unionOfEOfFloa
 }
 
 func (self __unionOfEOfFloat64AndFOfString) F() (val string, ok bool) {
-	if self.l.Get(0).(types.UInt32) != 1 {
+	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 1 {
 		return
 	}
-	return self.l.Get(1).(types.String).String(), true
+	return self.m.Get(types.NewString("$unionValue")).(types.String).String(), true
 }
 
 func (self __unionOfEOfFloat64AndFOfString) SetF(val string) __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfString{self.l.Set(0, types.UInt32(1)).Set(1, types.NewString(val))}
+	return __unionOfEOfFloat64AndFOfString{self.m.Set(types.NewString("$unionIndex"), types.UInt32(1)).Set(types.NewString("$unionValue"), types.NewString(val))}
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) F() (val string, ok bool) {


### PR DESCRIPTION
This is so that we can transition awapy from nongen

Fixes #312
