### PR TITLE
Fix codgen templates so they aren't changed by go fmt.

### DIFF
--- a/clients/flickr/types.go
+++ b/clients/flickr/types.go
@@ -580,4 +580,3 @@ func (m MapOfStringToAlbum) Iter(cb MapOfStringToAlbumIterCallback) {
 		return cb(types.StringFromVal(k), AlbumFromVal(v))
 	})
 }
-

--- a/clients/tagdex/types.go
+++ b/clients/tagdex/types.go
@@ -469,4 +469,3 @@ func (s Size) Height() types.UInt32 {
 func (s Size) SetHeight(p types.UInt32) Size {
 	return SizeFromVal(s.m.Set(types.NewString("height"), p))
 }
-

--- a/nomdl/codegen/header.tmpl
+++ b/nomdl/codegen/header.tmpl
@@ -25,4 +25,3 @@ func __{{.Name}}PackageInFile_{{.FileID}}_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 {{end}}
-

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -147,4 +147,3 @@ func (s {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
 		}
 	{{end}}
 {{end}}
-

--- a/nomdl/codegen/type_ref.tmpl
+++ b/nomdl/codegen/type_ref.tmpl
@@ -11,4 +11,3 @@ func init() {
 		return {{.Name}}FromVal(v)
 	})
 }
-

--- a/types/primitives.go
+++ b/types/primitives.go
@@ -347,4 +347,3 @@ var typeRefForFloat64 = MakePrimitiveTypeRef(Float64Kind)
 func (v Float64) TypeRef() TypeRef {
 	return typeRefForFloat64
 }
-


### PR DESCRIPTION
My editor plugin is a little agressive about running 'go fmt'. It's running fmt on files that haven't changed and then, since 'fmt' changes the file, git is showing them as modified. Deleting extra blank lines at the end of the file seems to fix my current problems.
