### PR TITLE
pkg.Parsed should embed a types.Package, not a types.PackageDef

### DIFF
--- a/nomdl/codegen/codegen.go
+++ b/nomdl/codegen/codegen.go
@@ -98,7 +98,7 @@ func generate(packageName, in, out, depsDir string, pkgDS dataset.Dataset) datas
 	p := pkg.ParseNomDL(packageName, inFile, filepath.Dir(in), pkgDS.Store())
 
 	// Generate code for all p's deps first.
-	deps := generateDepCode(depsDir, p.New(), pkgDS.Store())
+	deps := generateDepCode(depsDir, p.Package, pkgDS.Store())
 	generateAndEmit(getBareFileName(in), out, importPaths(depsDir, deps), deps, p)
 
 	// Since we're just building up a set of refs to all the packages in pkgDS, simply retrying is the logical response to commit failure.
@@ -115,7 +115,7 @@ func generateDepCode(depsDir string, p types.Package, cs chunks.ChunkSource) dep
 		p := r.GetValue(cs)
 		pDeps := generateDepCode(depsDir, p, cs)
 		tag := code.ToTag(p.Ref())
-		parsed := pkg.Parsed{PackageDef: p.Def(), Name: tag}
+		parsed := pkg.Parsed{Package: p, Name: tag}
 		generateAndEmit(tag, filepath.Join(depsDir, tag, tag+".go"), importPaths(depsDir, pDeps), pDeps, parsed)
 
 		for depRef, dep := range pDeps {
@@ -167,7 +167,7 @@ func buildSetOfRefOfPackage(pkg pkg.Parsed, deps depsMap, ds dataset.Dataset) ty
 		// TODO: consider moving all dataset work over into nomdl/pkg BUG 409
 		s = s.Insert(types.NewRefOfPackage(types.WriteValue(dep.NomsValue(), ds.Store())))
 	}
-	r := types.WriteValue(pkg.New().NomsValue(), ds.Store())
+	r := types.WriteValue(pkg.NomsValue(), ds.Store())
 	return s.Insert(types.NewRefOfPackage(r))
 }
 
@@ -242,7 +242,7 @@ func (gen *codeGen) Resolve(t types.TypeRef) types.TypeRef {
 		return t
 	}
 	if !t.HasPackageRef() {
-		return gen.pkg.Types[t.Ordinal()]
+		return gen.pkg.Types().Get(uint64(t.Ordinal()))
 	}
 
 	dep, ok := gen.deps[t.PackageRef()]
@@ -251,6 +251,7 @@ func (gen *codeGen) Resolve(t types.TypeRef) types.TypeRef {
 }
 
 func (gen *codeGen) WritePackage() {
+	pkgTypes := gen.pkg.Types().Def()
 	data := struct {
 		HasImports bool
 		HasTypes   bool
@@ -260,16 +261,16 @@ func (gen *codeGen) WritePackage() {
 		Types      []types.TypeRef
 	}{
 		len(gen.imports) > 0,
-		len(gen.pkg.Types) > 0,
+		len(pkgTypes) > 0,
 		gen.fileid,
 		gen.imports,
 		gen.pkg.Name,
-		gen.pkg.Types,
+		pkgTypes,
 	}
 	err := gen.templates.ExecuteTemplate(gen.w, "header.tmpl", data)
 	d.Exp.NoError(err)
 
-	for i, t := range gen.pkg.Types {
+	for i, t := range pkgTypes {
 		gen.writeTopLevel(t, i)
 	}
 
@@ -519,8 +520,7 @@ func (gen *codeGen) canUseDef(t types.TypeRef) bool {
 		}
 	}
 
-	// TODO: pkg.Parsed.New() gets called too often. Figure out whether we generally want a Package or a PackageDef and modify pkg.Parsed accordingly. BUG 420
-	return rec(t, gen.pkg.New())
+	return rec(t, gen.pkg.Package)
 }
 
 // We use a go map as the def for Set and Map. These cannot have a key that is a
@@ -558,8 +558,8 @@ func (gen *codeGen) containsNonComparable(t types.TypeRef) bool {
 			return false
 		}
 	}
-	// TODO: pkg.Parsed.New() gets called too often. Figure out whether we generally want a Package or a PackageDef and modify pkg.Parsed accordingly. BUG 420
-	return rec(t, gen.pkg.New())
+
+	return rec(t, gen.pkg.Package)
 }
 
 func resolveInPackage(t types.TypeRef, p *types.Package) types.TypeRef {

--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -78,7 +78,7 @@ func TestCanUseDef(t *testing.T) {
 		for _, t := range pkg.UsingDeclarations {
 			assert.Equal(using, gen.canUseDef(t))
 		}
-		for _, t := range pkg.Types {
+		for _, t := range pkg.Types().Def() {
 			assert.Equal(named, gen.canUseDef(t))
 		}
 	}

--- a/nomdl/pkg/import_test.go
+++ b/nomdl/pkg/import_test.go
@@ -123,7 +123,7 @@ func (suite *ImportTestSuite) TestImports() {
 		suite.NoError(err)
 		defer inFile.Close()
 		parsedDep := ParseNomDL("", inFile, filepath.Dir(path), cs)
-		return types.WriteValue(parsedDep.New().NomsValue(), cs)
+		return types.WriteValue(parsedDep.NomsValue(), cs)
 	}
 
 	dir, err := ioutil.TempDir("", "")
@@ -164,34 +164,34 @@ func (suite *ImportTestSuite) TestImports() {
 		}`, suite.importRef, filepath.Base(byPathNomDL)))
 	p := ParseNomDL("testing", r, dir, suite.cs)
 
-	named := p.Types[0]
+	named := p.Types().Get(0)
 	suite.Equal("Local1", named.Name())
 	field := find("a", named)
 	suite.EqualValues(suite.importRef, field.T.PackageRef())
 	field = find("c", named)
 	suite.EqualValues(ref.Ref{}, field.T.PackageRef())
 
-	named = p.Types[1]
+	named = p.Types().Get(1)
 	suite.Equal("Local2", named.Name())
 	field = find("a", named)
 	suite.EqualValues(refFromNomsFile(byPathNomDL), field.T.PackageRef())
 	field = find("b", named)
 	suite.EqualValues(suite.importRef, field.T.PackageRef())
 
-	named = p.Types[2]
+	named = p.Types().Get(2)
 	suite.Equal("Union", named.Name())
 	field = findChoice("a", named)
 	suite.EqualValues(suite.importRef, field.T.PackageRef())
 	field = findChoice("b", named)
 	suite.EqualValues(ref.Ref{}, field.T.PackageRef())
 
-	named = p.Types[3]
+	named = p.Types().Get(3)
 	suite.Equal("WithUnion", named.Name())
 	field = find("a", named)
 	suite.EqualValues(suite.importRef, field.T.PackageRef())
 	namedUnion := find("b", named).T
 	suite.True(namedUnion.IsUnresolved())
-	namedUnion = p.Types[namedUnion.Ordinal()]
+	namedUnion = p.Types().Get(uint64(namedUnion.Ordinal()))
 	field = findChoice("s", namedUnion)
 	suite.EqualValues(ref.Ref{}, field.T.PackageRef())
 	field = findChoice("t", namedUnion)

--- a/nomdl/pkg/parse.go
+++ b/nomdl/pkg/parse.go
@@ -24,7 +24,7 @@ func ParseNomDL(packageName string, r io.Reader, includePath string, cs chunks.C
 	resolveLocalOrdinals(&i)
 	resolveNamespaces(&i, imports, GetDeps(depRefs, cs))
 	return Parsed{
-		types.PackageDef{Dependencies: depRefs, Types: i.Types},
+		types.PackageDef{Dependencies: depRefs, Types: i.Types}.New(),
 		i.Name,
 		i.UsingDeclarations,
 	}
@@ -44,7 +44,7 @@ func GetDeps(depRefs types.SetOfRefOfPackageDef, cs chunks.ChunkStore) map[ref.R
 // Parsed represents a parsed Noms type package, which has some additional metadata beyond that which is present in a types.Package.
 // UsingDeclarations is kind of a hack to indicate specializations of Noms containers that need to be generated. These should all be one of ListKind, SetKind, MapKind or RefKind, and Desc should be a CompoundDesc instance.
 type Parsed struct {
-	types.PackageDef
+	types.Package
 	Name              string
 	UsingDeclarations []types.TypeRef
 }
@@ -96,7 +96,7 @@ func resolveImports(aliases map[string]string, includePath string, cs chunks.Chu
 			d.Chk.NoError(err)
 			defer inFile.Close()
 			parsedDep := ParseNomDL(alias, inFile, filepath.Dir(canonical), cs)
-			imports[alias] = types.WriteValue(parsedDep.New().NomsValue(), cs)
+			imports[alias] = types.WriteValue(parsedDep.NomsValue(), cs)
 		} else {
 			imports[alias] = r
 		}


### PR DESCRIPTION
Doing so makes it so we don't create new Package instances all over codegen.go

Fixes #420
