### PR TITLE
Naive crime search against flat list.

### DIFF
--- a/clients/sfcrime_search/sfcrime_search.go
+++ b/clients/sfcrime_search/sfcrime_search.go
@@ -17,12 +17,13 @@ import (
 )
 
 var (
-	datasFlags      = datas.NewFlags()
-	quadTreeRefFlag = flag.String("quadtree-ref", "", "ref containing root of quadtree")
-	latFlag         = flag.Float64("lat", 0.0, "latitude of point to search for crime instances")
-	lonFlag         = flag.Float64("lon", 0.0, "longitude of point to search for crime instances")
-	distanceFlag    = flag.Float64("distance", 0.5, "distince in kilometers from point to search for crime instances")
-	sqtRoot         SQuadTree
+	datasFlags          = datas.NewFlags()
+	quadTreeRefFlag     = flag.String("quadtree-ref", "", "ref to root of quadtree")
+	incidentListRefFlag = flag.String("incident-list-ref", "", "ref to list of incidents")
+	latFlag             = flag.Float64("lat", 0.0, "latitude of point to search for crime instances")
+	lonFlag             = flag.Float64("lon", 0.0, "longitude of point to search for crime instances")
+	distanceFlag        = flag.Float64("distance", 0.5, "distince in kilometers from point to search for crime instances")
+	sqtRoot             SQuadTree
 )
 
 const (
@@ -42,21 +43,11 @@ func main() {
 	start := time.Now()
 
 	datastore, ok := datasFlags.CreateDataStore()
-	if !ok || *quadTreeRefFlag == "" {
+	if !ok {
 		flag.Usage()
 		return
 	}
 	defer datastore.Close()
-
-	var qtRef ref.Ref
-	err := d.Try(func() {
-		qtRef = ref.Parse(*quadTreeRefFlag)
-	})
-	if err != nil {
-		log.Fatalf("Invalid quadtree-ref: %v", *quadTreeRefFlag)
-	}
-	qtVal := types.ReadValue(qtRef, datastore)
-	sqtRoot = SQuadTreeFromVal(qtVal)
 
 	if *latFlag == 0.0 || *lonFlag == 0.0 {
 		flag.Usage()
@@ -64,22 +55,93 @@ func main() {
 	}
 
 	gp := GeopositionDef{float32(*latFlag), float32(*lonFlag)}
-	if !sqtRoot.Georectangle().Def().ContainsPoint(gp) {
-		fmt.Printf("lat/lon: %+v is not within sf area: %+v\n", gp, sqtRoot.Georectangle().Def())
+	var incidents []Incident
+	if *quadTreeRefFlag != "" {
+		incidents = searchWithQuadTree(gp, datastore)
+	} else if *incidentListRefFlag != "" {
+		incidents = searchWithList(gp, datastore)
+	} else {
+		fmt.Println("You must supply either the 'quadtree-ref' or the 'incident-list-ref' argumements")
+		flag.Usage()
 		return
 	}
 
-	gr, incidents := sqtRoot.Query(gp, *distanceFlag)
-	fmt.Printf("bounding Rectangle: %+v, numIncidents: %d\n", gr, len(incidents))
 	var resDefs []IncidentDef
 	for _, incident := range incidents {
 		resDefs = append(resDefs, incident.Def())
 	}
 	sort.Sort(sort.Reverse(ByDate(resDefs)))
+
 	for _, n := range resDefs {
 		fmt.Printf("Incident, date: %s, category: %s, desc: %s, address: %s\n", n.Date, n.Category, n.Description, n.Address)
 	}
 	fmt.Printf("Done, elapsed time: %.2f secs\n", time.Now().Sub(start).Seconds())
+}
+
+func searchWithQuadTree(gp GeopositionDef, ds datas.DataStore) []Incident {
+	argName := "quadtree-ref"
+	expectedClass := "SQuadTree"
+	val := readRefValue(*quadTreeRefFlag, argName, ds)
+	m, ok := val.(types.Map)
+	if !ok {
+		log.Fatalf("Value for %s argument can not be converted to an object of type: %s\n", argName, expectedClass)
+	}
+	if !m.Get(types.NewString("$name")).Equals(types.NewString(expectedClass)) {
+		fmt.Println(m.Get(types.NewString("$name")), "!=", types.NewString(expectedClass))
+		log.Fatalf("Value found for quad-tree-ref argument has type: %+v", m.Get(types.NewString("$name")))
+	}
+	sqtRoot = SQuadTreeFromVal(val)
+	if !sqtRoot.Georectangle().Def().ContainsPoint(gp) {
+		log.Fatalf("lat/lon: %+v is not within sf area: %+v\n", gp, sqtRoot.Georectangle().Def())
+	}
+	gr, results := sqtRoot.Query(gp, *distanceFlag)
+	fmt.Printf("bounding Rectangle: %+v, numIncidents: %d\n", gr, len(results))
+	return results
+}
+
+func searchWithList(gp GeopositionDef, ds datas.DataStore) []Incident {
+	argName := "incident-list-ref"
+	expectedClass := "Incident"
+	val := readRefValue(*incidentListRefFlag, argName, ds)
+	l, ok := val.(types.List)
+	if !ok {
+		log.Fatalf("Value for %s argument is not a list object\n", argName)
+	}
+	if l.Len() == 0 {
+		log.Fatalf("Value for %s argument is an empty list\n", argName)
+	}
+	elem := l.Get(0)
+	m, ok := elem.(types.Map)
+	if !ok {
+		log.Fatalf("Value for %s argument is not an object of type: %s", argName, expectedClass)
+	}
+	if !m.Get(types.NewString("$name")).Equals(types.NewString(expectedClass)) {
+		log.Fatalf("Found object of type: %v in list supplied by %s argument", m.Get(types.NewString("$name")), argName)
+	}
+	results := []Incident{}
+	incidentList := ListOfIncidentFromVal(val)
+	for i := uint64(0); i < incidentList.Len(); i++ {
+		incident := incidentList.Get(i)
+		if incident.Geoposition().Def().DistanceTo(gp) <= float32(*distanceFlag) {
+			results = append(results, incident)
+		}
+	}
+	return results
+}
+
+func readRefValue(rs string, argName string, ds datas.DataStore) types.Value {
+	var r ref.Ref
+	err := d.Try(func() {
+		r = ref.Parse(rs)
+	})
+	if err != nil {
+		log.Fatalf("Invalid ref for %s arg: %v", argName, *quadTreeRefFlag)
+	}
+	val := types.ReadValue(r, ds)
+	if val == nil {
+		log.Fatalf("Unable to read %s: %s from datastore\n", argName, rs)
+	}
+	return val
 }
 
 type ByDate []IncidentDef

--- a/clients/sfcrime_search/types.go
+++ b/clients/sfcrime_search/types.go
@@ -25,6 +25,246 @@ func __mainPackageInFile_types_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// ListOfIncident
+
+type ListOfIncident struct {
+	l types.List
+}
+
+func NewListOfIncident() ListOfIncident {
+	return ListOfIncident{types.NewList()}
+}
+
+type ListOfIncidentDef []IncidentDef
+
+func (def ListOfIncidentDef) New() ListOfIncident {
+	l := make([]types.Value, len(def))
+	for i, d := range def {
+		l[i] = d.New().NomsValue()
+	}
+	return ListOfIncident{types.NewList(l...)}
+}
+
+func (l ListOfIncident) Def() ListOfIncidentDef {
+	d := make([]IncidentDef, l.Len())
+	for i := uint64(0); i < l.Len(); i++ {
+		d[i] = IncidentFromVal(l.l.Get(i)).Def()
+	}
+	return d
+}
+
+func ListOfIncidentFromVal(val types.Value) ListOfIncident {
+	// TODO: Validate here
+	return ListOfIncident{val.(types.List)}
+}
+
+func (l ListOfIncident) NomsValue() types.Value {
+	return l.l
+}
+
+func (l ListOfIncident) Equals(p ListOfIncident) bool {
+	return l.l.Equals(p.l)
+}
+
+func (l ListOfIncident) Ref() ref.Ref {
+	return l.l.Ref()
+}
+
+func (l ListOfIncident) Len() uint64 {
+	return l.l.Len()
+}
+
+func (l ListOfIncident) Empty() bool {
+	return l.Len() == uint64(0)
+}
+
+func (l ListOfIncident) Get(i uint64) Incident {
+	return IncidentFromVal(l.l.Get(i))
+}
+
+func (l ListOfIncident) Slice(idx uint64, end uint64) ListOfIncident {
+	return ListOfIncident{l.l.Slice(idx, end)}
+}
+
+func (l ListOfIncident) Set(i uint64, val Incident) ListOfIncident {
+	return ListOfIncident{l.l.Set(i, val.NomsValue())}
+}
+
+func (l ListOfIncident) Append(v ...Incident) ListOfIncident {
+	return ListOfIncident{l.l.Append(l.fromElemSlice(v)...)}
+}
+
+func (l ListOfIncident) Insert(idx uint64, v ...Incident) ListOfIncident {
+	return ListOfIncident{l.l.Insert(idx, l.fromElemSlice(v)...)}
+}
+
+func (l ListOfIncident) Remove(idx uint64, end uint64) ListOfIncident {
+	return ListOfIncident{l.l.Remove(idx, end)}
+}
+
+func (l ListOfIncident) RemoveAt(idx uint64) ListOfIncident {
+	return ListOfIncident{(l.l.RemoveAt(idx))}
+}
+
+func (l ListOfIncident) fromElemSlice(p []Incident) []types.Value {
+	r := make([]types.Value, len(p))
+	for i, v := range p {
+		r[i] = v.NomsValue()
+	}
+	return r
+}
+
+type ListOfIncidentIterCallback func(v Incident) (stop bool)
+
+func (l ListOfIncident) Iter(cb ListOfIncidentIterCallback) {
+	l.l.Iter(func(v types.Value) bool {
+		return cb(IncidentFromVal(v))
+	})
+}
+
+type ListOfIncidentIterAllCallback func(v Incident)
+
+func (l ListOfIncident) IterAll(cb ListOfIncidentIterAllCallback) {
+	l.l.IterAll(func(v types.Value) {
+		cb(IncidentFromVal(v))
+	})
+}
+
+type ListOfIncidentFilterCallback func(v Incident) (keep bool)
+
+func (l ListOfIncident) Filter(cb ListOfIncidentFilterCallback) ListOfIncident {
+	nl := NewListOfIncident()
+	l.IterAll(func(v Incident) {
+		if cb(v) {
+			nl = nl.Append(v)
+		}
+	})
+	return nl
+}
+
+// Incident
+
+type Incident struct {
+	m types.Map
+}
+
+func NewIncident() Incident {
+	return Incident{types.NewMap(
+		types.NewString("$name"), types.NewString("Incident"),
+		types.NewString("$type"), types.MakeTypeRef("Incident", __mainPackageInFile_types_CachedRef),
+		types.NewString("Category"), types.NewString(""),
+		types.NewString("Description"), types.NewString(""),
+		types.NewString("Address"), types.NewString(""),
+		types.NewString("Date"), types.NewString(""),
+		types.NewString("Geoposition"), NewGeoposition().NomsValue(),
+	)}
+}
+
+type IncidentDef struct {
+	Category    string
+	Description string
+	Address     string
+	Date        string
+	Geoposition GeopositionDef
+}
+
+func (def IncidentDef) New() Incident {
+	return Incident{
+		types.NewMap(
+			types.NewString("$name"), types.NewString("Incident"),
+			types.NewString("$type"), types.MakeTypeRef("Incident", __mainPackageInFile_types_CachedRef),
+			types.NewString("Category"), types.NewString(def.Category),
+			types.NewString("Description"), types.NewString(def.Description),
+			types.NewString("Address"), types.NewString(def.Address),
+			types.NewString("Date"), types.NewString(def.Date),
+			types.NewString("Geoposition"), def.Geoposition.New().NomsValue(),
+		)}
+}
+
+func (s Incident) Def() (d IncidentDef) {
+	d.Category = s.m.Get(types.NewString("Category")).(types.String).String()
+	d.Description = s.m.Get(types.NewString("Description")).(types.String).String()
+	d.Address = s.m.Get(types.NewString("Address")).(types.String).String()
+	d.Date = s.m.Get(types.NewString("Date")).(types.String).String()
+	d.Geoposition = GeopositionFromVal(s.m.Get(types.NewString("Geoposition"))).Def()
+	return
+}
+
+// Creates and returns a Noms Value that describes Incident.
+func __typeRefOfIncident() types.TypeRef {
+	return types.MakeStructTypeRef("Incident",
+		[]types.Field{
+			types.Field{"Category", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Description", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Address", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Date", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Geoposition", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
+		},
+		types.Choices{},
+	)
+}
+
+func IncidentFromVal(val types.Value) Incident {
+	// TODO: Validate here
+	return Incident{val.(types.Map)}
+}
+
+func (s Incident) NomsValue() types.Value {
+	return s.m
+}
+
+func (s Incident) Equals(other Incident) bool {
+	return s.m.Equals(other.m)
+}
+
+func (s Incident) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Incident) Type() types.TypeRef {
+	return s.m.Get(types.NewString("$type")).(types.TypeRef)
+}
+
+func (s Incident) Category() string {
+	return s.m.Get(types.NewString("Category")).(types.String).String()
+}
+
+func (s Incident) SetCategory(val string) Incident {
+	return Incident{s.m.Set(types.NewString("Category"), types.NewString(val))}
+}
+
+func (s Incident) Description() string {
+	return s.m.Get(types.NewString("Description")).(types.String).String()
+}
+
+func (s Incident) SetDescription(val string) Incident {
+	return Incident{s.m.Set(types.NewString("Description"), types.NewString(val))}
+}
+
+func (s Incident) Address() string {
+	return s.m.Get(types.NewString("Address")).(types.String).String()
+}
+
+func (s Incident) SetAddress(val string) Incident {
+	return Incident{s.m.Set(types.NewString("Address"), types.NewString(val))}
+}
+
+func (s Incident) Date() string {
+	return s.m.Get(types.NewString("Date")).(types.String).String()
+}
+
+func (s Incident) SetDate(val string) Incident {
+	return Incident{s.m.Set(types.NewString("Date"), types.NewString(val))}
+}
+
+func (s Incident) Geoposition() Geoposition {
+	return GeopositionFromVal(s.m.Get(types.NewString("Geoposition")))
+}
+
+func (s Incident) SetGeoposition(val Geoposition) Incident {
+	return Incident{s.m.Set(types.NewString("Geoposition"), val.NomsValue())}
+}
+
 // Geoposition
 
 type Geoposition struct {
@@ -193,129 +433,6 @@ func (s Georectangle) SetBottomRight(val Geoposition) Georectangle {
 	return Georectangle{s.m.Set(types.NewString("BottomRight"), val.NomsValue())}
 }
 
-// Incident
-
-type Incident struct {
-	m types.Map
-}
-
-func NewIncident() Incident {
-	return Incident{types.NewMap(
-		types.NewString("$name"), types.NewString("Incident"),
-		types.NewString("$type"), types.MakeTypeRef("Incident", __mainPackageInFile_types_CachedRef),
-		types.NewString("Category"), types.NewString(""),
-		types.NewString("Description"), types.NewString(""),
-		types.NewString("Address"), types.NewString(""),
-		types.NewString("Date"), types.NewString(""),
-		types.NewString("Geoposition"), NewGeoposition().NomsValue(),
-	)}
-}
-
-type IncidentDef struct {
-	Category    string
-	Description string
-	Address     string
-	Date        string
-	Geoposition GeopositionDef
-}
-
-func (def IncidentDef) New() Incident {
-	return Incident{
-		types.NewMap(
-			types.NewString("$name"), types.NewString("Incident"),
-			types.NewString("$type"), types.MakeTypeRef("Incident", __mainPackageInFile_types_CachedRef),
-			types.NewString("Category"), types.NewString(def.Category),
-			types.NewString("Description"), types.NewString(def.Description),
-			types.NewString("Address"), types.NewString(def.Address),
-			types.NewString("Date"), types.NewString(def.Date),
-			types.NewString("Geoposition"), def.Geoposition.New().NomsValue(),
-		)}
-}
-
-func (s Incident) Def() (d IncidentDef) {
-	d.Category = s.m.Get(types.NewString("Category")).(types.String).String()
-	d.Description = s.m.Get(types.NewString("Description")).(types.String).String()
-	d.Address = s.m.Get(types.NewString("Address")).(types.String).String()
-	d.Date = s.m.Get(types.NewString("Date")).(types.String).String()
-	d.Geoposition = GeopositionFromVal(s.m.Get(types.NewString("Geoposition"))).Def()
-	return
-}
-
-// Creates and returns a Noms Value that describes Incident.
-func __typeRefOfIncident() types.TypeRef {
-	return types.MakeStructTypeRef("Incident",
-		[]types.Field{
-			types.Field{"Category", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Description", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Address", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Date", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef("Geoposition", ref.Ref{}), false},
-		},
-		types.Choices{},
-	)
-}
-
-func IncidentFromVal(val types.Value) Incident {
-	// TODO: Validate here
-	return Incident{val.(types.Map)}
-}
-
-func (s Incident) NomsValue() types.Value {
-	return s.m
-}
-
-func (s Incident) Equals(other Incident) bool {
-	return s.m.Equals(other.m)
-}
-
-func (s Incident) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s Incident) Type() types.TypeRef {
-	return s.m.Get(types.NewString("$type")).(types.TypeRef)
-}
-
-func (s Incident) Category() string {
-	return s.m.Get(types.NewString("Category")).(types.String).String()
-}
-
-func (s Incident) SetCategory(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Category"), types.NewString(val))}
-}
-
-func (s Incident) Description() string {
-	return s.m.Get(types.NewString("Description")).(types.String).String()
-}
-
-func (s Incident) SetDescription(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Description"), types.NewString(val))}
-}
-
-func (s Incident) Address() string {
-	return s.m.Get(types.NewString("Address")).(types.String).String()
-}
-
-func (s Incident) SetAddress(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Address"), types.NewString(val))}
-}
-
-func (s Incident) Date() string {
-	return s.m.Get(types.NewString("Date")).(types.String).String()
-}
-
-func (s Incident) SetDate(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Date"), types.NewString(val))}
-}
-
-func (s Incident) Geoposition() Geoposition {
-	return GeopositionFromVal(s.m.Get(types.NewString("Geoposition")))
-}
-
-func (s Incident) SetGeoposition(val Geoposition) Incident {
-	return Incident{s.m.Set(types.NewString("Geoposition"), val.NomsValue())}
-}
-
 // SQuadTree
 
 type SQuadTree struct {
@@ -450,123 +567,6 @@ func (s SQuadTree) Georectangle() Georectangle {
 
 func (s SQuadTree) SetGeorectangle(val Georectangle) SQuadTree {
 	return SQuadTree{s.m.Set(types.NewString("Georectangle"), val.NomsValue())}
-}
-
-// ListOfIncident
-
-type ListOfIncident struct {
-	l types.List
-}
-
-func NewListOfIncident() ListOfIncident {
-	return ListOfIncident{types.NewList()}
-}
-
-type ListOfIncidentDef []IncidentDef
-
-func (def ListOfIncidentDef) New() ListOfIncident {
-	l := make([]types.Value, len(def))
-	for i, d := range def {
-		l[i] = d.New().NomsValue()
-	}
-	return ListOfIncident{types.NewList(l...)}
-}
-
-func (l ListOfIncident) Def() ListOfIncidentDef {
-	d := make([]IncidentDef, l.Len())
-	for i := uint64(0); i < l.Len(); i++ {
-		d[i] = IncidentFromVal(l.l.Get(i)).Def()
-	}
-	return d
-}
-
-func ListOfIncidentFromVal(val types.Value) ListOfIncident {
-	// TODO: Validate here
-	return ListOfIncident{val.(types.List)}
-}
-
-func (l ListOfIncident) NomsValue() types.Value {
-	return l.l
-}
-
-func (l ListOfIncident) Equals(p ListOfIncident) bool {
-	return l.l.Equals(p.l)
-}
-
-func (l ListOfIncident) Ref() ref.Ref {
-	return l.l.Ref()
-}
-
-func (l ListOfIncident) Len() uint64 {
-	return l.l.Len()
-}
-
-func (l ListOfIncident) Empty() bool {
-	return l.Len() == uint64(0)
-}
-
-func (l ListOfIncident) Get(i uint64) Incident {
-	return IncidentFromVal(l.l.Get(i))
-}
-
-func (l ListOfIncident) Slice(idx uint64, end uint64) ListOfIncident {
-	return ListOfIncident{l.l.Slice(idx, end)}
-}
-
-func (l ListOfIncident) Set(i uint64, val Incident) ListOfIncident {
-	return ListOfIncident{l.l.Set(i, val.NomsValue())}
-}
-
-func (l ListOfIncident) Append(v ...Incident) ListOfIncident {
-	return ListOfIncident{l.l.Append(l.fromElemSlice(v)...)}
-}
-
-func (l ListOfIncident) Insert(idx uint64, v ...Incident) ListOfIncident {
-	return ListOfIncident{l.l.Insert(idx, l.fromElemSlice(v)...)}
-}
-
-func (l ListOfIncident) Remove(idx uint64, end uint64) ListOfIncident {
-	return ListOfIncident{l.l.Remove(idx, end)}
-}
-
-func (l ListOfIncident) RemoveAt(idx uint64) ListOfIncident {
-	return ListOfIncident{(l.l.RemoveAt(idx))}
-}
-
-func (l ListOfIncident) fromElemSlice(p []Incident) []types.Value {
-	r := make([]types.Value, len(p))
-	for i, v := range p {
-		r[i] = v.NomsValue()
-	}
-	return r
-}
-
-type ListOfIncidentIterCallback func(v Incident) (stop bool)
-
-func (l ListOfIncident) Iter(cb ListOfIncidentIterCallback) {
-	l.l.Iter(func(v types.Value) bool {
-		return cb(IncidentFromVal(v))
-	})
-}
-
-type ListOfIncidentIterAllCallback func(v Incident)
-
-func (l ListOfIncident) IterAll(cb ListOfIncidentIterAllCallback) {
-	l.l.IterAll(func(v types.Value) {
-		cb(IncidentFromVal(v))
-	})
-}
-
-type ListOfIncidentFilterCallback func(v Incident) (keep bool)
-
-func (l ListOfIncident) Filter(cb ListOfIncidentFilterCallback) ListOfIncident {
-	nl := NewListOfIncident()
-	l.IterAll(func(v Incident) {
-		if cb(v) {
-			nl = nl.Append(v)
-		}
-	})
-	return nl
 }
 
 // MapOfStringToSQuadTree

--- a/clients/sfcrime_search/types.noms
+++ b/clients/sfcrime_search/types.noms
@@ -24,3 +24,5 @@ struct SQuadTree {
 	Path: String
 	Georectangle: Georectangle
 }
+
+using List(Incident)


### PR DESCRIPTION
Add ability to search using the list of incident objects created by sfcrime_importer py passing in incidient-list-ref argument.
Also added better checks to ensure that a suitable ref was given as argument.

use -quadtree-ref for fast quadtree search
use -incident-list-ref for naive linear search
