### PR TITLE
Modify codegen to include pacakge refs for unresolved types

### DIFF
--- a/clients/pitchmap/index/types.go
+++ b/clients/pitchmap/index/types.go
@@ -12,14 +12,14 @@ var __mainPackageInFile_types_CachedRef = __mainPackageInFile_types_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __mainPackageInFile_types_Ref() types.Ref {
+func __mainPackageInFile_types_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"Pitch": __typeRefOfPitch(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // ListOfMapOfStringToValue

--- a/clients/quad_tree/types.go
+++ b/clients/quad_tree/types.go
@@ -13,7 +13,7 @@ var __mainPackageInFile_types_CachedRef = __mainPackageInFile_types_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __mainPackageInFile_types_Ref() types.Ref {
+func __mainPackageInFile_types_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
@@ -24,7 +24,7 @@ func __mainPackageInFile_types_Ref() types.Ref {
 			"SQuadTree":    __typeRefOfSQuadTree(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // Geoposition
@@ -151,8 +151,8 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 func __typeRefOfGeorectangle() types.TypeRef {
 	return types.MakeStructTypeRef("Georectangle",
 		[]types.Field{
-			types.Field{"TopLeft", types.MakeTypeRef("Geoposition", types.Ref{}), false},
-			types.Field{"BottomRight", types.MakeTypeRef("Geoposition", types.Ref{}), false},
+			types.Field{"TopLeft", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
+			types.Field{"BottomRight", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)
@@ -235,7 +235,7 @@ func (s Node) Def() (d NodeDef) {
 func __typeRefOfNode() types.TypeRef {
 	return types.MakeStructTypeRef("Node",
 		[]types.Field{
-			types.Field{"Geoposition", types.MakeTypeRef("Geoposition", types.Ref{}), false},
+			types.Field{"Geoposition", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
 			types.Field{"Reference", types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind)), false},
 		},
 		types.Choices{},
@@ -370,12 +370,12 @@ func (s QuadTree) Def() (d QuadTreeDef) {
 func __typeRefOfQuadTree() types.TypeRef {
 	return types.MakeStructTypeRef("QuadTree",
 		[]types.Field{
-			types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Node", types.Ref{})), false},
-			types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef("QuadTree", types.Ref{})), false},
+			types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Node", ref.Ref{})), false},
+			types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef("QuadTree", ref.Ref{})), false},
 			types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
 			types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
 			types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Georectangle", types.MakeTypeRef("Georectangle", types.Ref{}), false},
+			types.Field{"Georectangle", types.MakeTypeRef("Georectangle", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)
@@ -724,11 +724,11 @@ func __typeRefOfSQuadTree() types.TypeRef {
 	return types.MakeStructTypeRef("SQuadTree",
 		[]types.Field{
 			types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))), false},
-			types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef("SQuadTree", types.Ref{}))), false},
+			types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef("SQuadTree", ref.Ref{}))), false},
 			types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
 			types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
 			types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Georectangle", types.MakeTypeRef("Georectangle", types.Ref{}), false},
+			types.Field{"Georectangle", types.MakeTypeRef("Georectangle", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)

--- a/clients/sfcrime_search/types.go
+++ b/clients/sfcrime_search/types.go
@@ -12,9 +12,9 @@ var __mainPackageInFile_types_CachedRef = __mainPackageInFile_types_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __mainPackageInFile_types_Ref() types.Ref {
+func __mainPackageInFile_types_Ref() ref.Ref {
 	p := types.PackageDef{
-		Types: types.MapOfStringToTypeRefDef{
+		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"Geoposition":  __typeRefOfGeoposition(),
 			"Georectangle": __typeRefOfGeorectangle(),
@@ -22,7 +22,7 @@ func __mainPackageInFile_types_Ref() types.Ref {
 			"SQuadTree":    __typeRefOfSQuadTree(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // Geoposition
@@ -149,8 +149,8 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 func __typeRefOfGeorectangle() types.TypeRef {
 	return types.MakeStructTypeRef("Georectangle",
 		[]types.Field{
-			types.Field{"TopLeft", types.MakeTypeRef("Geoposition", types.Ref{}), false},
-			types.Field{"BottomRight", types.MakeTypeRef("Geoposition", types.Ref{}), false},
+			types.Field{"TopLeft", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
+			types.Field{"BottomRight", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)
@@ -249,7 +249,7 @@ func __typeRefOfIncident() types.TypeRef {
 			types.Field{"Description", types.MakePrimitiveTypeRef(types.StringKind), false},
 			types.Field{"Address", types.MakePrimitiveTypeRef(types.StringKind), false},
 			types.Field{"Date", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef("Geoposition", types.Ref{}), false},
+			types.Field{"Geoposition", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)
@@ -372,12 +372,12 @@ func (s SQuadTree) Def() (d SQuadTreeDef) {
 func __typeRefOfSQuadTree() types.TypeRef {
 	return types.MakeStructTypeRef("SQuadTree",
 		[]types.Field{
-			types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Incident", types.Ref{})), false},
-			types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef("SQuadTree", types.Ref{})), false},
+			types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Incident", ref.Ref{})), false},
+			types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef("SQuadTree", ref.Ref{})), false},
 			types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
 			types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
 			types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Georectangle", types.MakeTypeRef("Georectangle", types.Ref{}), false},
+			types.Field{"Georectangle", types.MakeTypeRef("Georectangle", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)

--- a/datas/types.go
+++ b/datas/types.go
@@ -12,14 +12,14 @@ var __datasPackageInFile_types_CachedRef = __datasPackageInFile_types_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __datasPackageInFile_types_Ref() types.Ref {
+func __datasPackageInFile_types_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"Commit": __typeRefOfCommit(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // Commit
@@ -42,7 +42,7 @@ func __typeRefOfCommit() types.TypeRef {
 	return types.MakeStructTypeRef("Commit",
 		[]types.Field{
 			types.Field{"value", types.MakePrimitiveTypeRef(types.ValueKind), false},
-			types.Field{"parents", types.MakeCompoundTypeRef("", types.SetKind, types.MakeTypeRef("Commit", types.Ref{})), false},
+			types.Field{"parents", types.MakeCompoundTypeRef("", types.SetKind, types.MakeTypeRef("Commit", ref.Ref{})), false},
 		},
 		types.Choices{},
 	)

--- a/dataset/mgmt/types.go
+++ b/dataset/mgmt/types.go
@@ -12,14 +12,14 @@ var __mgmtPackageInFile_types_CachedRef = __mgmtPackageInFile_types_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __mgmtPackageInFile_types_Ref() types.Ref {
+func __mgmtPackageInFile_types_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"Dataset": __typeRefOfDataset(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // SetOfDataset

--- a/nomdl/codegen/codegen.go
+++ b/nomdl/codegen/codegen.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/attic-labs/noms/Godeps/_workspace/src/golang.org/x/tools/imports"
 	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/types"
-
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/nomdl/pkg"
+	"github.com/attic-labs/noms/ref"
+	"github.com/attic-labs/noms/types"
 )
 
 var (
@@ -383,8 +383,11 @@ func (gen *codeGen) userName(t types.TypeRef) string {
 
 func (gen *codeGen) toTypesTypeRef(t types.TypeRef) string {
 	if t.IsUnresolved() {
-		// needs to be pkgRef
-		return fmt.Sprintf(`types.MakeTypeRef("%s", types.Ref{})`, t.Name())
+		refCode := "ref.Ref{}"
+		if t.PackageRef() != (ref.Ref{}) {
+			refCode = fmt.Sprintf(`ref.Parse("%s")`, t.PackageRef().String())
+		}
+		return fmt.Sprintf(`types.MakeTypeRef("%s", %s)`, t.Name(), refCode)
 	}
 	if types.IsPrimitiveKind(t.Desc.Kind()) {
 		return fmt.Sprintf("types.MakePrimitiveTypeRef(types.%sKind)", kindToString(t.Desc.Kind()))

--- a/nomdl/codegen/header.tmpl
+++ b/nomdl/codegen/header.tmpl
@@ -2,21 +2,19 @@
 
 package {{.Name}}
 
-import "github.com/attic-labs/noms/types"
-
 {{if .HasTypes}}
 var __{{.Name}}PackageInFile_{{.FileID}}_CachedRef = __{{.Name}}PackageInFile_{{.FileID}}_Ref()
 
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __{{.Name}}PackageInFile_{{.FileID}}_Ref() types.Ref {
+func __{{.Name}}PackageInFile_{{.FileID}}_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 			{{range $name, $t := .NamedTypes}}
 			"{{$name}}": __typeRefOf{{$name}}(),{{end}}
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 {{end}}

--- a/nomdl/codegen/test/enum_struct.go
+++ b/nomdl/codegen/test/enum_struct.go
@@ -12,7 +12,7 @@ var __testPackageInFile_enum_struct_CachedRef = __testPackageInFile_enum_struct_
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_enum_struct_Ref() types.Ref {
+func __testPackageInFile_enum_struct_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
@@ -20,7 +20,7 @@ func __testPackageInFile_enum_struct_Ref() types.Ref {
 			"Handedness": __typeRefOfHandedness(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // EnumStruct
@@ -59,7 +59,7 @@ func (s EnumStruct) Def() (d EnumStructDef) {
 func __typeRefOfEnumStruct() types.TypeRef {
 	return types.MakeStructTypeRef("EnumStruct",
 		[]types.Field{
-			types.Field{"hand", types.MakeTypeRef("Handedness", types.Ref{}), false},
+			types.Field{"hand", types.MakeTypeRef("Handedness", ref.Ref{}), false},
 		},
 		types.Choices{},
 	)

--- a/nomdl/codegen/test/ref.go
+++ b/nomdl/codegen/test/ref.go
@@ -13,14 +13,14 @@ var __testPackageInFile_ref_CachedRef = __testPackageInFile_ref_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_ref_Ref() types.Ref {
+func __testPackageInFile_ref_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"StructWithRef": __typeRefOfStructWithRef(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // RefOfListOfString

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_CachedRef = __testPackageInFile_struct_Ref()
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_Ref() types.Ref {
+func __testPackageInFile_struct_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"Struct": __typeRefOfStruct(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // Struct

--- a/nomdl/codegen/test/struct_optional.go
+++ b/nomdl/codegen/test/struct_optional.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_optional_CachedRef = __testPackageInFile_struct_o
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_optional_Ref() types.Ref {
+func __testPackageInFile_struct_optional_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"OptionalStruct": __typeRefOfOptionalStruct(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // OptionalStruct

--- a/nomdl/codegen/test/struct_primitives.go
+++ b/nomdl/codegen/test/struct_primitives.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_primitives_CachedRef = __testPackageInFile_struct
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_primitives_Ref() types.Ref {
+func __testPackageInFile_struct_primitives_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"StructPrimitives": __typeRefOfStructPrimitives(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // StructPrimitives

--- a/nomdl/codegen/test/struct_recursive.go
+++ b/nomdl/codegen/test/struct_recursive.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_recursive_CachedRef = __testPackageInFile_struct_
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_recursive_Ref() types.Ref {
+func __testPackageInFile_struct_recursive_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"Tree": __typeRefOfTree(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // Tree
@@ -58,7 +58,7 @@ func (s Tree) Def() (d TreeDef) {
 func __typeRefOfTree() types.TypeRef {
 	return types.MakeStructTypeRef("Tree",
 		[]types.Field{
-			types.Field{"children", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Tree", types.Ref{})), false},
+			types.Field{"children", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("Tree", ref.Ref{})), false},
 		},
 		types.Choices{},
 	)

--- a/nomdl/codegen/test/struct_with_list.go
+++ b/nomdl/codegen/test/struct_with_list.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_with_list_CachedRef = __testPackageInFile_struct_
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_with_list_Ref() types.Ref {
+func __testPackageInFile_struct_with_list_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"StructWithList": __typeRefOfStructWithList(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // StructWithList

--- a/nomdl/codegen/test/struct_with_union_field.go
+++ b/nomdl/codegen/test/struct_with_union_field.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_with_union_field_CachedRef = __testPackageInFile_
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_with_union_field_Ref() types.Ref {
+func __testPackageInFile_struct_with_union_field_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"StructWithUnionField": __typeRefOfStructWithUnionField(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // StructWithUnionField

--- a/nomdl/codegen/test/struct_with_unions.go
+++ b/nomdl/codegen/test/struct_with_unions.go
@@ -12,14 +12,14 @@ var __testPackageInFile_struct_with_unions_CachedRef = __testPackageInFile_struc
 // This function builds up a Noms value that describes the type
 // package implemented by this file and registers it with the global
 // type package definition cache.
-func __testPackageInFile_struct_with_unions_Ref() types.Ref {
+func __testPackageInFile_struct_with_unions_Ref() ref.Ref {
 	p := types.PackageDef{
 		NamedTypes: types.MapOfStringToTypeRefDef{
 
 			"StructWithUnions": __typeRefOfStructWithUnions(),
 		},
 	}.New()
-	return types.Ref{R: types.RegisterPackage(&p)}
+	return types.RegisterPackage(&p)
 }
 
 // StructWithUnions

--- a/nomdl/pkg/import_test.go
+++ b/nomdl/pkg/import_test.go
@@ -35,7 +35,7 @@ func (suite *ImportTestSuite) SetupTest() {
 
 	fs := types.MakeStructTypeRef("ForeignStruct", []types.Field{
 		types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
-		types.Field{"n", types.MakeTypeRef("NestedDepStruct", types.Ref{R: suite.nestedRef}), false},
+		types.Field{"n", types.MakeTypeRef("NestedDepStruct", suite.nestedRef), false},
 	},
 		types.Choices{})
 	fe := types.MakeEnumTypeRef("ForeignEnum", "uno", "dos")
@@ -61,7 +61,7 @@ func (suite *ImportTestSuite) TestGetDeps() {
 func (suite *ImportTestSuite) TestResolveNamespace() {
 	deps := GetDeps(types.SetOfRefOfPackageDef{suite.importRef: true}, suite.cs)
 	t := resolveNamespace(types.MakeExternalTypeRef("Other", "ForeignEnum"), map[string]ref.Ref{"Other": suite.importRef}, deps)
-	suite.EqualValues(types.MakeTypeRef("ForeignEnum", types.Ref{R: suite.importRef}), t)
+	suite.EqualValues(types.MakeTypeRef("ForeignEnum", suite.importRef), t)
 }
 
 func (suite *ImportTestSuite) TestUnknownAlias() {
@@ -81,7 +81,7 @@ func (suite *ImportTestSuite) TestUnknownImportedType() {
 func (suite *ImportTestSuite) TestDetectFreeVariable() {
 	ls := types.MakeStructTypeRef("Local", []types.Field{
 		types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
-		types.Field{"n", types.MakeTypeRef("OtherLocal", types.Ref{}), false},
+		types.Field{"n", types.MakeTypeRef("OtherLocal", ref.Ref{}), false},
 	},
 		types.Choices{})
 	suite.Panics(func() {
@@ -142,26 +142,26 @@ func (suite *ImportTestSuite) TestImports() {
 
 	named := p.NamedTypes["Local1"]
 	field := find("a", named)
-	suite.EqualValues(suite.importRef, field.T.PackageRef().Ref())
+	suite.EqualValues(suite.importRef, field.T.PackageRef())
 	field = find("c", named)
-	suite.EqualValues(types.Ref{}, field.T.PackageRef())
+	suite.EqualValues(ref.Ref{}, field.T.PackageRef())
 
 	named = p.NamedTypes["Local2"]
 	field = find("b", named)
-	suite.EqualValues(suite.importRef, field.T.PackageRef().Ref())
+	suite.EqualValues(suite.importRef, field.T.PackageRef())
 
 	named = p.NamedTypes["Union"]
 	field = findChoice("a", named)
-	suite.EqualValues(suite.importRef, field.T.PackageRef().Ref())
+	suite.EqualValues(suite.importRef, field.T.PackageRef())
 	field = findChoice("b", named)
-	suite.EqualValues(types.Ref{}, field.T.PackageRef())
+	suite.EqualValues(ref.Ref{}, field.T.PackageRef())
 
 	named = p.NamedTypes["WithUnion"]
 	field = find("a", named)
-	suite.EqualValues(suite.importRef, field.T.PackageRef().Ref())
+	suite.EqualValues(suite.importRef, field.T.PackageRef())
 	namedUnion := find("b", named).T
 	field = findChoice("s", namedUnion)
-	suite.EqualValues(types.Ref{}, field.T.PackageRef())
+	suite.EqualValues(ref.Ref{}, field.T.PackageRef())
 	field = findChoice("t", namedUnion)
-	suite.EqualValues(suite.importRef, field.T.PackageRef().Ref())
+	suite.EqualValues(suite.importRef, field.T.PackageRef())
 }

--- a/nomdl/pkg/parse.go
+++ b/nomdl/pkg/parse.go
@@ -77,7 +77,7 @@ func resolveNamespaces(namedTypes map[string]types.TypeRef, aliases map[string]r
 		for idx, f := range fields {
 			if f.T.IsUnresolved() {
 				if f.T.Namespace() == "" {
-					d.Chk.Equal(types.Ref{}, f.T.PackageRef())
+					d.Chk.Equal(ref.Ref{}, f.T.PackageRef())
 					_, ok := namedTypes[f.T.Name()]
 					d.Exp.True(ok, "Could not find type %s in current package.", f.T.Name())
 					continue
@@ -112,5 +112,5 @@ func resolveNamespace(t types.TypeRef, aliases map[string]ref.Ref, deps map[ref.
 	d.Exp.True(ok, "Could not find import aliased to %s", t.Namespace())
 	_, ok = deps[target].NamedTypes[t.Name()]
 	d.Exp.True(ok, "Could not find type %s in package %s (aliased to %s).", t.Name(), target.String(), t.Namespace())
-	return types.MakeTypeRef(t.Name(), types.Ref{R: target})
+	return types.MakeTypeRef(t.Name(), target)
 }

--- a/types/package.go
+++ b/types/package.go
@@ -51,7 +51,7 @@ func (self Package) Def() PackageDef {
 func __typeRefOfPackage() TypeRef {
 	return MakeStructTypeRef("Package",
 		[]Field{
-			Field{"Dependencies", MakeCompoundTypeRef("", SetKind, MakeCompoundTypeRef("", RefKind, MakeTypeRef("Package", Ref{}))), false},
+			Field{"Dependencies", MakeCompoundTypeRef("", SetKind, MakeCompoundTypeRef("", RefKind, MakeTypeRef("Package", ref.Ref{}))), false},
 			Field{"NamedTypes", MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(TypeRefKind)), false},
 		},
 		Choices{})

--- a/types/read_value.go
+++ b/types/read_value.go
@@ -67,7 +67,7 @@ func fromEncodeable(i interface{}, cs chunks.ChunkSource) Future {
 		if i.PkgRef != (ref.Ref{}) {
 			d.Chk.Equal(TypeRefKind, kind)
 			d.Chk.Nil(i.Desc)
-			return futureFromValue(MakeTypeRef(i.Name, Ref{R: i.PkgRef}))
+			return futureFromValue(MakeTypeRef(i.Name, i.PkgRef))
 		}
 		desc := typeDescFromInterface(kind, i.Desc, cs)
 		return futureFromValue(buildType(i.Name, desc))

--- a/types/type_ref.go
+++ b/types/type_ref.go
@@ -59,11 +59,11 @@ func (t TypeRef) Kind() NomsKind {
 	return t.Desc.Kind()
 }
 
-func (t TypeRef) PackageRef() Ref {
+func (t TypeRef) PackageRef() ref.Ref {
 	if t.pkgRef == nil {
-		return Ref{}
+		return ref.Ref{}
 	}
-	return *t.pkgRef
+	return t.pkgRef.R
 }
 
 func (t TypeRef) Name() string {
@@ -126,8 +126,8 @@ func MakeStructTypeRef(name string, fields []Field, choices Choices) TypeRef {
 	return buildType(name, StructDesc{fields, choices})
 }
 
-func MakeTypeRef(n string, pkg Ref) TypeRef {
-	return TypeRef{name: name{name: n}, pkgRef: &pkg, Desc: UnresolvedDesc{}, ref: &ref.Ref{}}
+func MakeTypeRef(n string, pkg ref.Ref) TypeRef {
+	return TypeRef{name: name{name: n}, pkgRef: &Ref{R: pkg}, Desc: UnresolvedDesc{}, ref: &ref.Ref{}}
 }
 
 func MakeExternalTypeRef(namespace, n string) TypeRef {

--- a/types/type_ref_test.go
+++ b/types/type_ref_test.go
@@ -45,7 +45,7 @@ func TestTypeWithPkgRef(t *testing.T) {
 	}.New()
 
 	pkgRef := RegisterPackage(&pkg)
-	unresolvedType := MakeTypeRef("Spin", Ref{R: pkgRef})
+	unresolvedType := MakeTypeRef("Spin", pkgRef)
 	unresolvedRef := WriteValue(unresolvedType, cs)
 
 	assert.EqualValues(pkgRef, ReadValue(unresolvedRef, cs).Chunks()[0].Ref())

--- a/types/write_value.go
+++ b/types/write_value.go
@@ -108,7 +108,7 @@ func makeSetEncodeable(s Set, cs chunks.ChunkSink) interface{} {
 }
 
 func makeTypeEncodeable(t TypeRef, cs chunks.ChunkSink) interface{} {
-	pkgRef := t.PackageRef().Ref()
+	pkgRef := t.PackageRef()
 	p := LookupPackage(pkgRef)
 	if p != nil {
 		pkgRef = writeChildValueInternal(p.NomsValue(), cs)


### PR DESCRIPTION
Also, switch to using a ref.Ref when getting/setting the package
ref in a TypeRef. Using a types.Ref just led to lots of manual
boxing and unboxing every time I wanted to use the reference.

Toward issue #294
