### PR TITLE
Change types.TypeRef creation API to use native types instead of Noms.

### DIFF
--- a/clients/pitchmap/index/types.go
+++ b/clients/pitchmap/index/types.go
@@ -465,7 +465,7 @@ type Pitch struct {
 func NewPitch() Pitch {
 	return Pitch{types.NewMap(
 		types.NewString("$name"), types.NewString("Pitch"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("Pitch"), __mainPackageInFile_types_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("Pitch", __mainPackageInFile_types_CachedRef),
 		types.NewString("X"), types.Float64(0),
 		types.NewString("Z"), types.Float64(0),
 	)}
@@ -480,7 +480,7 @@ func (def PitchDef) New() Pitch {
 	return Pitch{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Pitch"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("Pitch"), __mainPackageInFile_types_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("Pitch", __mainPackageInFile_types_CachedRef),
 			types.NewString("X"), types.Float64(def.X),
 			types.NewString("Z"), types.Float64(def.Z),
 		)}
@@ -495,11 +495,11 @@ func (self Pitch) Def() PitchDef {
 
 // Creates and returns a Noms Value that describes Pitch.
 func __typeRefOfPitch() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("Pitch"),
-		types.NewList(
-			types.NewString("X"), types.MakePrimitiveTypeRef(types.Float64Kind),
-			types.NewString("Z"), types.MakePrimitiveTypeRef(types.Float64Kind),
-		),
+	return types.MakeStructTypeRef("Pitch",
+		[]types.Field{
+			types.Field{"X", types.MakePrimitiveTypeRef(types.Float64Kind)},
+			types.Field{"Z", types.MakePrimitiveTypeRef(types.Float64Kind)},
+		},
 		nil)
 
 }

--- a/nomdl/codegen/enum.tmpl
+++ b/nomdl/codegen/enum.tmpl
@@ -9,10 +9,6 @@ const ({{range $index, $id := .Ids}}
 
 // Creates and returns a Noms Value that describes {{.Name}}.
 func __typeRefOf{{.Name}}() types.TypeRef {
-	return types.MakeEnumTypeRef(types.NewString("{{.Name}}"), []types.String{
-			{{range $index, $id := .Ids}}
-			types.NewString("{{$id}}"),{{end}}
-		})
-
+	return types.MakeEnumTypeRef("{{.Name}}", {{range $index, $id := .Ids}}{{if gt $index 0}}, {{end}}"{{$id}}"{{end}})
 }
 

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -7,7 +7,7 @@ type {{.Name}} struct {
 func New{{.Name}}() {{.Name}} {
 	return {{.Name}}{types.NewMap(
 			types.NewString("$name"), types.NewString("{{.Name}}"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("{{.Name}}", __{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef),
 			{{range .Fields}}types.NewString("{{.Name}}"), {{valueZero .T}},
 			{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(0),
 			types.NewString("$unionValue"), {{valueZero .UnionZeroType}},{{end}}
@@ -25,7 +25,7 @@ func New{{.Name}}() {{.Name}} {
 		return {{.Name}}{
 			types.NewMap(
 				types.NewString("$name"), types.NewString("{{.Name}}"),
-				types.NewString("$type"), types.MakeTypeRef(types.NewString("{{.Name}}"), __{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef),
+				types.NewString("$type"), types.MakeTypeRef("{{.Name}}", __{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef),
 				{{range .Fields}}types.NewString("{{.Name}}"), {{defToValue (print "def." (title .Name)) .T}},
 				{{end}}{{if .HasUnion}}types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 				types.NewString("$unionValue"), def.__unionDefToValue(),
@@ -62,15 +62,15 @@ func New{{.Name}}() {{.Name}} {
 
 // Creates and returns a Noms Value that describes {{.Name}}.
 func __typeRefOf{{.Name}}() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("{{.Name}}"),
-		types.NewList(
-			{{range .Fields}}types.NewString("{{.Name}}"), {{toTypesTypeRef .T}},
+	return types.MakeStructTypeRef("{{.Name}}",
+		[]types.Field{
+			{{range .Fields}}types.Field{"{{.Name}}", {{toTypesTypeRef .T}}},
 			{{end}}
-		),
-		{{if .HasUnion}}types.NewList(
-			{{range .Choices}}types.NewString("{{.Name}}"), {{toTypesTypeRef .T}},
+		},
+		{{if .HasUnion}}[]types.Field{
+			{{range .Choices}}types.Field{"{{.Name}}", {{toTypesTypeRef .T}}},
 			{{end}}
-		){{else}}nil{{end}})
+		}{{else}}nil{{end}})
 
 }
 

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -32,7 +32,7 @@ type EnumStruct struct {
 func NewEnumStruct() EnumStruct {
 	return EnumStruct{types.NewMap(
 		types.NewString("$name"), types.NewString("EnumStruct"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("EnumStruct", __testPackageInFile_enum_struct_CachedRef),
 		types.NewString("hand"), types.Int32(0),
 	)}
 }
@@ -45,7 +45,7 @@ func (def EnumStructDef) New() EnumStruct {
 	return EnumStruct{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("EnumStruct"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("EnumStruct"), __testPackageInFile_enum_struct_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("EnumStruct", __testPackageInFile_enum_struct_CachedRef),
 			types.NewString("hand"), types.Int32(def.Hand),
 		)}
 }
@@ -58,10 +58,10 @@ func (self EnumStruct) Def() EnumStructDef {
 
 // Creates and returns a Noms Value that describes EnumStruct.
 func __typeRefOfEnumStruct() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("EnumStruct"),
-		types.NewList(
-			types.NewString("hand"), types.MakeTypeRef(types.NewString("Handedness"), types.Ref{}),
-		),
+	return types.MakeStructTypeRef("EnumStruct",
+		[]types.Field{
+			types.Field{"hand", types.MakeTypeRef("Handedness", types.Ref{})},
+		},
 		nil)
 
 }
@@ -107,11 +107,5 @@ const (
 
 // Creates and returns a Noms Value that describes Handedness.
 func __typeRefOfHandedness() types.TypeRef {
-	return types.MakeEnumTypeRef(types.NewString("Handedness"), []types.String{
-
-		types.NewString("right"),
-		types.NewString("left"),
-		types.NewString("switch"),
-	})
-
+	return types.MakeEnumTypeRef("Handedness", "right", "left", "switch")
 }

--- a/nomdl/codegen/test/ref.go
+++ b/nomdl/codegen/test/ref.go
@@ -336,7 +336,7 @@ type StructWithRef struct {
 func NewStructWithRef() StructWithRef {
 	return StructWithRef{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithRef"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("StructWithRef", __testPackageInFile_ref_CachedRef),
 		types.NewString("r"), types.Ref{R: ref.Ref{}},
 	)}
 }
@@ -349,7 +349,7 @@ func (def StructWithRefDef) New() StructWithRef {
 	return StructWithRef{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithRef"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithRef"), __testPackageInFile_ref_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("StructWithRef", __testPackageInFile_ref_CachedRef),
 			types.NewString("r"), types.Ref{R: def.R},
 		)}
 }
@@ -362,10 +362,10 @@ func (self StructWithRef) Def() StructWithRefDef {
 
 // Creates and returns a Noms Value that describes StructWithRef.
 func __typeRefOfStructWithRef() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("StructWithRef"),
-		types.NewList(
-			types.NewString("r"), types.MakeCompoundTypeRef(types.NewString(""), types.RefKind, types.MakeCompoundTypeRef(types.NewString(""), types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))),
-		),
+	return types.MakeStructTypeRef("StructWithRef",
+		[]types.Field{
+			types.Field{"r", types.MakeCompoundTypeRef("", types.RefKind, types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind)))},
+		},
 		nil)
 
 }

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -31,7 +31,7 @@ type Struct struct {
 func NewStruct() Struct {
 	return Struct{types.NewMap(
 		types.NewString("$name"), types.NewString("Struct"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("Struct", __testPackageInFile_struct_CachedRef),
 		types.NewString("s"), types.NewString(""),
 		types.NewString("b"), types.Bool(false),
 	)}
@@ -46,7 +46,7 @@ func (def StructDef) New() Struct {
 	return Struct{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Struct"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("Struct"), __testPackageInFile_struct_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("Struct", __testPackageInFile_struct_CachedRef),
 			types.NewString("s"), types.NewString(def.S),
 			types.NewString("b"), types.Bool(def.B),
 		)}
@@ -61,11 +61,11 @@ func (self Struct) Def() StructDef {
 
 // Creates and returns a Noms Value that describes Struct.
 func __typeRefOfStruct() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("Struct"),
-		types.NewList(
-			types.NewString("s"), types.MakePrimitiveTypeRef(types.StringKind),
-			types.NewString("b"), types.MakePrimitiveTypeRef(types.BoolKind),
-		),
+	return types.MakeStructTypeRef("Struct",
+		[]types.Field{
+			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind)},
+			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind)},
+		},
 		nil)
 
 }

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -31,7 +31,7 @@ type StructPrimitives struct {
 func NewStructPrimitives() StructPrimitives {
 	return StructPrimitives{types.NewMap(
 		types.NewString("$name"), types.NewString("StructPrimitives"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("StructPrimitives", __testPackageInFile_struct_primitives_CachedRef),
 		types.NewString("uint64"), types.UInt64(0),
 		types.NewString("uint32"), types.UInt32(0),
 		types.NewString("uint16"), types.UInt16(0),
@@ -70,7 +70,7 @@ func (def StructPrimitivesDef) New() StructPrimitives {
 	return StructPrimitives{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructPrimitives"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructPrimitives"), __testPackageInFile_struct_primitives_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("StructPrimitives", __testPackageInFile_struct_primitives_CachedRef),
 			types.NewString("uint64"), types.UInt64(def.Uint64),
 			types.NewString("uint32"), types.UInt32(def.Uint32),
 			types.NewString("uint16"), types.UInt16(def.Uint16),
@@ -109,23 +109,23 @@ func (self StructPrimitives) Def() StructPrimitivesDef {
 
 // Creates and returns a Noms Value that describes StructPrimitives.
 func __typeRefOfStructPrimitives() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("StructPrimitives"),
-		types.NewList(
-			types.NewString("uint64"), types.MakePrimitiveTypeRef(types.UInt64Kind),
-			types.NewString("uint32"), types.MakePrimitiveTypeRef(types.UInt32Kind),
-			types.NewString("uint16"), types.MakePrimitiveTypeRef(types.UInt16Kind),
-			types.NewString("uint8"), types.MakePrimitiveTypeRef(types.UInt8Kind),
-			types.NewString("int64"), types.MakePrimitiveTypeRef(types.Int64Kind),
-			types.NewString("int32"), types.MakePrimitiveTypeRef(types.Int32Kind),
-			types.NewString("int16"), types.MakePrimitiveTypeRef(types.Int16Kind),
-			types.NewString("int8"), types.MakePrimitiveTypeRef(types.Int8Kind),
-			types.NewString("float64"), types.MakePrimitiveTypeRef(types.Float64Kind),
-			types.NewString("float32"), types.MakePrimitiveTypeRef(types.Float32Kind),
-			types.NewString("bool"), types.MakePrimitiveTypeRef(types.BoolKind),
-			types.NewString("string"), types.MakePrimitiveTypeRef(types.StringKind),
-			types.NewString("blob"), types.MakePrimitiveTypeRef(types.BlobKind),
-			types.NewString("value"), types.MakePrimitiveTypeRef(types.ValueKind),
-		),
+	return types.MakeStructTypeRef("StructPrimitives",
+		[]types.Field{
+			types.Field{"uint64", types.MakePrimitiveTypeRef(types.UInt64Kind)},
+			types.Field{"uint32", types.MakePrimitiveTypeRef(types.UInt32Kind)},
+			types.Field{"uint16", types.MakePrimitiveTypeRef(types.UInt16Kind)},
+			types.Field{"uint8", types.MakePrimitiveTypeRef(types.UInt8Kind)},
+			types.Field{"int64", types.MakePrimitiveTypeRef(types.Int64Kind)},
+			types.Field{"int32", types.MakePrimitiveTypeRef(types.Int32Kind)},
+			types.Field{"int16", types.MakePrimitiveTypeRef(types.Int16Kind)},
+			types.Field{"int8", types.MakePrimitiveTypeRef(types.Int8Kind)},
+			types.Field{"float64", types.MakePrimitiveTypeRef(types.Float64Kind)},
+			types.Field{"float32", types.MakePrimitiveTypeRef(types.Float32Kind)},
+			types.Field{"bool", types.MakePrimitiveTypeRef(types.BoolKind)},
+			types.Field{"string", types.MakePrimitiveTypeRef(types.StringKind)},
+			types.Field{"blob", types.MakePrimitiveTypeRef(types.BlobKind)},
+			types.Field{"value", types.MakePrimitiveTypeRef(types.ValueKind)},
+		},
 		nil)
 
 }

--- a/nomdl/codegen/test/struct_recursive.go
+++ b/nomdl/codegen/test/struct_recursive.go
@@ -31,7 +31,7 @@ type Tree struct {
 func NewTree() Tree {
 	return Tree{types.NewMap(
 		types.NewString("$name"), types.NewString("Tree"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("Tree", __testPackageInFile_struct_recursive_CachedRef),
 		types.NewString("children"), types.NewList(),
 	)}
 }
@@ -44,7 +44,7 @@ func (def TreeDef) New() Tree {
 	return Tree{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("Tree"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("Tree"), __testPackageInFile_struct_recursive_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("Tree", __testPackageInFile_struct_recursive_CachedRef),
 			types.NewString("children"), def.Children.New().NomsValue(),
 		)}
 }
@@ -57,10 +57,10 @@ func (self Tree) Def() TreeDef {
 
 // Creates and returns a Noms Value that describes Tree.
 func __typeRefOfTree() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("Tree"),
-		types.NewList(
-			types.NewString("children"), types.MakeCompoundTypeRef(types.NewString(""), types.ListKind, types.MakeTypeRef(types.NewString("Tree"), types.Ref{})),
-		),
+	return types.MakeStructTypeRef("Tree",
+		[]types.Field{
+			types.Field{"children", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Tree", types.Ref{}))},
+		},
 		nil)
 
 }

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -31,7 +31,7 @@ type StructWithList struct {
 func NewStructWithList() StructWithList {
 	return StructWithList{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithList"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("StructWithList", __testPackageInFile_struct_with_list_CachedRef),
 		types.NewString("l"), types.NewList(),
 		types.NewString("b"), types.Bool(false),
 		types.NewString("s"), types.NewString(""),
@@ -50,7 +50,7 @@ func (def StructWithListDef) New() StructWithList {
 	return StructWithList{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithList"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithList"), __testPackageInFile_struct_with_list_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("StructWithList", __testPackageInFile_struct_with_list_CachedRef),
 			types.NewString("l"), def.L.New().NomsValue(),
 			types.NewString("b"), types.Bool(def.B),
 			types.NewString("s"), types.NewString(def.S),
@@ -69,13 +69,13 @@ func (self StructWithList) Def() StructWithListDef {
 
 // Creates and returns a Noms Value that describes StructWithList.
 func __typeRefOfStructWithList() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("StructWithList"),
-		types.NewList(
-			types.NewString("l"), types.MakeCompoundTypeRef(types.NewString(""), types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)),
-			types.NewString("b"), types.MakePrimitiveTypeRef(types.BoolKind),
-			types.NewString("s"), types.MakePrimitiveTypeRef(types.StringKind),
-			types.NewString("i"), types.MakePrimitiveTypeRef(types.Int64Kind),
-		),
+	return types.MakeStructTypeRef("StructWithList",
+		[]types.Field{
+			types.Field{"l", types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind))},
+			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind)},
+			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind)},
+			types.Field{"i", types.MakePrimitiveTypeRef(types.Int64Kind)},
+		},
 		nil)
 
 }

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -31,7 +31,7 @@ type StructWithUnionField struct {
 func NewStructWithUnionField() StructWithUnionField {
 	return StructWithUnionField{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithUnionField"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("StructWithUnionField", __testPackageInFile_struct_with_union_field_CachedRef),
 		types.NewString("a"), types.Float32(0),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
@@ -48,7 +48,7 @@ func (def StructWithUnionFieldDef) New() StructWithUnionField {
 	return StructWithUnionField{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithUnionField"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnionField"), __testPackageInFile_struct_with_union_field_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("StructWithUnionField", __testPackageInFile_struct_with_union_field_CachedRef),
 			types.NewString("a"), types.Float32(def.A),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),
@@ -97,17 +97,17 @@ func (self StructWithUnionField) __unionValueToDef() interface{} {
 
 // Creates and returns a Noms Value that describes StructWithUnionField.
 func __typeRefOfStructWithUnionField() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("StructWithUnionField"),
-		types.NewList(
-			types.NewString("a"), types.MakePrimitiveTypeRef(types.Float32Kind),
-		),
-		types.NewList(
-			types.NewString("b"), types.MakePrimitiveTypeRef(types.Float64Kind),
-			types.NewString("c"), types.MakePrimitiveTypeRef(types.StringKind),
-			types.NewString("d"), types.MakePrimitiveTypeRef(types.BlobKind),
-			types.NewString("e"), types.MakePrimitiveTypeRef(types.ValueKind),
-			types.NewString("f"), types.MakeCompoundTypeRef(types.NewString(""), types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind)),
-		))
+	return types.MakeStructTypeRef("StructWithUnionField",
+		[]types.Field{
+			types.Field{"a", types.MakePrimitiveTypeRef(types.Float32Kind)},
+		},
+		[]types.Field{
+			types.Field{"b", types.MakePrimitiveTypeRef(types.Float64Kind)},
+			types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind)},
+			types.Field{"d", types.MakePrimitiveTypeRef(types.BlobKind)},
+			types.Field{"e", types.MakePrimitiveTypeRef(types.ValueKind)},
+			types.Field{"f", types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind))},
+		})
 
 }
 

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -31,7 +31,7 @@ type StructWithUnions struct {
 func NewStructWithUnions() StructWithUnions {
 	return StructWithUnions{types.NewMap(
 		types.NewString("$name"), types.NewString("StructWithUnions"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("StructWithUnions", __testPackageInFile_struct_with_unions_CachedRef),
 		types.NewString("a"), New__unionOfBOfFloat64AndCOfString().NomsValue(),
 		types.NewString("d"), New__unionOfEOfFloat64AndFOfString().NomsValue(),
 	)}
@@ -46,7 +46,7 @@ func (def StructWithUnionsDef) New() StructWithUnions {
 	return StructWithUnions{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("StructWithUnions"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("StructWithUnions"), __testPackageInFile_struct_with_unions_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("StructWithUnions", __testPackageInFile_struct_with_unions_CachedRef),
 			types.NewString("a"), def.A.New().NomsValue(),
 			types.NewString("d"), def.D.New().NomsValue(),
 		)}
@@ -61,13 +61,13 @@ func (self StructWithUnions) Def() StructWithUnionsDef {
 
 // Creates and returns a Noms Value that describes StructWithUnions.
 func __typeRefOfStructWithUnions() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("StructWithUnions"),
-		types.NewList(
-			types.NewString("a"), types.MakeStructTypeRef(types.NewString(""), nil, types.NewList(types.NewString("b"), types.MakePrimitiveTypeRef(types.Float64Kind),
-				types.NewString("c"), types.MakePrimitiveTypeRef(types.StringKind))),
-			types.NewString("d"), types.MakeStructTypeRef(types.NewString(""), nil, types.NewList(types.NewString("e"), types.MakePrimitiveTypeRef(types.Float64Kind),
-				types.NewString("f"), types.MakePrimitiveTypeRef(types.StringKind))),
-		),
+	return types.MakeStructTypeRef("StructWithUnions",
+		[]types.Field{
+			types.Field{"a", types.MakeStructTypeRef("", nil, []types.Field{types.Field{"b", types.MakePrimitiveTypeRef(types.Float64Kind)},
+				types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind)}})},
+			types.Field{"d", types.MakeStructTypeRef("", nil, []types.Field{types.Field{"e", types.MakePrimitiveTypeRef(types.Float64Kind)},
+				types.Field{"f", types.MakePrimitiveTypeRef(types.StringKind)}})},
+		},
 		nil)
 
 }
@@ -118,7 +118,7 @@ type __unionOfBOfFloat64AndCOfString struct {
 func New__unionOfBOfFloat64AndCOfString() __unionOfBOfFloat64AndCOfString {
 	return __unionOfBOfFloat64AndCOfString{types.NewMap(
 		types.NewString("$name"), types.NewString("__unionOfBOfFloat64AndCOfString"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"), __testPackageInFile_struct_with_unions_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("__unionOfBOfFloat64AndCOfString", __testPackageInFile_struct_with_unions_CachedRef),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
@@ -133,7 +133,7 @@ func (def __unionOfBOfFloat64AndCOfStringDef) New() __unionOfBOfFloat64AndCOfStr
 	return __unionOfBOfFloat64AndCOfString{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("__unionOfBOfFloat64AndCOfString"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"), __testPackageInFile_struct_with_unions_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("__unionOfBOfFloat64AndCOfString", __testPackageInFile_struct_with_unions_CachedRef),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
@@ -168,12 +168,12 @@ func (self __unionOfBOfFloat64AndCOfString) __unionValueToDef() interface{} {
 
 // Creates and returns a Noms Value that describes __unionOfBOfFloat64AndCOfString.
 func __typeRefOf__unionOfBOfFloat64AndCOfString() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("__unionOfBOfFloat64AndCOfString"),
-		types.NewList(),
-		types.NewList(
-			types.NewString("b"), types.MakePrimitiveTypeRef(types.Float64Kind),
-			types.NewString("c"), types.MakePrimitiveTypeRef(types.StringKind),
-		))
+	return types.MakeStructTypeRef("__unionOfBOfFloat64AndCOfString",
+		[]types.Field{},
+		[]types.Field{
+			types.Field{"b", types.MakePrimitiveTypeRef(types.Float64Kind)},
+			types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind)},
+		})
 
 }
 
@@ -255,7 +255,7 @@ type __unionOfEOfFloat64AndFOfString struct {
 func New__unionOfEOfFloat64AndFOfString() __unionOfEOfFloat64AndFOfString {
 	return __unionOfEOfFloat64AndFOfString{types.NewMap(
 		types.NewString("$name"), types.NewString("__unionOfEOfFloat64AndFOfString"),
-		types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"), __testPackageInFile_struct_with_unions_CachedRef),
+		types.NewString("$type"), types.MakeTypeRef("__unionOfEOfFloat64AndFOfString", __testPackageInFile_struct_with_unions_CachedRef),
 		types.NewString("$unionIndex"), types.UInt32(0),
 		types.NewString("$unionValue"), types.Float64(0),
 	)}
@@ -270,7 +270,7 @@ func (def __unionOfEOfFloat64AndFOfStringDef) New() __unionOfEOfFloat64AndFOfStr
 	return __unionOfEOfFloat64AndFOfString{
 		types.NewMap(
 			types.NewString("$name"), types.NewString("__unionOfEOfFloat64AndFOfString"),
-			types.NewString("$type"), types.MakeTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"), __testPackageInFile_struct_with_unions_CachedRef),
+			types.NewString("$type"), types.MakeTypeRef("__unionOfEOfFloat64AndFOfString", __testPackageInFile_struct_with_unions_CachedRef),
 			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
 			types.NewString("$unionValue"), def.__unionDefToValue(),
 		)}
@@ -305,12 +305,12 @@ func (self __unionOfEOfFloat64AndFOfString) __unionValueToDef() interface{} {
 
 // Creates and returns a Noms Value that describes __unionOfEOfFloat64AndFOfString.
 func __typeRefOf__unionOfEOfFloat64AndFOfString() types.TypeRef {
-	return types.MakeStructTypeRef(types.NewString("__unionOfEOfFloat64AndFOfString"),
-		types.NewList(),
-		types.NewList(
-			types.NewString("e"), types.MakePrimitiveTypeRef(types.Float64Kind),
-			types.NewString("f"), types.MakePrimitiveTypeRef(types.StringKind),
-		))
+	return types.MakeStructTypeRef("__unionOfEOfFloat64AndFOfString",
+		[]types.Field{},
+		[]types.Field{
+			types.Field{"e", types.MakePrimitiveTypeRef(types.Float64Kind)},
+			types.Field{"f", types.MakePrimitiveTypeRef(types.StringKind)},
+		})
 
 }
 

--- a/types/package.go
+++ b/types/package.go
@@ -46,11 +46,11 @@ func (self Package) Def() PackageDef {
 
 // Creates and returns a Noms Value that describes Package.
 func __typeRefOfPackage() TypeRef {
-	return MakeStructTypeRef(NewString("Package"),
-		NewList(
-			NewString("Dependencies"), MakeCompoundTypeRef(NewString(""), SetKind, MakeCompoundTypeRef(NewString(""), RefKind, MakeTypeRef(NewString("Package"), Ref{}))),
-			NewString("Types"), MakeCompoundTypeRef(NewString(""), MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(TypeRefKind)),
-		),
+	return MakeStructTypeRef("Package",
+		[]Field{
+			Field{"Dependencies", MakeCompoundTypeRef("", SetKind, MakeCompoundTypeRef("", RefKind, MakeTypeRef("Package", Ref{})))},
+			Field{"Types", MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(TypeRefKind))},
+		},
 		nil)
 
 }

--- a/types/read_value.go
+++ b/types/read_value.go
@@ -67,10 +67,10 @@ func fromEncodeable(i interface{}, cs chunks.ChunkSource) Future {
 		if i.PkgRef != (ref.Ref{}) {
 			d.Chk.Equal(ValueKind, kind)
 			d.Chk.Nil(i.Desc)
-			return futureFromValue(MakeTypeRef(NewString(i.Name), Ref{R: i.PkgRef}))
+			return futureFromValue(MakeTypeRef(i.Name, Ref{R: i.PkgRef}))
 		}
 		desc := typeDescFromInterface(kind, i.Desc, cs)
-		return futureFromValue(buildType(NewString(i.Name), kind, desc))
+		return futureFromValue(buildType(i.Name, kind, desc))
 	case enc.CompoundBlob:
 		blobs := make([]Future, len(i.Blobs))
 		for idx, blobRef := range i.Blobs {

--- a/types/type_ref_test.go
+++ b/types/type_ref_test.go
@@ -14,15 +14,16 @@ func TestTypes(t *testing.T) {
 	boolType := MakePrimitiveTypeRef(BoolKind)
 	uint8Type := MakePrimitiveTypeRef(UInt8Kind)
 	stringType := MakePrimitiveTypeRef(StringKind)
-	mapType := MakeCompoundTypeRef(NewString("MapOfStringToUInt8"), MapKind, stringType, uint8Type)
-	setType := MakeCompoundTypeRef(NewString("SetOfString"), SetKind, stringType)
-	mahType := MakeStructTypeRef(NewString("MahStruct"), NewList(
-		NewString("Field1"), stringType,
-		NewString("Field2"), boolType), nil)
-	otherType := MakeStructTypeRef(NewString("MahOtherStruct"), nil,
-		NewList(
-			NewString("StructField"), mahType,
-			NewString("StringField"), stringType))
+	mapType := MakeCompoundTypeRef("MapOfStringToUInt8", MapKind, stringType, uint8Type)
+	setType := MakeCompoundTypeRef("SetOfString", SetKind, stringType)
+	mahType := MakeStructTypeRef("MahStruct", []Field{
+		Field{"Field1", stringType},
+		Field{"Field2", boolType},
+	}, nil)
+	otherType := MakeStructTypeRef("MahOtherStruct", nil, []Field{
+		Field{"StructField", mahType},
+		Field{"StringField", stringType},
+	})
 
 	mRef := WriteValue(mapType, cs)
 	setRef := WriteValue(setType, cs)
@@ -44,7 +45,7 @@ func TestTypeWithPkgRef(t *testing.T) {
 	}.New()
 
 	pkgRef := RegisterPackage(&pkg)
-	unresolvedType := MakeTypeRef(NewString("Spin"), Ref{R: pkgRef})
+	unresolvedType := MakeTypeRef("Spin", Ref{R: pkgRef})
 	unresolvedRef := WriteValue(unresolvedType, cs)
 
 	assert.EqualValues(pkgRef, ReadValue(unresolvedRef, cs).Chunks()[0].Ref())


### PR DESCRIPTION
These are just easier to work with. The internal representation remains
the same.

Towards issue #338
