### PR TITLE
Disable unmarshal test that depends on map iteration order

### DIFF
--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -236,11 +236,12 @@ var unmarshalTests = []unmarshalTest{
 			},
 		},
 	},
-	{
-		in:  types.NewMap(types.NewString("hello"), types.Int32(1)),
-		ptr: new(Ambig),
-		out: Ambig{First: 1},
-	},
+	// TODO: The ordering of the fields is based on the map iteration order. BUG 396
+	// {
+	// 	in:  types.NewMap(types.NewString("hello"), types.Int32(1)),
+	// 	ptr: new(Ambig),
+	// 	out: Ambig{First: 1},
+	// },
 
 	{
 		in:  types.NewMap(types.NewString("X"), types.Int32(1), types.NewString("Y"), types.Int32(2)),


### PR DESCRIPTION
Towards #396
