### PR TITLE
Update README.md with accurate Run instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ go test ./...
 ```
 cd <noms>/clients/counter
 go build
-./counter -fs="/tmp/foo" -ds="foo"
-./counter -fs="/tmp/foo" -ds="foo"
-./counter -fs="/tmp/foo" -ds="foo"
+./counter -ldb=/tmp/foo -ds=foo
+./counter -ldb=/tmp/foo -ds=foo
+./counter -ldb=/tmp/foo -ds=foo
 ```
 
 rejoice!
@@ -45,7 +45,7 @@ You can see the raw data:
 
 ```
 ls /tmp/foo
-cat /tmp/foo/root
+cat /tmp/foo/*.log | strings
 ```
 
 You can also explore the data visually. Follow the instructions in `clients/explore`.


### PR DESCRIPTION
The -fs argument doesn't exist and the raw data isn't at /root.
Now it's -ldb and /*.log.
