### PR TITLE
decode.js: Remove Ref wrapping

### DIFF
--- a/clients/pitchmap/ui/main.js
+++ b/clients/pitchmap/ui/main.js
@@ -5,8 +5,10 @@ var React = require('react');
 var Map = require('./map.js');
 
 noms.getRoot()
-    .then(ref => noms.readValue(ref, noms.getChunk))
-    .then(ref => noms.getDataset(ref.deref(), 'mlb/heatmap'))
+    .then(ref => {
+      var pRoot = noms.readValue(ref, noms.getChunk);
+      return noms.getDataset(pRoot, 'mlb/heatmap');
+    })
     .then(getPitchers)
     .then(renderPitchersList);
 

--- a/clients/splore/.gitignore
+++ b/clients/splore/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+out.js

--- a/clients/splore/main.js
+++ b/clients/splore/main.js
@@ -104,7 +104,6 @@ function handleToggle(id) {
       render();
     } else {
       noms.readValue(id, noms.getChunk)
-        .then(chunkRef => chunkRef.deref())
         .then(chunk => handleChunkLoad(id, chunk, id));
     }
   }

--- a/clients/tagshow/main.js
+++ b/clients/tagshow/main.js
@@ -30,8 +30,7 @@ function render() {
   // more frequently (e.g., in response to window resize), then this should
   // get moved someplace else.
   var pRoot = noms.getRoot()
-      .then(ref => noms.readValue(ref, noms.getChunk))
-      .then(ref => ref.deref());
+      .then(ref => noms.readValue(ref, noms.getChunk));
 
   React.render(
     <Root

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -1,5 +1,6 @@
-var store = require('./noms_store.js')
-var decode = require('./decode.js')
+const {getChunk, getRoot, setServer} = require('./noms_store.js')
+const {getRef, readValue, Ref} = require('./decode.js')
+
 
 function getDataset(pRoot, id) {
   return pRoot
@@ -23,12 +24,12 @@ function getDatasetIds(pRoot) {
 }
 
 module.exports = {
-  setServer: store.setServer,
-  getRoot: store.getRoot,
-  getDataset: getDataset,
-  getDatasetIds: getDatasetIds,
-  getChunk: store.getChunk,
-  readValue: decode.readValue,
-  getRef: decode.getRef,
-  Ref: decode.Ref
+  getChunk,
+  getDataset,
+  getDatasetIds,
+  getRef,
+  getRoot,
+  readValue,
+  Ref,
+  setServer,
 };

--- a/js/test/decode.js
+++ b/js/test/decode.js
@@ -56,9 +56,6 @@ suite('decode.js', function() {
       chunks[ref] = data;
       readValue(ref, (r) => {
         return stringToArrayBufferPromise(chunks[r]);
-      }).then(ref => {
-        assert.instanceOf(ref, Ref);
-        return ref.deref();
       }).then(func)
       .then(done, done);
     });
@@ -80,8 +77,11 @@ suite('decode.js', function() {
   });
 
   testCompound('ref', 'j {"ref":"sha1-list"}', value => {
-    assert.isTrue(Immutable.List.isList(value));
-    assert.isTrue(Immutable.List.of(true, false).equals(value));
+    assert.isTrue(Ref.isRef(value))
+    return value.deref().then(value => {
+      assert.isTrue(Immutable.List.isList(value));
+      assert.isTrue(Immutable.List.of(true, false).equals(value));
+    });
   });
 
   testCompound('type', 'j {"type":{"kind":{"uint8":0},"name":""}}', value => {
@@ -94,26 +94,23 @@ suite('decode.js', function() {
     assert.isTrue(Immutable.Map.isMap(value));
     assert.equal(value.get('kind'), 14);
     assert.equal(value.get('name'), 'T');
-    assert.isTrue(Ref.isRef(value.get('desc')));
-    return value.get('desc').deref().then(list => {
-      assert.isTrue(Immutable.List.isList(list));
-      assert.equal(2, list.size);
-      assert.isTrue(Ref.isRef(list.get(0)));
-      assert.isTrue(Ref.isRef(list.get(1)));
-    });
+    let list = value.get('desc');
+    assert.isTrue(Immutable.List.isList(list));
+    assert.isTrue(Immutable.List.isList(list));
+    assert.equal(2, list.size);
+    assert.isTrue(Ref.isRef(list.get(0)));
+    assert.isTrue(Ref.isRef(list.get(1)));
   });
 
   testCompound('type enum', 'j {"type":{"desc":{"list":["f","g"]},"kind":{"uint8":18},"name":"enum"}}', value => {
     assert.isTrue(Immutable.Map.isMap(value));
     assert.equal(value.get('kind'), 18);
     assert.equal(value.get('name'), 'enum');
-    assert.isTrue(Ref.isRef(value.get('desc')));
-    return value.get('desc').deref().then(list => {
-      assert.isTrue(Immutable.List.isList(list));
-      assert.equal(2, list.size);
-      assert.equal('f', list.get(0));
-      assert.equal('g', list.get(1));
-    })
+    let list = value.get('desc');
+    assert.isTrue(Immutable.List.isList(list));
+    assert.equal(2, list.size);
+    assert.equal('f', list.get(0));
+    assert.equal('g', list.get(1));
   });
 
   testCompound('type with pkg', 'j {"type":{"kind":{"uint8":13},"name":"Commit","pkgRef":{"ref":"sha1-map"}}}', value => {


### PR DESCRIPTION
It is not clear to me why we added the Ref wrapping? The Ref wrapping
causes the explorer.js IU to show the wrong ref for collections.
