### PR TITLE
NomDL Codegen: Do not create a Def if non comparable

### DIFF
--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/attic-labs/noms/Godeps/_workspace/src/golang.org/x/tools/imports"
@@ -44,5 +46,74 @@ func TestGeneratedFiles(t *testing.T) {
 	for _, n := range files {
 		_, file := filepath.Split(n)
 		assertOutput(n, "test/"+file[:len(file)-5]+".go", t)
+	}
+}
+
+func TestCanUseDef(t *testing.T) {
+	assert := assert.New(t)
+
+	assertCanUseDef := func(s string, using, named bool) {
+		pkg := parse.ParsePackage("", bytes.NewBufferString(s))
+		gen := NewCodeGen(nil, pkg)
+		for _, t := range pkg.UsingDeclarations {
+			assert.Equal(using, gen.canUseDef(t), s)
+		}
+		for _, t := range pkg.NamedTypes {
+			assert.Equal(named, gen.canUseDef(t), s)
+		}
+	}
+
+	good := `
+		using List(Int8)
+		using Set(Int8)
+		using Map(Int8, Int8)
+		using Map(Int8, Set(Int8))
+		using Map(Int8, Map(Int8, Int8))
+
+		struct Simple {
+			x: Int8
+		}
+		using Set(Simple)
+		using Map(Simple, Int8)
+		using Map(Simple, Simple)
+		`
+	assertCanUseDef(good, true, true)
+
+	bad := `
+		struct WithList {
+			x: List(Int8)
+		}
+		using Set(WithList)
+		using Map(WithList, Int8)
+
+		struct WithSet {
+			x: Set(Int8)
+		}
+		using Set(WithSet)
+		using Map(WithSet, Int8)
+
+		struct WithMap {
+			x: Map(Int8, Int8)
+		}
+		using Set(WithMap)
+		using Map(WithMap, Int8)
+		`
+	assertCanUseDef(bad, false, true)
+
+	bad = `
+		Set(Set(Int8))
+		Set(Map(Int, Int8))
+		Set(List(Int8))
+		Map(Set(Int8), Int8)
+		Map(Map(Int8, Int8), Int8)
+		Map(List(Int8), Int8)
+		`
+
+	for _, line := range strings.Split(bad, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		assertCanUseDef(fmt.Sprintf("using %s", line), false, false)
+		assertCanUseDef(fmt.Sprintf("struct S { x: %s }", line), false, false)
 	}
 }

--- a/nomdl/codegen/list.tmpl
+++ b/nomdl/codegen/list.tmpl
@@ -4,32 +4,35 @@ type {{.Name}} struct {
 	l types.List
 }
 
-type {{.Name}}Def []{{defType .ElemType}}
-
 func New{{.Name}}() {{.Name}} {
 	return {{.Name}}{types.NewList()}
 }
 
-func (def {{.Name}}Def) New() {{.Name}} {
-	l := make([]types.Value, len(def))
-	for i, d := range def {
-		l[i] = {{defToValue "d" .ElemType }}
+{{if .CanUseDef}}
+	type {{.Name}}Def []{{defType .ElemType}}
+
+	func (def {{.Name}}Def) New() {{.Name}} {
+		l := make([]types.Value, len(def))
+		for i, d := range def {
+			l[i] = {{defToValue "d" .ElemType }}
+		}
+		return {{.Name}}{types.NewList(l...)}
 	}
-	return {{.Name}}{types.NewList(l...)}
-}
+
+	func (self {{.Name}}) Def() {{.Name}}Def {
+		l := make([]{{defType .ElemType}}, self.Len())
+		for i := uint64(0); i < self.Len(); i++ {
+			l[i] = {{valueToDef "self.l.Get(i)" .ElemType }}
+		}
+		return l
+	}
+{{end}}
 
 func {{.Name}}FromVal(val types.Value) {{.Name}} {
 	// TODO: Validate here
 	return {{.Name}}{val.(types.List)}
 }
 
-func (self {{.Name}}) Def() {{.Name}}Def {
-	l := make([]{{defType .ElemType}}, self.Len())
-	for i := uint64(0); i < self.Len(); i++ {
-		l[i] = {{valueToDef "self.l.Get(i)" .ElemType }}
-	}
-	return l
-}
 
 func (self {{.Name}}) NomsValue() types.Value {
 	return self.l

--- a/nomdl/codegen/map.tmpl
+++ b/nomdl/codegen/map.tmpl
@@ -4,28 +4,31 @@ type {{.Name}} struct {
 	m types.Map
 }
 
-type {{.Name}}Def map[{{defType .KeyType}}]{{defType .ValueType}}
 
 func New{{.Name}}() {{.Name}} {
 	return {{.Name}}{types.NewMap()}
 }
 
-func (def {{.Name}}Def) New() {{.Name}} {
-	kv := make([]types.Value, 0, len(def)*2)
-	for k, v := range def {
-		kv = append(kv, {{defToValue "k" .KeyType}}, {{defToValue "v" .ValueType}})
-	}
-	return {{.Name}}{types.NewMap(kv...)}
-}
+{{if .CanUseDef}}
+	type {{.Name}}Def map[{{defType .KeyType}}]{{defType .ValueType}}
 
-func (self {{.Name}}) Def() {{.Name}}Def {
-	def := make(map[{{defType .KeyType}}]{{defType .ValueType}})
-	self.m.Iter(func(k, v types.Value) bool {
-		def[{{valueToDef "k" .KeyType}}] = {{valueToDef "v" .ValueType}}
-		return false
-	})
-	return def
-}
+	func (def {{.Name}}Def) New() {{.Name}} {
+		kv := make([]types.Value, 0, len(def)*2)
+		for k, v := range def {
+			kv = append(kv, {{defToValue "k" .KeyType}}, {{defToValue "v" .ValueType}})
+		}
+		return {{.Name}}{types.NewMap(kv...)}
+	}
+
+	func (self {{.Name}}) Def() {{.Name}}Def {
+		def := make(map[{{defType .KeyType}}]{{defType .ValueType}})
+		self.m.Iter(func(k, v types.Value) bool {
+			def[{{valueToDef "k" .KeyType}}] = {{valueToDef "v" .ValueType}}
+			return false
+		})
+		return def
+	}
+{{end}}
 
 func {{.Name}}FromVal(p types.Value) {{.Name}} {
 	// TODO: Validate here

--- a/nomdl/codegen/set.tmpl
+++ b/nomdl/codegen/set.tmpl
@@ -4,30 +4,32 @@ type {{.Name}} struct {
 	s types.Set
 }
 
-type {{.Name}}Def map[{{defType .ElemType}}]bool
-
 func New{{.Name}}() {{.Name}} {
 	return {{.Name}}{types.NewSet()}
 }
 
-func (def {{.Name}}Def) New() {{.Name}} {
-  l := make([]types.Value, len(def))
-	i := 0
-  for d, _ := range def  {
-    l[i] = {{defToValue "d" .ElemType}}
-		i++
-  }
-  return {{.Name}}{types.NewSet(l...)}
-}
+{{if .CanUseDef}}
+	type {{.Name}}Def map[{{defType .ElemType}}]bool
 
-func (s {{.Name}}) Def() {{.Name}}Def {
-	def := make(map[{{defType .ElemType}}]bool, s.Len())
-	s.s.Iter(func(v types.Value) bool {
-		def[{{valueToDef "v" .ElemType}}] = true
-		return false
-	})
-	return def
-}
+	func (def {{.Name}}Def) New() {{.Name}} {
+		l := make([]types.Value, len(def))
+		i := 0
+		for d, _ := range def  {
+			l[i] = {{defToValue "d" .ElemType}}
+			i++
+		}
+		return {{.Name}}{types.NewSet(l...)}
+	}
+
+	func (s {{.Name}}) Def() {{.Name}}Def {
+		def := make(map[{{defType .ElemType}}]bool, s.Len())
+		s.s.Iter(func(v types.Value) bool {
+			def[{{valueToDef "v" .ElemType}}] = true
+			return false
+		})
+		return def
+	}
+{{end}}
 
 func {{.Name}}FromVal(p types.Value) {{.Name}} {
 	return {{.Name}}{p.(types.Set)}

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -1,11 +1,5 @@
 // {{.Name}}
 
-type {{.Name}}Def struct {
-	{{range .Fields}}{{title .Name}} {{defType .T}}
-	{{end}}{{if .HasUnion}}__unionIndex uint32
-	__unionValue interface{}
-{{end}}}
-
 type {{.Name}} struct {
 	m types.Map
 }
@@ -19,41 +13,50 @@ func New{{.Name}}() {{.Name}} {
 		)}
 }
 
-func (def {{.Name}}Def) New() {{.Name}} {
-	return {{.Name}}{
-		types.NewMap(
-			types.NewString("$name"), types.NewString("{{.Name}}"),
-			{{range .Fields}}types.NewString("{{title .Name}}"), {{defToValue (print "def." (title .Name)) .T}},
-			{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
-			types.NewString("$unionValue"), def.__unionDefToValue(),
-		{{end}}
-	)}
-}
+{{if .CanUseDef}}
+	type {{.Name}}Def struct {
+		{{range .Fields}}{{title .Name}} {{defType .T}}
+		{{end}}{{if .HasUnion}}__unionIndex uint32
+		__unionValue interface{}
+	{{end}}}
 
-func (self {{.Name}}) Def() {{.Name}}Def {
-	return {{.Name}}Def{
-		{{range .Fields}}{{valueToDef (printf `self.m.Get(types.NewString("%s"))` (title .Name)) .T}},
-		{{end}}{{if .HasUnion}}uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
-		self.__unionValueToDef(),{{end}}
+
+	func (def {{.Name}}Def) New() {{.Name}} {
+		return {{.Name}}{
+			types.NewMap(
+				types.NewString("$name"), types.NewString("{{.Name}}"),
+				{{range .Fields}}types.NewString("{{title .Name}}"), {{defToValue (print "def." (title .Name)) .T}},
+				{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
+				types.NewString("$unionValue"), def.__unionDefToValue(),
+			{{end}}
+		)}
 	}
-}
 
-{{if .HasUnion}}
-func (def {{.Name}}Def) __unionDefToValue() types.Value {
-	switch def.__unionIndex {
-	{{range $index, $field := .Choices}}case {{$index}}:
-		return {{defToValue (printf "def.__unionValue.(%s)" (defType .T)) .T}}
-	{{end}}}
-	panic("unreachable")
-}
+	func (self {{.Name}}) Def() {{.Name}}Def {
+		return {{.Name}}Def{
+			{{range .Fields}}{{valueToDef (printf `self.m.Get(types.NewString("%s"))` (title .Name)) .T}},
+			{{end}}{{if .HasUnion}}uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
+			self.__unionValueToDef(),{{end}}
+		}
+	}
 
-func (self {{.Name}}) __unionValueToDef() interface{} {
-	switch uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
-	{{range $index, $field := .Choices}}case {{$index}}:
-		return {{valueToDef `self.m.Get(types.NewString("$unionValue"))` .T}}
-	{{end}}}
-	panic("unreachable")
-}
+	{{if .HasUnion}}
+		func (def {{.Name}}Def) __unionDefToValue() types.Value {
+			switch def.__unionIndex {
+			{{range $index, $field := .Choices}}case {{$index}}:
+				return {{defToValue (printf "def.__unionValue.(%s)" (defType .T)) .T}}
+			{{end}}}
+			panic("unreachable")
+		}
+
+		func (self {{.Name}}) __unionValueToDef() interface{} {
+			switch uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
+			{{range $index, $field := .Choices}}case {{$index}}:
+				return {{valueToDef `self.m.Get(types.NewString("$unionValue"))` .T}}
+			{{end}}}
+			panic("unreachable")
+		}
+	{{end}}
 {{end}}
 
 func {{.Name}}FromVal(val types.Value) {{.Name}} {
@@ -84,28 +87,31 @@ func (self {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
 }
 {{end}}
 
+{{$canUseDef := .CanUseDef}}
 {{range $index, $field := .Choices}}
-func (self {{$name}}) {{title .Name}}() (val {{userType .T}}, ok bool) {
-	if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != {{$index}} {
-		return
+	func (self {{$name}}) {{title .Name}}() (val {{userType .T}}, ok bool) {
+		if self.m.Get(types.NewString("$unionIndex")).(types.UInt32) != {{$index}} {
+			return
+		}
+		return {{valueToUser `self.m.Get(types.NewString("$unionValue"))` .T}}, true
 	}
-	return {{valueToUser `self.m.Get(types.NewString("$unionValue"))` .T}}, true
-}
 
-func (self {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
-	return {{$name}}{self.m.Set(types.NewString("$unionIndex"), types.UInt32({{$index}})).Set(types.NewString("$unionValue"), {{userToValue "val" .T}})}
-}
-
-func (def {{$name}}Def) {{title .Name}}() (val {{defType .T}}, ok bool) {
-	if def.__unionIndex != {{$index}} {
-		return
+	func (self {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
+		return {{$name}}{self.m.Set(types.NewString("$unionIndex"), types.UInt32({{$index}})).Set(types.NewString("$unionValue"), {{userToValue "val" .T}})}
 	}
-	return def.__unionValue.({{defType .T}}), true
-}
 
-func (def {{$name}}Def) Set{{title .Name}}(val {{defType .T}}) {{$name}}Def {
-	def.__unionIndex = {{$index}}
-	def.__unionValue = val
-	return def
-}
+	{{if $canUseDef}}
+		func (def {{$name}}Def) {{title .Name}}() (val {{defType .T}}, ok bool) {
+			if def.__unionIndex != {{$index}} {
+				return
+			}
+			return def.__unionValue.({{defType .T}}), true
+		}
+
+		func (def {{$name}}Def) Set{{title .Name}}(val {{defType .T}}) {{$name}}Def {
+			def.__unionIndex = {{$index}}
+			def.__unionValue = val
+			return def
+		}
+	{{end}}
 {{end}}

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -9,10 +9,6 @@ import (
 
 // EnumStruct
 
-type EnumStructDef struct {
-	Hand Handedness
-}
-
 type EnumStruct struct {
 	m types.Map
 }
@@ -22,6 +18,10 @@ func NewEnumStruct() EnumStruct {
 		types.NewString("$name"), types.NewString("EnumStruct"),
 		types.NewString("Hand"), types.Int32(0),
 	)}
+}
+
+type EnumStructDef struct {
+	Hand Handedness
 }
 
 func (def EnumStructDef) New() EnumStruct {

--- a/nomdl/codegen/test/list_int64.go
+++ b/nomdl/codegen/test/list_int64.go
@@ -13,11 +13,11 @@ type ListOfInt64 struct {
 	l types.List
 }
 
-type ListOfInt64Def []int64
-
 func NewListOfInt64() ListOfInt64 {
 	return ListOfInt64{types.NewList()}
 }
+
+type ListOfInt64Def []int64
 
 func (def ListOfInt64Def) New() ListOfInt64 {
 	l := make([]types.Value, len(def))
@@ -27,17 +27,17 @@ func (def ListOfInt64Def) New() ListOfInt64 {
 	return ListOfInt64{types.NewList(l...)}
 }
 
-func ListOfInt64FromVal(val types.Value) ListOfInt64 {
-	// TODO: Validate here
-	return ListOfInt64{val.(types.List)}
-}
-
 func (self ListOfInt64) Def() ListOfInt64Def {
 	l := make([]int64, self.Len())
 	for i := uint64(0); i < self.Len(); i++ {
 		l[i] = int64(self.l.Get(i).(types.Int64))
 	}
 	return l
+}
+
+func ListOfInt64FromVal(val types.Value) ListOfInt64 {
+	// TODO: Validate here
+	return ListOfInt64{val.(types.List)}
 }
 
 func (self ListOfInt64) NomsValue() types.Value {

--- a/nomdl/codegen/test/map.go
+++ b/nomdl/codegen/test/map.go
@@ -13,11 +13,11 @@ type MapOfBoolToString struct {
 	m types.Map
 }
 
-type MapOfBoolToStringDef map[bool]string
-
 func NewMapOfBoolToString() MapOfBoolToString {
 	return MapOfBoolToString{types.NewMap()}
 }
+
+type MapOfBoolToStringDef map[bool]string
 
 func (def MapOfBoolToStringDef) New() MapOfBoolToString {
 	kv := make([]types.Value, 0, len(def)*2)
@@ -113,11 +113,11 @@ type MapOfStringToValue struct {
 	m types.Map
 }
 
-type MapOfStringToValueDef map[string]types.Value
-
 func NewMapOfStringToValue() MapOfStringToValue {
 	return MapOfStringToValue{types.NewMap()}
 }
+
+type MapOfStringToValueDef map[string]types.Value
 
 func (def MapOfStringToValueDef) New() MapOfStringToValue {
 	kv := make([]types.Value, 0, len(def)*2)

--- a/nomdl/codegen/test/ref.go
+++ b/nomdl/codegen/test/ref.go
@@ -49,11 +49,11 @@ type ListOfString struct {
 	l types.List
 }
 
-type ListOfStringDef []string
-
 func NewListOfString() ListOfString {
 	return ListOfString{types.NewList()}
 }
+
+type ListOfStringDef []string
 
 func (def ListOfStringDef) New() ListOfString {
 	l := make([]types.Value, len(def))
@@ -63,17 +63,17 @@ func (def ListOfStringDef) New() ListOfString {
 	return ListOfString{types.NewList(l...)}
 }
 
-func ListOfStringFromVal(val types.Value) ListOfString {
-	// TODO: Validate here
-	return ListOfString{val.(types.List)}
-}
-
 func (self ListOfString) Def() ListOfStringDef {
 	l := make([]string, self.Len())
 	for i := uint64(0); i < self.Len(); i++ {
 		l[i] = self.l.Get(i).(types.String).String()
 	}
 	return l
+}
+
+func ListOfStringFromVal(val types.Value) ListOfString {
+	// TODO: Validate here
+	return ListOfString{val.(types.List)}
 }
 
 func (self ListOfString) NomsValue() types.Value {
@@ -166,11 +166,11 @@ type ListOfRefOfFloat32 struct {
 	l types.List
 }
 
-type ListOfRefOfFloat32Def []ref.Ref
-
 func NewListOfRefOfFloat32() ListOfRefOfFloat32 {
 	return ListOfRefOfFloat32{types.NewList()}
 }
+
+type ListOfRefOfFloat32Def []ref.Ref
 
 func (def ListOfRefOfFloat32Def) New() ListOfRefOfFloat32 {
 	l := make([]types.Value, len(def))
@@ -180,17 +180,17 @@ func (def ListOfRefOfFloat32Def) New() ListOfRefOfFloat32 {
 	return ListOfRefOfFloat32{types.NewList(l...)}
 }
 
-func ListOfRefOfFloat32FromVal(val types.Value) ListOfRefOfFloat32 {
-	// TODO: Validate here
-	return ListOfRefOfFloat32{val.(types.List)}
-}
-
 func (self ListOfRefOfFloat32) Def() ListOfRefOfFloat32Def {
 	l := make([]ref.Ref, self.Len())
 	for i := uint64(0); i < self.Len(); i++ {
 		l[i] = self.l.Get(i).Ref()
 	}
 	return l
+}
+
+func ListOfRefOfFloat32FromVal(val types.Value) ListOfRefOfFloat32 {
+	// TODO: Validate here
+	return ListOfRefOfFloat32{val.(types.List)}
 }
 
 func (self ListOfRefOfFloat32) NomsValue() types.Value {
@@ -314,10 +314,6 @@ func (r RefOfFloat32) SetValue(val float32, cs chunks.ChunkSink) RefOfFloat32 {
 
 // StructWithRef
 
-type StructWithRefDef struct {
-	R ref.Ref
-}
-
 type StructWithRef struct {
 	m types.Map
 }
@@ -327,6 +323,10 @@ func NewStructWithRef() StructWithRef {
 		types.NewString("$name"), types.NewString("StructWithRef"),
 		types.NewString("R"), types.Ref{R: ref.Ref{}},
 	)}
+}
+
+type StructWithRefDef struct {
+	R ref.Ref
 }
 
 func (def StructWithRefDef) New() StructWithRef {
@@ -409,11 +409,11 @@ type SetOfFloat32 struct {
 	s types.Set
 }
 
-type SetOfFloat32Def map[float32]bool
-
 func NewSetOfFloat32() SetOfFloat32 {
 	return SetOfFloat32{types.NewSet()}
 }
+
+type SetOfFloat32Def map[float32]bool
 
 func (def SetOfFloat32Def) New() SetOfFloat32 {
 	l := make([]types.Value, len(def))

--- a/nomdl/codegen/test/set.go
+++ b/nomdl/codegen/test/set.go
@@ -13,11 +13,11 @@ type SetOfBool struct {
 	s types.Set
 }
 
-type SetOfBoolDef map[bool]bool
-
 func NewSetOfBool() SetOfBool {
 	return SetOfBool{types.NewSet()}
 }
+
+type SetOfBoolDef map[bool]bool
 
 func (def SetOfBoolDef) New() SetOfBool {
 	l := make([]types.Value, len(def))

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -9,11 +9,6 @@ import (
 
 // Struct
 
-type StructDef struct {
-	S string
-	B bool
-}
-
 type Struct struct {
 	m types.Map
 }
@@ -24,6 +19,11 @@ func NewStruct() Struct {
 		types.NewString("S"), types.NewString(""),
 		types.NewString("B"), types.Bool(false),
 	)}
+}
+
+type StructDef struct {
+	S string
+	B bool
 }
 
 func (def StructDef) New() Struct {

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -9,23 +9,6 @@ import (
 
 // StructPrimitives
 
-type StructPrimitivesDef struct {
-	Uint64  uint64
-	Uint32  uint32
-	Uint16  uint16
-	Uint8   uint8
-	Int64   int64
-	Int32   int32
-	Int16   int16
-	Int8    int8
-	Float64 float64
-	Float32 float32
-	Bool    bool
-	String  string
-	Blob    types.Blob
-	Value   types.Value
-}
-
 type StructPrimitives struct {
 	m types.Map
 }
@@ -48,6 +31,23 @@ func NewStructPrimitives() StructPrimitives {
 		types.NewString("Blob"), types.NewEmptyBlob(),
 		types.NewString("Value"), types.Bool(false),
 	)}
+}
+
+type StructPrimitivesDef struct {
+	Uint64  uint64
+	Uint32  uint32
+	Uint16  uint16
+	Uint8   uint8
+	Int64   int64
+	Int32   int32
+	Int16   int16
+	Int8    int8
+	Float64 float64
+	Float32 float32
+	Bool    bool
+	String  string
+	Blob    types.Blob
+	Value   types.Value
 }
 
 func (def StructPrimitivesDef) New() StructPrimitives {

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -9,13 +9,6 @@ import (
 
 // StructWithList
 
-type StructWithListDef struct {
-	L ListOfUInt8Def
-	B bool
-	S string
-	I int64
-}
-
 type StructWithList struct {
 	m types.Map
 }
@@ -28,6 +21,13 @@ func NewStructWithList() StructWithList {
 		types.NewString("S"), types.NewString(""),
 		types.NewString("I"), types.Int64(0),
 	)}
+}
+
+type StructWithListDef struct {
+	L ListOfUInt8Def
+	B bool
+	S string
+	I int64
 }
 
 func (def StructWithListDef) New() StructWithList {
@@ -105,11 +105,11 @@ type ListOfUInt8 struct {
 	l types.List
 }
 
-type ListOfUInt8Def []uint8
-
 func NewListOfUInt8() ListOfUInt8 {
 	return ListOfUInt8{types.NewList()}
 }
+
+type ListOfUInt8Def []uint8
 
 func (def ListOfUInt8Def) New() ListOfUInt8 {
 	l := make([]types.Value, len(def))
@@ -119,17 +119,17 @@ func (def ListOfUInt8Def) New() ListOfUInt8 {
 	return ListOfUInt8{types.NewList(l...)}
 }
 
-func ListOfUInt8FromVal(val types.Value) ListOfUInt8 {
-	// TODO: Validate here
-	return ListOfUInt8{val.(types.List)}
-}
-
 func (self ListOfUInt8) Def() ListOfUInt8Def {
 	l := make([]uint8, self.Len())
 	for i := uint64(0); i < self.Len(); i++ {
 		l[i] = uint8(self.l.Get(i).(types.UInt8))
 	}
 	return l
+}
+
+func ListOfUInt8FromVal(val types.Value) ListOfUInt8 {
+	// TODO: Validate here
+	return ListOfUInt8{val.(types.List)}
 }
 
 func (self ListOfUInt8) NomsValue() types.Value {

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -9,12 +9,6 @@ import (
 
 // StructWithUnionField
 
-type StructWithUnionFieldDef struct {
-	A            float32
-	__unionIndex uint32
-	__unionValue interface{}
-}
-
 type StructWithUnionField struct {
 	m types.Map
 }
@@ -26,6 +20,12 @@ func NewStructWithUnionField() StructWithUnionField {
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
+}
+
+type StructWithUnionFieldDef struct {
+	A            float32
+	__unionIndex uint32
+	__unionValue interface{}
 }
 
 func (def StructWithUnionFieldDef) New() StructWithUnionField {
@@ -229,11 +229,11 @@ type SetOfUInt8 struct {
 	s types.Set
 }
 
-type SetOfUInt8Def map[uint8]bool
-
 func NewSetOfUInt8() SetOfUInt8 {
 	return SetOfUInt8{types.NewSet()}
 }
+
+type SetOfUInt8Def map[uint8]bool
 
 func (def SetOfUInt8Def) New() SetOfUInt8 {
 	l := make([]types.Value, len(def))

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -9,11 +9,6 @@ import (
 
 // StructWithUnions
 
-type StructWithUnionsDef struct {
-	A __unionOfBOfFloat64AndCOfStringDef
-	D __unionOfEOfFloat64AndFOfStringDef
-}
-
 type StructWithUnions struct {
 	m types.Map
 }
@@ -24,6 +19,11 @@ func NewStructWithUnions() StructWithUnions {
 		types.NewString("A"), New__unionOfBOfFloat64AndCOfString().NomsValue(),
 		types.NewString("D"), New__unionOfEOfFloat64AndFOfString().NomsValue(),
 	)}
+}
+
+type StructWithUnionsDef struct {
+	A __unionOfBOfFloat64AndCOfStringDef
+	D __unionOfEOfFloat64AndFOfStringDef
 }
 
 func (def StructWithUnionsDef) New() StructWithUnions {
@@ -77,11 +77,6 @@ func (self StructWithUnions) SetD(val __unionOfEOfFloat64AndFOfString) StructWit
 
 // __unionOfBOfFloat64AndCOfString
 
-type __unionOfBOfFloat64AndCOfStringDef struct {
-	__unionIndex uint32
-	__unionValue interface{}
-}
-
 type __unionOfBOfFloat64AndCOfString struct {
 	m types.Map
 }
@@ -92,6 +87,11 @@ func New__unionOfBOfFloat64AndCOfString() __unionOfBOfFloat64AndCOfString {
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
+}
+
+type __unionOfBOfFloat64AndCOfStringDef struct {
+	__unionIndex uint32
+	__unionValue interface{}
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) New() __unionOfBOfFloat64AndCOfString {
@@ -197,11 +197,6 @@ func (def __unionOfBOfFloat64AndCOfStringDef) SetC(val string) __unionOfBOfFloat
 
 // __unionOfEOfFloat64AndFOfString
 
-type __unionOfEOfFloat64AndFOfStringDef struct {
-	__unionIndex uint32
-	__unionValue interface{}
-}
-
 type __unionOfEOfFloat64AndFOfString struct {
 	m types.Map
 }
@@ -212,6 +207,11 @@ func New__unionOfEOfFloat64AndFOfString() __unionOfEOfFloat64AndFOfString {
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
+}
+
+type __unionOfEOfFloat64AndFOfStringDef struct {
+	__unionIndex uint32
+	__unionValue interface{}
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) New() __unionOfEOfFloat64AndFOfString {


### PR DESCRIPTION
Due to limitations in Go we cannot create a Def for a Map or Set that
has a key that is a Map, Set or a List. This is because the key if a Go
map needs to be a comparable and maps and slices are not comparable.
