### PR TITLE
NomDL Codegen: Make sure we keep the original key names

### DIFF
--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -8,7 +8,7 @@ func New{{.Name}}() {{.Name}} {
 	return {{.Name}}{types.NewMap(
 			types.NewString("$name"), types.NewString("{{.Name}}"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_Ref()),
-			{{range .Fields}}types.NewString("{{title .Name}}"), {{valueZero .T}},
+			{{range .Fields}}types.NewString("{{.Name}}"), {{valueZero .T}},
 			{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(0),
 			types.NewString("$unionValue"), {{valueZero .UnionZeroType}},{{end}}
 		)}
@@ -26,7 +26,7 @@ func New{{.Name}}() {{.Name}} {
 			types.NewMap(
 				types.NewString("$name"), types.NewString("{{.Name}}"),
 				types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_Ref()),
-				{{range .Fields}}types.NewString("{{title .Name}}"), {{defToValue (print "def." (title .Name)) .T}},
+				{{range .Fields}}types.NewString("{{.Name}}"), {{defToValue (print "def." (title .Name)) .T}},
 				{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 				types.NewString("$unionValue"), def.__unionDefToValue(),
 			{{end}}
@@ -35,7 +35,7 @@ func New{{.Name}}() {{.Name}} {
 
 	func (self {{.Name}}) Def() {{.Name}}Def {
 		return {{.Name}}Def{
-			{{range .Fields}}{{valueToDef (printf `self.m.Get(types.NewString("%s"))` (title .Name)) .T}},
+			{{range .Fields}}{{valueToDef (printf `self.m.Get(types.NewString("%s"))` .Name) .T}},
 			{{end}}{{if .HasUnion}}uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
 			self.__unionValueToDef(),{{end}}
 		}
@@ -98,11 +98,11 @@ func (self {{.Name}}) Type() types.TypeRef {
 {{$name := .Name}}
 {{range $index, $field := .Fields}}
 func (self {{$name}}) {{title .Name}}() {{userType .T}} {
-	return {{valueToUser (printf `self.m.Get(types.NewString("%s"))` (title .Name)) .T}}
+	return {{valueToUser (printf `self.m.Get(types.NewString("%s"))` .Name) .T}}
 }
 
 func (self {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
-	return {{$name}}{self.m.Set(types.NewString("{{title .Name}}"), {{userToValue "val" .T}})}
+	return {{$name}}{self.m.Set(types.NewString("{{.Name}}"), {{userToValue "val" .T}})}
 }
 {{end}}
 

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -31,7 +31,7 @@ func NewEnumStruct() EnumStruct {
 	return EnumStruct{types.NewMap(
 		types.NewString("$name"), types.NewString("EnumStruct"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_Ref()),
-		types.NewString("Hand"), types.Int32(0),
+		types.NewString("hand"), types.Int32(0),
 	)}
 }
 
@@ -44,13 +44,13 @@ func (def EnumStructDef) New() EnumStruct {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("EnumStruct"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_Ref()),
-			types.NewString("Hand"), types.Int32(def.Hand),
+			types.NewString("hand"), types.Int32(def.Hand),
 		)}
 }
 
 func (self EnumStruct) Def() EnumStructDef {
 	return EnumStructDef{
-		Handedness(self.m.Get(types.NewString("Hand")).(types.Int32)),
+		Handedness(self.m.Get(types.NewString("hand")).(types.Int32)),
 	}
 }
 
@@ -86,11 +86,11 @@ func (self EnumStruct) Type() types.TypeRef {
 }
 
 func (self EnumStruct) Hand() Handedness {
-	return Handedness(self.m.Get(types.NewString("Hand")).(types.Int32))
+	return Handedness(self.m.Get(types.NewString("hand")).(types.Int32))
 }
 
 func (self EnumStruct) SetHand(val Handedness) EnumStruct {
-	return EnumStruct{self.m.Set(types.NewString("Hand"), types.Int32(val))}
+	return EnumStruct{self.m.Set(types.NewString("hand"), types.Int32(val))}
 }
 
 // Handedness

--- a/nomdl/codegen/test/ref.go
+++ b/nomdl/codegen/test/ref.go
@@ -335,7 +335,7 @@ func NewStructWithRef() StructWithRef {
 	return StructWithRef{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithRef"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_Ref()),
-		types.NewString("R"), types.Ref{R: ref.Ref{}},
+		types.NewString("r"), types.Ref{R: ref.Ref{}},
 	)}
 }
 
@@ -348,13 +348,13 @@ func (def StructWithRefDef) New() StructWithRef {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithRef"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_Ref()),
-			types.NewString("R"), types.Ref{R: def.R},
+			types.NewString("r"), types.Ref{R: def.R},
 		)}
 }
 
 func (self StructWithRef) Def() StructWithRefDef {
 	return StructWithRefDef{
-		self.m.Get(types.NewString("R")).Ref(),
+		self.m.Get(types.NewString("r")).Ref(),
 	}
 }
 
@@ -390,11 +390,11 @@ func (self StructWithRef) Type() types.TypeRef {
 }
 
 func (self StructWithRef) R() RefOfSetOfFloat32 {
-	return RefOfSetOfFloat32FromVal(self.m.Get(types.NewString("R")))
+	return RefOfSetOfFloat32FromVal(self.m.Get(types.NewString("r")))
 }
 
 func (self StructWithRef) SetR(val RefOfSetOfFloat32) StructWithRef {
-	return StructWithRef{self.m.Set(types.NewString("R"), val.NomsValue())}
+	return StructWithRef{self.m.Set(types.NewString("r"), val.NomsValue())}
 }
 
 // RefOfSetOfFloat32

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -30,8 +30,8 @@ func NewStruct() Struct {
 	return Struct{types.NewMap(
 		types.NewString("$name"), types.NewString("Struct"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_Ref()),
-		types.NewString("S"), types.NewString(""),
-		types.NewString("B"), types.Bool(false),
+		types.NewString("s"), types.NewString(""),
+		types.NewString("b"), types.Bool(false),
 	)}
 }
 
@@ -45,15 +45,15 @@ func (def StructDef) New() Struct {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Struct"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_Ref()),
-			types.NewString("S"), types.NewString(def.S),
-			types.NewString("B"), types.Bool(def.B),
+			types.NewString("s"), types.NewString(def.S),
+			types.NewString("b"), types.Bool(def.B),
 		)}
 }
 
 func (self Struct) Def() StructDef {
 	return StructDef{
-		self.m.Get(types.NewString("S")).(types.String).String(),
-		bool(self.m.Get(types.NewString("B")).(types.Bool)),
+		self.m.Get(types.NewString("s")).(types.String).String(),
+		bool(self.m.Get(types.NewString("b")).(types.Bool)),
 	}
 }
 
@@ -90,17 +90,17 @@ func (self Struct) Type() types.TypeRef {
 }
 
 func (self Struct) S() string {
-	return self.m.Get(types.NewString("S")).(types.String).String()
+	return self.m.Get(types.NewString("s")).(types.String).String()
 }
 
 func (self Struct) SetS(val string) Struct {
-	return Struct{self.m.Set(types.NewString("S"), types.NewString(val))}
+	return Struct{self.m.Set(types.NewString("s"), types.NewString(val))}
 }
 
 func (self Struct) B() bool {
-	return bool(self.m.Get(types.NewString("B")).(types.Bool))
+	return bool(self.m.Get(types.NewString("b")).(types.Bool))
 }
 
 func (self Struct) SetB(val bool) Struct {
-	return Struct{self.m.Set(types.NewString("B"), types.Bool(val))}
+	return Struct{self.m.Set(types.NewString("b"), types.Bool(val))}
 }

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -30,20 +30,20 @@ func NewStructPrimitives() StructPrimitives {
 	return StructPrimitives{types.NewMap(
 		types.NewString("$name"), types.NewString("StructPrimitives"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_Ref()),
-		types.NewString("Uint64"), types.UInt64(0),
-		types.NewString("Uint32"), types.UInt32(0),
-		types.NewString("Uint16"), types.UInt16(0),
-		types.NewString("Uint8"), types.UInt8(0),
-		types.NewString("Int64"), types.Int64(0),
-		types.NewString("Int32"), types.Int32(0),
-		types.NewString("Int16"), types.Int16(0),
-		types.NewString("Int8"), types.Int8(0),
-		types.NewString("Float64"), types.Float64(0),
-		types.NewString("Float32"), types.Float32(0),
-		types.NewString("Bool"), types.Bool(false),
-		types.NewString("String"), types.NewString(""),
-		types.NewString("Blob"), types.NewEmptyBlob(),
-		types.NewString("Value"), types.Bool(false),
+		types.NewString("uint64"), types.UInt64(0),
+		types.NewString("uint32"), types.UInt32(0),
+		types.NewString("uint16"), types.UInt16(0),
+		types.NewString("uint8"), types.UInt8(0),
+		types.NewString("int64"), types.Int64(0),
+		types.NewString("int32"), types.Int32(0),
+		types.NewString("int16"), types.Int16(0),
+		types.NewString("int8"), types.Int8(0),
+		types.NewString("float64"), types.Float64(0),
+		types.NewString("float32"), types.Float32(0),
+		types.NewString("bool"), types.Bool(false),
+		types.NewString("string"), types.NewString(""),
+		types.NewString("blob"), types.NewEmptyBlob(),
+		types.NewString("value"), types.Bool(false),
 	)}
 }
 
@@ -69,39 +69,39 @@ func (def StructPrimitivesDef) New() StructPrimitives {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructPrimitives"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_Ref()),
-			types.NewString("Uint64"), types.UInt64(def.Uint64),
-			types.NewString("Uint32"), types.UInt32(def.Uint32),
-			types.NewString("Uint16"), types.UInt16(def.Uint16),
-			types.NewString("Uint8"), types.UInt8(def.Uint8),
-			types.NewString("Int64"), types.Int64(def.Int64),
-			types.NewString("Int32"), types.Int32(def.Int32),
-			types.NewString("Int16"), types.Int16(def.Int16),
-			types.NewString("Int8"), types.Int8(def.Int8),
-			types.NewString("Float64"), types.Float64(def.Float64),
-			types.NewString("Float32"), types.Float32(def.Float32),
-			types.NewString("Bool"), types.Bool(def.Bool),
-			types.NewString("String"), types.NewString(def.String),
-			types.NewString("Blob"), def.Blob,
-			types.NewString("Value"), def.Value,
+			types.NewString("uint64"), types.UInt64(def.Uint64),
+			types.NewString("uint32"), types.UInt32(def.Uint32),
+			types.NewString("uint16"), types.UInt16(def.Uint16),
+			types.NewString("uint8"), types.UInt8(def.Uint8),
+			types.NewString("int64"), types.Int64(def.Int64),
+			types.NewString("int32"), types.Int32(def.Int32),
+			types.NewString("int16"), types.Int16(def.Int16),
+			types.NewString("int8"), types.Int8(def.Int8),
+			types.NewString("float64"), types.Float64(def.Float64),
+			types.NewString("float32"), types.Float32(def.Float32),
+			types.NewString("bool"), types.Bool(def.Bool),
+			types.NewString("string"), types.NewString(def.String),
+			types.NewString("blob"), def.Blob,
+			types.NewString("value"), def.Value,
 		)}
 }
 
 func (self StructPrimitives) Def() StructPrimitivesDef {
 	return StructPrimitivesDef{
-		uint64(self.m.Get(types.NewString("Uint64")).(types.UInt64)),
-		uint32(self.m.Get(types.NewString("Uint32")).(types.UInt32)),
-		uint16(self.m.Get(types.NewString("Uint16")).(types.UInt16)),
-		uint8(self.m.Get(types.NewString("Uint8")).(types.UInt8)),
-		int64(self.m.Get(types.NewString("Int64")).(types.Int64)),
-		int32(self.m.Get(types.NewString("Int32")).(types.Int32)),
-		int16(self.m.Get(types.NewString("Int16")).(types.Int16)),
-		int8(self.m.Get(types.NewString("Int8")).(types.Int8)),
-		float64(self.m.Get(types.NewString("Float64")).(types.Float64)),
-		float32(self.m.Get(types.NewString("Float32")).(types.Float32)),
-		bool(self.m.Get(types.NewString("Bool")).(types.Bool)),
-		self.m.Get(types.NewString("String")).(types.String).String(),
-		self.m.Get(types.NewString("Blob")).(types.Blob),
-		self.m.Get(types.NewString("Value")),
+		uint64(self.m.Get(types.NewString("uint64")).(types.UInt64)),
+		uint32(self.m.Get(types.NewString("uint32")).(types.UInt32)),
+		uint16(self.m.Get(types.NewString("uint16")).(types.UInt16)),
+		uint8(self.m.Get(types.NewString("uint8")).(types.UInt8)),
+		int64(self.m.Get(types.NewString("int64")).(types.Int64)),
+		int32(self.m.Get(types.NewString("int32")).(types.Int32)),
+		int16(self.m.Get(types.NewString("int16")).(types.Int16)),
+		int8(self.m.Get(types.NewString("int8")).(types.Int8)),
+		float64(self.m.Get(types.NewString("float64")).(types.Float64)),
+		float32(self.m.Get(types.NewString("float32")).(types.Float32)),
+		bool(self.m.Get(types.NewString("bool")).(types.Bool)),
+		self.m.Get(types.NewString("string")).(types.String).String(),
+		self.m.Get(types.NewString("blob")).(types.Blob),
+		self.m.Get(types.NewString("value")),
 	}
 }
 
@@ -150,113 +150,113 @@ func (self StructPrimitives) Type() types.TypeRef {
 }
 
 func (self StructPrimitives) Uint64() uint64 {
-	return uint64(self.m.Get(types.NewString("Uint64")).(types.UInt64))
+	return uint64(self.m.Get(types.NewString("uint64")).(types.UInt64))
 }
 
 func (self StructPrimitives) SetUint64(val uint64) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Uint64"), types.UInt64(val))}
+	return StructPrimitives{self.m.Set(types.NewString("uint64"), types.UInt64(val))}
 }
 
 func (self StructPrimitives) Uint32() uint32 {
-	return uint32(self.m.Get(types.NewString("Uint32")).(types.UInt32))
+	return uint32(self.m.Get(types.NewString("uint32")).(types.UInt32))
 }
 
 func (self StructPrimitives) SetUint32(val uint32) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Uint32"), types.UInt32(val))}
+	return StructPrimitives{self.m.Set(types.NewString("uint32"), types.UInt32(val))}
 }
 
 func (self StructPrimitives) Uint16() uint16 {
-	return uint16(self.m.Get(types.NewString("Uint16")).(types.UInt16))
+	return uint16(self.m.Get(types.NewString("uint16")).(types.UInt16))
 }
 
 func (self StructPrimitives) SetUint16(val uint16) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Uint16"), types.UInt16(val))}
+	return StructPrimitives{self.m.Set(types.NewString("uint16"), types.UInt16(val))}
 }
 
 func (self StructPrimitives) Uint8() uint8 {
-	return uint8(self.m.Get(types.NewString("Uint8")).(types.UInt8))
+	return uint8(self.m.Get(types.NewString("uint8")).(types.UInt8))
 }
 
 func (self StructPrimitives) SetUint8(val uint8) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Uint8"), types.UInt8(val))}
+	return StructPrimitives{self.m.Set(types.NewString("uint8"), types.UInt8(val))}
 }
 
 func (self StructPrimitives) Int64() int64 {
-	return int64(self.m.Get(types.NewString("Int64")).(types.Int64))
+	return int64(self.m.Get(types.NewString("int64")).(types.Int64))
 }
 
 func (self StructPrimitives) SetInt64(val int64) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Int64"), types.Int64(val))}
+	return StructPrimitives{self.m.Set(types.NewString("int64"), types.Int64(val))}
 }
 
 func (self StructPrimitives) Int32() int32 {
-	return int32(self.m.Get(types.NewString("Int32")).(types.Int32))
+	return int32(self.m.Get(types.NewString("int32")).(types.Int32))
 }
 
 func (self StructPrimitives) SetInt32(val int32) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Int32"), types.Int32(val))}
+	return StructPrimitives{self.m.Set(types.NewString("int32"), types.Int32(val))}
 }
 
 func (self StructPrimitives) Int16() int16 {
-	return int16(self.m.Get(types.NewString("Int16")).(types.Int16))
+	return int16(self.m.Get(types.NewString("int16")).(types.Int16))
 }
 
 func (self StructPrimitives) SetInt16(val int16) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Int16"), types.Int16(val))}
+	return StructPrimitives{self.m.Set(types.NewString("int16"), types.Int16(val))}
 }
 
 func (self StructPrimitives) Int8() int8 {
-	return int8(self.m.Get(types.NewString("Int8")).(types.Int8))
+	return int8(self.m.Get(types.NewString("int8")).(types.Int8))
 }
 
 func (self StructPrimitives) SetInt8(val int8) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Int8"), types.Int8(val))}
+	return StructPrimitives{self.m.Set(types.NewString("int8"), types.Int8(val))}
 }
 
 func (self StructPrimitives) Float64() float64 {
-	return float64(self.m.Get(types.NewString("Float64")).(types.Float64))
+	return float64(self.m.Get(types.NewString("float64")).(types.Float64))
 }
 
 func (self StructPrimitives) SetFloat64(val float64) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Float64"), types.Float64(val))}
+	return StructPrimitives{self.m.Set(types.NewString("float64"), types.Float64(val))}
 }
 
 func (self StructPrimitives) Float32() float32 {
-	return float32(self.m.Get(types.NewString("Float32")).(types.Float32))
+	return float32(self.m.Get(types.NewString("float32")).(types.Float32))
 }
 
 func (self StructPrimitives) SetFloat32(val float32) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Float32"), types.Float32(val))}
+	return StructPrimitives{self.m.Set(types.NewString("float32"), types.Float32(val))}
 }
 
 func (self StructPrimitives) Bool() bool {
-	return bool(self.m.Get(types.NewString("Bool")).(types.Bool))
+	return bool(self.m.Get(types.NewString("bool")).(types.Bool))
 }
 
 func (self StructPrimitives) SetBool(val bool) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Bool"), types.Bool(val))}
+	return StructPrimitives{self.m.Set(types.NewString("bool"), types.Bool(val))}
 }
 
 func (self StructPrimitives) String() string {
-	return self.m.Get(types.NewString("String")).(types.String).String()
+	return self.m.Get(types.NewString("string")).(types.String).String()
 }
 
 func (self StructPrimitives) SetString(val string) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("String"), types.NewString(val))}
+	return StructPrimitives{self.m.Set(types.NewString("string"), types.NewString(val))}
 }
 
 func (self StructPrimitives) Blob() types.Blob {
-	return self.m.Get(types.NewString("Blob")).(types.Blob)
+	return self.m.Get(types.NewString("blob")).(types.Blob)
 }
 
 func (self StructPrimitives) SetBlob(val types.Blob) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Blob"), val)}
+	return StructPrimitives{self.m.Set(types.NewString("blob"), val)}
 }
 
 func (self StructPrimitives) Value() types.Value {
-	return self.m.Get(types.NewString("Value"))
+	return self.m.Get(types.NewString("value"))
 }
 
 func (self StructPrimitives) SetValue(val types.Value) StructPrimitives {
-	return StructPrimitives{self.m.Set(types.NewString("Value"), val)}
+	return StructPrimitives{self.m.Set(types.NewString("value"), val)}
 }

--- a/nomdl/codegen/test/struct_primitives_test.go
+++ b/nomdl/codegen/test/struct_primitives_test.go
@@ -116,3 +116,10 @@ func TestAccessors(t *testing.T) {
 	st = st.SetValue(types.NewString("x"))
 	assert.True(st.Value().Equals(types.NewString("x")))
 }
+
+func TestStructBackingMapKeyNames(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewStructPrimitives().SetBool(true)
+	assert.True(bool(s.NomsValue().(types.Map).Get(types.NewString("bool")).(types.Bool)))
+}

--- a/nomdl/codegen/test/struct_recursive.go
+++ b/nomdl/codegen/test/struct_recursive.go
@@ -30,7 +30,7 @@ func NewTree() Tree {
 	return Tree{types.NewMap(
 		types.NewString("$name"), types.NewString("Tree"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_Ref()),
-		types.NewString("Children"), types.NewList(),
+		types.NewString("children"), types.NewList(),
 	)}
 }
 
@@ -43,13 +43,13 @@ func (def TreeDef) New() Tree {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Tree"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_Ref()),
-			types.NewString("Children"), def.Children.New().NomsValue(),
+			types.NewString("children"), def.Children.New().NomsValue(),
 		)}
 }
 
 func (self Tree) Def() TreeDef {
 	return TreeDef{
-		ListOfTreeFromVal(self.m.Get(types.NewString("Children"))).Def(),
+		ListOfTreeFromVal(self.m.Get(types.NewString("children"))).Def(),
 	}
 }
 
@@ -85,11 +85,11 @@ func (self Tree) Type() types.TypeRef {
 }
 
 func (self Tree) Children() ListOfTree {
-	return ListOfTreeFromVal(self.m.Get(types.NewString("Children")))
+	return ListOfTreeFromVal(self.m.Get(types.NewString("children")))
 }
 
 func (self Tree) SetChildren(val ListOfTree) Tree {
-	return Tree{self.m.Set(types.NewString("Children"), val.NomsValue())}
+	return Tree{self.m.Set(types.NewString("children"), val.NomsValue())}
 }
 
 // ListOfTree

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -30,10 +30,10 @@ func NewStructWithList() StructWithList {
 	return StructWithList{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithList"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_Ref()),
-		types.NewString("L"), types.NewList(),
-		types.NewString("B"), types.Bool(false),
-		types.NewString("S"), types.NewString(""),
-		types.NewString("I"), types.Int64(0),
+		types.NewString("l"), types.NewList(),
+		types.NewString("b"), types.Bool(false),
+		types.NewString("s"), types.NewString(""),
+		types.NewString("i"), types.Int64(0),
 	)}
 }
 
@@ -49,19 +49,19 @@ func (def StructWithListDef) New() StructWithList {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithList"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_Ref()),
-			types.NewString("L"), def.L.New().NomsValue(),
-			types.NewString("B"), types.Bool(def.B),
-			types.NewString("S"), types.NewString(def.S),
-			types.NewString("I"), types.Int64(def.I),
+			types.NewString("l"), def.L.New().NomsValue(),
+			types.NewString("b"), types.Bool(def.B),
+			types.NewString("s"), types.NewString(def.S),
+			types.NewString("i"), types.Int64(def.I),
 		)}
 }
 
 func (self StructWithList) Def() StructWithListDef {
 	return StructWithListDef{
-		ListOfUInt8FromVal(self.m.Get(types.NewString("L"))).Def(),
-		bool(self.m.Get(types.NewString("B")).(types.Bool)),
-		self.m.Get(types.NewString("S")).(types.String).String(),
-		int64(self.m.Get(types.NewString("I")).(types.Int64)),
+		ListOfUInt8FromVal(self.m.Get(types.NewString("l"))).Def(),
+		bool(self.m.Get(types.NewString("b")).(types.Bool)),
+		self.m.Get(types.NewString("s")).(types.String).String(),
+		int64(self.m.Get(types.NewString("i")).(types.Int64)),
 	}
 }
 
@@ -100,35 +100,35 @@ func (self StructWithList) Type() types.TypeRef {
 }
 
 func (self StructWithList) L() ListOfUInt8 {
-	return ListOfUInt8FromVal(self.m.Get(types.NewString("L")))
+	return ListOfUInt8FromVal(self.m.Get(types.NewString("l")))
 }
 
 func (self StructWithList) SetL(val ListOfUInt8) StructWithList {
-	return StructWithList{self.m.Set(types.NewString("L"), val.NomsValue())}
+	return StructWithList{self.m.Set(types.NewString("l"), val.NomsValue())}
 }
 
 func (self StructWithList) B() bool {
-	return bool(self.m.Get(types.NewString("B")).(types.Bool))
+	return bool(self.m.Get(types.NewString("b")).(types.Bool))
 }
 
 func (self StructWithList) SetB(val bool) StructWithList {
-	return StructWithList{self.m.Set(types.NewString("B"), types.Bool(val))}
+	return StructWithList{self.m.Set(types.NewString("b"), types.Bool(val))}
 }
 
 func (self StructWithList) S() string {
-	return self.m.Get(types.NewString("S")).(types.String).String()
+	return self.m.Get(types.NewString("s")).(types.String).String()
 }
 
 func (self StructWithList) SetS(val string) StructWithList {
-	return StructWithList{self.m.Set(types.NewString("S"), types.NewString(val))}
+	return StructWithList{self.m.Set(types.NewString("s"), types.NewString(val))}
 }
 
 func (self StructWithList) I() int64 {
-	return int64(self.m.Get(types.NewString("I")).(types.Int64))
+	return int64(self.m.Get(types.NewString("i")).(types.Int64))
 }
 
 func (self StructWithList) SetI(val int64) StructWithList {
-	return StructWithList{self.m.Set(types.NewString("I"), types.Int64(val))}
+	return StructWithList{self.m.Set(types.NewString("i"), types.Int64(val))}
 }
 
 // ListOfUInt8

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -30,7 +30,7 @@ func NewStructWithUnionField() StructWithUnionField {
 	return StructWithUnionField{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithUnionField"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_Ref()),
-		types.NewString("A"), types.Float32(0),
+		types.NewString("a"), types.Float32(0),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
@@ -47,7 +47,7 @@ func (def StructWithUnionFieldDef) New() StructWithUnionField {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithUnionField"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_Ref()),
-			types.NewString("A"), types.Float32(def.A),
+			types.NewString("a"), types.Float32(def.A),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
@@ -55,7 +55,7 @@ func (def StructWithUnionFieldDef) New() StructWithUnionField {
 
 func (self StructWithUnionField) Def() StructWithUnionFieldDef {
 	return StructWithUnionFieldDef{
-		float32(self.m.Get(types.NewString("A")).(types.Float32)),
+		float32(self.m.Get(types.NewString("a")).(types.Float32)),
 		uint32(self.m.Get(types.NewString("$unionIndex")).(types.UInt32)),
 		self.__unionValueToDef(),
 	}
@@ -131,11 +131,11 @@ func (self StructWithUnionField) Type() types.TypeRef {
 }
 
 func (self StructWithUnionField) A() float32 {
-	return float32(self.m.Get(types.NewString("A")).(types.Float32))
+	return float32(self.m.Get(types.NewString("a")).(types.Float32))
 }
 
 func (self StructWithUnionField) SetA(val float32) StructWithUnionField {
-	return StructWithUnionField{self.m.Set(types.NewString("A"), types.Float32(val))}
+	return StructWithUnionField{self.m.Set(types.NewString("a"), types.Float32(val))}
 }
 
 func (self StructWithUnionField) B() (val float64, ok bool) {

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -30,8 +30,8 @@ func NewStructWithUnions() StructWithUnions {
 	return StructWithUnions{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithUnions"),
 		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_Ref()),
-		types.NewString("A"), New__unionOfBOfFloat64AndCOfString().NomsValue(),
-		types.NewString("D"), New__unionOfEOfFloat64AndFOfString().NomsValue(),
+		types.NewString("a"), New__unionOfBOfFloat64AndCOfString().NomsValue(),
+		types.NewString("d"), New__unionOfEOfFloat64AndFOfString().NomsValue(),
 	)}
 }
 
@@ -45,15 +45,15 @@ func (def StructWithUnionsDef) New() StructWithUnions {
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithUnions"),
 			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_Ref()),
-			types.NewString("A"), def.A.New().NomsValue(),
-			types.NewString("D"), def.D.New().NomsValue(),
+			types.NewString("a"), def.A.New().NomsValue(),
+			types.NewString("d"), def.D.New().NomsValue(),
 		)}
 }
 
 func (self StructWithUnions) Def() StructWithUnionsDef {
 	return StructWithUnionsDef{
-		__unionOfBOfFloat64AndCOfStringFromVal(self.m.Get(types.NewString("A"))).Def(),
-		__unionOfEOfFloat64AndFOfStringFromVal(self.m.Get(types.NewString("D"))).Def(),
+		__unionOfBOfFloat64AndCOfStringFromVal(self.m.Get(types.NewString("a"))).Def(),
+		__unionOfEOfFloat64AndFOfStringFromVal(self.m.Get(types.NewString("d"))).Def(),
 	}
 }
 
@@ -92,19 +92,19 @@ func (self StructWithUnions) Type() types.TypeRef {
 }
 
 func (self StructWithUnions) A() __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfStringFromVal(self.m.Get(types.NewString("A")))
+	return __unionOfBOfFloat64AndCOfStringFromVal(self.m.Get(types.NewString("a")))
 }
 
 func (self StructWithUnions) SetA(val __unionOfBOfFloat64AndCOfString) StructWithUnions {
-	return StructWithUnions{self.m.Set(types.NewString("A"), val.NomsValue())}
+	return StructWithUnions{self.m.Set(types.NewString("a"), val.NomsValue())}
 }
 
 func (self StructWithUnions) D() __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfStringFromVal(self.m.Get(types.NewString("D")))
+	return __unionOfEOfFloat64AndFOfStringFromVal(self.m.Get(types.NewString("d")))
 }
 
 func (self StructWithUnions) SetD(val __unionOfEOfFloat64AndFOfString) StructWithUnions {
-	return StructWithUnions{self.m.Set(types.NewString("D"), val.NomsValue())}
+	return StructWithUnions{self.m.Set(types.NewString("d"), val.NomsValue())}
 }
 
 // __unionOfBOfFloat64AndCOfString


### PR DESCRIPTION
The underlying map for structs should use the original field names as
the map keys.
