### PR TITLE
Fix types.Ref and RefKind objects

### DIFF
--- a/clients/csv_importer/csv_importer.go
+++ b/clients/csv_importer/csv_importer.go
@@ -99,7 +99,7 @@ func main() {
 				m = m.Set(types.NewString(keys[i]), types.NewString(v))
 			}
 
-			r := types.Ref{types.WriteValue(m, ds.Store())}
+			r := types.NewRef(types.WriteValue(m, ds.Store()))
 			refChan <- refIndex{r, row.index}
 		}
 	}

--- a/clients/picasa/picasa.go
+++ b/clients/picasa/picasa.go
@@ -198,7 +198,7 @@ func getPhotos(album Album, albumIndex int) (nomsPhotoList types.List) {
 	sort.Sort(ByIndex(refMessages))
 	nomsPhotoList = types.NewList()
 	for _, refMsg := range refMessages {
-		nomsPhotoList = nomsPhotoList.Append(types.Ref{R: refMsg.Ref})
+		nomsPhotoList = nomsPhotoList.Append(types.NewRef(refMsg.Ref))
 	}
 
 	if !*quietFlag {

--- a/clients/quad_tree/types.go
+++ b/clients/quad_tree/types.go
@@ -425,12 +425,16 @@ func (s SQuadTree) SetGeorectangle(val Georectangle) SQuadTree {
 // RefOfValue
 
 type RefOfValue struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfValue(r ref.Ref) RefOfValue {
-	return RefOfValue{r, &ref.Ref{}}
+func NewRefOfValue(target ref.Ref) RefOfValue {
+	return RefOfValue{target, &ref.Ref{}}
+}
+
+func (r RefOfValue) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfValue) Ref() ref.Ref {
@@ -448,16 +452,12 @@ func (r RefOfValue) Chunks() []types.Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfValue) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfValueFromVal(val types.Value) RefOfValue {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfValue); ok {
 		return val
 	}
-	return RefOfValue{val.(types.Ref).Ref(), &ref.Ref{}}
+	return NewRefOfValue(val.(types.Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfValue.
@@ -474,12 +474,12 @@ func init() {
 	})
 }
 
-func (r RefOfValue) GetValue(cs chunks.ChunkSource) types.Value {
-	return types.ReadValue(r.r, cs)
+func (r RefOfValue) TargetValue(cs chunks.ChunkSource) types.Value {
+	return types.ReadValue(r.target, cs)
 }
 
-func (r RefOfValue) SetValue(val types.Value, cs chunks.ChunkSink) RefOfValue {
-	return RefOfValue{types.WriteValue(val, cs), &ref.Ref{}}
+func (r RefOfValue) SetTargetValue(val types.Value, cs chunks.ChunkSink) RefOfValue {
+	return NewRefOfValue(types.WriteValue(val, cs))
 }
 
 // ListOfNode
@@ -1047,12 +1047,16 @@ func (m MapOfStringToRefOfSQuadTree) Filter(cb MapOfStringToRefOfSQuadTreeFilter
 // RefOfSQuadTree
 
 type RefOfSQuadTree struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfSQuadTree(r ref.Ref) RefOfSQuadTree {
-	return RefOfSQuadTree{r, &ref.Ref{}}
+func NewRefOfSQuadTree(target ref.Ref) RefOfSQuadTree {
+	return RefOfSQuadTree{target, &ref.Ref{}}
+}
+
+func (r RefOfSQuadTree) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfSQuadTree) Ref() ref.Ref {
@@ -1070,16 +1074,12 @@ func (r RefOfSQuadTree) Chunks() []types.Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfSQuadTree) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfSQuadTreeFromVal(val types.Value) RefOfSQuadTree {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfSQuadTree); ok {
 		return val
 	}
-	return RefOfSQuadTree{val.(types.Ref).Ref(), &ref.Ref{}}
+	return NewRefOfSQuadTree(val.(types.Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfSQuadTree.
@@ -1096,10 +1096,10 @@ func init() {
 	})
 }
 
-func (r RefOfSQuadTree) GetValue(cs chunks.ChunkSource) SQuadTree {
-	return types.ReadValue(r.r, cs).(SQuadTree)
+func (r RefOfSQuadTree) TargetValue(cs chunks.ChunkSource) SQuadTree {
+	return types.ReadValue(r.target, cs).(SQuadTree)
 }
 
-func (r RefOfSQuadTree) SetValue(val SQuadTree, cs chunks.ChunkSink) RefOfSQuadTree {
-	return RefOfSQuadTree{types.WriteValue(val, cs), &ref.Ref{}}
+func (r RefOfSQuadTree) SetTargetValue(val SQuadTree, cs chunks.ChunkSink) RefOfSQuadTree {
+	return NewRefOfSQuadTree(types.WriteValue(val, cs))
 }

--- a/clients/sfcrime_importer/sfcrime.go
+++ b/clients/sfcrime_importer/sfcrime.go
@@ -167,7 +167,7 @@ func getNomsWriter(cs chunks.ChunkSink) (iChan chan incidentWithIndex, rChan cha
 			for incidentRecord := range iChan {
 				v := incidentRecord.incident.New()
 				r := types.WriteValue(v, cs)
-				rChan <- refIndex{types.Ref{R: r}, incidentRecord.index}
+				rChan <- refIndex{types.NewRef(r), incidentRecord.index}
 			}
 			wg.Done()
 		}()

--- a/clients/xml_importer/xml_importer.go
+++ b/clients/xml_importer/xml_importer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/attic-labs/noms/clients/util"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
+	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
 
@@ -93,10 +94,10 @@ func main() {
 				file.Close()
 
 				nomsObj := util.NomsValueFromDecodedJSON(object)
-				r := types.Ref{}
+				r := types.NewRef(ref.Ref{})
 
 				if !*noIO {
-					r = types.Ref{types.WriteValue(nomsObj, ds.Store())}
+					r = types.NewRef(types.WriteValue(nomsObj, ds.Store()))
 				}
 
 				refsChan <- refIndex{r, f.index}

--- a/datas/datastore_common.go
+++ b/datas/datastore_common.go
@@ -20,7 +20,7 @@ func datasetsFromRef(datasetsRef ref.Ref, cs chunks.ChunkSource) *MapOfStringToR
 func (ds *dataStoreCommon) MaybeHead(datasetID string) (Commit, bool) {
 	if ds.datasets != nil {
 		if r, ok := ds.datasets.MaybeGet(datasetID); ok {
-			return r.GetValue(ds), true
+			return r.TargetValue(ds), true
 		}
 	}
 	return NewCommit(), false
@@ -98,7 +98,7 @@ func descendsFrom(commitRef, currentHeadRef RefOfCommit, cs chunks.ChunkSource) 
 func getAncestors(commits SetOfRefOfCommit, cs chunks.ChunkSource) SetOfRefOfCommit {
 	ancestors := NewSetOfRefOfCommit()
 	commits.Iter(func(r RefOfCommit) (stop bool) {
-		c := r.GetValue(cs)
+		c := r.TargetValue(cs)
 		ancestors =
 			ancestors.Union(c.Parents())
 		return

--- a/datas/types.go
+++ b/datas/types.go
@@ -408,12 +408,16 @@ func (s SetOfRefOfCommit) fromElemSlice(p []RefOfCommit) []types.Value {
 // RefOfCommit
 
 type RefOfCommit struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfCommit(r ref.Ref) RefOfCommit {
-	return RefOfCommit{r, &ref.Ref{}}
+func NewRefOfCommit(target ref.Ref) RefOfCommit {
+	return RefOfCommit{target, &ref.Ref{}}
+}
+
+func (r RefOfCommit) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfCommit) Ref() ref.Ref {
@@ -431,16 +435,12 @@ func (r RefOfCommit) Chunks() []types.Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfCommit) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfCommitFromVal(val types.Value) RefOfCommit {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfCommit); ok {
 		return val
 	}
-	return RefOfCommit{val.(types.Ref).Ref(), &ref.Ref{}}
+	return NewRefOfCommit(val.(types.Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfCommit.
@@ -457,10 +457,10 @@ func init() {
 	})
 }
 
-func (r RefOfCommit) GetValue(cs chunks.ChunkSource) Commit {
-	return types.ReadValue(r.r, cs).(Commit)
+func (r RefOfCommit) TargetValue(cs chunks.ChunkSource) Commit {
+	return types.ReadValue(r.target, cs).(Commit)
 }
 
-func (r RefOfCommit) SetValue(val Commit, cs chunks.ChunkSink) RefOfCommit {
-	return RefOfCommit{types.WriteValue(val, cs), &ref.Ref{}}
+func (r RefOfCommit) SetTargetValue(val Commit, cs chunks.ChunkSink) RefOfCommit {
+	return NewRefOfCommit(types.WriteValue(val, cs))
 }

--- a/dataset/pull_test.go
+++ b/dataset/pull_test.go
@@ -24,19 +24,19 @@ func TestValidateRef(t *testing.T) {
 func NewList(ds Dataset, vs ...types.Value) types.Ref {
 	v := types.NewList(vs...)
 	r := types.WriteValue(v, ds.store)
-	return types.Ref{R: r}
+	return types.NewRef(r)
 }
 
 func NewMap(ds Dataset, vs ...types.Value) types.Ref {
 	v := types.NewMap(vs...)
 	r := types.WriteValue(v, ds.store)
-	return types.Ref{R: r}
+	return types.NewRef(r)
 }
 
 func NewSet(ds Dataset, vs ...types.Value) types.Ref {
 	v := types.NewSet(vs...)
 	r := types.WriteValue(v, ds.store)
-	return types.Ref{R: r}
+	return types.NewRef(r)
 }
 
 func SkipTestPull(t *testing.T) {

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -222,7 +222,7 @@ func newTypeEncoder(t reflect.Type) encoderFunc {
 }
 
 func invalidValueEncoder(v reflect.Value) types.Value {
-	return types.Ref{R: ref.Ref{}} // Eh?
+	return types.NewRef(ref.Ref{}) // Eh?
 }
 
 func boolEncoder(v reflect.Value) types.Value {
@@ -325,9 +325,9 @@ func readerEncoder(v reflect.Value) types.Value {
 // Noms has no notion of a general-purpose nil value. Thus, if struct encoding encounters a field that holds a nil pointer or interface, it skips it even if that field doesn't have the omitempty option set. Nil maps and slices are encoded as an empty Noms map, set, list or blob as appropriate.
 func (se *structEncoder) encode(v reflect.Value) types.Value {
 	if v.Type() == refRefType {
-		typesRef := types.Ref{}
-		reflect.ValueOf(&typesRef.R).Elem().Set(v)
-		return typesRef
+		r := ref.Ref{}
+		reflect.ValueOf(&r).Elem().Set(v)
+		return types.NewRef(r)
 	}
 	nom := types.NewMap()
 	for i, f := range se.fields {

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -346,10 +346,10 @@ func unmarshalRef(nom types.Ref, v reflect.Value) {
 
 	// Decoding into nil interface? Stuff a string in there.
 	if v.Kind() == reflect.Interface && v.NumMethod() == 0 {
-		v.Set(reflect.ValueOf(nom.Ref().String()))
+		v.Set(reflect.ValueOf(nom.TargetRef().String()))
 		return
 	} else if v.Kind() == reflect.Struct && v.Type() == refRefType {
-		v.Set(reflect.ValueOf(nom.Ref()))
+		v.Set(reflect.ValueOf(nom.TargetRef()))
 		return
 	}
 
@@ -359,14 +359,14 @@ func unmarshalRef(nom types.Ref, v reflect.Value) {
 		d.Exp.Fail(invalidTypeMsg(reflect.TypeOf(nom).Name(), origType))
 		return
 	case reflect.String:
-		v.SetString(nom.Ref().String())
+		v.SetString(nom.TargetRef().String())
 		return
 	case reflect.Slice:
 		if v.Type().Elem().Kind() == reflect.Uint8 {
 			// A byte-slice
-			digestLen := len(nom.Ref().Digest())
+			digestLen := len(nom.TargetRef().Digest())
 			v.Set(reflect.MakeSlice(v.Type(), digestLen, digestLen))
-			reflect.Copy(v, reflect.ValueOf(nom.Ref().Digest()))
+			reflect.Copy(v, reflect.ValueOf(nom.TargetRef().Digest()))
 			return
 		}
 		d.Exp.Fail(invalidTypeMsg(reflect.TypeOf(nom).Name(), origType))

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -180,12 +180,12 @@ var unmarshalTests = []unmarshalTest{
 
 	// ref tests
 	{
-		in:  types.Ref{R: ref.Parse("sha1-ffffffffffffffffffffffffffffffffffffffff")},
+		in:  types.NewRef(ref.Parse("sha1-ffffffffffffffffffffffffffffffffffffffff")),
 		ptr: new(string),
 		out: "sha1-" + strings.Repeat("f", 40),
 	},
 	{
-		in:  types.Ref{R: ref.Parse("sha1-ffffffffffffffffffffffffffffffffffffffff")},
+		in:  types.NewRef(ref.Parse("sha1-ffffffffffffffffffffffffffffffffffffffff")),
 		ptr: &[]byte{},
 		out: byteSlice(0xff, len(ref.Sha1Digest{})),
 	},

--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -227,6 +227,6 @@ func TestCommitNewPackages(t *testing.T) {
 	pkgDS = generate("name", inFile, filepath.Join(dir, "out.go"), dir, map[string]bool{}, pkgDS)
 	s := types.SetOfRefOfPackageFromVal(pkgDS.Head().Value())
 	assert.EqualValues(1, s.Len())
-	tr := s.Any().GetValue(ds).Types()[0]
+	tr := s.Any().TargetValue(ds).Types()[0]
 	assert.EqualValues(types.StructKind, tr.Kind())
 }

--- a/nomdl/codegen/ref.tmpl
+++ b/nomdl/codegen/ref.tmpl
@@ -3,12 +3,16 @@
 // {{.Name}}
 
 type {{.Name}} struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func New{{.Name}}(r ref.Ref) {{.Name}} {
-	return {{.Name}}{r, &ref.Ref{}}
+func New{{.Name}}(target ref.Ref) {{.Name}} {
+	return {{.Name}}{target, &ref.Ref{}}
+}
+
+func (r {{.Name}}) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r {{.Name}}) Ref() ref.Ref {
@@ -26,24 +30,20 @@ func (r {{.Name}}) Chunks() []{{$typesPackage}}Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r {{.Name}}) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func {{.Name}}FromVal(val {{$typesPackage}}Value) {{.Name}} {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.({{.Name}}); ok {
 		return val
 	}
-	return {{.Name}}{val.({{$typesPackage}}Ref).Ref(), &ref.Ref{}}
+	return New{{.Name}}(val.({{$typesPackage}}Ref).TargetRef())
 }
 
 {{template "type_ref.tmpl" .}}
 
-func (r {{.Name}}) GetValue(cs chunks.ChunkSource) {{userType .ElemType}} {
-	return {{valueToUser (printf "%sReadValue(r.r, cs)" $typesPackage) .ElemType}}
+func (r {{.Name}}) TargetValue(cs chunks.ChunkSource) {{userType .ElemType}} {
+	return {{valueToUser (printf "%sReadValue(r.target, cs)" $typesPackage) .ElemType}}
 }
 
-func (r {{.Name}}) SetValue(val {{userType .ElemType}}, cs chunks.ChunkSink) {{.Name}} {
-	return {{.Name}}{ {{$typesPackage}}WriteValue({{userToValue "val" .ElemType}}, cs), &ref.Ref{}}
+func (r {{.Name}}) SetTargetValue(val {{userType .ElemType}}, cs chunks.ChunkSink) {{.Name}} {
+	return New{{.Name}}({{$typesPackage}}WriteValue({{userToValue "val" .ElemType}}, cs))
 }

--- a/nomdl/codegen/test/gen/ref.go
+++ b/nomdl/codegen/test/gen/ref.go
@@ -108,12 +108,16 @@ func (s StructWithRef) SetR(val RefOfSetOfFloat32) StructWithRef {
 // RefOfListOfString
 
 type RefOfListOfString struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfListOfString(r ref.Ref) RefOfListOfString {
-	return RefOfListOfString{r, &ref.Ref{}}
+func NewRefOfListOfString(target ref.Ref) RefOfListOfString {
+	return RefOfListOfString{target, &ref.Ref{}}
+}
+
+func (r RefOfListOfString) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfListOfString) Ref() ref.Ref {
@@ -131,16 +135,12 @@ func (r RefOfListOfString) Chunks() []types.Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfListOfString) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfListOfStringFromVal(val types.Value) RefOfListOfString {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfListOfString); ok {
 		return val
 	}
-	return RefOfListOfString{val.(types.Ref).Ref(), &ref.Ref{}}
+	return NewRefOfListOfString(val.(types.Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfListOfString.
@@ -157,12 +157,12 @@ func init() {
 	})
 }
 
-func (r RefOfListOfString) GetValue(cs chunks.ChunkSource) ListOfString {
-	return types.ReadValue(r.r, cs).(ListOfString)
+func (r RefOfListOfString) TargetValue(cs chunks.ChunkSource) ListOfString {
+	return types.ReadValue(r.target, cs).(ListOfString)
 }
 
-func (r RefOfListOfString) SetValue(val ListOfString, cs chunks.ChunkSink) RefOfListOfString {
-	return RefOfListOfString{types.WriteValue(val, cs), &ref.Ref{}}
+func (r RefOfListOfString) SetTargetValue(val ListOfString, cs chunks.ChunkSink) RefOfListOfString {
+	return NewRefOfListOfString(types.WriteValue(val, cs))
 }
 
 // ListOfRefOfFloat32
@@ -313,12 +313,16 @@ func (l ListOfRefOfFloat32) Filter(cb ListOfRefOfFloat32FilterCallback) ListOfRe
 // RefOfSetOfFloat32
 
 type RefOfSetOfFloat32 struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfSetOfFloat32(r ref.Ref) RefOfSetOfFloat32 {
-	return RefOfSetOfFloat32{r, &ref.Ref{}}
+func NewRefOfSetOfFloat32(target ref.Ref) RefOfSetOfFloat32 {
+	return RefOfSetOfFloat32{target, &ref.Ref{}}
+}
+
+func (r RefOfSetOfFloat32) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfSetOfFloat32) Ref() ref.Ref {
@@ -336,16 +340,12 @@ func (r RefOfSetOfFloat32) Chunks() []types.Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfSetOfFloat32) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfSetOfFloat32FromVal(val types.Value) RefOfSetOfFloat32 {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfSetOfFloat32); ok {
 		return val
 	}
-	return RefOfSetOfFloat32{val.(types.Ref).Ref(), &ref.Ref{}}
+	return NewRefOfSetOfFloat32(val.(types.Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfSetOfFloat32.
@@ -362,12 +362,12 @@ func init() {
 	})
 }
 
-func (r RefOfSetOfFloat32) GetValue(cs chunks.ChunkSource) SetOfFloat32 {
-	return types.ReadValue(r.r, cs).(SetOfFloat32)
+func (r RefOfSetOfFloat32) TargetValue(cs chunks.ChunkSource) SetOfFloat32 {
+	return types.ReadValue(r.target, cs).(SetOfFloat32)
 }
 
-func (r RefOfSetOfFloat32) SetValue(val SetOfFloat32, cs chunks.ChunkSink) RefOfSetOfFloat32 {
-	return RefOfSetOfFloat32{types.WriteValue(val, cs), &ref.Ref{}}
+func (r RefOfSetOfFloat32) SetTargetValue(val SetOfFloat32, cs chunks.ChunkSink) RefOfSetOfFloat32 {
+	return NewRefOfSetOfFloat32(types.WriteValue(val, cs))
 }
 
 // ListOfString
@@ -518,12 +518,16 @@ func (l ListOfString) Filter(cb ListOfStringFilterCallback) ListOfString {
 // RefOfFloat32
 
 type RefOfFloat32 struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfFloat32(r ref.Ref) RefOfFloat32 {
-	return RefOfFloat32{r, &ref.Ref{}}
+func NewRefOfFloat32(target ref.Ref) RefOfFloat32 {
+	return RefOfFloat32{target, &ref.Ref{}}
+}
+
+func (r RefOfFloat32) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfFloat32) Ref() ref.Ref {
@@ -541,16 +545,12 @@ func (r RefOfFloat32) Chunks() []types.Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfFloat32) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfFloat32FromVal(val types.Value) RefOfFloat32 {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfFloat32); ok {
 		return val
 	}
-	return RefOfFloat32{val.(types.Ref).Ref(), &ref.Ref{}}
+	return NewRefOfFloat32(val.(types.Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfFloat32.
@@ -567,12 +567,12 @@ func init() {
 	})
 }
 
-func (r RefOfFloat32) GetValue(cs chunks.ChunkSource) float32 {
-	return float32(types.ReadValue(r.r, cs).(types.Float32))
+func (r RefOfFloat32) TargetValue(cs chunks.ChunkSource) float32 {
+	return float32(types.ReadValue(r.target, cs).(types.Float32))
 }
 
-func (r RefOfFloat32) SetValue(val float32, cs chunks.ChunkSink) RefOfFloat32 {
-	return RefOfFloat32{types.WriteValue(types.Float32(val), cs), &ref.Ref{}}
+func (r RefOfFloat32) SetTargetValue(val float32, cs chunks.ChunkSink) RefOfFloat32 {
+	return NewRefOfFloat32(types.WriteValue(types.Float32(val), cs))
 }
 
 // SetOfFloat32

--- a/nomdl/codegen/test/ref_test.go
+++ b/nomdl/codegen/test/ref_test.go
@@ -21,15 +21,15 @@ func TestRef(t *testing.T) {
 	v := types.ReadValue(l.Ref(), cs)
 	assert.Nil(v)
 
-	assert.Panics(func() { r.GetValue(cs) })
+	assert.Panics(func() { r.TargetValue(cs) })
 
-	r2 := r.SetValue(l, cs)
+	r2 := r.SetTargetValue(l, cs)
 	assert.True(r.Equals(r2))
-	v2 := r2.GetValue(cs)
-	v3 := r.GetValue(cs)
+	v2 := r2.TargetValue(cs)
+	v3 := r.TargetValue(cs)
 	assert.True(v2.Equals(v3))
 
-	r3 := r2.SetValue(l2, cs)
+	r3 := r2.SetTargetValue(l2, cs)
 	assert.False(r.Equals(r3))
 }
 
@@ -37,12 +37,12 @@ func TestRefFromValAndNomsValue(t *testing.T) {
 	assert := assert.New(t)
 
 	l := gen.ListOfStringDef{"a", "b", "c"}.New()
-	rv := types.Ref{R: l.Ref()}
+	rv := types.NewRef(l.Ref())
 	r := gen.RefOfListOfStringFromVal(rv)
 	r2 := gen.NewRefOfListOfString(l.Ref())
 	assert.True(r.Equals(r2))
 
-	rv2 := types.Ref{R: r.InternalImplementation()}
+	rv2 := types.NewRef(r.TargetRef())
 	assert.True(rv.Equals(rv2))
 }
 
@@ -59,10 +59,10 @@ func TestListOfRef(t *testing.T) {
 	r2 := l.Get(0)
 	assert.True(r.Equals(r2))
 
-	l = l.Set(0, r.SetValue(1, cs))
+	l = l.Set(0, r.SetTargetValue(1, cs))
 	r3 := l.Get(0)
 	assert.False(r.Equals(r3))
-	assert.Panics(func() { r.GetValue(cs) })
+	assert.Panics(func() { r.TargetValue(cs) })
 }
 
 func TestStructWithRef(t *testing.T) {
@@ -78,13 +78,13 @@ func TestStructWithRef(t *testing.T) {
 	r2 := gen.NewRefOfSetOfFloat32(set.Ref())
 	assert.True(r.Equals(r2))
 
-	assert.Panics(func() { r2.GetValue(cs) })
+	assert.Panics(func() { r2.TargetValue(cs) })
 
 	types.WriteValue(str, cs)
-	assert.Panics(func() { r2.GetValue(cs) })
+	assert.Panics(func() { r2.TargetValue(cs) })
 
 	types.WriteValue(set, cs)
-	set2 := r2.GetValue(cs)
+	set2 := r2.TargetValue(cs)
 	assert.True(set.Equals(set2))
 }
 

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -161,7 +161,7 @@ func (r *jsonArrayReader) readPackage(t TypeRef, pkg *Package) Value {
 
 func (r *jsonArrayReader) readRefValue(t TypeRef) Value {
 	ref := r.readRef()
-	v := Ref{R: ref}
+	v := NewRef(ref)
 	return ToNomsValueFromTypeRef(t, v)
 }
 

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -441,7 +441,7 @@ func TestReadRef(t *testing.T) {
 	})
 
 	v := reader.readTopLevelValue()
-	assert.True(Ref{r}.Equals(v))
+	assert.True(NewRef(r).Equals(v))
 }
 
 func TestReadValueRef(t *testing.T) {
@@ -459,7 +459,7 @@ func TestReadValueRef(t *testing.T) {
 	})
 
 	v := reader.readTopLevelValue()
-	assert.True(Ref{r}.Equals(v))
+	assert.True(NewRef(r).Equals(v))
 }
 
 func TestReadStructWithEnum(t *testing.T) {

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -144,7 +144,7 @@ type mapImplementation interface {
 }
 
 type refImplementation interface {
-	InternalImplementation() ref.Ref
+	TargetRef() ref.Ref
 }
 
 type setImplementation interface {
@@ -170,10 +170,7 @@ func getMapFromMapKind(v Value) Map {
 }
 
 func getRefFromRefKind(v Value) ref.Ref {
-	if v, ok := v.(Ref); ok {
-		return v.Ref()
-	}
-	return v.(refImplementation).InternalImplementation()
+	return v.(refImplementation).TargetRef()
 }
 
 func getSetFromSetKind(v Value) Set {

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -424,16 +424,16 @@ func (r testRef) TypeRef() TypeRef {
 	return r.t
 }
 
-func (r testRef) InternalImplementation() ref.Ref {
-	return r.Value.Ref()
+func (r testRef) TargetRef() ref.Ref {
+	return r.Value.(Ref).TargetRef()
 }
 
 func TestWriteRef(t *testing.T) {
 	assert := assert.New(t)
 
 	tref := MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(UInt32Kind))
-	r := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
-	v := Ref{R: r}
+	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
+	v := NewRef(r)
 
 	w := newJsonArrayWriter()
 	w.writeTopLevelValue(testRef{Value: v, t: tref})
@@ -531,7 +531,7 @@ func TestWritePackage2(t *testing.T) {
 	assert := assert.New(t)
 
 	setTref := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(UInt32Kind))
-	r := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
+	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
 	v := Package{[]TypeRef{setTref}, []ref.Ref{r}, &ref.Ref{}}
 
 	w := newJsonArrayWriter()

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -82,7 +82,7 @@ func TestPrimitiveEquals(t *testing.T) {
 		}
 		v := f1()
 		if v != nil {
-			r := Ref{R: v.Ref()}
+			r := NewRef(v.Ref())
 			assert.False(r.Equals(v))
 			assert.False(v.Equals(r))
 		}

--- a/types/future.go
+++ b/types/future.go
@@ -43,6 +43,10 @@ func futureFromValue(v Value) Future {
 	return resolvedFuture{v}
 }
 
+type targetRef interface {
+	TargetRef() ref.Ref
+}
+
 func appendChunks(chunks []Future, f Future) []Future {
 	if uf, ok := f.(*unresolvedFuture); ok {
 		chunks = append(chunks, uf)
@@ -50,7 +54,7 @@ func appendChunks(chunks []Future, f Future) []Future {
 		v := f.Val()
 		if v != nil {
 			if v.TypeRef().Kind() == RefKind {
-				chunks = append(chunks, futureFromRef(v.Ref()))
+				chunks = append(chunks, futureFromRef(v.(targetRef).TargetRef()))
 			}
 		}
 	}
@@ -60,8 +64,7 @@ func appendChunks(chunks []Future, f Future) []Future {
 
 func appendValueToChunks(chunks []Future, v Value) []Future {
 	if v.TypeRef().Kind() == RefKind {
-		// TODO: Wrong ref here. We don't want the Ref of the Ref Value but the ref of the value it is referring to. BUG 464
-		chunks = append(chunks, futureFromRef(v.Ref()))
+		chunks = append(chunks, futureFromRef(v.(targetRef).TargetRef()))
 	}
 	return chunks
 }

--- a/types/incremental_test.go
+++ b/types/incremental_test.go
@@ -110,7 +110,7 @@ func SkipTestIncrementalAddRef(t *testing.T) {
 	expectedItem := UInt32(42)
 	ref := WriteValue(expectedItem, cs)
 
-	expected := NewList(Ref{ref})
+	expected := NewList(NewRef(ref))
 	ref = WriteValue(expected, cs)
 	actualVar := ReadValue(ref, cs)
 

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -351,7 +351,7 @@ func TestListChunks(t *testing.T) {
 	c1 := l1.Chunks()
 	assert.Len(c1, 0)
 
-	l2 := NewList(Ref{R: Int32(0).Ref()})
+	l2 := NewList(NewRef(Int32(0).Ref()))
 	c2 := l2.Chunks()
 	assert.Len(c2, 1)
 }

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -229,11 +229,11 @@ func TestMapChunks(t *testing.T) {
 	c1 := l1.Chunks()
 	assert.Len(c1, 0)
 
-	l2 := NewMap(Ref{R: Int32(0).Ref()}, Int32(1))
+	l2 := NewMap(NewRef(Int32(0).Ref()), Int32(1))
 	c2 := l2.Chunks()
 	assert.Len(c2, 1)
 
-	l3 := NewMap(Int32(0), Ref{R: Int32(1).Ref()})
+	l3 := NewMap(Int32(0), NewRef(Int32(1).Ref()))
 	c3 := l3.Chunks()
 	assert.Len(c3, 1)
 }

--- a/types/package_set_of_ref.go
+++ b/types/package_set_of_ref.go
@@ -162,12 +162,16 @@ func (s SetOfRefOfPackage) fromElemSlice(p []RefOfPackage) []Value {
 // RefOfPackage
 
 type RefOfPackage struct {
-	r   ref.Ref
-	ref *ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
 }
 
-func NewRefOfPackage(r ref.Ref) RefOfPackage {
-	return RefOfPackage{r, &ref.Ref{}}
+func NewRefOfPackage(target ref.Ref) RefOfPackage {
+	return RefOfPackage{target, &ref.Ref{}}
+}
+
+func (r RefOfPackage) TargetRef() ref.Ref {
+	return r.target
 }
 
 func (r RefOfPackage) Ref() ref.Ref {
@@ -185,16 +189,12 @@ func (r RefOfPackage) Chunks() []Future {
 	return r.TypeRef().Chunks()
 }
 
-func (r RefOfPackage) InternalImplementation() ref.Ref {
-	return r.r
-}
-
 func RefOfPackageFromVal(val Value) RefOfPackage {
 	// TODO: Do we still need FromVal?
 	if val, ok := val.(RefOfPackage); ok {
 		return val
 	}
-	return RefOfPackage{val.(Ref).Ref(), &ref.Ref{}}
+	return NewRefOfPackage(val.(Ref).TargetRef())
 }
 
 // A Noms Value that describes RefOfPackage.
@@ -211,10 +211,10 @@ func init() {
 	})
 }
 
-func (r RefOfPackage) GetValue(cs chunks.ChunkSource) Package {
-	return ReadValue(r.r, cs).(Package)
+func (r RefOfPackage) TargetValue(cs chunks.ChunkSource) Package {
+	return ReadValue(r.target, cs).(Package)
 }
 
-func (r RefOfPackage) SetValue(val Package, cs chunks.ChunkSink) RefOfPackage {
-	return RefOfPackage{WriteValue(val, cs), &ref.Ref{}}
+func (r RefOfPackage) SetTargetValue(val Package, cs chunks.ChunkSink) RefOfPackage {
+	return NewRefOfPackage(WriteValue(val, cs))
 }

--- a/types/ref.go
+++ b/types/ref.go
@@ -1,11 +1,17 @@
 package types
 
 import (
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 )
 
 type Ref struct {
-	R ref.Ref
+	target ref.Ref
+	ref    *ref.Ref
+}
+
+func NewRef(target ref.Ref) Ref {
+	return Ref{target, &ref.Ref{}}
 }
 
 func (r Ref) Equals(other Value) bool {
@@ -16,11 +22,15 @@ func (r Ref) Equals(other Value) bool {
 }
 
 func (r Ref) Ref() ref.Ref {
-	return r.R
+	return EnsureRef(r.ref, r)
 }
 
 func (r Ref) Chunks() []Future {
 	return nil
+}
+
+func (r Ref) TargetRef() ref.Ref {
+	return r.target
 }
 
 var refTypeRef = MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(ValueKind))
@@ -33,4 +43,12 @@ func init() {
 	RegisterFromValFunction(refTypeRef, func(v Value) Value {
 		return v.(Ref)
 	})
+}
+
+func (r Ref) TargetValue(cs chunks.ChunkSource) Value {
+	return ReadValue(r.target, cs)
+}
+
+func (r Ref) SetTargetValue(val Value, cs chunks.ChunkSink) Ref {
+	return NewRef(WriteValue(val, cs))
 }

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -9,7 +9,7 @@ import (
 func TestRefInList(t *testing.T) {
 	assert := assert.New(t)
 	l := NewList()
-	r := Ref{R: l.Ref()}
+	r := NewRef(l.Ref())
 	l = l.Append(r)
 	r2 := l.Get(0)
 	assert.True(r.Equals(r2))
@@ -18,7 +18,7 @@ func TestRefInList(t *testing.T) {
 func TestRefInSet(t *testing.T) {
 	assert := assert.New(t)
 	s := NewSet()
-	r := Ref{R: s.Ref()}
+	r := NewRef(s.Ref())
 	s = s.Insert(r)
 	r2 := s.Any()
 	assert.True(r.Equals(r2))
@@ -28,7 +28,7 @@ func TestRefInMap(t *testing.T) {
 	assert := assert.New(t)
 
 	m := NewMap()
-	r := Ref{R: m.Ref()}
+	r := NewRef(m.Ref())
 	m = m.Set(Int32(0), r).Set(r, Int32(1))
 	r2 := m.Get(Int32(0))
 	assert.True(r.Equals(r2))
@@ -40,6 +40,6 @@ func TestRefInMap(t *testing.T) {
 func TestRefTypeRef(t *testing.T) {
 	assert := assert.New(t)
 	l := NewList()
-	r := Ref{R: l.Ref()}
+	r := NewRef(l.Ref())
 	assert.True(r.TypeRef().Equals(MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(ValueKind))))
 }

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -198,7 +198,7 @@ func TestSetChunks(t *testing.T) {
 	c1 := l1.Chunks()
 	assert.Len(c1, 0)
 
-	l2 := NewSet(Ref{R: Int32(0).Ref()})
+	l2 := NewSet(NewRef(Int32(0).Ref()))
 	c2 := l2.Chunks()
 	assert.Len(c2, 1)
 }

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -102,7 +102,7 @@ func (u UnresolvedDesc) Equals(other TypeDesc) bool {
 }
 
 func (u UnresolvedDesc) ToValue() Value {
-	return NewList(Ref{R: u.pkgRef}, Int16(u.ordinal))
+	return NewList(NewRef(u.pkgRef), Int16(u.ordinal))
 }
 
 func (u UnresolvedDesc) Describe() string {

--- a/types/type_ref_test.go
+++ b/types/type_ref_test.go
@@ -51,7 +51,8 @@ func TestTypeWithPkgRef(t *testing.T) {
 	unresolvedType := MakeTypeRef(pkgRef, 42)
 	unresolvedRef := WriteValue(unresolvedType, cs)
 
-	assert.EqualValues(pkgRef, ReadValue(unresolvedRef, cs).Chunks()[0].Ref())
+	v := ReadValue(unresolvedRef, cs)
+	assert.EqualValues(pkgRef, v.Chunks()[0].Ref())
 	assert.NotNil(ReadValue(pkgRef, cs))
 }
 


### PR DESCRIPTION
Ref Values now have a TargetRef() method that returns the ref.Ref of
the target the Value is referencing.

Note: This is a breaking change. In old code the Ref() of the Value was
the Ref of the underlying target.

Fixes #464
