### PR TITLE
NomDL Serialization: Need to handle Name and Namespace

### DIFF
--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -84,6 +84,7 @@ func (r *jsonArrayReader) readTypeRefAsTag() TypeRef {
 	case UnresolvedKind:
 		pkgRef := r.readRef()
 		ordinal := int16(r.read().(float64))
+		d.Chk.NotEqual(int16(-1), ordinal)
 		return MakeTypeRef(pkgRef, ordinal)
 	}
 
@@ -291,6 +292,12 @@ func (r *jsonArrayReader) readTypeRefAsValue(pkg *Package) TypeRef {
 	case UnresolvedKind:
 		pkgRef := r.readRef()
 		ordinal := int16(r.read().(float64))
+		if ordinal == -1 {
+			namespace := r.readString()
+			name := r.readString()
+			d.Chk.Equal(ref.Ref{}, pkgRef, "Unresolved TypeRefs may not have a package ref")
+			return MakeUnresolvedTypeRef(namespace, name)
+		}
 		return MakeTypeRef(pkgRef, ordinal)
 	}
 

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -569,6 +569,8 @@ func TestReadTypeRefValue(t *testing.T) {
 		Field{"x", MakePrimitiveTypeRef(Int64Kind), false},
 	}, Choices{}),
 		`[%d, %d, "S", ["e", %d, "%s", 123, false, "x", %d, false], []]`, TypeRefKind, StructKind, UnresolvedKind, pkgRef.String(), Int64Kind)
+
+	test(MakeUnresolvedTypeRef("ns", "n"), `[%d, %d, "%s", -1, "ns", "n"]`, TypeRefKind, UnresolvedKind, ref.Ref{}.String())
 }
 
 func TestReadPackage(t *testing.T) {

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -165,7 +165,14 @@ func (w *jsonArrayWriter) writeTypeRefAsValue(v TypeRef) {
 		w.write(choiceWriter.toArray())
 	case UnresolvedKind:
 		w.writeRef(v.PackageRef())
-		w.write(v.Ordinal())
+		// Don't use Ordinal() here since we might need to serialize a TypeRef that hasn't gotten a valid ordinal yet.
+		ordinal := v.Desc.(UnresolvedDesc).ordinal
+		w.write(ordinal)
+		if ordinal == -1 {
+			w.write(v.Namespace())
+			w.write(v.Name())
+		}
+
 	default:
 		d.Chk.True(IsPrimitiveKind(k), v.Describe())
 	}

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -416,6 +416,9 @@ func TestWriteTypeRefValue(t *testing.T) {
 			Field{"e", MakeTypeRef(pkgRef, 123), false},
 			Field{"x", MakePrimitiveTypeRef(Int64Kind), false},
 		}, Choices{}))
+
+	test([]interface{}{TypeRefKind, UnresolvedKind, ref.Ref{}.String(), int16(-1), "ns", "n"},
+		MakeUnresolvedTypeRef("ns", "n"))
 }
 
 func TestWriteListOfTypeRefs(t *testing.T) {


### PR DESCRIPTION
MakeUnresolvedTypeRef has a Name and a Namespace and we should
serialize these too or we break Ref equality
