### PR TITLE
Only build each Package object once

### DIFF
--- a/clients/pitchmap/index/types.go
+++ b/clients/pitchmap/index/types.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __mainPackageInFile_types_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __mainPackageInFile_types_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__mainPackageInFile_types_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"Pitch": __typeRefOfPitch(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"Pitch": __typeRefOfPitch(),
+			},
+		}.New()
+		__mainPackageInFile_types_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __mainPackageInFile_types_CachedRef
 }
 
 // ListOfMapOfStringToValue

--- a/clients/pitchmap/index/types.go
+++ b/clients/pitchmap/index/types.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __mainPackageInFile_types_CachedRef = types.Ref{}
+var __mainPackageInFile_types_CachedRef = __mainPackageInFile_types_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __mainPackageInFile_types_Ref() types.Ref {
-	if types.LookupPackage(__mainPackageInFile_types_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"Pitch": __typeRefOfPitch(),
-			},
-		}.New()
-		__mainPackageInFile_types_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __mainPackageInFile_types_CachedRef
+			"Pitch": __typeRefOfPitch(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // ListOfMapOfStringToValue
@@ -468,7 +465,7 @@ type Pitch struct {
 func NewPitch() Pitch {
 	return Pitch{types.NewMap(
 		types.NewString("$name"), types.NewString("Pitch"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("Pitch"), __mainPackageInFile_types_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("Pitch"), __mainPackageInFile_types_CachedRef),
 		types.NewString("X"), types.Float64(0),
 		types.NewString("Z"), types.Float64(0),
 	)}
@@ -483,7 +480,7 @@ func (def PitchDef) New() Pitch {
 	return Pitch{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Pitch"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("Pitch"), __mainPackageInFile_types_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("Pitch"), __mainPackageInFile_types_CachedRef),
 			types.NewString("X"), types.Float64(def.X),
 			types.NewString("Z"), types.Float64(def.Z),
 		)}

--- a/nomdl/codegen/header.tmpl
+++ b/nomdl/codegen/header.tmpl
@@ -5,16 +5,21 @@ package {{.Name}}
 import "github.com/attic-labs/noms/types"
 
 {{if .HasTypes}}
+var __{{.Name}}PackageInFile_{{.FileID}}_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __{{.Name}}PackageInFile_{{.FileID}}_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
-			{{range $name, $t := .NamedTypes}}
-			"{{$name}}": __typeRefOf{{$name}}(),{{end}}
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	if types.LookupPackage(__{{.Name}}PackageInFile_{{.FileID}}_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
+				{{range $name, $t := .NamedTypes}}
+				"{{$name}}": __typeRefOf{{$name}}(),{{end}}
+			},
+		}.New()
+		__{{.Name}}PackageInFile_{{.FileID}}_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __{{.Name}}PackageInFile_{{.FileID}}_CachedRef
 }
 {{end}}

--- a/nomdl/codegen/header.tmpl
+++ b/nomdl/codegen/header.tmpl
@@ -5,21 +5,18 @@ package {{.Name}}
 import "github.com/attic-labs/noms/types"
 
 {{if .HasTypes}}
-var __{{.Name}}PackageInFile_{{.FileID}}_CachedRef = types.Ref{}
+var __{{.Name}}PackageInFile_{{.FileID}}_CachedRef = __{{.Name}}PackageInFile_{{.FileID}}_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __{{.Name}}PackageInFile_{{.FileID}}_Ref() types.Ref {
-	if types.LookupPackage(__{{.Name}}PackageInFile_{{.FileID}}_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
-				{{range $name, $t := .NamedTypes}}
-				"{{$name}}": __typeRefOf{{$name}}(),{{end}}
-			},
-		}.New()
-		__{{.Name}}PackageInFile_{{.FileID}}_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __{{.Name}}PackageInFile_{{.FileID}}_CachedRef
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
+			{{range $name, $t := .NamedTypes}}
+			"{{$name}}": __typeRefOf{{$name}}(),{{end}}
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 {{end}}

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -7,7 +7,7 @@ type {{.Name}} struct {
 func New{{.Name}}() {{.Name}} {
 	return {{.Name}}{types.NewMap(
 			types.NewString("$name"), types.NewString("{{.Name}}"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef),
 			{{range .Fields}}types.NewString("{{.Name}}"), {{valueZero .T}},
 			{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(0),
 			types.NewString("$unionValue"), {{valueZero .UnionZeroType}},{{end}}
@@ -25,7 +25,7 @@ func New{{.Name}}() {{.Name}} {
 		return {{.Name}}{
 			types.NewMap(
 				types.NewString("$name"), types.NewString("{{.Name}}"),
-				types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_Ref()),
+				types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef),
 				{{range .Fields}}types.NewString("{{.Name}}"), {{defToValue (print "def." (title .Name)) .T}},
 				{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 				types.NewString("$unionValue"), def.__unionDefToValue(),

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -7,18 +7,23 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_enum_struct_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_enum_struct_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_enum_struct_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"EnumStruct": __typeRefOfEnumStruct(),
-			"Handedness": __typeRefOfHandedness(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"EnumStruct": __typeRefOfEnumStruct(),
+				"Handedness": __typeRefOfHandedness(),
+			},
+		}.New()
+		__testPackageInFile_enum_struct_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_enum_struct_CachedRef
 }
 
 // EnumStruct

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -7,23 +7,20 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_enum_struct_CachedRef = types.Ref{}
+var __testPackageInFile_enum_struct_CachedRef = __testPackageInFile_enum_struct_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_enum_struct_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_enum_struct_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"EnumStruct": __typeRefOfEnumStruct(),
-				"Handedness": __typeRefOfHandedness(),
-			},
-		}.New()
-		__testPackageInFile_enum_struct_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_enum_struct_CachedRef
+			"EnumStruct": __typeRefOfEnumStruct(),
+			"Handedness": __typeRefOfHandedness(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // EnumStruct
@@ -35,7 +32,7 @@ type EnumStruct struct {
 func NewEnumStruct() EnumStruct {
 	return EnumStruct{types.NewMap(
 		types.NewString("$name"), types.NewString("EnumStruct"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_CachedRef),
 		types.NewString("hand"), types.Int32(0),
 	)}
 }
@@ -48,7 +45,7 @@ func (def EnumStructDef) New() EnumStruct {
 	return EnumStruct{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("EnumStruct"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_CachedRef),
 			types.NewString("hand"), types.Int32(def.Hand),
 		)}
 }

--- a/nomdl/codegen/test/ref.go
+++ b/nomdl/codegen/test/ref.go
@@ -8,22 +8,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_ref_CachedRef = types.Ref{}
+var __testPackageInFile_ref_CachedRef = __testPackageInFile_ref_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_ref_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_ref_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"StructWithRef": __typeRefOfStructWithRef(),
-			},
-		}.New()
-		__testPackageInFile_ref_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_ref_CachedRef
+			"StructWithRef": __typeRefOfStructWithRef(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // RefOfListOfString
@@ -339,7 +336,7 @@ type StructWithRef struct {
 func NewStructWithRef() StructWithRef {
 	return StructWithRef{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithRef"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_CachedRef),
 		types.NewString("r"), types.Ref{R: ref.Ref{}},
 	)}
 }
@@ -352,7 +349,7 @@ func (def StructWithRefDef) New() StructWithRef {
 	return StructWithRef{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithRef"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_CachedRef),
 			types.NewString("r"), types.Ref{R: def.R},
 		)}
 }

--- a/nomdl/codegen/test/ref.go
+++ b/nomdl/codegen/test/ref.go
@@ -8,17 +8,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_ref_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_ref_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_ref_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"StructWithRef": __typeRefOfStructWithRef(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"StructWithRef": __typeRefOfStructWithRef(),
+			},
+		}.New()
+		__testPackageInFile_ref_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_ref_CachedRef
 }
 
 // RefOfListOfString

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_struct_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_struct_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"Struct": __typeRefOfStruct(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"Struct": __typeRefOfStruct(),
+			},
+		}.New()
+		__testPackageInFile_struct_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_struct_CachedRef
 }
 
 // Struct

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_struct_CachedRef = types.Ref{}
+var __testPackageInFile_struct_CachedRef = __testPackageInFile_struct_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_struct_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"Struct": __typeRefOfStruct(),
-			},
-		}.New()
-		__testPackageInFile_struct_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_struct_CachedRef
+			"Struct": __typeRefOfStruct(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // Struct
@@ -34,7 +31,7 @@ type Struct struct {
 func NewStruct() Struct {
 	return Struct{types.NewMap(
 		types.NewString("$name"), types.NewString("Struct"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_CachedRef),
 		types.NewString("s"), types.NewString(""),
 		types.NewString("b"), types.Bool(false),
 	)}
@@ -49,7 +46,7 @@ func (def StructDef) New() Struct {
 	return Struct{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Struct"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_CachedRef),
 			types.NewString("s"), types.NewString(def.S),
 			types.NewString("b"), types.Bool(def.B),
 		)}

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_struct_primitives_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_primitives_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_struct_primitives_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"StructPrimitives": __typeRefOfStructPrimitives(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"StructPrimitives": __typeRefOfStructPrimitives(),
+			},
+		}.New()
+		__testPackageInFile_struct_primitives_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_struct_primitives_CachedRef
 }
 
 // StructPrimitives

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_struct_primitives_CachedRef = types.Ref{}
+var __testPackageInFile_struct_primitives_CachedRef = __testPackageInFile_struct_primitives_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_primitives_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_struct_primitives_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"StructPrimitives": __typeRefOfStructPrimitives(),
-			},
-		}.New()
-		__testPackageInFile_struct_primitives_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_struct_primitives_CachedRef
+			"StructPrimitives": __typeRefOfStructPrimitives(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // StructPrimitives
@@ -34,7 +31,7 @@ type StructPrimitives struct {
 func NewStructPrimitives() StructPrimitives {
 	return StructPrimitives{types.NewMap(
 		types.NewString("$name"), types.NewString("StructPrimitives"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_CachedRef),
 		types.NewString("uint64"), types.UInt64(0),
 		types.NewString("uint32"), types.UInt32(0),
 		types.NewString("uint16"), types.UInt16(0),
@@ -73,7 +70,7 @@ func (def StructPrimitivesDef) New() StructPrimitives {
 	return StructPrimitives{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructPrimitives"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_CachedRef),
 			types.NewString("uint64"), types.UInt64(def.Uint64),
 			types.NewString("uint32"), types.UInt32(def.Uint32),
 			types.NewString("uint16"), types.UInt16(def.Uint16),

--- a/nomdl/codegen/test/struct_recursive.go
+++ b/nomdl/codegen/test/struct_recursive.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_struct_recursive_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_recursive_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_struct_recursive_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"Tree": __typeRefOfTree(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"Tree": __typeRefOfTree(),
+			},
+		}.New()
+		__testPackageInFile_struct_recursive_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_struct_recursive_CachedRef
 }
 
 // Tree

--- a/nomdl/codegen/test/struct_recursive.go
+++ b/nomdl/codegen/test/struct_recursive.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_struct_recursive_CachedRef = types.Ref{}
+var __testPackageInFile_struct_recursive_CachedRef = __testPackageInFile_struct_recursive_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_recursive_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_struct_recursive_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"Tree": __typeRefOfTree(),
-			},
-		}.New()
-		__testPackageInFile_struct_recursive_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_struct_recursive_CachedRef
+			"Tree": __typeRefOfTree(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // Tree
@@ -34,7 +31,7 @@ type Tree struct {
 func NewTree() Tree {
 	return Tree{types.NewMap(
 		types.NewString("$name"), types.NewString("Tree"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_CachedRef),
 		types.NewString("children"), types.NewList(),
 	)}
 }
@@ -47,7 +44,7 @@ func (def TreeDef) New() Tree {
 	return Tree{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Tree"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_CachedRef),
 			types.NewString("children"), def.Children.New().NomsValue(),
 		)}
 }

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_struct_with_list_CachedRef = types.Ref{}
+var __testPackageInFile_struct_with_list_CachedRef = __testPackageInFile_struct_with_list_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_with_list_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_struct_with_list_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"StructWithList": __typeRefOfStructWithList(),
-			},
-		}.New()
-		__testPackageInFile_struct_with_list_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_struct_with_list_CachedRef
+			"StructWithList": __typeRefOfStructWithList(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // StructWithList
@@ -34,7 +31,7 @@ type StructWithList struct {
 func NewStructWithList() StructWithList {
 	return StructWithList{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithList"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_CachedRef),
 		types.NewString("l"), types.NewList(),
 		types.NewString("b"), types.Bool(false),
 		types.NewString("s"), types.NewString(""),
@@ -53,7 +50,7 @@ func (def StructWithListDef) New() StructWithList {
 	return StructWithList{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithList"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_CachedRef),
 			types.NewString("l"), def.L.New().NomsValue(),
 			types.NewString("b"), types.Bool(def.B),
 			types.NewString("s"), types.NewString(def.S),

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_struct_with_list_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_with_list_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_struct_with_list_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"StructWithList": __typeRefOfStructWithList(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"StructWithList": __typeRefOfStructWithList(),
+			},
+		}.New()
+		__testPackageInFile_struct_with_list_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_struct_with_list_CachedRef
 }
 
 // StructWithList

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_struct_with_union_field_CachedRef = types.Ref{}
+var __testPackageInFile_struct_with_union_field_CachedRef = __testPackageInFile_struct_with_union_field_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_with_union_field_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_struct_with_union_field_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"StructWithUnionField": __typeRefOfStructWithUnionField(),
-			},
-		}.New()
-		__testPackageInFile_struct_with_union_field_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_struct_with_union_field_CachedRef
+			"StructWithUnionField": __typeRefOfStructWithUnionField(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // StructWithUnionField
@@ -34,7 +31,7 @@ type StructWithUnionField struct {
 func NewStructWithUnionField() StructWithUnionField {
 	return StructWithUnionField{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithUnionField"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_CachedRef),
 		types.NewString("a"), types.Float32(0),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
@@ -51,7 +48,7 @@ func (def StructWithUnionFieldDef) New() StructWithUnionField {
 	return StructWithUnionField{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithUnionField"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_CachedRef),
 			types.NewString("a"), types.Float32(def.A),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_struct_with_union_field_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_with_union_field_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_struct_with_union_field_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"StructWithUnionField": __typeRefOfStructWithUnionField(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"StructWithUnionField": __typeRefOfStructWithUnionField(),
+			},
+		}.New()
+		__testPackageInFile_struct_with_union_field_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_struct_with_union_field_CachedRef
 }
 
 // StructWithUnionField

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -7,17 +7,22 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+var __testPackageInFile_struct_with_unions_CachedRef = types.Ref{}
+
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_with_unions_Ref() types.Ref {
-	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+	if types.LookupPackage(__testPackageInFile_struct_with_unions_CachedRef.Ref()) == nil {
+		p := types.PackageDef{
+			Types: types.MapOfStringToTypeRefDef{
 
-			"StructWithUnions": __typeRefOfStructWithUnions(),
-		},
-	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+				"StructWithUnions": __typeRefOfStructWithUnions(),
+			},
+		}.New()
+		__testPackageInFile_struct_with_unions_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
+	}
+	return __testPackageInFile_struct_with_unions_CachedRef
 }
 
 // StructWithUnions

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -7,22 +7,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-var __testPackageInFile_struct_with_unions_CachedRef = types.Ref{}
+var __testPackageInFile_struct_with_unions_CachedRef = __testPackageInFile_struct_with_unions_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func __testPackageInFile_struct_with_unions_Ref() types.Ref {
-	if types.LookupPackage(__testPackageInFile_struct_with_unions_CachedRef.Ref()) == nil {
-		p := types.PackageDef{
-			Types: types.MapOfStringToTypeRefDef{
+	p := types.PackageDef{
+		Types: types.MapOfStringToTypeRefDef{
 
-				"StructWithUnions": __typeRefOfStructWithUnions(),
-			},
-		}.New()
-		__testPackageInFile_struct_with_unions_CachedRef = types.Ref{R: types.RegisterPackage(&p)}
-	}
-	return __testPackageInFile_struct_with_unions_CachedRef
+			"StructWithUnions": __typeRefOfStructWithUnions(),
+		},
+	}.New()
+	return types.Ref{R: types.RegisterPackage(&p)}
 }
 
 // StructWithUnions
@@ -34,7 +31,7 @@ type StructWithUnions struct {
 func NewStructWithUnions() StructWithUnions {
 	return StructWithUnions{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithUnions"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_CachedRef),
 		types.NewString("a"), New__unionOfBOfFloat64AndCOfString().NomsValue(),
 		types.NewString("d"), New__unionOfEOfFloat64AndFOfString().NomsValue(),
 	)}
@@ -49,7 +46,7 @@ func (def StructWithUnionsDef) New() StructWithUnions {
 	return StructWithUnions{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithUnions"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_CachedRef),
 			types.NewString("a"), def.A.New().NomsValue(),
 			types.NewString("d"), def.D.New().NomsValue(),
 		)}
@@ -121,7 +118,7 @@ type __unionOfBOfFloat64AndCOfString struct {
 func New__unionOfBOfFloat64AndCOfString() __unionOfBOfFloat64AndCOfString {
 	return __unionOfBOfFloat64AndCOfString{types.NewMap(
 		types.NewString("$name"), types.NewString("__unionOfBOfFloat64AndCOfString"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"), __testPackageInFile_struct_with_unions_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"), __testPackageInFile_struct_with_unions_CachedRef),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
@@ -136,7 +133,7 @@ func (def __unionOfBOfFloat64AndCOfStringDef) New() __unionOfBOfFloat64AndCOfStr
 	return __unionOfBOfFloat64AndCOfString{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("__unionOfBOfFloat64AndCOfString"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"), __testPackageInFile_struct_with_unions_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"), __testPackageInFile_struct_with_unions_CachedRef),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
@@ -258,7 +255,7 @@ type __unionOfEOfFloat64AndFOfString struct {
 func New__unionOfEOfFloat64AndFOfString() __unionOfEOfFloat64AndFOfString {
 	return __unionOfEOfFloat64AndFOfString{types.NewMap(
 		types.NewString("$name"), types.NewString("__unionOfEOfFloat64AndFOfString"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"), __testPackageInFile_struct_with_unions_Ref()),
+		types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"), __testPackageInFile_struct_with_unions_CachedRef),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
@@ -273,7 +270,7 @@ func (def __unionOfEOfFloat64AndFOfStringDef) New() __unionOfEOfFloat64AndFOfStr
 	return __unionOfEOfFloat64AndFOfString{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("__unionOfEOfFloat64AndFOfString"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"), __testPackageInFile_struct_with_unions_Ref()),
+			types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"), __testPackageInFile_struct_with_unions_CachedRef),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}


### PR DESCRIPTION
The initial, naive generated code that adds type info to Noms structs
built a new Package object every time a new struct instance was
created. They always had the same ref, so the result was correct, but
there was a lot of work for nothing. This patch caches Package objects
so that we only build them once.
