### PR TITLE
NomDL codegen: Clean up write and improve ordering

### DIFF
--- a/clients/music/mp3_importer/types.go
+++ b/clients/music/mp3_importer/types.go
@@ -31,6 +31,130 @@ func __mainPackageInFile_types_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// Song
+
+type Song struct {
+	m types.Map
+}
+
+func NewSong() Song {
+	return Song{types.NewMap(
+		types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
+		types.NewString("Title"), types.NewString(""),
+		types.NewString("Artist"), types.NewString(""),
+		types.NewString("Album"), types.NewString(""),
+		types.NewString("Year"), types.NewString(""),
+		types.NewString("Mp3"), types.NewEmptyBlob(),
+	)}
+}
+
+type SongDef struct {
+	Title  string
+	Artist string
+	Album  string
+	Year   string
+	Mp3    types.Blob
+}
+
+func (def SongDef) New() Song {
+	return Song{
+		types.NewMap(
+			types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
+			types.NewString("Title"), types.NewString(def.Title),
+			types.NewString("Artist"), types.NewString(def.Artist),
+			types.NewString("Album"), types.NewString(def.Album),
+			types.NewString("Year"), types.NewString(def.Year),
+			types.NewString("Mp3"), def.Mp3,
+		)}
+}
+
+func (s Song) Def() (d SongDef) {
+	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
+	d.Artist = s.m.Get(types.NewString("Artist")).(types.String).String()
+	d.Album = s.m.Get(types.NewString("Album")).(types.String).String()
+	d.Year = s.m.Get(types.NewString("Year")).(types.String).String()
+	d.Mp3 = s.m.Get(types.NewString("Mp3")).(types.Blob)
+	return
+}
+
+var __typeRefForSong = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
+
+func (m Song) TypeRef() types.TypeRef {
+	return __typeRefForSong
+}
+
+func init() {
+	types.RegisterFromValFunction(__typeRefForSong, func(v types.Value) types.NomsValue {
+		return SongFromVal(v)
+	})
+}
+
+func SongFromVal(val types.Value) Song {
+	// TODO: Validate here
+	return Song{val.(types.Map)}
+}
+
+func (s Song) NomsValue() types.Value {
+	return s.m
+}
+
+func (s Song) Equals(other types.Value) bool {
+	if other, ok := other.(Song); ok {
+		return s.m.Equals(other.m)
+	}
+	return false
+}
+
+func (s Song) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Song) Chunks() (futures []types.Future) {
+	futures = append(futures, s.TypeRef().Chunks()...)
+	futures = append(futures, s.m.Chunks()...)
+	return
+}
+
+func (s Song) Title() string {
+	return s.m.Get(types.NewString("Title")).(types.String).String()
+}
+
+func (s Song) SetTitle(val string) Song {
+	return Song{s.m.Set(types.NewString("Title"), types.NewString(val))}
+}
+
+func (s Song) Artist() string {
+	return s.m.Get(types.NewString("Artist")).(types.String).String()
+}
+
+func (s Song) SetArtist(val string) Song {
+	return Song{s.m.Set(types.NewString("Artist"), types.NewString(val))}
+}
+
+func (s Song) Album() string {
+	return s.m.Get(types.NewString("Album")).(types.String).String()
+}
+
+func (s Song) SetAlbum(val string) Song {
+	return Song{s.m.Set(types.NewString("Album"), types.NewString(val))}
+}
+
+func (s Song) Year() string {
+	return s.m.Get(types.NewString("Year")).(types.String).String()
+}
+
+func (s Song) SetYear(val string) Song {
+	return Song{s.m.Set(types.NewString("Year"), types.NewString(val))}
+}
+
+func (s Song) Mp3() types.Blob {
+	return s.m.Get(types.NewString("Mp3")).(types.Blob)
+}
+
+func (s Song) SetMp3(val types.Blob) Song {
+	return Song{s.m.Set(types.NewString("Mp3"), val)}
+}
+
 // ListOfSong
 
 type ListOfSong struct {
@@ -169,128 +293,4 @@ func (l ListOfSong) Filter(cb ListOfSongFilterCallback) ListOfSong {
 		}
 	})
 	return nl
-}
-
-// Song
-
-type Song struct {
-	m types.Map
-}
-
-func NewSong() Song {
-	return Song{types.NewMap(
-		types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Artist"), types.NewString(""),
-		types.NewString("Album"), types.NewString(""),
-		types.NewString("Year"), types.NewString(""),
-		types.NewString("Mp3"), types.NewEmptyBlob(),
-	)}
-}
-
-type SongDef struct {
-	Title  string
-	Artist string
-	Album  string
-	Year   string
-	Mp3    types.Blob
-}
-
-func (def SongDef) New() Song {
-	return Song{
-		types.NewMap(
-			types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Artist"), types.NewString(def.Artist),
-			types.NewString("Album"), types.NewString(def.Album),
-			types.NewString("Year"), types.NewString(def.Year),
-			types.NewString("Mp3"), def.Mp3,
-		)}
-}
-
-func (s Song) Def() (d SongDef) {
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Artist = s.m.Get(types.NewString("Artist")).(types.String).String()
-	d.Album = s.m.Get(types.NewString("Album")).(types.String).String()
-	d.Year = s.m.Get(types.NewString("Year")).(types.String).String()
-	d.Mp3 = s.m.Get(types.NewString("Mp3")).(types.Blob)
-	return
-}
-
-var __typeRefForSong = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-
-func (m Song) TypeRef() types.TypeRef {
-	return __typeRefForSong
-}
-
-func init() {
-	types.RegisterFromValFunction(__typeRefForSong, func(v types.Value) types.NomsValue {
-		return SongFromVal(v)
-	})
-}
-
-func SongFromVal(val types.Value) Song {
-	// TODO: Validate here
-	return Song{val.(types.Map)}
-}
-
-func (s Song) NomsValue() types.Value {
-	return s.m
-}
-
-func (s Song) Equals(other types.Value) bool {
-	if other, ok := other.(Song); ok {
-		return s.m.Equals(other.m)
-	}
-	return false
-}
-
-func (s Song) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s Song) Chunks() (futures []types.Future) {
-	futures = append(futures, s.TypeRef().Chunks()...)
-	futures = append(futures, s.m.Chunks()...)
-	return
-}
-
-func (s Song) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
-}
-
-func (s Song) SetTitle(val string) Song {
-	return Song{s.m.Set(types.NewString("Title"), types.NewString(val))}
-}
-
-func (s Song) Artist() string {
-	return s.m.Get(types.NewString("Artist")).(types.String).String()
-}
-
-func (s Song) SetArtist(val string) Song {
-	return Song{s.m.Set(types.NewString("Artist"), types.NewString(val))}
-}
-
-func (s Song) Album() string {
-	return s.m.Get(types.NewString("Album")).(types.String).String()
-}
-
-func (s Song) SetAlbum(val string) Song {
-	return Song{s.m.Set(types.NewString("Album"), types.NewString(val))}
-}
-
-func (s Song) Year() string {
-	return s.m.Get(types.NewString("Year")).(types.String).String()
-}
-
-func (s Song) SetYear(val string) Song {
-	return Song{s.m.Set(types.NewString("Year"), types.NewString(val))}
-}
-
-func (s Song) Mp3() types.Blob {
-	return s.m.Get(types.NewString("Mp3")).(types.Blob)
-}
-
-func (s Song) SetMp3(val types.Blob) Song {
-	return Song{s.m.Set(types.NewString("Mp3"), val)}
 }

--- a/clients/pitchmap/index/types.go
+++ b/clients/pitchmap/index/types.go
@@ -28,6 +28,94 @@ func __mainPackageInFile_types_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// Pitch
+
+type Pitch struct {
+	m types.Map
+}
+
+func NewPitch() Pitch {
+	return Pitch{types.NewMap(
+		types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
+		types.NewString("X"), types.Float64(0),
+		types.NewString("Z"), types.Float64(0),
+	)}
+}
+
+type PitchDef struct {
+	X float64
+	Z float64
+}
+
+func (def PitchDef) New() Pitch {
+	return Pitch{
+		types.NewMap(
+			types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
+			types.NewString("X"), types.Float64(def.X),
+			types.NewString("Z"), types.Float64(def.Z),
+		)}
+}
+
+func (s Pitch) Def() (d PitchDef) {
+	d.X = float64(s.m.Get(types.NewString("X")).(types.Float64))
+	d.Z = float64(s.m.Get(types.NewString("Z")).(types.Float64))
+	return
+}
+
+var __typeRefForPitch = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
+
+func (m Pitch) TypeRef() types.TypeRef {
+	return __typeRefForPitch
+}
+
+func init() {
+	types.RegisterFromValFunction(__typeRefForPitch, func(v types.Value) types.NomsValue {
+		return PitchFromVal(v)
+	})
+}
+
+func PitchFromVal(val types.Value) Pitch {
+	// TODO: Validate here
+	return Pitch{val.(types.Map)}
+}
+
+func (s Pitch) NomsValue() types.Value {
+	return s.m
+}
+
+func (s Pitch) Equals(other types.Value) bool {
+	if other, ok := other.(Pitch); ok {
+		return s.m.Equals(other.m)
+	}
+	return false
+}
+
+func (s Pitch) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Pitch) Chunks() (futures []types.Future) {
+	futures = append(futures, s.TypeRef().Chunks()...)
+	futures = append(futures, s.m.Chunks()...)
+	return
+}
+
+func (s Pitch) X() float64 {
+	return float64(s.m.Get(types.NewString("X")).(types.Float64))
+}
+
+func (s Pitch) SetX(val float64) Pitch {
+	return Pitch{s.m.Set(types.NewString("X"), types.Float64(val))}
+}
+
+func (s Pitch) Z() float64 {
+	return float64(s.m.Get(types.NewString("Z")).(types.Float64))
+}
+
+func (s Pitch) SetZ(val float64) Pitch {
+	return Pitch{s.m.Set(types.NewString("Z"), types.Float64(val))}
+}
+
 // ListOfMapOfStringToValue
 
 type ListOfMapOfStringToValue struct {
@@ -168,137 +256,6 @@ func (l ListOfMapOfStringToValue) Filter(cb ListOfMapOfStringToValueFilterCallba
 	return nl
 }
 
-// MapOfStringToValue
-
-type MapOfStringToValue struct {
-	m types.Map
-}
-
-func NewMapOfStringToValue() MapOfStringToValue {
-	return MapOfStringToValue{types.NewMap()}
-}
-
-type MapOfStringToValueDef map[string]types.Value
-
-func (def MapOfStringToValueDef) New() MapOfStringToValue {
-	kv := make([]types.Value, 0, len(def)*2)
-	for k, v := range def {
-		kv = append(kv, types.NewString(k), v)
-	}
-	return MapOfStringToValue{types.NewMap(kv...)}
-}
-
-func (m MapOfStringToValue) Def() MapOfStringToValueDef {
-	def := make(map[string]types.Value)
-	m.m.Iter(func(k, v types.Value) bool {
-		def[k.(types.String).String()] = v
-		return false
-	})
-	return def
-}
-
-func MapOfStringToValueFromVal(p types.Value) MapOfStringToValue {
-	// TODO: Validate here
-	return MapOfStringToValue{p.(types.Map)}
-}
-
-func (m MapOfStringToValue) NomsValue() types.Value {
-	return m.m
-}
-
-func (m MapOfStringToValue) Equals(other types.Value) bool {
-	if other, ok := other.(MapOfStringToValue); ok {
-		return m.m.Equals(other.m)
-	}
-	return false
-}
-
-func (m MapOfStringToValue) Ref() ref.Ref {
-	return m.m.Ref()
-}
-
-func (m MapOfStringToValue) Chunks() (futures []types.Future) {
-	futures = append(futures, m.TypeRef().Chunks()...)
-	futures = append(futures, m.m.Chunks()...)
-	return
-}
-
-// A Noms Value that describes MapOfStringToValue.
-var __typeRefForMapOfStringToValue types.TypeRef
-
-func (m MapOfStringToValue) TypeRef() types.TypeRef {
-	return __typeRefForMapOfStringToValue
-}
-
-func init() {
-	__typeRefForMapOfStringToValue = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind))
-	types.RegisterFromValFunction(__typeRefForMapOfStringToValue, func(v types.Value) types.NomsValue {
-		return MapOfStringToValueFromVal(v)
-	})
-}
-
-func (m MapOfStringToValue) Empty() bool {
-	return m.m.Empty()
-}
-
-func (m MapOfStringToValue) Len() uint64 {
-	return m.m.Len()
-}
-
-func (m MapOfStringToValue) Has(p string) bool {
-	return m.m.Has(types.NewString(p))
-}
-
-func (m MapOfStringToValue) Get(p string) types.Value {
-	return m.m.Get(types.NewString(p))
-}
-
-func (m MapOfStringToValue) MaybeGet(p string) (types.Value, bool) {
-	v, ok := m.m.MaybeGet(types.NewString(p))
-	if !ok {
-		return types.Bool(false), false
-	}
-	return v, ok
-}
-
-func (m MapOfStringToValue) Set(k string, v types.Value) MapOfStringToValue {
-	return MapOfStringToValue{m.m.Set(types.NewString(k), v)}
-}
-
-// TODO: Implement SetM?
-
-func (m MapOfStringToValue) Remove(p string) MapOfStringToValue {
-	return MapOfStringToValue{m.m.Remove(types.NewString(p))}
-}
-
-type MapOfStringToValueIterCallback func(k string, v types.Value) (stop bool)
-
-func (m MapOfStringToValue) Iter(cb MapOfStringToValueIterCallback) {
-	m.m.Iter(func(k, v types.Value) bool {
-		return cb(k.(types.String).String(), v)
-	})
-}
-
-type MapOfStringToValueIterAllCallback func(k string, v types.Value)
-
-func (m MapOfStringToValue) IterAll(cb MapOfStringToValueIterAllCallback) {
-	m.m.IterAll(func(k, v types.Value) {
-		cb(k.(types.String).String(), v)
-	})
-}
-
-type MapOfStringToValueFilterCallback func(k string, v types.Value) (keep bool)
-
-func (m MapOfStringToValue) Filter(cb MapOfStringToValueFilterCallback) MapOfStringToValue {
-	nm := NewMapOfStringToValue()
-	m.IterAll(func(k string, v types.Value) {
-		if cb(k, v) {
-			nm = nm.Set(k, v)
-		}
-	})
-	return nm
-}
-
 // MapOfStringToListOfPitch
 
 type MapOfStringToListOfPitch struct {
@@ -423,6 +380,268 @@ type MapOfStringToListOfPitchFilterCallback func(k string, v ListOfPitch) (keep 
 func (m MapOfStringToListOfPitch) Filter(cb MapOfStringToListOfPitchFilterCallback) MapOfStringToListOfPitch {
 	nm := NewMapOfStringToListOfPitch()
 	m.IterAll(func(k string, v ListOfPitch) {
+		if cb(k, v) {
+			nm = nm.Set(k, v)
+		}
+	})
+	return nm
+}
+
+// MapOfStringToString
+
+type MapOfStringToString struct {
+	m types.Map
+}
+
+func NewMapOfStringToString() MapOfStringToString {
+	return MapOfStringToString{types.NewMap()}
+}
+
+type MapOfStringToStringDef map[string]string
+
+func (def MapOfStringToStringDef) New() MapOfStringToString {
+	kv := make([]types.Value, 0, len(def)*2)
+	for k, v := range def {
+		kv = append(kv, types.NewString(k), types.NewString(v))
+	}
+	return MapOfStringToString{types.NewMap(kv...)}
+}
+
+func (m MapOfStringToString) Def() MapOfStringToStringDef {
+	def := make(map[string]string)
+	m.m.Iter(func(k, v types.Value) bool {
+		def[k.(types.String).String()] = v.(types.String).String()
+		return false
+	})
+	return def
+}
+
+func MapOfStringToStringFromVal(p types.Value) MapOfStringToString {
+	// TODO: Validate here
+	return MapOfStringToString{p.(types.Map)}
+}
+
+func (m MapOfStringToString) NomsValue() types.Value {
+	return m.m
+}
+
+func (m MapOfStringToString) Equals(other types.Value) bool {
+	if other, ok := other.(MapOfStringToString); ok {
+		return m.m.Equals(other.m)
+	}
+	return false
+}
+
+func (m MapOfStringToString) Ref() ref.Ref {
+	return m.m.Ref()
+}
+
+func (m MapOfStringToString) Chunks() (futures []types.Future) {
+	futures = append(futures, m.TypeRef().Chunks()...)
+	futures = append(futures, m.m.Chunks()...)
+	return
+}
+
+// A Noms Value that describes MapOfStringToString.
+var __typeRefForMapOfStringToString types.TypeRef
+
+func (m MapOfStringToString) TypeRef() types.TypeRef {
+	return __typeRefForMapOfStringToString
+}
+
+func init() {
+	__typeRefForMapOfStringToString = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.StringKind))
+	types.RegisterFromValFunction(__typeRefForMapOfStringToString, func(v types.Value) types.NomsValue {
+		return MapOfStringToStringFromVal(v)
+	})
+}
+
+func (m MapOfStringToString) Empty() bool {
+	return m.m.Empty()
+}
+
+func (m MapOfStringToString) Len() uint64 {
+	return m.m.Len()
+}
+
+func (m MapOfStringToString) Has(p string) bool {
+	return m.m.Has(types.NewString(p))
+}
+
+func (m MapOfStringToString) Get(p string) string {
+	return m.m.Get(types.NewString(p)).(types.String).String()
+}
+
+func (m MapOfStringToString) MaybeGet(p string) (string, bool) {
+	v, ok := m.m.MaybeGet(types.NewString(p))
+	if !ok {
+		return "", false
+	}
+	return v.(types.String).String(), ok
+}
+
+func (m MapOfStringToString) Set(k string, v string) MapOfStringToString {
+	return MapOfStringToString{m.m.Set(types.NewString(k), types.NewString(v))}
+}
+
+// TODO: Implement SetM?
+
+func (m MapOfStringToString) Remove(p string) MapOfStringToString {
+	return MapOfStringToString{m.m.Remove(types.NewString(p))}
+}
+
+type MapOfStringToStringIterCallback func(k string, v string) (stop bool)
+
+func (m MapOfStringToString) Iter(cb MapOfStringToStringIterCallback) {
+	m.m.Iter(func(k, v types.Value) bool {
+		return cb(k.(types.String).String(), v.(types.String).String())
+	})
+}
+
+type MapOfStringToStringIterAllCallback func(k string, v string)
+
+func (m MapOfStringToString) IterAll(cb MapOfStringToStringIterAllCallback) {
+	m.m.IterAll(func(k, v types.Value) {
+		cb(k.(types.String).String(), v.(types.String).String())
+	})
+}
+
+type MapOfStringToStringFilterCallback func(k string, v string) (keep bool)
+
+func (m MapOfStringToString) Filter(cb MapOfStringToStringFilterCallback) MapOfStringToString {
+	nm := NewMapOfStringToString()
+	m.IterAll(func(k string, v string) {
+		if cb(k, v) {
+			nm = nm.Set(k, v)
+		}
+	})
+	return nm
+}
+
+// MapOfStringToValue
+
+type MapOfStringToValue struct {
+	m types.Map
+}
+
+func NewMapOfStringToValue() MapOfStringToValue {
+	return MapOfStringToValue{types.NewMap()}
+}
+
+type MapOfStringToValueDef map[string]types.Value
+
+func (def MapOfStringToValueDef) New() MapOfStringToValue {
+	kv := make([]types.Value, 0, len(def)*2)
+	for k, v := range def {
+		kv = append(kv, types.NewString(k), v)
+	}
+	return MapOfStringToValue{types.NewMap(kv...)}
+}
+
+func (m MapOfStringToValue) Def() MapOfStringToValueDef {
+	def := make(map[string]types.Value)
+	m.m.Iter(func(k, v types.Value) bool {
+		def[k.(types.String).String()] = v
+		return false
+	})
+	return def
+}
+
+func MapOfStringToValueFromVal(p types.Value) MapOfStringToValue {
+	// TODO: Validate here
+	return MapOfStringToValue{p.(types.Map)}
+}
+
+func (m MapOfStringToValue) NomsValue() types.Value {
+	return m.m
+}
+
+func (m MapOfStringToValue) Equals(other types.Value) bool {
+	if other, ok := other.(MapOfStringToValue); ok {
+		return m.m.Equals(other.m)
+	}
+	return false
+}
+
+func (m MapOfStringToValue) Ref() ref.Ref {
+	return m.m.Ref()
+}
+
+func (m MapOfStringToValue) Chunks() (futures []types.Future) {
+	futures = append(futures, m.TypeRef().Chunks()...)
+	futures = append(futures, m.m.Chunks()...)
+	return
+}
+
+// A Noms Value that describes MapOfStringToValue.
+var __typeRefForMapOfStringToValue types.TypeRef
+
+func (m MapOfStringToValue) TypeRef() types.TypeRef {
+	return __typeRefForMapOfStringToValue
+}
+
+func init() {
+	__typeRefForMapOfStringToValue = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind))
+	types.RegisterFromValFunction(__typeRefForMapOfStringToValue, func(v types.Value) types.NomsValue {
+		return MapOfStringToValueFromVal(v)
+	})
+}
+
+func (m MapOfStringToValue) Empty() bool {
+	return m.m.Empty()
+}
+
+func (m MapOfStringToValue) Len() uint64 {
+	return m.m.Len()
+}
+
+func (m MapOfStringToValue) Has(p string) bool {
+	return m.m.Has(types.NewString(p))
+}
+
+func (m MapOfStringToValue) Get(p string) types.Value {
+	return m.m.Get(types.NewString(p))
+}
+
+func (m MapOfStringToValue) MaybeGet(p string) (types.Value, bool) {
+	v, ok := m.m.MaybeGet(types.NewString(p))
+	if !ok {
+		return types.Bool(false), false
+	}
+	return v, ok
+}
+
+func (m MapOfStringToValue) Set(k string, v types.Value) MapOfStringToValue {
+	return MapOfStringToValue{m.m.Set(types.NewString(k), v)}
+}
+
+// TODO: Implement SetM?
+
+func (m MapOfStringToValue) Remove(p string) MapOfStringToValue {
+	return MapOfStringToValue{m.m.Remove(types.NewString(p))}
+}
+
+type MapOfStringToValueIterCallback func(k string, v types.Value) (stop bool)
+
+func (m MapOfStringToValue) Iter(cb MapOfStringToValueIterCallback) {
+	m.m.Iter(func(k, v types.Value) bool {
+		return cb(k.(types.String).String(), v)
+	})
+}
+
+type MapOfStringToValueIterAllCallback func(k string, v types.Value)
+
+func (m MapOfStringToValue) IterAll(cb MapOfStringToValueIterAllCallback) {
+	m.m.IterAll(func(k, v types.Value) {
+		cb(k.(types.String).String(), v)
+	})
+}
+
+type MapOfStringToValueFilterCallback func(k string, v types.Value) (keep bool)
+
+func (m MapOfStringToValue) Filter(cb MapOfStringToValueFilterCallback) MapOfStringToValue {
+	nm := NewMapOfStringToValue()
+	m.IterAll(func(k string, v types.Value) {
 		if cb(k, v) {
 			nm = nm.Set(k, v)
 		}
@@ -568,223 +787,4 @@ func (l ListOfPitch) Filter(cb ListOfPitchFilterCallback) ListOfPitch {
 		}
 	})
 	return nl
-}
-
-// MapOfStringToString
-
-type MapOfStringToString struct {
-	m types.Map
-}
-
-func NewMapOfStringToString() MapOfStringToString {
-	return MapOfStringToString{types.NewMap()}
-}
-
-type MapOfStringToStringDef map[string]string
-
-func (def MapOfStringToStringDef) New() MapOfStringToString {
-	kv := make([]types.Value, 0, len(def)*2)
-	for k, v := range def {
-		kv = append(kv, types.NewString(k), types.NewString(v))
-	}
-	return MapOfStringToString{types.NewMap(kv...)}
-}
-
-func (m MapOfStringToString) Def() MapOfStringToStringDef {
-	def := make(map[string]string)
-	m.m.Iter(func(k, v types.Value) bool {
-		def[k.(types.String).String()] = v.(types.String).String()
-		return false
-	})
-	return def
-}
-
-func MapOfStringToStringFromVal(p types.Value) MapOfStringToString {
-	// TODO: Validate here
-	return MapOfStringToString{p.(types.Map)}
-}
-
-func (m MapOfStringToString) NomsValue() types.Value {
-	return m.m
-}
-
-func (m MapOfStringToString) Equals(other types.Value) bool {
-	if other, ok := other.(MapOfStringToString); ok {
-		return m.m.Equals(other.m)
-	}
-	return false
-}
-
-func (m MapOfStringToString) Ref() ref.Ref {
-	return m.m.Ref()
-}
-
-func (m MapOfStringToString) Chunks() (futures []types.Future) {
-	futures = append(futures, m.TypeRef().Chunks()...)
-	futures = append(futures, m.m.Chunks()...)
-	return
-}
-
-// A Noms Value that describes MapOfStringToString.
-var __typeRefForMapOfStringToString types.TypeRef
-
-func (m MapOfStringToString) TypeRef() types.TypeRef {
-	return __typeRefForMapOfStringToString
-}
-
-func init() {
-	__typeRefForMapOfStringToString = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.StringKind))
-	types.RegisterFromValFunction(__typeRefForMapOfStringToString, func(v types.Value) types.NomsValue {
-		return MapOfStringToStringFromVal(v)
-	})
-}
-
-func (m MapOfStringToString) Empty() bool {
-	return m.m.Empty()
-}
-
-func (m MapOfStringToString) Len() uint64 {
-	return m.m.Len()
-}
-
-func (m MapOfStringToString) Has(p string) bool {
-	return m.m.Has(types.NewString(p))
-}
-
-func (m MapOfStringToString) Get(p string) string {
-	return m.m.Get(types.NewString(p)).(types.String).String()
-}
-
-func (m MapOfStringToString) MaybeGet(p string) (string, bool) {
-	v, ok := m.m.MaybeGet(types.NewString(p))
-	if !ok {
-		return "", false
-	}
-	return v.(types.String).String(), ok
-}
-
-func (m MapOfStringToString) Set(k string, v string) MapOfStringToString {
-	return MapOfStringToString{m.m.Set(types.NewString(k), types.NewString(v))}
-}
-
-// TODO: Implement SetM?
-
-func (m MapOfStringToString) Remove(p string) MapOfStringToString {
-	return MapOfStringToString{m.m.Remove(types.NewString(p))}
-}
-
-type MapOfStringToStringIterCallback func(k string, v string) (stop bool)
-
-func (m MapOfStringToString) Iter(cb MapOfStringToStringIterCallback) {
-	m.m.Iter(func(k, v types.Value) bool {
-		return cb(k.(types.String).String(), v.(types.String).String())
-	})
-}
-
-type MapOfStringToStringIterAllCallback func(k string, v string)
-
-func (m MapOfStringToString) IterAll(cb MapOfStringToStringIterAllCallback) {
-	m.m.IterAll(func(k, v types.Value) {
-		cb(k.(types.String).String(), v.(types.String).String())
-	})
-}
-
-type MapOfStringToStringFilterCallback func(k string, v string) (keep bool)
-
-func (m MapOfStringToString) Filter(cb MapOfStringToStringFilterCallback) MapOfStringToString {
-	nm := NewMapOfStringToString()
-	m.IterAll(func(k string, v string) {
-		if cb(k, v) {
-			nm = nm.Set(k, v)
-		}
-	})
-	return nm
-}
-
-// Pitch
-
-type Pitch struct {
-	m types.Map
-}
-
-func NewPitch() Pitch {
-	return Pitch{types.NewMap(
-		types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
-		types.NewString("X"), types.Float64(0),
-		types.NewString("Z"), types.Float64(0),
-	)}
-}
-
-type PitchDef struct {
-	X float64
-	Z float64
-}
-
-func (def PitchDef) New() Pitch {
-	return Pitch{
-		types.NewMap(
-			types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0),
-			types.NewString("X"), types.Float64(def.X),
-			types.NewString("Z"), types.Float64(def.Z),
-		)}
-}
-
-func (s Pitch) Def() (d PitchDef) {
-	d.X = float64(s.m.Get(types.NewString("X")).(types.Float64))
-	d.Z = float64(s.m.Get(types.NewString("Z")).(types.Float64))
-	return
-}
-
-var __typeRefForPitch = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-
-func (m Pitch) TypeRef() types.TypeRef {
-	return __typeRefForPitch
-}
-
-func init() {
-	types.RegisterFromValFunction(__typeRefForPitch, func(v types.Value) types.NomsValue {
-		return PitchFromVal(v)
-	})
-}
-
-func PitchFromVal(val types.Value) Pitch {
-	// TODO: Validate here
-	return Pitch{val.(types.Map)}
-}
-
-func (s Pitch) NomsValue() types.Value {
-	return s.m
-}
-
-func (s Pitch) Equals(other types.Value) bool {
-	if other, ok := other.(Pitch); ok {
-		return s.m.Equals(other.m)
-	}
-	return false
-}
-
-func (s Pitch) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s Pitch) Chunks() (futures []types.Future) {
-	futures = append(futures, s.TypeRef().Chunks()...)
-	futures = append(futures, s.m.Chunks()...)
-	return
-}
-
-func (s Pitch) X() float64 {
-	return float64(s.m.Get(types.NewString("X")).(types.Float64))
-}
-
-func (s Pitch) SetX(val float64) Pitch {
-	return Pitch{s.m.Set(types.NewString("X"), types.Float64(val))}
-}
-
-func (s Pitch) Z() float64 {
-	return float64(s.m.Get(types.NewString("Z")).(types.Float64))
-}
-
-func (s Pitch) SetZ(val float64) Pitch {
-	return Pitch{s.m.Set(types.NewString("Z"), types.Float64(val))}
 }

--- a/clients/quad_tree/types.go
+++ b/clients/quad_tree/types.go
@@ -329,62 +329,6 @@ func (s Node) SetReference(val RefOfValue) Node {
 	return Node{s.m.Set(types.NewString("Reference"), val.NomsValue())}
 }
 
-// RefOfValue
-
-type RefOfValue struct {
-	r ref.Ref
-}
-
-func NewRefOfValue(r ref.Ref) RefOfValue {
-	return RefOfValue{r}
-}
-
-func (r RefOfValue) Ref() ref.Ref {
-	return r.r
-}
-
-func (r RefOfValue) Equals(other types.Value) bool {
-	if other, ok := other.(RefOfValue); ok {
-		return r.r == other.r
-	}
-	return false
-}
-
-func (r RefOfValue) Chunks() []types.Future {
-	return r.TypeRef().Chunks()
-}
-
-func (r RefOfValue) NomsValue() types.Value {
-	return types.Ref{R: r.r}
-}
-
-func RefOfValueFromVal(p types.Value) RefOfValue {
-	return RefOfValue{p.(types.Ref).Ref()}
-}
-
-// A Noms Value that describes RefOfValue.
-var __typeRefForRefOfValue types.TypeRef
-
-func (m RefOfValue) TypeRef() types.TypeRef {
-	return __typeRefForRefOfValue
-}
-
-func init() {
-	__typeRefForRefOfValue = types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))
-	types.RegisterFromValFunction(__typeRefForRefOfValue, func(v types.Value) types.NomsValue {
-		return RefOfValueFromVal(v)
-	})
-}
-
-func (r RefOfValue) GetValue(cs chunks.ChunkSource) types.Value {
-	return types.ReadValue(r.r, cs)
-}
-
-func (r RefOfValue) SetValue(val types.Value, cs chunks.ChunkSink) RefOfValue {
-	ref := types.WriteValue(val, cs)
-	return RefOfValue{ref}
-}
-
 // QuadTree
 
 type QuadTree struct {
@@ -519,6 +463,198 @@ func (s QuadTree) Georectangle() Georectangle {
 
 func (s QuadTree) SetGeorectangle(val Georectangle) QuadTree {
 	return QuadTree{s.m.Set(types.NewString("Georectangle"), val.NomsValue())}
+}
+
+// SQuadTree
+
+type SQuadTree struct {
+	m types.Map
+}
+
+func NewSQuadTree() SQuadTree {
+	return SQuadTree{types.NewMap(
+		types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 4),
+		types.NewString("Nodes"), types.NewList(),
+		types.NewString("Tiles"), types.NewMap(),
+		types.NewString("Depth"), types.UInt8(0),
+		types.NewString("NumDescendents"), types.UInt32(0),
+		types.NewString("Path"), types.NewString(""),
+		types.NewString("Georectangle"), NewGeorectangle().NomsValue(),
+	)}
+}
+
+type SQuadTreeDef struct {
+	Nodes          ListOfRefOfValueDef
+	Tiles          MapOfStringToRefOfSQuadTreeDef
+	Depth          uint8
+	NumDescendents uint32
+	Path           string
+	Georectangle   GeorectangleDef
+}
+
+func (def SQuadTreeDef) New() SQuadTree {
+	return SQuadTree{
+		types.NewMap(
+			types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 4),
+			types.NewString("Nodes"), def.Nodes.New().NomsValue(),
+			types.NewString("Tiles"), def.Tiles.New().NomsValue(),
+			types.NewString("Depth"), types.UInt8(def.Depth),
+			types.NewString("NumDescendents"), types.UInt32(def.NumDescendents),
+			types.NewString("Path"), types.NewString(def.Path),
+			types.NewString("Georectangle"), def.Georectangle.New().NomsValue(),
+		)}
+}
+
+func (s SQuadTree) Def() (d SQuadTreeDef) {
+	d.Nodes = ListOfRefOfValueFromVal(s.m.Get(types.NewString("Nodes"))).Def()
+	d.Tiles = MapOfStringToRefOfSQuadTreeFromVal(s.m.Get(types.NewString("Tiles"))).Def()
+	d.Depth = uint8(s.m.Get(types.NewString("Depth")).(types.UInt8))
+	d.NumDescendents = uint32(s.m.Get(types.NewString("NumDescendents")).(types.UInt32))
+	d.Path = s.m.Get(types.NewString("Path")).(types.String).String()
+	d.Georectangle = GeorectangleFromVal(s.m.Get(types.NewString("Georectangle"))).Def()
+	return
+}
+
+var __typeRefForSQuadTree = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 4)
+
+func (m SQuadTree) TypeRef() types.TypeRef {
+	return __typeRefForSQuadTree
+}
+
+func init() {
+	types.RegisterFromValFunction(__typeRefForSQuadTree, func(v types.Value) types.NomsValue {
+		return SQuadTreeFromVal(v)
+	})
+}
+
+func SQuadTreeFromVal(val types.Value) SQuadTree {
+	// TODO: Validate here
+	return SQuadTree{val.(types.Map)}
+}
+
+func (s SQuadTree) NomsValue() types.Value {
+	return s.m
+}
+
+func (s SQuadTree) Equals(other types.Value) bool {
+	if other, ok := other.(SQuadTree); ok {
+		return s.m.Equals(other.m)
+	}
+	return false
+}
+
+func (s SQuadTree) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s SQuadTree) Chunks() (futures []types.Future) {
+	futures = append(futures, s.TypeRef().Chunks()...)
+	futures = append(futures, s.m.Chunks()...)
+	return
+}
+
+func (s SQuadTree) Nodes() ListOfRefOfValue {
+	return ListOfRefOfValueFromVal(s.m.Get(types.NewString("Nodes")))
+}
+
+func (s SQuadTree) SetNodes(val ListOfRefOfValue) SQuadTree {
+	return SQuadTree{s.m.Set(types.NewString("Nodes"), val.NomsValue())}
+}
+
+func (s SQuadTree) Tiles() MapOfStringToRefOfSQuadTree {
+	return MapOfStringToRefOfSQuadTreeFromVal(s.m.Get(types.NewString("Tiles")))
+}
+
+func (s SQuadTree) SetTiles(val MapOfStringToRefOfSQuadTree) SQuadTree {
+	return SQuadTree{s.m.Set(types.NewString("Tiles"), val.NomsValue())}
+}
+
+func (s SQuadTree) Depth() uint8 {
+	return uint8(s.m.Get(types.NewString("Depth")).(types.UInt8))
+}
+
+func (s SQuadTree) SetDepth(val uint8) SQuadTree {
+	return SQuadTree{s.m.Set(types.NewString("Depth"), types.UInt8(val))}
+}
+
+func (s SQuadTree) NumDescendents() uint32 {
+	return uint32(s.m.Get(types.NewString("NumDescendents")).(types.UInt32))
+}
+
+func (s SQuadTree) SetNumDescendents(val uint32) SQuadTree {
+	return SQuadTree{s.m.Set(types.NewString("NumDescendents"), types.UInt32(val))}
+}
+
+func (s SQuadTree) Path() string {
+	return s.m.Get(types.NewString("Path")).(types.String).String()
+}
+
+func (s SQuadTree) SetPath(val string) SQuadTree {
+	return SQuadTree{s.m.Set(types.NewString("Path"), types.NewString(val))}
+}
+
+func (s SQuadTree) Georectangle() Georectangle {
+	return GeorectangleFromVal(s.m.Get(types.NewString("Georectangle")))
+}
+
+func (s SQuadTree) SetGeorectangle(val Georectangle) SQuadTree {
+	return SQuadTree{s.m.Set(types.NewString("Georectangle"), val.NomsValue())}
+}
+
+// RefOfValue
+
+type RefOfValue struct {
+	r ref.Ref
+}
+
+func NewRefOfValue(r ref.Ref) RefOfValue {
+	return RefOfValue{r}
+}
+
+func (r RefOfValue) Ref() ref.Ref {
+	return r.r
+}
+
+func (r RefOfValue) Equals(other types.Value) bool {
+	if other, ok := other.(RefOfValue); ok {
+		return r.r == other.r
+	}
+	return false
+}
+
+func (r RefOfValue) Chunks() []types.Future {
+	return r.TypeRef().Chunks()
+}
+
+func (r RefOfValue) NomsValue() types.Value {
+	return types.Ref{R: r.r}
+}
+
+func RefOfValueFromVal(p types.Value) RefOfValue {
+	return RefOfValue{p.(types.Ref).Ref()}
+}
+
+// A Noms Value that describes RefOfValue.
+var __typeRefForRefOfValue types.TypeRef
+
+func (m RefOfValue) TypeRef() types.TypeRef {
+	return __typeRefForRefOfValue
+}
+
+func init() {
+	__typeRefForRefOfValue = types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))
+	types.RegisterFromValFunction(__typeRefForRefOfValue, func(v types.Value) types.NomsValue {
+		return RefOfValueFromVal(v)
+	})
+}
+
+func (r RefOfValue) GetValue(cs chunks.ChunkSource) types.Value {
+	return types.ReadValue(r.r, cs)
+}
+
+func (r RefOfValue) SetValue(val types.Value, cs chunks.ChunkSink) RefOfValue {
+	ref := types.WriteValue(val, cs)
+	return RefOfValue{ref}
 }
 
 // ListOfNode
@@ -790,142 +926,6 @@ func (m MapOfStringToQuadTree) Filter(cb MapOfStringToQuadTreeFilterCallback) Ma
 		}
 	})
 	return nm
-}
-
-// SQuadTree
-
-type SQuadTree struct {
-	m types.Map
-}
-
-func NewSQuadTree() SQuadTree {
-	return SQuadTree{types.NewMap(
-		types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 4),
-		types.NewString("Nodes"), types.NewList(),
-		types.NewString("Tiles"), types.NewMap(),
-		types.NewString("Depth"), types.UInt8(0),
-		types.NewString("NumDescendents"), types.UInt32(0),
-		types.NewString("Path"), types.NewString(""),
-		types.NewString("Georectangle"), NewGeorectangle().NomsValue(),
-	)}
-}
-
-type SQuadTreeDef struct {
-	Nodes          ListOfRefOfValueDef
-	Tiles          MapOfStringToRefOfSQuadTreeDef
-	Depth          uint8
-	NumDescendents uint32
-	Path           string
-	Georectangle   GeorectangleDef
-}
-
-func (def SQuadTreeDef) New() SQuadTree {
-	return SQuadTree{
-		types.NewMap(
-			types.NewString("$type"), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 4),
-			types.NewString("Nodes"), def.Nodes.New().NomsValue(),
-			types.NewString("Tiles"), def.Tiles.New().NomsValue(),
-			types.NewString("Depth"), types.UInt8(def.Depth),
-			types.NewString("NumDescendents"), types.UInt32(def.NumDescendents),
-			types.NewString("Path"), types.NewString(def.Path),
-			types.NewString("Georectangle"), def.Georectangle.New().NomsValue(),
-		)}
-}
-
-func (s SQuadTree) Def() (d SQuadTreeDef) {
-	d.Nodes = ListOfRefOfValueFromVal(s.m.Get(types.NewString("Nodes"))).Def()
-	d.Tiles = MapOfStringToRefOfSQuadTreeFromVal(s.m.Get(types.NewString("Tiles"))).Def()
-	d.Depth = uint8(s.m.Get(types.NewString("Depth")).(types.UInt8))
-	d.NumDescendents = uint32(s.m.Get(types.NewString("NumDescendents")).(types.UInt32))
-	d.Path = s.m.Get(types.NewString("Path")).(types.String).String()
-	d.Georectangle = GeorectangleFromVal(s.m.Get(types.NewString("Georectangle"))).Def()
-	return
-}
-
-var __typeRefForSQuadTree = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 4)
-
-func (m SQuadTree) TypeRef() types.TypeRef {
-	return __typeRefForSQuadTree
-}
-
-func init() {
-	types.RegisterFromValFunction(__typeRefForSQuadTree, func(v types.Value) types.NomsValue {
-		return SQuadTreeFromVal(v)
-	})
-}
-
-func SQuadTreeFromVal(val types.Value) SQuadTree {
-	// TODO: Validate here
-	return SQuadTree{val.(types.Map)}
-}
-
-func (s SQuadTree) NomsValue() types.Value {
-	return s.m
-}
-
-func (s SQuadTree) Equals(other types.Value) bool {
-	if other, ok := other.(SQuadTree); ok {
-		return s.m.Equals(other.m)
-	}
-	return false
-}
-
-func (s SQuadTree) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s SQuadTree) Chunks() (futures []types.Future) {
-	futures = append(futures, s.TypeRef().Chunks()...)
-	futures = append(futures, s.m.Chunks()...)
-	return
-}
-
-func (s SQuadTree) Nodes() ListOfRefOfValue {
-	return ListOfRefOfValueFromVal(s.m.Get(types.NewString("Nodes")))
-}
-
-func (s SQuadTree) SetNodes(val ListOfRefOfValue) SQuadTree {
-	return SQuadTree{s.m.Set(types.NewString("Nodes"), val.NomsValue())}
-}
-
-func (s SQuadTree) Tiles() MapOfStringToRefOfSQuadTree {
-	return MapOfStringToRefOfSQuadTreeFromVal(s.m.Get(types.NewString("Tiles")))
-}
-
-func (s SQuadTree) SetTiles(val MapOfStringToRefOfSQuadTree) SQuadTree {
-	return SQuadTree{s.m.Set(types.NewString("Tiles"), val.NomsValue())}
-}
-
-func (s SQuadTree) Depth() uint8 {
-	return uint8(s.m.Get(types.NewString("Depth")).(types.UInt8))
-}
-
-func (s SQuadTree) SetDepth(val uint8) SQuadTree {
-	return SQuadTree{s.m.Set(types.NewString("Depth"), types.UInt8(val))}
-}
-
-func (s SQuadTree) NumDescendents() uint32 {
-	return uint32(s.m.Get(types.NewString("NumDescendents")).(types.UInt32))
-}
-
-func (s SQuadTree) SetNumDescendents(val uint32) SQuadTree {
-	return SQuadTree{s.m.Set(types.NewString("NumDescendents"), types.UInt32(val))}
-}
-
-func (s SQuadTree) Path() string {
-	return s.m.Get(types.NewString("Path")).(types.String).String()
-}
-
-func (s SQuadTree) SetPath(val string) SQuadTree {
-	return SQuadTree{s.m.Set(types.NewString("Path"), types.NewString(val))}
-}
-
-func (s SQuadTree) Georectangle() Georectangle {
-	return GeorectangleFromVal(s.m.Get(types.NewString("Georectangle")))
-}
-
-func (s SQuadTree) SetGeorectangle(val Georectangle) SQuadTree {
-	return SQuadTree{s.m.Set(types.NewString("Georectangle"), val.NomsValue())}
 }
 
 // ListOfRefOfValue

--- a/clients/sfcrime_importer/types.go
+++ b/clients/sfcrime_importer/types.go
@@ -44,146 +44,6 @@ func __mainPackageInFile_types_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
-// ListOfIncident
-
-type ListOfIncident struct {
-	l types.List
-}
-
-func NewListOfIncident() ListOfIncident {
-	return ListOfIncident{types.NewList()}
-}
-
-type ListOfIncidentDef []IncidentDef
-
-func (def ListOfIncidentDef) New() ListOfIncident {
-	l := make([]types.Value, len(def))
-	for i, d := range def {
-		l[i] = d.New().NomsValue()
-	}
-	return ListOfIncident{types.NewList(l...)}
-}
-
-func (l ListOfIncident) Def() ListOfIncidentDef {
-	d := make([]IncidentDef, l.Len())
-	for i := uint64(0); i < l.Len(); i++ {
-		d[i] = IncidentFromVal(l.l.Get(i)).Def()
-	}
-	return d
-}
-
-func ListOfIncidentFromVal(val types.Value) ListOfIncident {
-	// TODO: Validate here
-	return ListOfIncident{val.(types.List)}
-}
-
-func (l ListOfIncident) NomsValue() types.Value {
-	return l.l
-}
-
-func (l ListOfIncident) Equals(other types.Value) bool {
-	if other, ok := other.(ListOfIncident); ok {
-		return l.l.Equals(other.l)
-	}
-	return false
-}
-
-func (l ListOfIncident) Ref() ref.Ref {
-	return l.l.Ref()
-}
-
-func (l ListOfIncident) Chunks() (futures []types.Future) {
-	futures = append(futures, l.TypeRef().Chunks()...)
-	futures = append(futures, l.l.Chunks()...)
-	return
-}
-
-// A Noms Value that describes ListOfIncident.
-var __typeRefForListOfIncident types.TypeRef
-
-func (m ListOfIncident) TypeRef() types.TypeRef {
-	return __typeRefForListOfIncident
-}
-
-func init() {
-	__typeRefForListOfIncident = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
-	types.RegisterFromValFunction(__typeRefForListOfIncident, func(v types.Value) types.NomsValue {
-		return ListOfIncidentFromVal(v)
-	})
-}
-
-func (l ListOfIncident) Len() uint64 {
-	return l.l.Len()
-}
-
-func (l ListOfIncident) Empty() bool {
-	return l.Len() == uint64(0)
-}
-
-func (l ListOfIncident) Get(i uint64) Incident {
-	return IncidentFromVal(l.l.Get(i))
-}
-
-func (l ListOfIncident) Slice(idx uint64, end uint64) ListOfIncident {
-	return ListOfIncident{l.l.Slice(idx, end)}
-}
-
-func (l ListOfIncident) Set(i uint64, val Incident) ListOfIncident {
-	return ListOfIncident{l.l.Set(i, val.NomsValue())}
-}
-
-func (l ListOfIncident) Append(v ...Incident) ListOfIncident {
-	return ListOfIncident{l.l.Append(l.fromElemSlice(v)...)}
-}
-
-func (l ListOfIncident) Insert(idx uint64, v ...Incident) ListOfIncident {
-	return ListOfIncident{l.l.Insert(idx, l.fromElemSlice(v)...)}
-}
-
-func (l ListOfIncident) Remove(idx uint64, end uint64) ListOfIncident {
-	return ListOfIncident{l.l.Remove(idx, end)}
-}
-
-func (l ListOfIncident) RemoveAt(idx uint64) ListOfIncident {
-	return ListOfIncident{(l.l.RemoveAt(idx))}
-}
-
-func (l ListOfIncident) fromElemSlice(p []Incident) []types.Value {
-	r := make([]types.Value, len(p))
-	for i, v := range p {
-		r[i] = v.NomsValue()
-	}
-	return r
-}
-
-type ListOfIncidentIterCallback func(v Incident, i uint64) (stop bool)
-
-func (l ListOfIncident) Iter(cb ListOfIncidentIterCallback) {
-	l.l.Iter(func(v types.Value, i uint64) bool {
-		return cb(IncidentFromVal(v), i)
-	})
-}
-
-type ListOfIncidentIterAllCallback func(v Incident, i uint64)
-
-func (l ListOfIncident) IterAll(cb ListOfIncidentIterAllCallback) {
-	l.l.IterAll(func(v types.Value, i uint64) {
-		cb(IncidentFromVal(v), i)
-	})
-}
-
-type ListOfIncidentFilterCallback func(v Incident, i uint64) (keep bool)
-
-func (l ListOfIncident) Filter(cb ListOfIncidentFilterCallback) ListOfIncident {
-	nl := NewListOfIncident()
-	l.IterAll(func(v Incident, i uint64) {
-		if cb(v, i) {
-			nl = nl.Append(v)
-		}
-	})
-	return nl
-}
-
 // Geoposition
 
 type Geoposition struct {
@@ -466,4 +326,144 @@ func (s Incident) PdID() string {
 
 func (s Incident) SetPdID(val string) Incident {
 	return Incident{s.m.Set(types.NewString("PdID"), types.NewString(val))}
+}
+
+// ListOfIncident
+
+type ListOfIncident struct {
+	l types.List
+}
+
+func NewListOfIncident() ListOfIncident {
+	return ListOfIncident{types.NewList()}
+}
+
+type ListOfIncidentDef []IncidentDef
+
+func (def ListOfIncidentDef) New() ListOfIncident {
+	l := make([]types.Value, len(def))
+	for i, d := range def {
+		l[i] = d.New().NomsValue()
+	}
+	return ListOfIncident{types.NewList(l...)}
+}
+
+func (l ListOfIncident) Def() ListOfIncidentDef {
+	d := make([]IncidentDef, l.Len())
+	for i := uint64(0); i < l.Len(); i++ {
+		d[i] = IncidentFromVal(l.l.Get(i)).Def()
+	}
+	return d
+}
+
+func ListOfIncidentFromVal(val types.Value) ListOfIncident {
+	// TODO: Validate here
+	return ListOfIncident{val.(types.List)}
+}
+
+func (l ListOfIncident) NomsValue() types.Value {
+	return l.l
+}
+
+func (l ListOfIncident) Equals(other types.Value) bool {
+	if other, ok := other.(ListOfIncident); ok {
+		return l.l.Equals(other.l)
+	}
+	return false
+}
+
+func (l ListOfIncident) Ref() ref.Ref {
+	return l.l.Ref()
+}
+
+func (l ListOfIncident) Chunks() (futures []types.Future) {
+	futures = append(futures, l.TypeRef().Chunks()...)
+	futures = append(futures, l.l.Chunks()...)
+	return
+}
+
+// A Noms Value that describes ListOfIncident.
+var __typeRefForListOfIncident types.TypeRef
+
+func (m ListOfIncident) TypeRef() types.TypeRef {
+	return __typeRefForListOfIncident
+}
+
+func init() {
+	__typeRefForListOfIncident = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
+	types.RegisterFromValFunction(__typeRefForListOfIncident, func(v types.Value) types.NomsValue {
+		return ListOfIncidentFromVal(v)
+	})
+}
+
+func (l ListOfIncident) Len() uint64 {
+	return l.l.Len()
+}
+
+func (l ListOfIncident) Empty() bool {
+	return l.Len() == uint64(0)
+}
+
+func (l ListOfIncident) Get(i uint64) Incident {
+	return IncidentFromVal(l.l.Get(i))
+}
+
+func (l ListOfIncident) Slice(idx uint64, end uint64) ListOfIncident {
+	return ListOfIncident{l.l.Slice(idx, end)}
+}
+
+func (l ListOfIncident) Set(i uint64, val Incident) ListOfIncident {
+	return ListOfIncident{l.l.Set(i, val.NomsValue())}
+}
+
+func (l ListOfIncident) Append(v ...Incident) ListOfIncident {
+	return ListOfIncident{l.l.Append(l.fromElemSlice(v)...)}
+}
+
+func (l ListOfIncident) Insert(idx uint64, v ...Incident) ListOfIncident {
+	return ListOfIncident{l.l.Insert(idx, l.fromElemSlice(v)...)}
+}
+
+func (l ListOfIncident) Remove(idx uint64, end uint64) ListOfIncident {
+	return ListOfIncident{l.l.Remove(idx, end)}
+}
+
+func (l ListOfIncident) RemoveAt(idx uint64) ListOfIncident {
+	return ListOfIncident{(l.l.RemoveAt(idx))}
+}
+
+func (l ListOfIncident) fromElemSlice(p []Incident) []types.Value {
+	r := make([]types.Value, len(p))
+	for i, v := range p {
+		r[i] = v.NomsValue()
+	}
+	return r
+}
+
+type ListOfIncidentIterCallback func(v Incident, i uint64) (stop bool)
+
+func (l ListOfIncident) Iter(cb ListOfIncidentIterCallback) {
+	l.l.Iter(func(v types.Value, i uint64) bool {
+		return cb(IncidentFromVal(v), i)
+	})
+}
+
+type ListOfIncidentIterAllCallback func(v Incident, i uint64)
+
+func (l ListOfIncident) IterAll(cb ListOfIncidentIterAllCallback) {
+	l.l.IterAll(func(v types.Value, i uint64) {
+		cb(IncidentFromVal(v), i)
+	})
+}
+
+type ListOfIncidentFilterCallback func(v Incident, i uint64) (keep bool)
+
+func (l ListOfIncident) Filter(cb ListOfIncidentFilterCallback) ListOfIncident {
+	nl := NewListOfIncident()
+	l.IterAll(func(v Incident, i uint64) {
+		if cb(v, i) {
+			nl = nl.Append(v)
+		}
+	})
+	return nl
 }

--- a/clients/sfcrime_search/types.go
+++ b/clients/sfcrime_search/types.go
@@ -56,146 +56,6 @@ func __mainPackageInFile_types_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
-// ListOfIncident
-
-type ListOfIncident struct {
-	l types.List
-}
-
-func NewListOfIncident() ListOfIncident {
-	return ListOfIncident{types.NewList()}
-}
-
-type ListOfIncidentDef []IncidentDef
-
-func (def ListOfIncidentDef) New() ListOfIncident {
-	l := make([]types.Value, len(def))
-	for i, d := range def {
-		l[i] = d.New().NomsValue()
-	}
-	return ListOfIncident{types.NewList(l...)}
-}
-
-func (l ListOfIncident) Def() ListOfIncidentDef {
-	d := make([]IncidentDef, l.Len())
-	for i := uint64(0); i < l.Len(); i++ {
-		d[i] = IncidentFromVal(l.l.Get(i)).Def()
-	}
-	return d
-}
-
-func ListOfIncidentFromVal(val types.Value) ListOfIncident {
-	// TODO: Validate here
-	return ListOfIncident{val.(types.List)}
-}
-
-func (l ListOfIncident) NomsValue() types.Value {
-	return l.l
-}
-
-func (l ListOfIncident) Equals(other types.Value) bool {
-	if other, ok := other.(ListOfIncident); ok {
-		return l.l.Equals(other.l)
-	}
-	return false
-}
-
-func (l ListOfIncident) Ref() ref.Ref {
-	return l.l.Ref()
-}
-
-func (l ListOfIncident) Chunks() (futures []types.Future) {
-	futures = append(futures, l.TypeRef().Chunks()...)
-	futures = append(futures, l.l.Chunks()...)
-	return
-}
-
-// A Noms Value that describes ListOfIncident.
-var __typeRefForListOfIncident types.TypeRef
-
-func (m ListOfIncident) TypeRef() types.TypeRef {
-	return __typeRefForListOfIncident
-}
-
-func init() {
-	__typeRefForListOfIncident = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 2))
-	types.RegisterFromValFunction(__typeRefForListOfIncident, func(v types.Value) types.NomsValue {
-		return ListOfIncidentFromVal(v)
-	})
-}
-
-func (l ListOfIncident) Len() uint64 {
-	return l.l.Len()
-}
-
-func (l ListOfIncident) Empty() bool {
-	return l.Len() == uint64(0)
-}
-
-func (l ListOfIncident) Get(i uint64) Incident {
-	return IncidentFromVal(l.l.Get(i))
-}
-
-func (l ListOfIncident) Slice(idx uint64, end uint64) ListOfIncident {
-	return ListOfIncident{l.l.Slice(idx, end)}
-}
-
-func (l ListOfIncident) Set(i uint64, val Incident) ListOfIncident {
-	return ListOfIncident{l.l.Set(i, val.NomsValue())}
-}
-
-func (l ListOfIncident) Append(v ...Incident) ListOfIncident {
-	return ListOfIncident{l.l.Append(l.fromElemSlice(v)...)}
-}
-
-func (l ListOfIncident) Insert(idx uint64, v ...Incident) ListOfIncident {
-	return ListOfIncident{l.l.Insert(idx, l.fromElemSlice(v)...)}
-}
-
-func (l ListOfIncident) Remove(idx uint64, end uint64) ListOfIncident {
-	return ListOfIncident{l.l.Remove(idx, end)}
-}
-
-func (l ListOfIncident) RemoveAt(idx uint64) ListOfIncident {
-	return ListOfIncident{(l.l.RemoveAt(idx))}
-}
-
-func (l ListOfIncident) fromElemSlice(p []Incident) []types.Value {
-	r := make([]types.Value, len(p))
-	for i, v := range p {
-		r[i] = v.NomsValue()
-	}
-	return r
-}
-
-type ListOfIncidentIterCallback func(v Incident, i uint64) (stop bool)
-
-func (l ListOfIncident) Iter(cb ListOfIncidentIterCallback) {
-	l.l.Iter(func(v types.Value, i uint64) bool {
-		return cb(IncidentFromVal(v), i)
-	})
-}
-
-type ListOfIncidentIterAllCallback func(v Incident, i uint64)
-
-func (l ListOfIncident) IterAll(cb ListOfIncidentIterAllCallback) {
-	l.l.IterAll(func(v types.Value, i uint64) {
-		cb(IncidentFromVal(v), i)
-	})
-}
-
-type ListOfIncidentFilterCallback func(v Incident, i uint64) (keep bool)
-
-func (l ListOfIncident) Filter(cb ListOfIncidentFilterCallback) ListOfIncident {
-	nl := NewListOfIncident()
-	l.IterAll(func(v Incident, i uint64) {
-		if cb(v, i) {
-			nl = nl.Append(v)
-		}
-	})
-	return nl
-}
-
 // Geoposition
 
 type Geoposition struct {
@@ -630,6 +490,146 @@ func (s SQuadTree) Georectangle() Georectangle {
 
 func (s SQuadTree) SetGeorectangle(val Georectangle) SQuadTree {
 	return SQuadTree{s.m.Set(types.NewString("Georectangle"), val.NomsValue())}
+}
+
+// ListOfIncident
+
+type ListOfIncident struct {
+	l types.List
+}
+
+func NewListOfIncident() ListOfIncident {
+	return ListOfIncident{types.NewList()}
+}
+
+type ListOfIncidentDef []IncidentDef
+
+func (def ListOfIncidentDef) New() ListOfIncident {
+	l := make([]types.Value, len(def))
+	for i, d := range def {
+		l[i] = d.New().NomsValue()
+	}
+	return ListOfIncident{types.NewList(l...)}
+}
+
+func (l ListOfIncident) Def() ListOfIncidentDef {
+	d := make([]IncidentDef, l.Len())
+	for i := uint64(0); i < l.Len(); i++ {
+		d[i] = IncidentFromVal(l.l.Get(i)).Def()
+	}
+	return d
+}
+
+func ListOfIncidentFromVal(val types.Value) ListOfIncident {
+	// TODO: Validate here
+	return ListOfIncident{val.(types.List)}
+}
+
+func (l ListOfIncident) NomsValue() types.Value {
+	return l.l
+}
+
+func (l ListOfIncident) Equals(other types.Value) bool {
+	if other, ok := other.(ListOfIncident); ok {
+		return l.l.Equals(other.l)
+	}
+	return false
+}
+
+func (l ListOfIncident) Ref() ref.Ref {
+	return l.l.Ref()
+}
+
+func (l ListOfIncident) Chunks() (futures []types.Future) {
+	futures = append(futures, l.TypeRef().Chunks()...)
+	futures = append(futures, l.l.Chunks()...)
+	return
+}
+
+// A Noms Value that describes ListOfIncident.
+var __typeRefForListOfIncident types.TypeRef
+
+func (m ListOfIncident) TypeRef() types.TypeRef {
+	return __typeRefForListOfIncident
+}
+
+func init() {
+	__typeRefForListOfIncident = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 2))
+	types.RegisterFromValFunction(__typeRefForListOfIncident, func(v types.Value) types.NomsValue {
+		return ListOfIncidentFromVal(v)
+	})
+}
+
+func (l ListOfIncident) Len() uint64 {
+	return l.l.Len()
+}
+
+func (l ListOfIncident) Empty() bool {
+	return l.Len() == uint64(0)
+}
+
+func (l ListOfIncident) Get(i uint64) Incident {
+	return IncidentFromVal(l.l.Get(i))
+}
+
+func (l ListOfIncident) Slice(idx uint64, end uint64) ListOfIncident {
+	return ListOfIncident{l.l.Slice(idx, end)}
+}
+
+func (l ListOfIncident) Set(i uint64, val Incident) ListOfIncident {
+	return ListOfIncident{l.l.Set(i, val.NomsValue())}
+}
+
+func (l ListOfIncident) Append(v ...Incident) ListOfIncident {
+	return ListOfIncident{l.l.Append(l.fromElemSlice(v)...)}
+}
+
+func (l ListOfIncident) Insert(idx uint64, v ...Incident) ListOfIncident {
+	return ListOfIncident{l.l.Insert(idx, l.fromElemSlice(v)...)}
+}
+
+func (l ListOfIncident) Remove(idx uint64, end uint64) ListOfIncident {
+	return ListOfIncident{l.l.Remove(idx, end)}
+}
+
+func (l ListOfIncident) RemoveAt(idx uint64) ListOfIncident {
+	return ListOfIncident{(l.l.RemoveAt(idx))}
+}
+
+func (l ListOfIncident) fromElemSlice(p []Incident) []types.Value {
+	r := make([]types.Value, len(p))
+	for i, v := range p {
+		r[i] = v.NomsValue()
+	}
+	return r
+}
+
+type ListOfIncidentIterCallback func(v Incident, i uint64) (stop bool)
+
+func (l ListOfIncident) Iter(cb ListOfIncidentIterCallback) {
+	l.l.Iter(func(v types.Value, i uint64) bool {
+		return cb(IncidentFromVal(v), i)
+	})
+}
+
+type ListOfIncidentIterAllCallback func(v Incident, i uint64)
+
+func (l ListOfIncident) IterAll(cb ListOfIncidentIterAllCallback) {
+	l.l.IterAll(func(v types.Value, i uint64) {
+		cb(IncidentFromVal(v), i)
+	})
+}
+
+type ListOfIncidentFilterCallback func(v Incident, i uint64) (keep bool)
+
+func (l ListOfIncident) Filter(cb ListOfIncidentFilterCallback) ListOfIncident {
+	nl := NewListOfIncident()
+	l.IterAll(func(v Incident, i uint64) {
+		if cb(v, i) {
+			nl = nl.Append(v)
+		}
+	})
+	return nl
 }
 
 // MapOfStringToSQuadTree

--- a/datas/types.go
+++ b/datas/types.go
@@ -28,6 +28,74 @@ func __datasPackageInFile_types_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// Commit
+
+type Commit struct {
+	m types.Map
+}
+
+func NewCommit() Commit {
+	return Commit{types.NewMap(
+		types.NewString("$type"), types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0),
+		types.NewString("value"), types.Bool(false),
+		types.NewString("parents"), types.NewSet(),
+	)}
+}
+
+var __typeRefForCommit = types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)
+
+func (m Commit) TypeRef() types.TypeRef {
+	return __typeRefForCommit
+}
+
+func init() {
+	types.RegisterFromValFunction(__typeRefForCommit, func(v types.Value) types.NomsValue {
+		return CommitFromVal(v)
+	})
+}
+
+func CommitFromVal(val types.Value) Commit {
+	// TODO: Validate here
+	return Commit{val.(types.Map)}
+}
+
+func (s Commit) NomsValue() types.Value {
+	return s.m
+}
+
+func (s Commit) Equals(other types.Value) bool {
+	if other, ok := other.(Commit); ok {
+		return s.m.Equals(other.m)
+	}
+	return false
+}
+
+func (s Commit) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Commit) Chunks() (futures []types.Future) {
+	futures = append(futures, s.TypeRef().Chunks()...)
+	futures = append(futures, s.m.Chunks()...)
+	return
+}
+
+func (s Commit) Value() types.Value {
+	return s.m.Get(types.NewString("value"))
+}
+
+func (s Commit) SetValue(val types.Value) Commit {
+	return Commit{s.m.Set(types.NewString("value"), val)}
+}
+
+func (s Commit) Parents() SetOfCommit {
+	return SetOfCommitFromVal(s.m.Get(types.NewString("parents")))
+}
+
+func (s Commit) SetParents(val SetOfCommit) Commit {
+	return Commit{s.m.Set(types.NewString("parents"), val.NomsValue())}
+}
+
 // MapOfStringToCommit
 
 type MapOfStringToCommit struct {
@@ -138,74 +206,6 @@ func (m MapOfStringToCommit) Filter(cb MapOfStringToCommitFilterCallback) MapOfS
 		}
 	})
 	return nm
-}
-
-// Commit
-
-type Commit struct {
-	m types.Map
-}
-
-func NewCommit() Commit {
-	return Commit{types.NewMap(
-		types.NewString("$type"), types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0),
-		types.NewString("value"), types.Bool(false),
-		types.NewString("parents"), types.NewSet(),
-	)}
-}
-
-var __typeRefForCommit = types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)
-
-func (m Commit) TypeRef() types.TypeRef {
-	return __typeRefForCommit
-}
-
-func init() {
-	types.RegisterFromValFunction(__typeRefForCommit, func(v types.Value) types.NomsValue {
-		return CommitFromVal(v)
-	})
-}
-
-func CommitFromVal(val types.Value) Commit {
-	// TODO: Validate here
-	return Commit{val.(types.Map)}
-}
-
-func (s Commit) NomsValue() types.Value {
-	return s.m
-}
-
-func (s Commit) Equals(other types.Value) bool {
-	if other, ok := other.(Commit); ok {
-		return s.m.Equals(other.m)
-	}
-	return false
-}
-
-func (s Commit) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s Commit) Chunks() (futures []types.Future) {
-	futures = append(futures, s.TypeRef().Chunks()...)
-	futures = append(futures, s.m.Chunks()...)
-	return
-}
-
-func (s Commit) Value() types.Value {
-	return s.m.Get(types.NewString("value"))
-}
-
-func (s Commit) SetValue(val types.Value) Commit {
-	return Commit{s.m.Set(types.NewString("value"), val)}
-}
-
-func (s Commit) Parents() SetOfCommit {
-	return SetOfCommitFromVal(s.m.Get(types.NewString("parents")))
-}
-
-func (s Commit) SetParents(val SetOfCommit) Commit {
-	return Commit{s.m.Set(types.NewString("parents"), val.NomsValue())}
 }
 
 // SetOfCommit

--- a/nomdl/codegen/test/struct.go
+++ b/nomdl/codegen/test/struct.go
@@ -28,6 +28,94 @@ func __testPackageInFile_struct_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// Struct
+
+type Struct struct {
+	m types.Map
+}
+
+func NewStruct() Struct {
+	return Struct{types.NewMap(
+		types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_CachedRef, 0),
+		types.NewString("s"), types.NewString(""),
+		types.NewString("b"), types.Bool(false),
+	)}
+}
+
+type StructDef struct {
+	S string
+	B bool
+}
+
+func (def StructDef) New() Struct {
+	return Struct{
+		types.NewMap(
+			types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_CachedRef, 0),
+			types.NewString("s"), types.NewString(def.S),
+			types.NewString("b"), types.Bool(def.B),
+		)}
+}
+
+func (s Struct) Def() (d StructDef) {
+	d.S = s.m.Get(types.NewString("s")).(types.String).String()
+	d.B = bool(s.m.Get(types.NewString("b")).(types.Bool))
+	return
+}
+
+var __typeRefForStruct = types.MakeTypeRef(__testPackageInFile_struct_CachedRef, 0)
+
+func (m Struct) TypeRef() types.TypeRef {
+	return __typeRefForStruct
+}
+
+func init() {
+	types.RegisterFromValFunction(__typeRefForStruct, func(v types.Value) types.NomsValue {
+		return StructFromVal(v)
+	})
+}
+
+func StructFromVal(val types.Value) Struct {
+	// TODO: Validate here
+	return Struct{val.(types.Map)}
+}
+
+func (s Struct) NomsValue() types.Value {
+	return s.m
+}
+
+func (s Struct) Equals(other types.Value) bool {
+	if other, ok := other.(Struct); ok {
+		return s.m.Equals(other.m)
+	}
+	return false
+}
+
+func (s Struct) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s Struct) Chunks() (futures []types.Future) {
+	futures = append(futures, s.TypeRef().Chunks()...)
+	futures = append(futures, s.m.Chunks()...)
+	return
+}
+
+func (s Struct) S() string {
+	return s.m.Get(types.NewString("s")).(types.String).String()
+}
+
+func (s Struct) SetS(val string) Struct {
+	return Struct{s.m.Set(types.NewString("s"), types.NewString(val))}
+}
+
+func (s Struct) B() bool {
+	return bool(s.m.Get(types.NewString("b")).(types.Bool))
+}
+
+func (s Struct) SetB(val bool) Struct {
+	return Struct{s.m.Set(types.NewString("b"), types.Bool(val))}
+}
+
 // ListOfStruct
 
 type ListOfStruct struct {
@@ -166,92 +254,4 @@ func (l ListOfStruct) Filter(cb ListOfStructFilterCallback) ListOfStruct {
 		}
 	})
 	return nl
-}
-
-// Struct
-
-type Struct struct {
-	m types.Map
-}
-
-func NewStruct() Struct {
-	return Struct{types.NewMap(
-		types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_CachedRef, 0),
-		types.NewString("s"), types.NewString(""),
-		types.NewString("b"), types.Bool(false),
-	)}
-}
-
-type StructDef struct {
-	S string
-	B bool
-}
-
-func (def StructDef) New() Struct {
-	return Struct{
-		types.NewMap(
-			types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_CachedRef, 0),
-			types.NewString("s"), types.NewString(def.S),
-			types.NewString("b"), types.Bool(def.B),
-		)}
-}
-
-func (s Struct) Def() (d StructDef) {
-	d.S = s.m.Get(types.NewString("s")).(types.String).String()
-	d.B = bool(s.m.Get(types.NewString("b")).(types.Bool))
-	return
-}
-
-var __typeRefForStruct = types.MakeTypeRef(__testPackageInFile_struct_CachedRef, 0)
-
-func (m Struct) TypeRef() types.TypeRef {
-	return __typeRefForStruct
-}
-
-func init() {
-	types.RegisterFromValFunction(__typeRefForStruct, func(v types.Value) types.NomsValue {
-		return StructFromVal(v)
-	})
-}
-
-func StructFromVal(val types.Value) Struct {
-	// TODO: Validate here
-	return Struct{val.(types.Map)}
-}
-
-func (s Struct) NomsValue() types.Value {
-	return s.m
-}
-
-func (s Struct) Equals(other types.Value) bool {
-	if other, ok := other.(Struct); ok {
-		return s.m.Equals(other.m)
-	}
-	return false
-}
-
-func (s Struct) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s Struct) Chunks() (futures []types.Future) {
-	futures = append(futures, s.TypeRef().Chunks()...)
-	futures = append(futures, s.m.Chunks()...)
-	return
-}
-
-func (s Struct) S() string {
-	return s.m.Get(types.NewString("s")).(types.String).String()
-}
-
-func (s Struct) SetS(val string) Struct {
-	return Struct{s.m.Set(types.NewString("s"), types.NewString(val))}
-}
-
-func (s Struct) B() bool {
-	return bool(s.m.Get(types.NewString("b")).(types.Bool))
-}
-
-func (s Struct) SetB(val bool) Struct {
-	return Struct{s.m.Set(types.NewString("b"), types.Bool(val))}
 }

--- a/nomdl/codegen/test/struct_with_imports.go
+++ b/nomdl/codegen/test/struct_with_imports.go
@@ -30,6 +30,103 @@ func __testPackageInFile_struct_with_imports_Ref() ref.Ref {
 	return types.RegisterPackage(&p)
 }
 
+// E
+
+type E uint32
+
+const (
+	E1 E = iota
+	Ignored
+)
+
+// ImportUser
+
+type ImportUser struct {
+	m types.Map
+}
+
+func NewImportUser() ImportUser {
+	return ImportUser{types.NewMap(
+		types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_with_imports_CachedRef, 1),
+		types.NewString("importedStruct"), sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.NewD().NomsValue(),
+		types.NewString("enum"), types.UInt32(0),
+	)}
+}
+
+type ImportUserDef struct {
+	ImportedStruct sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.DDef
+	Enum           E
+}
+
+func (def ImportUserDef) New() ImportUser {
+	return ImportUser{
+		types.NewMap(
+			types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_with_imports_CachedRef, 1),
+			types.NewString("importedStruct"), def.ImportedStruct.New().NomsValue(),
+			types.NewString("enum"), types.UInt32(def.Enum),
+		)}
+}
+
+func (s ImportUser) Def() (d ImportUserDef) {
+	d.ImportedStruct = sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.DFromVal(s.m.Get(types.NewString("importedStruct"))).Def()
+	d.Enum = E(s.m.Get(types.NewString("enum")).(types.UInt32))
+	return
+}
+
+var __typeRefForImportUser = types.MakeTypeRef(__testPackageInFile_struct_with_imports_CachedRef, 1)
+
+func (m ImportUser) TypeRef() types.TypeRef {
+	return __typeRefForImportUser
+}
+
+func init() {
+	types.RegisterFromValFunction(__typeRefForImportUser, func(v types.Value) types.NomsValue {
+		return ImportUserFromVal(v)
+	})
+}
+
+func ImportUserFromVal(val types.Value) ImportUser {
+	// TODO: Validate here
+	return ImportUser{val.(types.Map)}
+}
+
+func (s ImportUser) NomsValue() types.Value {
+	return s.m
+}
+
+func (s ImportUser) Equals(other types.Value) bool {
+	if other, ok := other.(ImportUser); ok {
+		return s.m.Equals(other.m)
+	}
+	return false
+}
+
+func (s ImportUser) Ref() ref.Ref {
+	return s.m.Ref()
+}
+
+func (s ImportUser) Chunks() (futures []types.Future) {
+	futures = append(futures, s.TypeRef().Chunks()...)
+	futures = append(futures, s.m.Chunks()...)
+	return
+}
+
+func (s ImportUser) ImportedStruct() sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.D {
+	return sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.DFromVal(s.m.Get(types.NewString("importedStruct")))
+}
+
+func (s ImportUser) SetImportedStruct(val sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.D) ImportUser {
+	return ImportUser{s.m.Set(types.NewString("importedStruct"), val.NomsValue())}
+}
+
+func (s ImportUser) Enum() E {
+	return E(s.m.Get(types.NewString("enum")).(types.UInt32))
+}
+
+func (s ImportUser) SetEnum(val E) ImportUser {
+	return ImportUser{s.m.Set(types.NewString("enum"), types.UInt32(val))}
+}
+
 // ListOfsha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5_D
 
 type ListOfsha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5_D struct {
@@ -168,101 +265,4 @@ func (l ListOfsha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5_D) Filter(cb ListOfs
 		}
 	})
 	return nl
-}
-
-// E
-
-type E uint32
-
-const (
-	E1 E = iota
-	Ignored
-)
-
-// ImportUser
-
-type ImportUser struct {
-	m types.Map
-}
-
-func NewImportUser() ImportUser {
-	return ImportUser{types.NewMap(
-		types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_with_imports_CachedRef, 1),
-		types.NewString("importedStruct"), sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.NewD().NomsValue(),
-		types.NewString("enum"), types.UInt32(0),
-	)}
-}
-
-type ImportUserDef struct {
-	ImportedStruct sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.DDef
-	Enum           E
-}
-
-func (def ImportUserDef) New() ImportUser {
-	return ImportUser{
-		types.NewMap(
-			types.NewString("$type"), types.MakeTypeRef(__testPackageInFile_struct_with_imports_CachedRef, 1),
-			types.NewString("importedStruct"), def.ImportedStruct.New().NomsValue(),
-			types.NewString("enum"), types.UInt32(def.Enum),
-		)}
-}
-
-func (s ImportUser) Def() (d ImportUserDef) {
-	d.ImportedStruct = sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.DFromVal(s.m.Get(types.NewString("importedStruct"))).Def()
-	d.Enum = E(s.m.Get(types.NewString("enum")).(types.UInt32))
-	return
-}
-
-var __typeRefForImportUser = types.MakeTypeRef(__testPackageInFile_struct_with_imports_CachedRef, 1)
-
-func (m ImportUser) TypeRef() types.TypeRef {
-	return __typeRefForImportUser
-}
-
-func init() {
-	types.RegisterFromValFunction(__typeRefForImportUser, func(v types.Value) types.NomsValue {
-		return ImportUserFromVal(v)
-	})
-}
-
-func ImportUserFromVal(val types.Value) ImportUser {
-	// TODO: Validate here
-	return ImportUser{val.(types.Map)}
-}
-
-func (s ImportUser) NomsValue() types.Value {
-	return s.m
-}
-
-func (s ImportUser) Equals(other types.Value) bool {
-	if other, ok := other.(ImportUser); ok {
-		return s.m.Equals(other.m)
-	}
-	return false
-}
-
-func (s ImportUser) Ref() ref.Ref {
-	return s.m.Ref()
-}
-
-func (s ImportUser) Chunks() (futures []types.Future) {
-	futures = append(futures, s.TypeRef().Chunks()...)
-	futures = append(futures, s.m.Chunks()...)
-	return
-}
-
-func (s ImportUser) ImportedStruct() sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.D {
-	return sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.DFromVal(s.m.Get(types.NewString("importedStruct")))
-}
-
-func (s ImportUser) SetImportedStruct(val sha1_d64765d6f185e4e5f7d9e67d1fc4e084b38229f5.D) ImportUser {
-	return ImportUser{s.m.Set(types.NewString("importedStruct"), val.NomsValue())}
-}
-
-func (s ImportUser) Enum() E {
-	return E(s.m.Get(types.NewString("enum")).(types.UInt32))
-}
-
-func (s ImportUser) SetEnum(val E) ImportUser {
-	return ImportUser{s.m.Set(types.NewString("enum"), types.UInt32(val))}
 }


### PR DESCRIPTION
Now we write the named types first, then the using types and finally
the inline type defs in the order that they were defined.
