### PR TITLE
Make types.Ref explicit

### DIFF
--- a/types/blob_leaf.go
+++ b/types/blob_leaf.go
@@ -36,10 +36,9 @@ func (bl blobLeaf) Chunks() []Future {
 	return nil
 }
 
-func (fb blobLeaf) Equals(other Value) bool {
-	if other == nil {
-		return false
-	} else {
-		return fb.Ref() == other.Ref()
+func (bl blobLeaf) Equals(other Value) bool {
+	if other, ok := other.(blobLeaf); ok {
+		return bl.Ref() == other.Ref()
 	}
+	return false
 }

--- a/types/compound_blob.go
+++ b/types/compound_blob.go
@@ -112,8 +112,8 @@ func (cb compoundBlob) Ref() ref.Ref {
 }
 
 func (cb compoundBlob) Equals(other Value) bool {
-	if other == nil {
-		return false
+	if other, ok := other.(compoundBlob); ok {
+		return cb.Ref() == other.Ref()
 	}
-	return cb.Ref() == other.Ref()
+	return false
 }

--- a/types/compound_list.go
+++ b/types/compound_list.go
@@ -309,10 +309,10 @@ func (cl compoundList) Release() {
 }
 
 func (cl compoundList) Equals(other Value) bool {
-	if other == nil {
-		return false
+	if other, ok := other.(compoundList); ok {
+		return cl.Ref() == other.Ref()
 	}
-	return cl.Ref() == other.Ref()
+	return false
 }
 
 // startsChunk determines if idx refers to the first element in one of cl's chunks.

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -80,5 +80,11 @@ func TestPrimitiveEquals(t *testing.T) {
 				assert.False(f1().Equals(f2()))
 			}
 		}
+		v := f1()
+		if v != nil {
+			r := Ref{R: v.Ref()}
+			assert.False(r.Equals(v))
+			assert.False(v.Equals(r))
+		}
 	}
 }

--- a/types/future.go
+++ b/types/future.go
@@ -40,9 +40,5 @@ func futureEqualsValue(f Future, v Value) bool {
 }
 
 func futureFromValue(v Value) Future {
-	if r, ok := v.(Ref); ok {
-		return &unresolvedFuture{ref: r.Ref()}
-	} else {
-		return resolvedFuture{v}
-	}
+	return resolvedFuture{v}
 }

--- a/types/gen/primitive.tmpl
+++ b/types/gen/primitive.tmpl
@@ -3,9 +3,8 @@ type {{.NomsType}} {{.GoType}}
 func (self {{.NomsType}}) Equals(other Value) bool {
 	if other, ok := other.({{.NomsType}}); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v {{.NomsType}}) Ref() ref.Ref {

--- a/types/list_leaf.go
+++ b/types/list_leaf.go
@@ -146,11 +146,10 @@ func (l listLeaf) Release() {
 }
 
 func (l listLeaf) Equals(other Value) bool {
-	if other == nil {
-		return false
-	} else {
+	if other, ok := other.(listLeaf); ok {
 		return l.Ref() == other.Ref()
 	}
+	return false
 }
 
 func (l listLeaf) Chunks() (futures []Future) {

--- a/types/map.go
+++ b/types/map.go
@@ -123,12 +123,11 @@ func (fm Map) Ref() ref.Ref {
 	return ensureRef(fm.ref, fm)
 }
 
-func (fm Map) Equals(other Value) (res bool) {
-	if other == nil {
-		return false
-	} else {
-		return fm.Ref() == other.Ref()
+func (m Map) Equals(other Value) (res bool) {
+	if other, ok := other.(Map); ok {
+		return m.Ref() == other.Ref()
 	}
+	return false
 }
 
 func (fm Map) Chunks() (futures []Future) {

--- a/types/primitives.go
+++ b/types/primitives.go
@@ -12,9 +12,8 @@ type Bool bool
 func (self Bool) Equals(other Value) bool {
 	if other, ok := other.(Bool); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Bool) Ref() ref.Ref {
@@ -38,9 +37,8 @@ type Int8 int8
 func (self Int8) Equals(other Value) bool {
 	if other, ok := other.(Int8); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Int8) Ref() ref.Ref {
@@ -64,9 +62,8 @@ type Int16 int16
 func (self Int16) Equals(other Value) bool {
 	if other, ok := other.(Int16); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Int16) Ref() ref.Ref {
@@ -90,9 +87,8 @@ type Int32 int32
 func (self Int32) Equals(other Value) bool {
 	if other, ok := other.(Int32); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Int32) Ref() ref.Ref {
@@ -116,9 +112,8 @@ type Int64 int64
 func (self Int64) Equals(other Value) bool {
 	if other, ok := other.(Int64); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Int64) Ref() ref.Ref {
@@ -142,9 +137,8 @@ type UInt8 uint8
 func (self UInt8) Equals(other Value) bool {
 	if other, ok := other.(UInt8); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v UInt8) Ref() ref.Ref {
@@ -168,9 +162,8 @@ type UInt16 uint16
 func (self UInt16) Equals(other Value) bool {
 	if other, ok := other.(UInt16); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v UInt16) Ref() ref.Ref {
@@ -194,9 +187,8 @@ type UInt32 uint32
 func (self UInt32) Equals(other Value) bool {
 	if other, ok := other.(UInt32); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v UInt32) Ref() ref.Ref {
@@ -220,9 +212,8 @@ type UInt64 uint64
 func (self UInt64) Equals(other Value) bool {
 	if other, ok := other.(UInt64); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v UInt64) Ref() ref.Ref {
@@ -246,9 +237,8 @@ type Float32 float32
 func (self Float32) Equals(other Value) bool {
 	if other, ok := other.(Float32); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Float32) Ref() ref.Ref {
@@ -272,9 +262,8 @@ type Float64 float64
 func (self Float64) Equals(other Value) bool {
 	if other, ok := other.(Float64); ok {
 		return self == other
-	} else {
-		return false
 	}
+	return false
 }
 
 func (v Float64) Ref() ref.Ref {

--- a/types/ref.go
+++ b/types/ref.go
@@ -9,7 +9,10 @@ type Ref struct {
 }
 
 func (r Ref) Equals(other Value) bool {
-	return r.R == other.Ref()
+	if other, ok := other.(Ref); ok {
+		return r.Ref() == other.Ref()
+	}
+	return false
 }
 
 func (r Ref) Ref() ref.Ref {

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+)
+
+func TestRefInList(t *testing.T) {
+	assert := assert.New(t)
+	l := NewList()
+	r := Ref{R: l.Ref()}
+	l = l.Append(r)
+	r2 := l.Get(0)
+	assert.True(r.Equals(r2))
+}
+
+func TestRefInSet(t *testing.T) {
+	assert := assert.New(t)
+	s := NewSet()
+	r := Ref{R: s.Ref()}
+	s = s.Insert(r)
+	r2 := s.Any()
+	assert.True(r.Equals(r2))
+}
+
+func TestRefInMap(t *testing.T) {
+	assert := assert.New(t)
+
+	m := NewMap()
+	r := Ref{R: m.Ref()}
+	m = m.Set(Int32(0), r).Set(r, Int32(1))
+	r2 := m.Get(Int32(0))
+	assert.True(r.Equals(r2))
+
+	i := m.Get(r)
+	assert.Equal(int32(1), int32(i.(Int32)))
+}

--- a/types/set.go
+++ b/types/set.go
@@ -125,11 +125,10 @@ func (fs Set) Ref() ref.Ref {
 }
 
 func (fs Set) Equals(other Value) bool {
-	if other == nil {
-		return false
-	} else {
+	if other, ok := other.(Set); ok {
 		return fs.Ref() == other.Ref()
 	}
+	return false
 }
 
 func (fs Set) Chunks() (futures []Future) {

--- a/types/string.go
+++ b/types/string.go
@@ -27,12 +27,11 @@ func (fs String) Ref() ref.Ref {
 	return ensureRef(fs.ref, fs)
 }
 
-func (fs String) Equals(other Value) bool {
-	if other == nil {
-		return false
-	} else {
-		return fs.Ref() == other.Ref()
+func (s String) Equals(other Value) bool {
+	if other, ok := other.(String); ok {
+		return s.Ref() == other.Ref()
 	}
+	return false
 }
 
 func (fs String) Chunks() []Future {


### PR DESCRIPTION
No more implicit Get or Equals
