### PR TITLE
Update stretchr/testify

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/attic-labs/noms",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.5.1",
 	"Packages": [
 		"./..."
 	],
@@ -47,18 +47,18 @@
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",
-			"Comment": "v1.0-36-gacfa84d",
-			"Rev": "acfa84d4543a981cf308682732f84872d4296ac5"
+			"Comment": "v1.0-45-gbcd32dc",
+			"Rev": "bcd32dcc8b1e09b14f55703dcf891fdd82561143"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/require",
-			"Comment": "v1.0-36-gacfa84d",
-			"Rev": "acfa84d4543a981cf308682732f84872d4296ac5"
+			"Comment": "v1.0-45-gbcd32dc",
+			"Rev": "bcd32dcc8b1e09b14f55703dcf891fdd82561143"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/suite",
-			"Comment": "v1.0-36-gacfa84d",
-			"Rev": "acfa84d4543a981cf308682732f84872d4296ac5"
+			"Comment": "v1.0-45-gbcd32dc",
+			"Rev": "bcd32dcc8b1e09b14f55703dcf891fdd82561143"
 		},
 		{
 			"ImportPath": "github.com/syndtr/goleveldb/leveldb",

--- a/Godeps/_workspace/src/github.com/stretchr/testify/assert/assertions.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/assert/assertions.go
@@ -54,7 +54,7 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	expectedValue := reflect.ValueOf(expected)
 	if expectedValue.Type().ConvertibleTo(actualType) {
 		// Attempt comparison after type conversion
-		if reflect.DeepEqual(actual, expectedValue.Convert(actualType).Interface()) {
+		if reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual) {
 			return true
 		}
 	}
@@ -239,7 +239,7 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 	if !ObjectsAreEqual(expected, actual) {
 		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)", actual, expected), msgAndArgs...)
+			"        != %#v (actual)", expected, actual), msgAndArgs...)
 	}
 
 	return true
@@ -287,24 +287,10 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-
-	success := true
-
-	if object == nil {
-		success = false
-	} else {
-		value := reflect.ValueOf(object)
-		kind := value.Kind()
-		if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
-			success = false
-		}
+	if !isNil(object) {
+		return true
 	}
-
-	if !success {
-		Fail(t, "Expected value not to be nil.", msgAndArgs...)
-	}
-
-	return success
+	return Fail(t, "Expected value not to be nil.", msgAndArgs...)
 }
 
 // isNil checks if a specified object is nil or not, without Failing.

--- a/Godeps/_workspace/src/github.com/stretchr/testify/assert/assertions_test.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/assert/assertions_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	i      interface{}
+	i     interface{}
 	zeros = []interface{}{
 		false,
 		byte(0),
@@ -198,6 +198,9 @@ func TestNotNil(t *testing.T) {
 	if NotNil(mockT, nil) {
 		t.Error("NotNil should return false: object is nil")
 	}
+	if NotNil(mockT, (*struct{})(nil)) {
+		t.Error("NotNil should return false: object is (*struct{})(nil)")
+	}
 
 }
 
@@ -207,6 +210,9 @@ func TestNil(t *testing.T) {
 
 	if !Nil(mockT, nil) {
 		t.Error("Nil should return true: object is nil")
+	}
+	if !Nil(mockT, (*struct{})(nil)) {
+		t.Error("Nil should return true: object is (*struct{})(nil)")
 	}
 	if Nil(mockT, new(AssertionTesterConformingObject)) {
 		t.Error("Nil should return false: object is not nil")


### PR DESCRIPTION
This update fixes a bug in assert.Equals that made it report the wrong
expectation (it was driving me insane).
