### PR TITLE
Fix concurrency overwrite on dataset.

### DIFF
--- a/datas/datastore_common.go
+++ b/datas/datastore_common.go
@@ -47,10 +47,16 @@ func (ds *dataStoreCommon) doCommit(commit Commit) bool {
 	currentRootRef := ds.Root()
 
 	// Note: |currentHead| may be different from ds.head and *must* be consistent with currentRootRef.
-	// If ds.head is nil, then any commit is allowed.
+	// If currentRoot or currentHead is nil, then any commit is allowed.
+	emptyRef := ref.Ref{}
+	dsHeadRef := emptyRef
 	if ds.head != nil {
-		var currentHead Commit
-		if currentRootRef == ds.head.Ref() {
+		dsHeadRef = ds.head.Ref()
+	}
+
+	var currentHead Commit
+	if currentRootRef != emptyRef {
+		if currentRootRef == dsHeadRef {
 			currentHead = *ds.head
 		} else {
 			currentHead = *commitFromRef(currentRootRef, ds)

--- a/datas/datastore_common.go
+++ b/datas/datastore_common.go
@@ -46,17 +46,11 @@ func (ds *dataStoreCommon) commitWithParents(v types.Value, p SetOfCommit) bool 
 func (ds *dataStoreCommon) doCommit(commit Commit) bool {
 	currentRootRef := ds.Root()
 
-	// Note: |currentHead| may be different from ds.head and *must* be consistent with currentRootRef.
-	// If currentRoot or currentHead is nil, then any commit is allowed.
-	emptyRef := ref.Ref{}
-	dsHeadRef := emptyRef
-	if ds.head != nil {
-		dsHeadRef = ds.head.Ref()
-	}
-
-	var currentHead Commit
-	if currentRootRef != emptyRef {
-		if currentRootRef == dsHeadRef {
+    // First commit is always fast-foward.
+    if currentRootRef != ref.EmptyRef {
+        // Note: |currentHead| may be different from ds.head and *must* be consistent with currentRootRef.
+        var currentHead Commit
+        if ds.head != nil && currentRootRef == ds.head.Ref() {
 			currentHead = *ds.head
 		} else {
 			currentHead = *commitFromRef(currentRootRef, ds)

--- a/ref/ref.go
+++ b/ref/ref.go
@@ -14,7 +14,8 @@ import (
 
 var (
 	// In the future we will allow different digest types, so this will get more complicated. For now sha1 is fine.
-	pattern = regexp.MustCompile("^sha1-([0-9a-f]{40})$")
+	pattern  = regexp.MustCompile("^sha1-([0-9a-f]{40})$")
+	EmptyRef = Ref{}
 )
 
 type Sha1Digest [sha1.Size]byte


### PR DESCRIPTION
When there are two dataset clients working on the same empty dataset. The second one to commit would override the first.
