### PR TITLE
Support compounding types with imported types.

### DIFF
--- a/nomdl/codegen/code/generate.go
+++ b/nomdl/codegen/code/generate.go
@@ -1,0 +1,348 @@
+// Package code provides Generator, which has methods for generating code snippets from a types.TypeRef.
+// Conceptually there are few type spaces here:
+//
+// - Def - MyStructDef, ListOfBoolDef; convenient Go types for working with data from a given Noms Value.
+// - Native - such as string, uint32
+// - Value - the generic types.Value
+// - Nom - types.String, types.UInt32, MyStruct, ListOfBool
+// - User - User defined structs, enums etc as well as native primitves. This uses Native when possible or Nom if not. These are to be used in APIs for generated types -- Getters and setters for maps and structs, etc.
+package code
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/attic-labs/noms/d"
+	"github.com/attic-labs/noms/types"
+)
+
+// Resolver provides a single method for resolving an unresolved types.TypeRef.
+type Resolver interface {
+	Resolve(t types.TypeRef) types.TypeRef
+}
+
+// Generator provides methods for generating code snippets from both resolved and unresolved types.TypeRefs. In the latter case, it uses R to resolve the types.TypeRef before generating code.
+type Generator struct {
+	R Resolver
+}
+
+// DefType returns a string containing the Go type that should be used as the 'Def' for the Noms type described by t.
+func (gen Generator) DefType(t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind:
+		return "types.Blob"
+	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return strings.ToLower(kindToString(k))
+	case types.EnumKind:
+		return gen.UserName(t)
+	case types.ListKind, types.MapKind, types.SetKind, types.StructKind:
+		return gen.UserName(t) + "Def"
+	case types.RefKind:
+		return "ref.Ref"
+	case types.ValueKind:
+		return "types.Value"
+	case types.TypeRefKind:
+		return "types.TypeRef"
+	}
+	panic("unreachable")
+}
+
+// UserType returns a string containing the Go type that should be used when the Noms type described by t needs to be returned by a generated getter or taken as a parameter to a generated setter.
+func (gen Generator) UserType(t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind:
+		return "types.Blob"
+	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return strings.ToLower(kindToString(k))
+	case types.EnumKind, types.ListKind, types.MapKind, types.RefKind, types.SetKind, types.StructKind:
+		return gen.UserName(t)
+	case types.ValueKind:
+		return "types.Value"
+	case types.TypeRefKind:
+		return "types.TypeRef"
+	}
+	panic("unreachable")
+}
+
+// DefToValue returns a string containing Go code to convert an instance of a Def type (named val) to a Noms types.Value of the type described by t.
+func (gen Generator) DefToValue(val string, t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	switch t.Desc.Kind() {
+	case types.BlobKind, types.ValueKind, types.TypeRefKind:
+		return val // Blob & Value type has no Def
+	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return gen.NativeToValue(val, t)
+	case types.EnumKind:
+		return fmt.Sprintf("types.UInt32(%s)", val)
+	case types.ListKind, types.MapKind, types.SetKind, types.StructKind:
+		return fmt.Sprintf("%s.New().NomsValue()", val)
+	case types.RefKind:
+		return fmt.Sprintf("types.Ref{R: %s}", val)
+	}
+	panic("unreachable")
+}
+
+// ValueToDef returns a string containing Go code to convert an instance of a types.Value (val) into the Def type appropriate for t.
+func (gen Generator) ValueToDef(val string, t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	switch t.Desc.Kind() {
+	case types.BlobKind:
+		return gen.ValueToUser(val, t)
+	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return gen.ValueToNative(val, t)
+	case types.EnumKind:
+		return fmt.Sprintf("%s(%s.(types.UInt32))", gen.UserName(t), val)
+	case types.ListKind, types.MapKind, types.SetKind, types.StructKind:
+		return fmt.Sprintf("%s.Def()", gen.ValueToUser(val, t))
+	case types.RefKind:
+		return fmt.Sprintf("%s.Ref()", val)
+	case types.ValueKind:
+		return val // Value type has no Def
+	case types.TypeRefKind:
+		return gen.ValueToUser(val, t)
+	}
+	panic("unreachable")
+}
+
+// NativeToValue returns a string containing Go code to convert an instance of a native type (named val) to a Noms types.Value of the type described by t.
+func (gen Generator) NativeToValue(val string, t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return fmt.Sprintf("types.%s(%s)", kindToString(k), val)
+	case types.EnumKind:
+		return fmt.Sprintf("types.UInt32(%s)", val)
+	case types.StringKind:
+		return "types.NewString(" + val + ")"
+	}
+	panic("unreachable")
+}
+
+// ValueToNative returns a string containing Go code to convert an instance of a types.Value (val) into the native type appropriate for t.
+func (gen Generator) ValueToNative(val string, t types.TypeRef) string {
+	k := t.Desc.Kind()
+	switch k {
+	case types.EnumKind:
+		return fmt.Sprintf("%s(%s.(types.UInt32))", gen.UserType(t), val)
+	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		n := kindToString(k)
+		return fmt.Sprintf("%s(%s.(types.%s))", strings.ToLower(n), val, n)
+	case types.StringKind:
+		return val + ".(types.String).String()"
+	}
+	panic("unreachable")
+}
+
+// UserToValue returns a string containing Go code to convert an instance of a User type (named val) to a Noms types.Value of the type described by t. For Go primitive types, this will use NativeToValue(). For other types, their UserType is a Noms types.Value (or a wrapper around one), so this is more-or-less a pass-through.
+func (gen Generator) UserToValue(val string, t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind, types.ValueKind, types.TypeRefKind:
+		return val
+	case types.BoolKind, types.EnumKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return gen.NativeToValue(val, t)
+	case types.ListKind, types.MapKind, types.RefKind, types.SetKind, types.StructKind:
+		return fmt.Sprintf("%s.NomsValue()", val)
+	}
+	panic("unreachable")
+}
+
+// ValueToUser returns a string containing Go code to convert an instance of a types.Value (val) into the User type appropriate for t. For Go primitives, this will use ValueToNative().
+func (gen Generator) ValueToUser(val string, t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind:
+		return fmt.Sprintf("%s.(types.Blob)", val)
+	case types.BoolKind, types.EnumKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return gen.ValueToNative(val, t)
+	case types.ListKind, types.MapKind, types.RefKind, types.SetKind, types.StructKind:
+		return fmt.Sprintf("%sFromVal(%s)", gen.UserName(t), val)
+	case types.ValueKind:
+		return val
+	case types.TypeRefKind:
+		return fmt.Sprintf("%s.(types.TypeRef)", val)
+	}
+	panic("unreachable")
+}
+
+// UserZero returns a string containing Go code to create an uninitialized instance of the User type appropriate for t.
+func (gen Generator) UserZero(t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind:
+		return "types.NewEmptyBlob()"
+	case types.BoolKind:
+		return "false"
+	case types.EnumKind:
+		return fmt.Sprintf("%s(0)", gen.UserType(t))
+	case types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return fmt.Sprintf("%s(0)", strings.ToLower(kindToString(k)))
+	case types.ListKind, types.MapKind, types.SetKind:
+		return fmt.Sprintf("New%s()", gen.UserType(t))
+	case types.RefKind:
+		return fmt.Sprintf("%s{ref.Ref{}}", gen.UserType(t))
+	case types.StringKind:
+		return `""`
+	case types.StructKind:
+		return fmt.Sprintf("New%s()", gen.UserName(t))
+	case types.ValueKind:
+		// TODO: This is where a null Value would have been useful.
+		return "types.Bool(false)"
+	case types.TypeRefKind:
+		return "types.TypeRef{}"
+	}
+	panic("unreachable")
+}
+
+// ValueZero returns a string containing Go code to create an uninitialized instance of the Noms types.Value appropriate for t.
+func (gen Generator) ValueZero(t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind:
+		return "types.NewEmptyBlob()"
+	case types.BoolKind:
+		return "types.Bool(false)"
+	case types.EnumKind:
+		return "types.UInt32(0)"
+	case types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return fmt.Sprintf("types.%s(0)", kindToString(k))
+	case types.ListKind:
+		return "types.NewList()"
+	case types.MapKind:
+		return "types.NewMap()"
+	case types.RefKind:
+		return "types.Ref{R: ref.Ref{}}"
+	case types.SetKind:
+		return "types.NewSet()"
+	case types.StringKind:
+		return `types.NewString("")`
+	case types.StructKind:
+		components := gen.userNameComponents(t)
+		d.Chk.True(len(components) == 1 || len(components) == 2)
+		if len(components) == 2 {
+			return fmt.Sprintf("%s.New%s().NomsValue()", components[0], components[1])
+		}
+		return fmt.Sprintf("New%s().NomsValue()", components[0])
+	case types.ValueKind:
+		// TODO: This is where a null Value would have been useful.
+		return "types.Bool(false)"
+	case types.TypeRefKind:
+		return "types.TypeRef{}"
+	}
+	panic("unreachable")
+}
+
+// UserName returns the name of the User type appropriate for t, taking into account Noms types imported from other packages.
+func (gen Generator) UserName(t types.TypeRef) string {
+	t = gen.R.Resolve(t)
+	toID := func(t types.TypeRef) string {
+		return strings.Join(gen.userNameComponents(t), "_")
+	}
+	k := t.Desc.Kind()
+	switch k {
+	case types.BlobKind, types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind, types.ValueKind, types.TypeRefKind:
+		return kindToString(k)
+	case types.EnumKind:
+		if t.HasPackageRef() {
+			return ToTag(t.PackageRef().String()) + "." + t.Name()
+		}
+		return t.Name()
+	case types.ListKind:
+		return fmt.Sprintf("ListOf%s", toID(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+	case types.MapKind:
+		elemTypes := t.Desc.(types.CompoundDesc).ElemTypes
+		return fmt.Sprintf("MapOf%sTo%s", toID(elemTypes[0]), toID(elemTypes[1]))
+	case types.RefKind:
+		return fmt.Sprintf("RefOf%s", toID(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+	case types.SetKind:
+		return fmt.Sprintf("SetOf%s", toID(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+	case types.StructKind:
+		// We get an empty name when we have a struct that is used as union
+		if t.Name() == "" {
+			choices := t.Desc.(types.StructDesc).Union
+			s := "__unionOf"
+			for i, f := range choices {
+				if i > 0 {
+					s += "And"
+				}
+				s += strings.Title(f.Name) + "Of" + toID(f.T)
+			}
+			return s
+		}
+		if t.HasPackageRef() {
+			return ToTag(t.PackageRef().String()) + "." + t.Name()
+		}
+		return t.Name()
+	}
+	panic("unreachable")
+}
+
+func (gen Generator) userNameComponents(t types.TypeRef) []string {
+	userName := gen.UserName(t)
+	if period := strings.LastIndex(userName, "."); period != -1 {
+		return []string{userName[:period], userName[period+1:]}
+	}
+	return []string{userName}
+}
+
+// ToTypeRef returns a string containing Go code that instantiates a types.TypeRef instance equivalent to t.
+func (gen Generator) ToTypeRef(t types.TypeRef, fileID, packageName string) string {
+	if t.HasPackageRef() {
+		return fmt.Sprintf(`types.MakeTypeRef("%s", ref.Parse("%s"))`, t.Name(), t.PackageRef().String())
+	}
+	if t.IsUnresolved() && fileID != "" {
+		return fmt.Sprintf(`types.MakeTypeRef("%s", __%sPackageInFile_%s_CachedRef)`, t.Name(), packageName, fileID)
+	}
+	if t.IsUnresolved() {
+		return fmt.Sprintf(`types.MakeTypeRef("%s", ref.Ref{})`, t.Name())
+	}
+
+	if types.IsPrimitiveKind(t.Desc.Kind()) {
+		return fmt.Sprintf("types.MakePrimitiveTypeRef(types.%sKind)", kindToString(t.Desc.Kind()))
+	}
+	switch desc := t.Desc.(type) {
+	case types.CompoundDesc:
+		typerefs := make([]string, len(desc.ElemTypes))
+		for i, t := range desc.ElemTypes {
+			typerefs[i] = gen.ToTypeRef(t, fileID, packageName)
+		}
+		return fmt.Sprintf(`types.MakeCompoundTypeRef("%s", types.%sKind, %s)`, t.Name(), kindToString(t.Desc.Kind()), strings.Join(typerefs, ", "))
+	case types.EnumDesc:
+		return fmt.Sprintf(`types.MakeEnumTypeRef("%s", "%s")`, t.Name(), strings.Join(desc.IDs, `", "`))
+	case types.StructDesc:
+		flatten := func(f []types.Field) string {
+			out := make([]string, 0, len(f))
+			for _, field := range f {
+				out = append(out, fmt.Sprintf(`types.Field{"%s", %s, %t},`, field.Name, gen.ToTypeRef(field.T, fileID, packageName), field.Optional))
+			}
+			return strings.Join(out, "\n")
+		}
+		fields := fmt.Sprintf("[]types.Field{\n%s\n}", flatten(desc.Fields))
+		choices := fmt.Sprintf("types.Choices{\n%s\n}", flatten(desc.Union))
+		return fmt.Sprintf("types.MakeStructTypeRef(\"%s\",\n%s,\n%s,\n)", t.Name(), fields, choices)
+	default:
+		d.Chk.Fail("Unknown TypeDesc.", "%#v (%T)", desc, desc)
+	}
+	panic("Unreachable")
+}
+
+// ToTag replaces "-" characters in s with "_", so it can be used in a Go identifier.
+// TODO: replace other illegal chars as well?
+func ToTag(s string) string {
+	return strings.Replace(s, "-", "_", -1)
+}
+
+func kindToString(k types.NomsKind) (out string) {
+	out = types.KindToString[k]
+	d.Chk.NotEmpty(out, "Unknown NomsKind %d", k)
+	return
+}

--- a/nomdl/codegen/code/generate_test.go
+++ b/nomdl/codegen/code/generate_test.go
@@ -1,0 +1,52 @@
+package code
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/attic-labs/noms/ref"
+	"github.com/attic-labs/noms/types"
+)
+
+type testResolver struct {
+	assert *assert.Assertions
+	deps   map[ref.Ref]types.Package
+}
+
+func (res *testResolver) Resolve(t types.TypeRef) types.TypeRef {
+	if !t.IsUnresolved() {
+		return t
+	}
+
+	dep, ok := res.deps[t.PackageRef()]
+	res.assert.True(ok, "Package %s is referenced in %+v, but is not a dependency.", t.PackageRef().String(), t)
+	depTypes := dep.NamedTypes()
+	res.assert.True(depTypes.Has(t.Name()), "Cannot import type %s from package %s.", t.Name(), t.PackageRef().String())
+	return depTypes.Get(t.Name()).MakeImported(t.PackageRef())
+}
+
+func TestUserName(t *testing.T) {
+	assert := assert.New(t)
+
+	imported := types.PackageDef{
+		NamedTypes: types.MapOfStringToTypeRefDef{
+			"E1": types.MakeEnumTypeRef("E1", "a", "b"),
+			"S1": types.MakeStructTypeRef("S1", []types.Field{
+				types.Field{"f", types.MakePrimitiveTypeRef(types.BoolKind), false},
+			}, types.Choices{})},
+	}.New()
+
+	res := testResolver{assert, map[ref.Ref]types.Package{imported.Ref(): imported}}
+
+	localStructName := "Local"
+	resolved := types.MakeStructTypeRef(localStructName, []types.Field{
+		types.Field{"a", types.MakePrimitiveTypeRef(types.Int8Kind), false},
+	}, types.Choices{})
+
+	g := Generator{&res}
+	assert.Equal(localStructName, g.UserName(resolved))
+
+	listOfImported := types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("S1", imported.Ref()))
+	assert.Equal(fmt.Sprintf("ListOf%s_%s", ToTag(imported.Ref().String()), "S1"), g.UserName(listOfImported))
+}

--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/dataset"
+	"github.com/attic-labs/noms/nomdl/codegen/code"
 	"github.com/attic-labs/noms/nomdl/pkg"
 	"github.com/attic-labs/noms/types"
 )
@@ -135,7 +136,7 @@ func TestCanUseDef(t *testing.T) {
 
 	bad = `
 		Set(Set(Int8))
-		Set(Map(Int, Int8))
+		Set(Map(Int8, Int8))
 		Set(List(Int8))
 		Map(Set(Int8), Int8)
 		Map(Map(Int8, Int8), Int8)
@@ -173,6 +174,7 @@ func TestImportedTypes(t *testing.T) {
 	good := fmt.Sprintf(`
 		alias Other = import "%s"
 
+		using List(Other.S1)
 		struct Simple {
 			E: Other.E1
 			S: Other.S1
@@ -190,7 +192,7 @@ func TestImportedTypes(t *testing.T) {
 	pkgDS = generate("name", inFile, outFile, depsDir, pkgDS)
 
 	// Check that dependency code was generated.
-	expectedDepPkgAbs := filepath.Join(depsDir, toTag(importedRef.String()))
+	expectedDepPkgAbs := filepath.Join(depsDir, code.ToTag(importedRef.String()))
 	_, err = os.Stat(expectedDepPkgAbs)
 	assert.NoError(err)
 
@@ -235,9 +237,9 @@ func TestGenerateDeps(t *testing.T) {
 
 	generateDepCode(dir, top, cs)
 
-	leaf1Path := filepath.Join(dir, toTag(leaf1.Ref().String()), toTag(leaf1.Ref().String())+".go")
-	leaf2Path := filepath.Join(dir, toTag(leaf2.Ref().String()), toTag(leaf2.Ref().String())+".go")
-	leaf3Path := filepath.Join(dir, toTag(depender.Ref().String()), toTag(depender.Ref().String())+".go")
+	leaf1Path := filepath.Join(dir, code.ToTag(leaf1.Ref().String()), code.ToTag(leaf1.Ref().String())+".go")
+	leaf2Path := filepath.Join(dir, code.ToTag(leaf2.Ref().String()), code.ToTag(leaf2.Ref().String())+".go")
+	leaf3Path := filepath.Join(dir, code.ToTag(depender.Ref().String()), code.ToTag(depender.Ref().String())+".go")
 	_, err = os.Stat(leaf1Path)
 	assert.NoError(err)
 	_, err = os.Stat(leaf2Path)

--- a/nomdl/codegen/test/struct_with_imports.go
+++ b/nomdl/codegen/test/struct_with_imports.go
@@ -30,6 +30,144 @@ func __testPackageInFile_struct_with_imports_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D
+
+type ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D struct {
+	l types.List
+}
+
+func NewListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D() ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{types.NewList()}
+}
+
+type ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DDef []sha1_f9397427926127f67d8f3edb21c92bf642262e9b.DDef
+
+func (def ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DDef) New() ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	l := make([]types.Value, len(def))
+	for i, d := range def {
+		l[i] = d.New().NomsValue()
+	}
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{types.NewList(l...)}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Def() ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DDef {
+	d := make([]sha1_f9397427926127f67d8f3edb21c92bf642262e9b.DDef, l.Len())
+	for i := uint64(0); i < l.Len(); i++ {
+		d[i] = sha1_f9397427926127f67d8f3edb21c92bf642262e9b.DFromVal(l.l.Get(i)).Def()
+	}
+	return d
+}
+
+func ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DFromVal(val types.Value) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	// TODO: Validate here
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{val.(types.List)}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) NomsValue() types.Value {
+	return l.l
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Equals(other types.Value) bool {
+	if other, ok := other.(ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D); ok {
+		return l.l.Equals(other.l)
+	}
+	return false
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Ref() ref.Ref {
+	return l.l.Ref()
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Chunks() []types.Future {
+	return l.l.Chunks()
+}
+
+// A Noms Value that describes ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D.
+var __typeRefForListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D types.TypeRef
+
+func (m ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) TypeRef() types.TypeRef {
+	return __typeRefForListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D
+}
+
+func init() {
+	__typeRefForListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef("D", ref.Parse("sha1-f9397427926127f67d8f3edb21c92bf642262e9b")))
+	types.RegisterFromValFunction(__typeRefForListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D, func(v types.Value) types.NomsValue {
+		return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DFromVal(v)
+	})
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Len() uint64 {
+	return l.l.Len()
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Empty() bool {
+	return l.Len() == uint64(0)
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Get(i uint64) sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D {
+	return sha1_f9397427926127f67d8f3edb21c92bf642262e9b.DFromVal(l.l.Get(i))
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Slice(idx uint64, end uint64) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{l.l.Slice(idx, end)}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Set(i uint64, val sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{l.l.Set(i, val.NomsValue())}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Append(v ...sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{l.l.Append(l.fromElemSlice(v)...)}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Insert(idx uint64, v ...sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{l.l.Insert(idx, l.fromElemSlice(v)...)}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Remove(idx uint64, end uint64) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{l.l.Remove(idx, end)}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) RemoveAt(idx uint64) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	return ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D{(l.l.RemoveAt(idx))}
+}
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) fromElemSlice(p []sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D) []types.Value {
+	r := make([]types.Value, len(p))
+	for i, v := range p {
+		r[i] = v.NomsValue()
+	}
+	return r
+}
+
+type ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DIterCallback func(v sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D, i uint64) (stop bool)
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Iter(cb ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DIterCallback) {
+	l.l.Iter(func(v types.Value, i uint64) bool {
+		return cb(sha1_f9397427926127f67d8f3edb21c92bf642262e9b.DFromVal(v), i)
+	})
+}
+
+type ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DIterAllCallback func(v sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D, i uint64)
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) IterAll(cb ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DIterAllCallback) {
+	l.l.IterAll(func(v types.Value, i uint64) {
+		cb(sha1_f9397427926127f67d8f3edb21c92bf642262e9b.DFromVal(v), i)
+	})
+}
+
+type ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DFilterCallback func(v sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D, i uint64) (keep bool)
+
+func (l ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D) Filter(cb ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DFilterCallback) ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D {
+	nl := NewListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_D()
+	l.IterAll(func(v sha1_f9397427926127f67d8f3edb21c92bf642262e9b.D, i uint64) {
+		if cb(v, i) {
+			nl = nl.Append(v)
+		}
+	})
+	return nl
+}
+
 // E
 
 type E uint32

--- a/nomdl/codegen/test/struct_with_imports.noms
+++ b/nomdl/codegen/test/struct_with_imports.noms
@@ -9,3 +9,5 @@ struct ImportUser {
 	importedStruct :dep.D
 	enum :E
 }
+
+using List(dep.D)

--- a/nomdl/codegen/test/struct_with_imports_test.go
+++ b/nomdl/codegen/test/struct_with_imports_test.go
@@ -35,3 +35,18 @@ func TestWithImportsDef(t *testing.T) {
 	assert.Equal(true, ddef.StructField.B)
 	assert.Equal(leaf.E2, ddef.EnumField)
 }
+
+func TestListOfImportsDef(t *testing.T) {
+	assert := assert.New(t)
+	lDef := ListOfsha1_f9397427926127f67d8f3edb21c92bf642262e9b_DDef{
+		dep.DDef{EnumField: leaf.E3},
+		dep.DDef{EnumField: leaf.E2},
+		dep.DDef{EnumField: leaf.E1},
+	}
+
+	l := lDef.New()
+	assert.EqualValues(3, l.Len())
+	assert.EqualValues(leaf.E3, l.Get(0).EnumField())
+	assert.EqualValues(leaf.E2, l.Get(1).EnumField())
+	assert.EqualValues(leaf.E1, l.Get(2).EnumField())
+}


### PR DESCRIPTION
Sets, Lists, Refs and Maps of imported types work now.

This PR also factors some of codegen.go into a separate package, to slim down
that file a bit.

Towards issue #294
