### PR TITLE
Value should also have a TypeRef

### DIFF
--- a/types/blob.go
+++ b/types/blob.go
@@ -18,6 +18,8 @@ const (
 	blobWindowSize = 64
 )
 
+var typeRefForBlob = MakePrimitiveTypeRef(BlobKind)
+
 type Blob interface {
 	Value
 	Len() uint64

--- a/types/blob_leaf.go
+++ b/types/blob_leaf.go
@@ -36,6 +36,10 @@ func (bl blobLeaf) Chunks() []Future {
 	return nil
 }
 
+func (bl blobLeaf) TypeRef() TypeRef {
+	return typeRefForBlob
+}
+
 func (bl blobLeaf) Equals(other Value) bool {
 	if other, ok := other.(blobLeaf); ok {
 		return bl.Ref() == other.Ref()

--- a/types/blob_leaf_test.go
+++ b/types/blob_leaf_test.go
@@ -35,3 +35,9 @@ func TestBlobLeafChunks(t *testing.T) {
 	b = newBlobLeaf([]byte{0x01})
 	assert.Equal(0, len(b.Chunks()))
 }
+
+func TestBlobLeafTypeRef(t *testing.T) {
+	assert := assert.New(t)
+	b := newBlobLeaf([]byte{})
+	assert.True(b.TypeRef().Equals(MakePrimitiveTypeRef(BlobKind)))
+}

--- a/types/compound_blob.go
+++ b/types/compound_blob.go
@@ -117,3 +117,7 @@ func (cb compoundBlob) Equals(other Value) bool {
 	}
 	return false
 }
+
+func (cb compoundBlob) TypeRef() TypeRef {
+	return typeRefForBlob
+}

--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -336,3 +336,10 @@ func printBlob(b Blob, indent int) {
 		}
 	}
 }
+
+func TestCompoundBlobTypeRef(t *testing.T) {
+	assert := assert.New(t)
+
+	cb := getTestCompoundBlob("hello", "world")
+	assert.True(cb.TypeRef().Equals(MakePrimitiveTypeRef(BlobKind)))
+}

--- a/types/compound_list.go
+++ b/types/compound_list.go
@@ -315,6 +315,11 @@ func (cl compoundList) Equals(other Value) bool {
 	return false
 }
 
+func (cl compoundList) TypeRef() TypeRef {
+	// TODO: The element type needs to be configurable.
+	return MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+}
+
 // startsChunk determines if idx refers to the first element in one of cl's chunks.
 // If so, it also returns the index of the chunk into which idx points.
 func (cl compoundList) startsChunk(idx uint64) (bool, uint64) {

--- a/types/compound_list_test.go
+++ b/types/compound_list_test.go
@@ -222,3 +222,9 @@ func TestCompoundListRemove(t *testing.T) {
 	assert.True(UInt8(3).Equals(l4.Get(1)))
 	assert.True(UInt8(5).Equals(l4.Get(2)))
 }
+
+func TestCompoundListTypeRef(t *testing.T) {
+	assert := assert.New(t)
+	cl := getFakeCompoundList("hi", "bye")
+	assert.True(cl.TypeRef().Equals(MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))))
+}

--- a/types/gen/primitive.tmpl
+++ b/types/gen/primitive.tmpl
@@ -22,3 +22,10 @@ func {{.NomsType}}FromVal(v Value) {{.NomsType}} {
 func (v {{.NomsType}}) ToPrimitive() interface{} {
 	return {{.GoType}}(v)
 }
+
+var typeRefFor{{.NomsType}} = MakePrimitiveTypeRef({{.NomsType}}Kind)
+
+func (v {{.NomsType}}) TypeRef() TypeRef {
+	return typeRefFor{{.NomsType}}
+}
+

--- a/types/list.go
+++ b/types/list.go
@@ -25,6 +25,7 @@ type List interface {
 	Release()
 	Equals(other Value) bool
 	Chunks() (futures []Future)
+	TypeRef() TypeRef
 	Iter(f listIterFunc)
 	IterAll(f listIterAllFunc)
 	Map(mf MapFunc) []interface{}

--- a/types/list_leaf.go
+++ b/types/list_leaf.go
@@ -160,3 +160,8 @@ func (l listLeaf) Chunks() (futures []Future) {
 	}
 	return
 }
+
+func (cl listLeaf) TypeRef() TypeRef {
+	// TODO: The element type needs to be configurable.
+	return MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+}

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -289,3 +289,9 @@ func TestListIterAll(t *testing.T) {
 	})
 	assert.Equal([]string{"a", "b", "c", "d", "e", "f"}, acc2)
 }
+
+func TestListTypeRef(t *testing.T) {
+	assert := assert.New(t)
+	l := NewList(Int32(0))
+	assert.True(l.TypeRef().Equals(MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))))
+}

--- a/types/map.go
+++ b/types/map.go
@@ -150,6 +150,11 @@ func (fm Map) Chunks() (futures []Future) {
 	return
 }
 
+func (fm Map) TypeRef() TypeRef {
+	// TODO: The key and value type needs to be configurable.
+	return MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(ValueKind), MakePrimitiveTypeRef(ValueKind))
+}
+
 type mapEntry struct {
 	key   Future
 	value Future

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -215,3 +215,9 @@ func TestMapFutures(t *testing.T) {
 	assert.Len(m.Chunks(), 1)
 	assert.EqualValues(kRef, m.Chunks()[0].Ref())
 }
+
+func TestMapTypeRef(t *testing.T) {
+	assert := assert.New(t)
+	m := NewMap()
+	assert.True(m.TypeRef().Equals(MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(ValueKind), MakePrimitiveTypeRef(ValueKind))))
+}

--- a/types/primitives.go
+++ b/types/primitives.go
@@ -31,6 +31,13 @@ func BoolFromVal(v Value) Bool {
 func (v Bool) ToPrimitive() interface{} {
 	return bool(v)
 }
+
+var typeRefForBool = MakePrimitiveTypeRef(BoolKind)
+
+func (v Bool) TypeRef() TypeRef {
+	return typeRefForBool
+}
+
 type Int8 int8
 
 func (p Int8) Equals(other Value) bool {
@@ -55,6 +62,13 @@ func Int8FromVal(v Value) Int8 {
 func (v Int8) ToPrimitive() interface{} {
 	return int8(v)
 }
+
+var typeRefForInt8 = MakePrimitiveTypeRef(Int8Kind)
+
+func (v Int8) TypeRef() TypeRef {
+	return typeRefForInt8
+}
+
 type Int16 int16
 
 func (p Int16) Equals(other Value) bool {
@@ -79,6 +93,13 @@ func Int16FromVal(v Value) Int16 {
 func (v Int16) ToPrimitive() interface{} {
 	return int16(v)
 }
+
+var typeRefForInt16 = MakePrimitiveTypeRef(Int16Kind)
+
+func (v Int16) TypeRef() TypeRef {
+	return typeRefForInt16
+}
+
 type Int32 int32
 
 func (p Int32) Equals(other Value) bool {
@@ -103,6 +124,13 @@ func Int32FromVal(v Value) Int32 {
 func (v Int32) ToPrimitive() interface{} {
 	return int32(v)
 }
+
+var typeRefForInt32 = MakePrimitiveTypeRef(Int32Kind)
+
+func (v Int32) TypeRef() TypeRef {
+	return typeRefForInt32
+}
+
 type Int64 int64
 
 func (p Int64) Equals(other Value) bool {
@@ -127,6 +155,13 @@ func Int64FromVal(v Value) Int64 {
 func (v Int64) ToPrimitive() interface{} {
 	return int64(v)
 }
+
+var typeRefForInt64 = MakePrimitiveTypeRef(Int64Kind)
+
+func (v Int64) TypeRef() TypeRef {
+	return typeRefForInt64
+}
+
 type UInt8 uint8
 
 func (p UInt8) Equals(other Value) bool {
@@ -151,6 +186,13 @@ func UInt8FromVal(v Value) UInt8 {
 func (v UInt8) ToPrimitive() interface{} {
 	return uint8(v)
 }
+
+var typeRefForUInt8 = MakePrimitiveTypeRef(UInt8Kind)
+
+func (v UInt8) TypeRef() TypeRef {
+	return typeRefForUInt8
+}
+
 type UInt16 uint16
 
 func (p UInt16) Equals(other Value) bool {
@@ -175,6 +217,13 @@ func UInt16FromVal(v Value) UInt16 {
 func (v UInt16) ToPrimitive() interface{} {
 	return uint16(v)
 }
+
+var typeRefForUInt16 = MakePrimitiveTypeRef(UInt16Kind)
+
+func (v UInt16) TypeRef() TypeRef {
+	return typeRefForUInt16
+}
+
 type UInt32 uint32
 
 func (p UInt32) Equals(other Value) bool {
@@ -199,6 +248,13 @@ func UInt32FromVal(v Value) UInt32 {
 func (v UInt32) ToPrimitive() interface{} {
 	return uint32(v)
 }
+
+var typeRefForUInt32 = MakePrimitiveTypeRef(UInt32Kind)
+
+func (v UInt32) TypeRef() TypeRef {
+	return typeRefForUInt32
+}
+
 type UInt64 uint64
 
 func (p UInt64) Equals(other Value) bool {
@@ -223,6 +279,13 @@ func UInt64FromVal(v Value) UInt64 {
 func (v UInt64) ToPrimitive() interface{} {
 	return uint64(v)
 }
+
+var typeRefForUInt64 = MakePrimitiveTypeRef(UInt64Kind)
+
+func (v UInt64) TypeRef() TypeRef {
+	return typeRefForUInt64
+}
+
 type Float32 float32
 
 func (p Float32) Equals(other Value) bool {
@@ -247,6 +310,13 @@ func Float32FromVal(v Value) Float32 {
 func (v Float32) ToPrimitive() interface{} {
 	return float32(v)
 }
+
+var typeRefForFloat32 = MakePrimitiveTypeRef(Float32Kind)
+
+func (v Float32) TypeRef() TypeRef {
+	return typeRefForFloat32
+}
+
 type Float64 float64
 
 func (p Float64) Equals(other Value) bool {
@@ -271,3 +341,10 @@ func Float64FromVal(v Value) Float64 {
 func (v Float64) ToPrimitive() interface{} {
 	return float64(v)
 }
+
+var typeRefForFloat64 = MakePrimitiveTypeRef(Float64Kind)
+
+func (v Float64) TypeRef() TypeRef {
+	return typeRefForFloat64
+}
+

--- a/types/primitives_test.go
+++ b/types/primitives_test.go
@@ -29,3 +29,26 @@ func TestPrimitives(t *testing.T) {
 		}
 	}
 }
+
+func TestPrimitivesTypeRef(t *testing.T) {
+	data := []struct {
+		v Value
+		k NomsKind
+	}{
+		{Bool(false), BoolKind},
+		{Int8(0), Int8Kind},
+		{Int16(0), Int16Kind},
+		{Int32(0), Int32Kind},
+		{Int64(0), Int64Kind},
+		{Float32(0), Float32Kind},
+		{Float64(0), Float64Kind},
+		{UInt8(0), UInt8Kind},
+		{UInt16(0), UInt16Kind},
+		{UInt32(0), UInt32Kind},
+		{UInt64(0), UInt64Kind},
+	}
+
+	for _, d := range data {
+		assert.True(t, d.v.TypeRef().Equals(MakePrimitiveTypeRef(d.k)))
+	}
+}

--- a/types/ref.go
+++ b/types/ref.go
@@ -22,3 +22,8 @@ func (r Ref) Ref() ref.Ref {
 func (r Ref) Chunks() []Future {
 	return nil
 }
+
+func (r Ref) TypeRef() TypeRef {
+	// TODO: The element type needs to be configurable.
+	return MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(ValueKind))
+}

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -36,3 +36,10 @@ func TestRefInMap(t *testing.T) {
 	i := m.Get(r)
 	assert.Equal(int32(1), int32(i.(Int32)))
 }
+
+func TestRefTypeRef(t *testing.T) {
+	assert := assert.New(t)
+	l := NewList()
+	r := Ref{R: l.Ref()}
+	assert.True(r.TypeRef().Equals(MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(ValueKind))))
+}

--- a/types/set.go
+++ b/types/set.go
@@ -140,6 +140,11 @@ func (fs Set) Chunks() (futures []Future) {
 	return
 }
 
+func (fs Set) TypeRef() TypeRef {
+	// TODO: The element type needs to be configurable.
+	return MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(ValueKind))
+}
+
 func newSetFromData(m setData, cs chunks.ChunkSource) Set {
 	return Set{m, cs, &ref.Ref{}}
 }

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -184,3 +184,9 @@ func TestSetFilter(t *testing.T) {
 
 	assert.True(NewSet(Int32(0), Int32(2), Int32(4)).Equals(s2))
 }
+
+func TestSetTypeRef(t *testing.T) {
+	assert := assert.New(t)
+	s := NewSet()
+	assert.True(s.TypeRef().Equals(MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(ValueKind))))
+}

--- a/types/string.go
+++ b/types/string.go
@@ -38,6 +38,12 @@ func (fs String) Chunks() []Future {
 	return nil
 }
 
+var typeRefForString = MakePrimitiveTypeRef(StringKind)
+
+func (fs String) TypeRef() TypeRef {
+	return typeRefForString
+}
+
 func StringFromVal(v Value) String {
 	return v.(String)
 }

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -27,3 +27,7 @@ func TestStringString(t *testing.T) {
 	assert.Equal("", s1.String())
 	assert.Equal("foo", s2.String())
 }
+
+func TestStringTypeRef(t *testing.T) {
+	assert.True(t, NewString("hi").TypeRef().Equals(MakePrimitiveTypeRef(StringKind)))
+}

--- a/types/type_ref.go
+++ b/types/type_ref.go
@@ -100,6 +100,12 @@ func (t TypeRef) Chunks() (out []Future) {
 	return
 }
 
+var typeRefForTypeRef = MakePrimitiveTypeRef(TypeRefKind)
+
+func (t TypeRef) TypeRef() TypeRef {
+	return typeRefForTypeRef
+}
+
 func MakePrimitiveTypeRef(k NomsKind) TypeRef {
 	return buildType("", PrimitiveDesc(k))
 }

--- a/types/type_ref_test.go
+++ b/types/type_ref_test.go
@@ -51,3 +51,7 @@ func TestTypeWithPkgRef(t *testing.T) {
 	assert.EqualValues(pkgRef, ReadValue(unresolvedRef, cs).Chunks()[0].Ref())
 	assert.NotNil(ReadValue(pkgRef, cs))
 }
+
+func TestTypeRefTypeRef(t *testing.T) {
+	assert.True(t, MakePrimitiveTypeRef(BoolKind).TypeRef().Equals(MakePrimitiveTypeRef(TypeRefKind)))
+}

--- a/types/value.go
+++ b/types/value.go
@@ -9,4 +9,5 @@ type Value interface {
 	Equals(other Value) bool
 	Ref() ref.Ref
 	Chunks() []Future
+	TypeRef() TypeRef
 }


### PR DESCRIPTION
This is so that we can get the runtime type of a value
