### PR TITLE
NomDL: Rename SetOrderedType to SetTypes

### DIFF
--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -209,7 +209,7 @@ func TestReadStruct(t *testing.T) {
 		Field{"s", MakePrimitiveTypeRef(StringKind), false},
 		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
 	}, Choices{})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -239,7 +239,7 @@ func TestReadStructUnion(t *testing.T) {
 		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
 		Field{"s", MakePrimitiveTypeRef(StringKind), false},
 	})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", 0, 42, 1, "hi"]`, TypeRefKind, pkgRef.String())
@@ -269,7 +269,7 @@ func TestReadStructOptional(t *testing.T) {
 		Field{"s", MakePrimitiveTypeRef(StringKind), true},
 		Field{"b", MakePrimitiveTypeRef(BoolKind), true},
 	}, Choices{})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -304,7 +304,7 @@ func TestReadStructWithList(t *testing.T) {
 		Field{"l", MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int32Kind)), false},
 		Field{"s", MakePrimitiveTypeRef(StringKind), false},
 	}, Choices{})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -344,7 +344,7 @@ func TestReadStructWithValue(t *testing.T) {
 		Field{"v", MakePrimitiveTypeRef(ValueKind), false},
 		Field{"s", MakePrimitiveTypeRef(StringKind), false},
 	}, Choices{})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -379,7 +379,7 @@ func TestReadValueStruct(t *testing.T) {
 		Field{"s", MakePrimitiveTypeRef(StringKind), false},
 		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
 	}, Choices{})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -404,7 +404,7 @@ func TestReadEnum(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	tref := MakeEnumTypeRef("E", "a", "b", "c")
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -420,7 +420,7 @@ func TestReadValueEnum(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	tref := MakeEnumTypeRef("E", "a", "b", "c")
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -487,7 +487,7 @@ func TestReadStructWithEnum(t *testing.T) {
 		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
 	}, Choices{})
 	enumTref := MakeEnumTypeRef("E", "a", "b", "c")
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(structTref, enumTref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(structTref, enumTref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name
@@ -518,7 +518,7 @@ func TestReadStructWithBlob(t *testing.T) {
 	tref := MakeStructTypeRef("A5", []Field{
 		Field{"b", MakePrimitiveTypeRef(BlobKind), false},
 	}, Choices{})
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(tref))
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(tref))
 	pkgRef := RegisterPackage(&pkg)
 
 	// TODO: Should use ordinal of type and not name

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -117,7 +117,7 @@ func TestWriteMapOfMap(t *testing.T) {
 func TestWriteEmptyStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{}, Choices{})))
 	pkgRef := RegisterPackage(&pkg)
 	tref := MakeTypeRef(pkgRef, 0)
@@ -131,7 +131,7 @@ func TestWriteEmptyStruct(t *testing.T) {
 func TestWriteStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"x", MakePrimitiveTypeRef(Int8Kind), false},
 			Field{"b", MakePrimitiveTypeRef(BoolKind), false},
@@ -148,7 +148,7 @@ func TestWriteStruct(t *testing.T) {
 func TestWriteStructOptionalField(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"x", MakePrimitiveTypeRef(Int8Kind), true},
 			Field{"b", MakePrimitiveTypeRef(BoolKind), false},
@@ -171,7 +171,7 @@ func TestWriteStructOptionalField(t *testing.T) {
 func TestWriteStructWithUnion(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"x", MakePrimitiveTypeRef(Int8Kind), false},
 		}, Choices{
@@ -196,7 +196,7 @@ func TestWriteStructWithUnion(t *testing.T) {
 func TestWriteStructWithList(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"l", MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(StringKind)), false},
 		}, Choices{})))
@@ -217,7 +217,7 @@ func TestWriteStructWithList(t *testing.T) {
 func TestWriteStructWithStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S2", []Field{
 			Field{"x", MakePrimitiveTypeRef(Int32Kind), false},
 		}, Choices{}),
@@ -236,7 +236,7 @@ func TestWriteStructWithStruct(t *testing.T) {
 func TestWriteStructWithBlob(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"b", MakePrimitiveTypeRef(BlobKind), false},
 		}, Choices{})))
@@ -253,7 +253,7 @@ func TestWriteStructWithBlob(t *testing.T) {
 func TestWriteEnum(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeEnumTypeRef("E", "a", "b", "c")))
 	pkgRef := RegisterPackage(&pkg)
 	tref := MakeTypeRef(pkgRef, 0)
@@ -267,7 +267,7 @@ func TestWriteEnum(t *testing.T) {
 func TestWriteListOfEnum(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeEnumTypeRef("E", "a", "b", "c")))
 	pkgRef := RegisterPackage(&pkg)
 	et := MakeTypeRef(pkgRef, 0)
@@ -323,7 +323,7 @@ func TestWriteListOfValue(t *testing.T) {
 func TestWriteListOfValueWithStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"x", MakePrimitiveTypeRef(Int32Kind), false},
 		}, Choices{})))
@@ -341,7 +341,7 @@ func TestWriteListOfValueWithStruct(t *testing.T) {
 func TestWriteListOfValueWithTypeRefs(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage().SetOrderedTypes(NewListOfTypeRef().Append(
+	pkg := NewPackage().SetTypes(NewListOfTypeRef().Append(
 		MakeStructTypeRef("S", []Field{
 			Field{"x", MakePrimitiveTypeRef(Int32Kind), false},
 		}, Choices{})))

--- a/types/package.go
+++ b/types/package.go
@@ -240,7 +240,7 @@ func (s Package) Types() ListOfTypeRef {
 	return ListOfTypeRefFromVal(s.m.Get(NewString("Types")))
 }
 
-func (s Package) SetOrderedTypes(val ListOfTypeRef) Package {
+func (s Package) SetTypes(val ListOfTypeRef) Package {
 	return Package{s.m.Set(NewString("Types"), val.NomsValue())}
 }
 


### PR DESCRIPTION
I missed this when I renamed the field previously
