### PR TITLE
Update TypeRef comment and get rid of useless param

### DIFF
--- a/clients/flickr/sha1_b525f9bca5e451c21dd9af564f0960045fbaa304.go
+++ b/clients/flickr/sha1_b525f9bca5e451c21dd9af564f0960045fbaa304.go
@@ -20,8 +20,8 @@ func init() {
 				types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-fb09d21d144c518467325465327d46489cff7c47"), 0), false},
-				types.Field{"Sizes", types.MakeCompoundTypeRef("", types.MapKind, types.MakeTypeRef(ref.Ref{}, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
-				types.Field{"Tags", types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
+				types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(ref.Ref{}, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
+				types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
 			},
 			types.Choices{},
 		),
@@ -338,7 +338,7 @@ func (m MapOfSizeToString) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfSizeToString = types.MakeCompoundTypeRef("", types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_b525f9bca5e451c21dd9af564f0960045fbaa304_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind))
+	__typeRefForMapOfSizeToString = types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_b525f9bca5e451c21dd9af564f0960045fbaa304_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind))
 	types.RegisterFromValFunction(__typeRefForMapOfSizeToString, func(v types.Value) types.Value {
 		return MapOfSizeToStringFromVal(v)
 	})
@@ -475,7 +475,7 @@ func (m SetOfString) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfString = types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.StringKind))
+	__typeRefForSetOfString = types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind))
 	types.RegisterFromValFunction(__typeRefForSetOfString, func(v types.Value) types.Value {
 		return SetOfStringFromVal(v)
 	})

--- a/clients/flickr/types.go
+++ b/clients/flickr/types.go
@@ -20,7 +20,7 @@ func init() {
 				types.Field{"Name", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"OAuthToken", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"OAuthSecret", types.MakePrimitiveTypeRef(types.StringKind), false},
-				types.Field{"Albums", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(ref.Ref{}, 1)), false},
+				types.Field{"Albums", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(ref.Ref{}, 1)), false},
 			},
 			types.Choices{},
 		),
@@ -28,7 +28,7 @@ func init() {
 			[]types.Field{
 				types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-				types.Field{"Photos", types.MakeCompoundTypeRef("", types.SetKind, types.MakeTypeRef(ref.Parse("sha1-b525f9bca5e451c21dd9af564f0960045fbaa304"), 0)), false},
+				types.Field{"Photos", types.MakeCompoundTypeRef(types.SetKind, types.MakeTypeRef(ref.Parse("sha1-b525f9bca5e451c21dd9af564f0960045fbaa304"), 0)), false},
 			},
 			types.Choices{},
 		),
@@ -269,7 +269,7 @@ func (m MapOfStringToAlbum) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToAlbum = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
+	__typeRefForMapOfStringToAlbum = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToAlbum, func(v types.Value) types.Value {
 		return MapOfStringToAlbumFromVal(v)
 	})
@@ -385,7 +385,7 @@ func (m SetOfRemotePhoto) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfRemotePhoto = types.MakeCompoundTypeRef("", types.SetKind, types.MakeTypeRef(ref.Parse("sha1-b525f9bca5e451c21dd9af564f0960045fbaa304"), 0))
+	__typeRefForSetOfRemotePhoto = types.MakeCompoundTypeRef(types.SetKind, types.MakeTypeRef(ref.Parse("sha1-b525f9bca5e451c21dd9af564f0960045fbaa304"), 0))
 	types.RegisterFromValFunction(__typeRefForSetOfRemotePhoto, func(v types.Value) types.Value {
 		return SetOfRemotePhotoFromVal(v)
 	})

--- a/clients/music/mp3_importer/types.go
+++ b/clients/music/mp3_importer/types.go
@@ -223,7 +223,7 @@ func (m ListOfSong) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfSong = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
+	__typeRefForListOfSong = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfSong, func(v types.Value) types.Value {
 		return ListOfSongFromVal(v)
 	})

--- a/clients/pitchmap/index/types.go
+++ b/clients/pitchmap/index/types.go
@@ -184,7 +184,7 @@ func (m ListOfMapOfStringToValue) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfMapOfStringToValue = types.MakeCompoundTypeRef("", types.ListKind, types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind)))
+	__typeRefForListOfMapOfStringToValue = types.MakeCompoundTypeRef(types.ListKind, types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind)))
 	types.RegisterFromValFunction(__typeRefForListOfMapOfStringToValue, func(v types.Value) types.Value {
 		return ListOfMapOfStringToValueFromVal(v)
 	})
@@ -330,7 +330,7 @@ func (m MapOfStringToListOfPitch) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToListOfPitch = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)))
+	__typeRefForMapOfStringToListOfPitch = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToListOfPitch, func(v types.Value) types.Value {
 		return MapOfStringToListOfPitchFromVal(v)
 	})
@@ -466,7 +466,7 @@ func (m MapOfStringToString) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToString = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.StringKind))
+	__typeRefForMapOfStringToString = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.StringKind))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToString, func(v types.Value) types.Value {
 		return MapOfStringToStringFromVal(v)
 	})
@@ -602,7 +602,7 @@ func (m MapOfStringToValue) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToValue = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind))
+	__typeRefForMapOfStringToValue = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToValue, func(v types.Value) types.Value {
 		return MapOfStringToValueFromVal(v)
 	})
@@ -737,7 +737,7 @@ func (m ListOfPitch) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfPitch = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
+	__typeRefForListOfPitch = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfPitch, func(v types.Value) types.Value {
 		return ListOfPitchFromVal(v)
 	})

--- a/clients/quad_tree/types.go
+++ b/clients/quad_tree/types.go
@@ -18,14 +18,14 @@ func init() {
 		types.MakeStructTypeRef("Node",
 			[]types.Field{
 				types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-fb09d21d144c518467325465327d46489cff7c47"), 0), false},
-				types.Field{"Reference", types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind)), false},
+				types.Field{"Reference", types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind)), false},
 			},
 			types.Choices{},
 		),
 		types.MakeStructTypeRef("QuadTree",
 			[]types.Field{
-				types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(ref.Ref{}, 0)), false},
-				types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(ref.Ref{}, 1)), false},
+				types.Field{"Nodes", types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(ref.Ref{}, 0)), false},
+				types.Field{"Tiles", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(ref.Ref{}, 1)), false},
 				types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
 				types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
 				types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
@@ -35,8 +35,8 @@ func init() {
 		),
 		types.MakeStructTypeRef("SQuadTree",
 			[]types.Field{
-				types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))), false},
-				types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(ref.Ref{}, 2))), false},
+				types.Field{"Nodes", types.MakeCompoundTypeRef(types.ListKind, types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))), false},
+				types.Field{"Tiles", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Ref{}, 2))), false},
 				types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
 				types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
 				types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
@@ -468,7 +468,7 @@ func (m RefOfValue) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfValue = types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))
+	__typeRefForRefOfValue = types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))
 	types.RegisterFromValFunction(__typeRefForRefOfValue, func(v types.Value) types.Value {
 		return RefOfValueFromVal(v)
 	})
@@ -549,7 +549,7 @@ func (m ListOfNode) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfNode = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
+	__typeRefForListOfNode = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfNode, func(v types.Value) types.Value {
 		return ListOfNodeFromVal(v)
 	})
@@ -695,7 +695,7 @@ func (m MapOfStringToQuadTree) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToQuadTree = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
+	__typeRefForMapOfStringToQuadTree = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToQuadTree, func(v types.Value) types.Value {
 		return MapOfStringToQuadTreeFromVal(v)
 	})
@@ -830,7 +830,7 @@ func (m ListOfRefOfValue) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfRefOfValue = types.MakeCompoundTypeRef("", types.ListKind, types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind)))
+	__typeRefForListOfRefOfValue = types.MakeCompoundTypeRef(types.ListKind, types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind)))
 	types.RegisterFromValFunction(__typeRefForListOfRefOfValue, func(v types.Value) types.Value {
 		return ListOfRefOfValueFromVal(v)
 	})
@@ -976,7 +976,7 @@ func (m MapOfStringToRefOfSQuadTree) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToRefOfSQuadTree = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 2)))
+	__typeRefForMapOfStringToRefOfSQuadTree = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 2)))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToRefOfSQuadTree, func(v types.Value) types.Value {
 		return MapOfStringToRefOfSQuadTreeFromVal(v)
 	})
@@ -1090,7 +1090,7 @@ func (m RefOfSQuadTree) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfSQuadTree = types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 2))
+	__typeRefForRefOfSQuadTree = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 2))
 	types.RegisterFromValFunction(__typeRefForRefOfSQuadTree, func(v types.Value) types.Value {
 		return RefOfSQuadTreeFromVal(v)
 	})

--- a/clients/sfcrime_importer/types.go
+++ b/clients/sfcrime_importer/types.go
@@ -303,7 +303,7 @@ func (m ListOfIncident) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfIncident = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
+	__typeRefForListOfIncident = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfIncident, func(v types.Value) types.Value {
 		return ListOfIncidentFromVal(v)
 	})

--- a/clients/sfcrime_search/types.go
+++ b/clients/sfcrime_search/types.go
@@ -26,8 +26,8 @@ func init() {
 		),
 		types.MakeStructTypeRef("SQuadTree",
 			[]types.Field{
-				types.Field{"Nodes", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(ref.Ref{}, 0)), false},
-				types.Field{"Tiles", types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(ref.Ref{}, 1)), false},
+				types.Field{"Nodes", types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(ref.Ref{}, 0)), false},
+				types.Field{"Tiles", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(ref.Ref{}, 1)), false},
 				types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
 				types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
 				types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
@@ -376,7 +376,7 @@ func (m ListOfIncident) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfIncident = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
+	__typeRefForListOfIncident = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfIncident, func(v types.Value) types.Value {
 		return ListOfIncidentFromVal(v)
 	})
@@ -522,7 +522,7 @@ func (m MapOfStringToSQuadTree) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToSQuadTree = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
+	__typeRefForMapOfStringToSQuadTree = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToSQuadTree, func(v types.Value) types.Value {
 		return MapOfStringToSQuadTreeFromVal(v)
 	})

--- a/datas/types.go
+++ b/datas/types.go
@@ -18,7 +18,7 @@ func init() {
 		types.MakeStructTypeRef("Commit",
 			[]types.Field{
 				types.Field{"value", types.MakePrimitiveTypeRef(types.ValueKind), false},
-				types.Field{"parents", types.MakeCompoundTypeRef("", types.SetKind, types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(ref.Ref{}, 0))), false},
+				types.Field{"parents", types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Ref{}, 0))), false},
 			},
 			types.Choices{},
 		),
@@ -186,7 +186,7 @@ func (m MapOfStringToRefOfCommit) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToRefOfCommit = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)))
+	__typeRefForMapOfStringToRefOfCommit = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToRefOfCommit, func(v types.Value) types.Value {
 		return MapOfStringToRefOfCommitFromVal(v)
 	})
@@ -323,7 +323,7 @@ func (m SetOfRefOfCommit) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfRefOfCommit = types.MakeCompoundTypeRef("", types.SetKind, types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)))
+	__typeRefForSetOfRefOfCommit = types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)))
 	types.RegisterFromValFunction(__typeRefForSetOfRefOfCommit, func(v types.Value) types.Value {
 		return SetOfRefOfCommitFromVal(v)
 	})
@@ -451,7 +451,7 @@ func (m RefOfCommit) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfCommit = types.MakeCompoundTypeRef("", types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0))
+	__typeRefForRefOfCommit = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForRefOfCommit, func(v types.Value) types.Value {
 		return RefOfCommitFromVal(v)
 	})

--- a/nomdl/codegen/code/generate.go
+++ b/nomdl/codegen/code/generate.go
@@ -293,7 +293,7 @@ func (gen Generator) ToTypeRef(t types.TypeRef, fileID, packageName string) stri
 		for i, t := range desc.ElemTypes {
 			typerefs[i] = gen.ToTypeRef(t, fileID, packageName)
 		}
-		return fmt.Sprintf(`%sMakeCompoundTypeRef("%s", %s%sKind, %s)`, gen.TypesPackage, t.Name(), gen.TypesPackage, kindToString(t.Kind()), strings.Join(typerefs, ", "))
+		return fmt.Sprintf(`%sMakeCompoundTypeRef(%s%sKind, %s)`, gen.TypesPackage, gen.TypesPackage, kindToString(t.Kind()), strings.Join(typerefs, ", "))
 	case types.EnumDesc:
 		return fmt.Sprintf(`%sMakeEnumTypeRef("%s", "%s")`, gen.TypesPackage, t.Name(), strings.Join(desc.IDs, `", "`))
 	case types.StructDesc:

--- a/nomdl/codegen/code/generate_test.go
+++ b/nomdl/codegen/code/generate_test.go
@@ -48,6 +48,6 @@ func TestUserName(t *testing.T) {
 	g := Generator{R: &res}
 	assert.Equal(localStructName, g.UserName(resolved))
 
-	listOfImported := types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(imported.Ref(), 1))
+	listOfImported := types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(imported.Ref(), 1))
 	assert.Equal(fmt.Sprintf("ListOfS1"), g.UserName(listOfImported))
 }

--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -157,13 +157,13 @@ func TestSkipDuplicateTypes(t *testing.T) {
 	leaf1 := types.NewPackage([]types.TypeRef{
 		types.MakeEnumTypeRef("E1", "a", "b"),
 		types.MakeStructTypeRef("S1", []types.Field{
-			types.Field{"f", types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.UInt16Kind)), false},
+			types.Field{"f", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt16Kind)), false},
 			types.Field{"e", types.MakeTypeRef(ref.Ref{}, 0), false},
 		}, types.Choices{}),
 	}, []ref.Ref{})
 	leaf2 := types.NewPackage([]types.TypeRef{
 		types.MakeStructTypeRef("S2", []types.Field{
-			types.Field{"f", types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.UInt16Kind)), false},
+			types.Field{"f", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt16Kind)), false},
 		}, types.Choices{}),
 	}, []ref.Ref{})
 

--- a/nomdl/codegen/test/gen/list_int64.go
+++ b/nomdl/codegen/test/gen/list_int64.go
@@ -74,7 +74,7 @@ func (m ListOfInt64) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfInt64 = types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.Int64Kind))
+	__typeRefForListOfInt64 = types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.Int64Kind))
 	types.RegisterFromValFunction(__typeRefForListOfInt64, func(v types.Value) types.Value {
 		return ListOfInt64FromVal(v)
 	})

--- a/nomdl/codegen/test/gen/map.go
+++ b/nomdl/codegen/test/gen/map.go
@@ -75,7 +75,7 @@ func (m MapOfBoolToString) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfBoolToString = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.BoolKind), types.MakePrimitiveTypeRef(types.StringKind))
+	__typeRefForMapOfBoolToString = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.BoolKind), types.MakePrimitiveTypeRef(types.StringKind))
 	types.RegisterFromValFunction(__typeRefForMapOfBoolToString, func(v types.Value) types.Value {
 		return MapOfBoolToStringFromVal(v)
 	})
@@ -211,7 +211,7 @@ func (m MapOfStringToValue) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForMapOfStringToValue = types.MakeCompoundTypeRef("", types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind))
+	__typeRefForMapOfStringToValue = types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakePrimitiveTypeRef(types.ValueKind))
 	types.RegisterFromValFunction(__typeRefForMapOfStringToValue, func(v types.Value) types.Value {
 		return MapOfStringToValueFromVal(v)
 	})

--- a/nomdl/codegen/test/gen/ref.go
+++ b/nomdl/codegen/test/gen/ref.go
@@ -17,7 +17,7 @@ func init() {
 	p := types.NewPackage([]types.TypeRef{
 		types.MakeStructTypeRef("StructWithRef",
 			[]types.Field{
-				types.Field{"r", types.MakeCompoundTypeRef("", types.RefKind, types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))), false},
+				types.Field{"r", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))), false},
 			},
 			types.Choices{},
 		),
@@ -151,7 +151,7 @@ func (m RefOfListOfString) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfListOfString = types.MakeCompoundTypeRef("", types.RefKind, types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.StringKind)))
+	__typeRefForRefOfListOfString = types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.StringKind)))
 	types.RegisterFromValFunction(__typeRefForRefOfListOfString, func(v types.Value) types.Value {
 		return RefOfListOfStringFromVal(v)
 	})
@@ -232,7 +232,7 @@ func (m ListOfRefOfFloat32) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfRefOfFloat32 = types.MakeCompoundTypeRef("", types.ListKind, types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.Float32Kind)))
+	__typeRefForListOfRefOfFloat32 = types.MakeCompoundTypeRef(types.ListKind, types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.Float32Kind)))
 	types.RegisterFromValFunction(__typeRefForListOfRefOfFloat32, func(v types.Value) types.Value {
 		return ListOfRefOfFloat32FromVal(v)
 	})
@@ -356,7 +356,7 @@ func (m RefOfSetOfFloat32) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfSetOfFloat32 = types.MakeCompoundTypeRef("", types.RefKind, types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind)))
+	__typeRefForRefOfSetOfFloat32 = types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind)))
 	types.RegisterFromValFunction(__typeRefForRefOfSetOfFloat32, func(v types.Value) types.Value {
 		return RefOfSetOfFloat32FromVal(v)
 	})
@@ -437,7 +437,7 @@ func (m ListOfString) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfString = types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.StringKind))
+	__typeRefForListOfString = types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.StringKind))
 	types.RegisterFromValFunction(__typeRefForListOfString, func(v types.Value) types.Value {
 		return ListOfStringFromVal(v)
 	})
@@ -561,7 +561,7 @@ func (m RefOfFloat32) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfFloat32 = types.MakeCompoundTypeRef("", types.RefKind, types.MakePrimitiveTypeRef(types.Float32Kind))
+	__typeRefForRefOfFloat32 = types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.Float32Kind))
 	types.RegisterFromValFunction(__typeRefForRefOfFloat32, func(v types.Value) types.Value {
 		return RefOfFloat32FromVal(v)
 	})
@@ -644,7 +644,7 @@ func (m SetOfFloat32) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfFloat32 = types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))
+	__typeRefForSetOfFloat32 = types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))
 	types.RegisterFromValFunction(__typeRefForSetOfFloat32, func(v types.Value) types.Value {
 		return SetOfFloat32FromVal(v)
 	})

--- a/nomdl/codegen/test/gen/set.go
+++ b/nomdl/codegen/test/gen/set.go
@@ -76,7 +76,7 @@ func (m SetOfBool) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfBool = types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.BoolKind))
+	__typeRefForSetOfBool = types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.BoolKind))
 	types.RegisterFromValFunction(__typeRefForSetOfBool, func(v types.Value) types.Value {
 		return SetOfBoolFromVal(v)
 	})

--- a/nomdl/codegen/test/gen/struct.go
+++ b/nomdl/codegen/test/gen/struct.go
@@ -184,7 +184,7 @@ func (m ListOfStruct) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfStruct = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__genPackageInFile_struct_CachedRef, 0))
+	__typeRefForListOfStruct = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__genPackageInFile_struct_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfStruct, func(v types.Value) types.Value {
 		return ListOfStructFromVal(v)
 	})

--- a/nomdl/codegen/test/gen/struct_recursive.go
+++ b/nomdl/codegen/test/gen/struct_recursive.go
@@ -16,7 +16,7 @@ func init() {
 	p := types.NewPackage([]types.TypeRef{
 		types.MakeStructTypeRef("Tree",
 			[]types.Field{
-				types.Field{"children", types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(ref.Ref{}, 0)), false},
+				types.Field{"children", types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(ref.Ref{}, 0)), false},
 			},
 			types.Choices{},
 		),
@@ -171,7 +171,7 @@ func (m ListOfTree) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfTree = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(__genPackageInFile_struct_recursive_CachedRef, 0))
+	__typeRefForListOfTree = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__genPackageInFile_struct_recursive_CachedRef, 0))
 	types.RegisterFromValFunction(__typeRefForListOfTree, func(v types.Value) types.Value {
 		return ListOfTreeFromVal(v)
 	})

--- a/nomdl/codegen/test/gen/struct_with_dup_list.go
+++ b/nomdl/codegen/test/gen/struct_with_dup_list.go
@@ -16,7 +16,7 @@ func init() {
 	p := types.NewPackage([]types.TypeRef{
 		types.MakeStructTypeRef("StructWithDupList",
 			[]types.Field{
-				types.Field{"l", types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
+				types.Field{"l", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
 			},
 			types.Choices{},
 		),
@@ -171,7 +171,7 @@ func (m ListOfUInt8) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfUInt8 = types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind))
+	__typeRefForListOfUInt8 = types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind))
 	types.RegisterFromValFunction(__typeRefForListOfUInt8, func(v types.Value) types.Value {
 		return ListOfUInt8FromVal(v)
 	})

--- a/nomdl/codegen/test/gen/struct_with_imports.go
+++ b/nomdl/codegen/test/gen/struct_with_imports.go
@@ -233,7 +233,7 @@ func (m ListOfD) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForListOfD = types.MakeCompoundTypeRef("", types.ListKind, types.MakeTypeRef(ref.Parse("sha1-d31b592f480b7659b03b72a7d1271f31dde57b2d"), 0))
+	__typeRefForListOfD = types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(ref.Parse("sha1-d31b592f480b7659b03b72a7d1271f31dde57b2d"), 0))
 	types.RegisterFromValFunction(__typeRefForListOfD, func(v types.Value) types.Value {
 		return ListOfDFromVal(v)
 	})

--- a/nomdl/codegen/test/gen/struct_with_list.go
+++ b/nomdl/codegen/test/gen/struct_with_list.go
@@ -16,7 +16,7 @@ func init() {
 	p := types.NewPackage([]types.TypeRef{
 		types.MakeStructTypeRef("StructWithList",
 			[]types.Field{
-				types.Field{"l", types.MakeCompoundTypeRef("", types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
+				types.Field{"l", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
 				types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
 				types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"i", types.MakePrimitiveTypeRef(types.Int64Kind), false},

--- a/nomdl/codegen/test/gen/struct_with_union_field.go
+++ b/nomdl/codegen/test/gen/struct_with_union_field.go
@@ -23,7 +23,7 @@ func init() {
 				types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind), false},
 				types.Field{"d", types.MakePrimitiveTypeRef(types.BlobKind), false},
 				types.Field{"e", types.MakePrimitiveTypeRef(types.ValueKind), false},
-				types.Field{"f", types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
+				types.Field{"f", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
 			},
 		),
 	}, []ref.Ref{})
@@ -339,7 +339,7 @@ func (m SetOfUInt8) TypeRef() types.TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfUInt8 = types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind))
+	__typeRefForSetOfUInt8 = types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind))
 	types.RegisterFromValFunction(__typeRefForSetOfUInt8, func(v types.Value) types.Value {
 		return SetOfUInt8FromVal(v)
 	})

--- a/nomdl/pkg/grammar.peg
+++ b/nomdl/pkg/grammar.peg
@@ -150,13 +150,13 @@ Type <- t:(PrimitiveType / CompoundType / Union / NamespaceIdent) {
 }
 
 CompoundType <- `List` _ `(` _ t:Type _ `)` _ {
-	return types.MakeCompoundTypeRef("", types.ListKind, t.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.ListKind, t.(types.TypeRef)), nil
 } / `Map` _ `(` _ k:Type _ `,` _ v:Type _ `)` _ {
-	return types.MakeCompoundTypeRef("", types.MapKind, k.(types.TypeRef), v.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.MapKind, k.(types.TypeRef), v.(types.TypeRef)), nil
 } / `Set` _ `(` _ t:Type _ `)` _ {
-	return types.MakeCompoundTypeRef("", types.SetKind, t.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.SetKind, t.(types.TypeRef)), nil
 } / `Ref` _ `(` _ t:Type _ `)` _ {
-	return types.MakeCompoundTypeRef("", types.RefKind, t.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.RefKind, t.(types.TypeRef)), nil
 }
 
 PrimitiveType <- p:(`UInt64` / `UInt32` / `UInt16` / `UInt8` / `Int64` / `Int32` / `Int16` / `Int8` / `Float64` / `Float32` / `Bool` / `String` / `Blob` / `Value` / `TypeRef`) {

--- a/nomdl/pkg/grammar.peg.go
+++ b/nomdl/pkg/grammar.peg.go
@@ -617,165 +617,165 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 154, col: 5, offset: 3922},
+						pos: position{line: 154, col: 5, offset: 3918},
 						run: (*parser).callonCompoundType13,
 						expr: &seqExpr{
-							pos: position{line: 154, col: 5, offset: 3922},
+							pos: position{line: 154, col: 5, offset: 3918},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 154, col: 5, offset: 3922},
+									pos:        position{line: 154, col: 5, offset: 3918},
 									val:        "Map",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 154, col: 11, offset: 3928},
+									pos:  position{line: 154, col: 11, offset: 3924},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 154, col: 13, offset: 3930},
+									pos:        position{line: 154, col: 13, offset: 3926},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 154, col: 17, offset: 3934},
+									pos:  position{line: 154, col: 17, offset: 3930},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 154, col: 19, offset: 3936},
+									pos:   position{line: 154, col: 19, offset: 3932},
 									label: "k",
 									expr: &ruleRefExpr{
-										pos:  position{line: 154, col: 21, offset: 3938},
+										pos:  position{line: 154, col: 21, offset: 3934},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 154, col: 26, offset: 3943},
+									pos:  position{line: 154, col: 26, offset: 3939},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 154, col: 28, offset: 3945},
+									pos:        position{line: 154, col: 28, offset: 3941},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 154, col: 32, offset: 3949},
+									pos:  position{line: 154, col: 32, offset: 3945},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 154, col: 34, offset: 3951},
+									pos:   position{line: 154, col: 34, offset: 3947},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 154, col: 36, offset: 3953},
+										pos:  position{line: 154, col: 36, offset: 3949},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 154, col: 41, offset: 3958},
+									pos:  position{line: 154, col: 41, offset: 3954},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 154, col: 43, offset: 3960},
+									pos:        position{line: 154, col: 43, offset: 3956},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 154, col: 47, offset: 3964},
+									pos:  position{line: 154, col: 47, offset: 3960},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 156, col: 5, offset: 4068},
+						pos: position{line: 156, col: 5, offset: 4060},
 						run: (*parser).callonCompoundType29,
 						expr: &seqExpr{
-							pos: position{line: 156, col: 5, offset: 4068},
+							pos: position{line: 156, col: 5, offset: 4060},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 156, col: 5, offset: 4068},
+									pos:        position{line: 156, col: 5, offset: 4060},
 									val:        "Set",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 156, col: 11, offset: 4074},
+									pos:  position{line: 156, col: 11, offset: 4066},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 156, col: 13, offset: 4076},
+									pos:        position{line: 156, col: 13, offset: 4068},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 156, col: 17, offset: 4080},
+									pos:  position{line: 156, col: 17, offset: 4072},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 156, col: 19, offset: 4082},
+									pos:   position{line: 156, col: 19, offset: 4074},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 156, col: 21, offset: 4084},
+										pos:  position{line: 156, col: 21, offset: 4076},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 156, col: 26, offset: 4089},
+									pos:  position{line: 156, col: 26, offset: 4081},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 156, col: 28, offset: 4091},
+									pos:        position{line: 156, col: 28, offset: 4083},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 156, col: 32, offset: 4095},
+									pos:  position{line: 156, col: 32, offset: 4087},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 158, col: 5, offset: 4180},
+						pos: position{line: 158, col: 5, offset: 4168},
 						run: (*parser).callonCompoundType40,
 						expr: &seqExpr{
-							pos: position{line: 158, col: 5, offset: 4180},
+							pos: position{line: 158, col: 5, offset: 4168},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 158, col: 5, offset: 4180},
+									pos:        position{line: 158, col: 5, offset: 4168},
 									val:        "Ref",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 158, col: 11, offset: 4186},
+									pos:  position{line: 158, col: 11, offset: 4174},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 158, col: 13, offset: 4188},
+									pos:        position{line: 158, col: 13, offset: 4176},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 158, col: 17, offset: 4192},
+									pos:  position{line: 158, col: 17, offset: 4180},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 158, col: 19, offset: 4194},
+									pos:   position{line: 158, col: 19, offset: 4182},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 158, col: 21, offset: 4196},
+										pos:  position{line: 158, col: 21, offset: 4184},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 158, col: 26, offset: 4201},
+									pos:  position{line: 158, col: 26, offset: 4189},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 158, col: 28, offset: 4203},
+									pos:        position{line: 158, col: 28, offset: 4191},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 158, col: 32, offset: 4207},
+									pos:  position{line: 158, col: 32, offset: 4195},
 									name: "_",
 								},
 							},
@@ -786,88 +786,88 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 162, col: 1, offset: 4291},
+			pos:  position{line: 162, col: 1, offset: 4275},
 			expr: &actionExpr{
-				pos: position{line: 162, col: 18, offset: 4308},
+				pos: position{line: 162, col: 18, offset: 4292},
 				run: (*parser).callonPrimitiveType1,
 				expr: &labeledExpr{
-					pos:   position{line: 162, col: 18, offset: 4308},
+					pos:   position{line: 162, col: 18, offset: 4292},
 					label: "p",
 					expr: &choiceExpr{
-						pos: position{line: 162, col: 21, offset: 4311},
+						pos: position{line: 162, col: 21, offset: 4295},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 162, col: 21, offset: 4311},
+								pos:        position{line: 162, col: 21, offset: 4295},
 								val:        "UInt64",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 32, offset: 4322},
+								pos:        position{line: 162, col: 32, offset: 4306},
 								val:        "UInt32",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 43, offset: 4333},
+								pos:        position{line: 162, col: 43, offset: 4317},
 								val:        "UInt16",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 54, offset: 4344},
+								pos:        position{line: 162, col: 54, offset: 4328},
 								val:        "UInt8",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 64, offset: 4354},
+								pos:        position{line: 162, col: 64, offset: 4338},
 								val:        "Int64",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 74, offset: 4364},
+								pos:        position{line: 162, col: 74, offset: 4348},
 								val:        "Int32",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 84, offset: 4374},
+								pos:        position{line: 162, col: 84, offset: 4358},
 								val:        "Int16",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 94, offset: 4384},
+								pos:        position{line: 162, col: 94, offset: 4368},
 								val:        "Int8",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 103, offset: 4393},
+								pos:        position{line: 162, col: 103, offset: 4377},
 								val:        "Float64",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 115, offset: 4405},
+								pos:        position{line: 162, col: 115, offset: 4389},
 								val:        "Float32",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 127, offset: 4417},
+								pos:        position{line: 162, col: 127, offset: 4401},
 								val:        "Bool",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 136, offset: 4426},
+								pos:        position{line: 162, col: 136, offset: 4410},
 								val:        "String",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 147, offset: 4437},
+								pos:        position{line: 162, col: 147, offset: 4421},
 								val:        "Blob",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 156, offset: 4446},
+								pos:        position{line: 162, col: 156, offset: 4430},
 								val:        "Value",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 162, col: 166, offset: 4456},
+								pos:        position{line: 162, col: 166, offset: 4440},
 								val:        "TypeRef",
 								ignoreCase: false,
 							},
@@ -878,28 +878,28 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 166, col: 1, offset: 4541},
+			pos:  position{line: 166, col: 1, offset: 4525},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 17, offset: 4557},
+				pos: position{line: 166, col: 17, offset: 4541},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 17, offset: 4557},
+					pos: position{line: 166, col: 17, offset: 4541},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 166, col: 17, offset: 4557},
+							pos:        position{line: 166, col: 17, offset: 4541},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 21, offset: 4561},
+							pos:   position{line: 166, col: 21, offset: 4545},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 23, offset: 4563},
+								pos:  position{line: 166, col: 23, offset: 4547},
 								name: "String",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 166, col: 30, offset: 4570},
+							pos:        position{line: 166, col: 30, offset: 4554},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -909,42 +909,42 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 170, col: 1, offset: 4603},
+			pos:  position{line: 170, col: 1, offset: 4587},
 			expr: &actionExpr{
-				pos: position{line: 170, col: 11, offset: 4613},
+				pos: position{line: 170, col: 11, offset: 4597},
 				run: (*parser).callonString1,
 				expr: &choiceExpr{
-					pos: position{line: 170, col: 12, offset: 4614},
+					pos: position{line: 170, col: 12, offset: 4598},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 170, col: 12, offset: 4614},
+							pos: position{line: 170, col: 12, offset: 4598},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 170, col: 12, offset: 4614},
+									pos:  position{line: 170, col: 12, offset: 4598},
 									name: "StringPiece",
 								},
 								&litMatcher{
-									pos:        position{line: 170, col: 24, offset: 4626},
+									pos:        position{line: 170, col: 24, offset: 4610},
 									val:        "\\\"",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 170, col: 29, offset: 4631},
+									pos:  position{line: 170, col: 29, offset: 4615},
 									name: "StringPiece",
 								},
 								&litMatcher{
-									pos:        position{line: 170, col: 41, offset: 4643},
+									pos:        position{line: 170, col: 41, offset: 4627},
 									val:        "\\\"",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 170, col: 46, offset: 4648},
+									pos:  position{line: 170, col: 46, offset: 4632},
 									name: "StringPiece",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 170, col: 60, offset: 4662},
+							pos:  position{line: 170, col: 60, offset: 4646},
 							name: "StringPiece",
 						},
 					},
@@ -953,24 +953,24 @@ var g = &grammar{
 		},
 		{
 			name: "StringPiece",
-			pos:  position{line: 174, col: 1, offset: 4708},
+			pos:  position{line: 174, col: 1, offset: 4692},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 174, col: 16, offset: 4723},
+				pos: position{line: 174, col: 16, offset: 4707},
 				expr: &choiceExpr{
-					pos: position{line: 174, col: 17, offset: 4724},
+					pos: position{line: 174, col: 17, offset: 4708},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 174, col: 17, offset: 4724},
+							pos: position{line: 174, col: 17, offset: 4708},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 174, col: 17, offset: 4724},
+									pos:        position{line: 174, col: 17, offset: 4708},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 174, col: 21, offset: 4728},
+									pos: position{line: 174, col: 21, offset: 4712},
 									expr: &litMatcher{
-										pos:        position{line: 174, col: 22, offset: 4729},
+										pos:        position{line: 174, col: 22, offset: 4713},
 										val:        "\"",
 										ignoreCase: false,
 									},
@@ -978,7 +978,7 @@ var g = &grammar{
 							},
 						},
 						&charClassMatcher{
-							pos:        position{line: 174, col: 28, offset: 4735},
+							pos:        position{line: 174, col: 28, offset: 4719},
 							val:        "[^\"\\\\]",
 							chars:      []rune{'"', '\\'},
 							ignoreCase: false,
@@ -990,27 +990,27 @@ var g = &grammar{
 		},
 		{
 			name: "NamespaceIdent",
-			pos:  position{line: 176, col: 1, offset: 4745},
+			pos:  position{line: 176, col: 1, offset: 4729},
 			expr: &actionExpr{
-				pos: position{line: 176, col: 19, offset: 4763},
+				pos: position{line: 176, col: 19, offset: 4747},
 				run: (*parser).callonNamespaceIdent1,
 				expr: &seqExpr{
-					pos: position{line: 176, col: 19, offset: 4763},
+					pos: position{line: 176, col: 19, offset: 4747},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 176, col: 19, offset: 4763},
+							pos:   position{line: 176, col: 19, offset: 4747},
 							label: "n",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 176, col: 21, offset: 4765},
+								pos: position{line: 176, col: 21, offset: 4749},
 								expr: &seqExpr{
-									pos: position{line: 176, col: 22, offset: 4766},
+									pos: position{line: 176, col: 22, offset: 4750},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 176, col: 22, offset: 4766},
+											pos:  position{line: 176, col: 22, offset: 4750},
 											name: "Ident",
 										},
 										&litMatcher{
-											pos:        position{line: 176, col: 28, offset: 4772},
+											pos:        position{line: 176, col: 28, offset: 4756},
 											val:        ".",
 											ignoreCase: false,
 										},
@@ -1019,10 +1019,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 176, col: 34, offset: 4778},
+							pos:   position{line: 176, col: 34, offset: 4762},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 176, col: 37, offset: 4781},
+								pos:  position{line: 176, col: 37, offset: 4765},
 								name: "Ident",
 							},
 						},
@@ -1032,15 +1032,15 @@ var g = &grammar{
 		},
 		{
 			name: "Ident",
-			pos:  position{line: 185, col: 1, offset: 4979},
+			pos:  position{line: 185, col: 1, offset: 4963},
 			expr: &actionExpr{
-				pos: position{line: 185, col: 10, offset: 4988},
+				pos: position{line: 185, col: 10, offset: 4972},
 				run: (*parser).callonIdent1,
 				expr: &seqExpr{
-					pos: position{line: 185, col: 10, offset: 4988},
+					pos: position{line: 185, col: 10, offset: 4972},
 					exprs: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 185, col: 10, offset: 4988},
+							pos:        position{line: 185, col: 10, offset: 4972},
 							val:        "[\\pL_]",
 							chars:      []rune{'_'},
 							classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -1048,9 +1048,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 185, col: 17, offset: 4995},
+							pos: position{line: 185, col: 17, offset: 4979},
 							expr: &charClassMatcher{
-								pos:        position{line: 185, col: 17, offset: 4995},
+								pos:        position{line: 185, col: 17, offset: 4979},
 								val:        "[\\pL\\pN_]",
 								chars:      []rune{'_'},
 								classes:    []*unicode.RangeTable{rangeTable("L"), rangeTable("N")},
@@ -1065,28 +1065,28 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"optional whitespace\"",
-			pos:         position{line: 189, col: 1, offset: 5039},
+			pos:         position{line: 189, col: 1, offset: 5023},
 			expr: &actionExpr{
-				pos: position{line: 189, col: 28, offset: 5066},
+				pos: position{line: 189, col: 28, offset: 5050},
 				run: (*parser).callon_1,
 				expr: &seqExpr{
-					pos: position{line: 189, col: 28, offset: 5066},
+					pos: position{line: 189, col: 28, offset: 5050},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 189, col: 28, offset: 5066},
+							pos:  position{line: 189, col: 28, offset: 5050},
 							name: "WS",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 189, col: 31, offset: 5069},
+							pos: position{line: 189, col: 31, offset: 5053},
 							expr: &seqExpr{
-								pos: position{line: 189, col: 32, offset: 5070},
+								pos: position{line: 189, col: 32, offset: 5054},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 189, col: 32, offset: 5070},
+										pos:  position{line: 189, col: 32, offset: 5054},
 										name: "Comment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 189, col: 40, offset: 5078},
+										pos:  position{line: 189, col: 40, offset: 5062},
 										name: "WS",
 									},
 								},
@@ -1098,11 +1098,11 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 193, col: 1, offset: 5105},
+			pos:  position{line: 193, col: 1, offset: 5089},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 193, col: 7, offset: 5111},
+				pos: position{line: 193, col: 7, offset: 5095},
 				expr: &charClassMatcher{
-					pos:        position{line: 193, col: 7, offset: 5111},
+					pos:        position{line: 193, col: 7, offset: 5095},
 					val:        "[\\r\\n\\t\\pZ]",
 					chars:      []rune{'\r', '\n', '\t'},
 					classes:    []*unicode.RangeTable{rangeTable("Z")},
@@ -1113,22 +1113,22 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 195, col: 1, offset: 5125},
+			pos:  position{line: 195, col: 1, offset: 5109},
 			expr: &choiceExpr{
-				pos: position{line: 195, col: 12, offset: 5136},
+				pos: position{line: 195, col: 12, offset: 5120},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 195, col: 12, offset: 5136},
+						pos: position{line: 195, col: 12, offset: 5120},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 195, col: 12, offset: 5136},
+								pos:        position{line: 195, col: 12, offset: 5120},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 195, col: 17, offset: 5141},
+								pos: position{line: 195, col: 17, offset: 5125},
 								expr: &charClassMatcher{
-									pos:        position{line: 195, col: 17, offset: 5141},
+									pos:        position{line: 195, col: 17, offset: 5125},
 									val:        "[^\\n]",
 									chars:      []rune{'\n'},
 									ignoreCase: false,
@@ -1138,7 +1138,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 195, col: 26, offset: 5150},
+						pos:  position{line: 195, col: 26, offset: 5134},
 						name: "MultilineComment",
 					},
 				},
@@ -1146,32 +1146,32 @@ var g = &grammar{
 		},
 		{
 			name: "MultilineComment",
-			pos:  position{line: 197, col: 1, offset: 5168},
+			pos:  position{line: 197, col: 1, offset: 5152},
 			expr: &seqExpr{
-				pos: position{line: 197, col: 21, offset: 5188},
+				pos: position{line: 197, col: 21, offset: 5172},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 197, col: 21, offset: 5188},
+						pos:        position{line: 197, col: 21, offset: 5172},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 197, col: 26, offset: 5193},
+						pos: position{line: 197, col: 26, offset: 5177},
 						expr: &choiceExpr{
-							pos: position{line: 197, col: 27, offset: 5194},
+							pos: position{line: 197, col: 27, offset: 5178},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 197, col: 27, offset: 5194},
+									pos: position{line: 197, col: 27, offset: 5178},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 197, col: 27, offset: 5194},
+											pos:        position{line: 197, col: 27, offset: 5178},
 											val:        "*",
 											ignoreCase: false,
 										},
 										&notExpr{
-											pos: position{line: 197, col: 31, offset: 5198},
+											pos: position{line: 197, col: 31, offset: 5182},
 											expr: &litMatcher{
-												pos:        position{line: 197, col: 32, offset: 5199},
+												pos:        position{line: 197, col: 32, offset: 5183},
 												val:        "/",
 												ignoreCase: false,
 											},
@@ -1179,7 +1179,7 @@ var g = &grammar{
 									},
 								},
 								&charClassMatcher{
-									pos:        position{line: 197, col: 38, offset: 5205},
+									pos:        position{line: 197, col: 38, offset: 5189},
 									val:        "[^*]",
 									chars:      []rune{'*'},
 									ignoreCase: false,
@@ -1189,7 +1189,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 197, col: 45, offset: 5212},
+						pos:        position{line: 197, col: 45, offset: 5196},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -1198,18 +1198,18 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 199, col: 1, offset: 5218},
+			pos:  position{line: 199, col: 1, offset: 5202},
 			expr: &seqExpr{
-				pos: position{line: 199, col: 8, offset: 5225},
+				pos: position{line: 199, col: 8, offset: 5209},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 8, offset: 5225},
+						pos:  position{line: 199, col: 8, offset: 5209},
 						name: "_",
 					},
 					&notExpr{
-						pos: position{line: 199, col: 10, offset: 5227},
+						pos: position{line: 199, col: 10, offset: 5211},
 						expr: &anyMatcher{
-							line: 199, col: 11, offset: 5228,
+							line: 199, col: 11, offset: 5212,
 						},
 					},
 				},
@@ -1409,7 +1409,7 @@ func (p *parser) callonType1() (interface{}, error) {
 }
 
 func (c *current) onCompoundType2(t interface{}) (interface{}, error) {
-	return types.MakeCompoundTypeRef("", types.ListKind, t.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.ListKind, t.(types.TypeRef)), nil
 }
 
 func (p *parser) callonCompoundType2() (interface{}, error) {
@@ -1419,7 +1419,7 @@ func (p *parser) callonCompoundType2() (interface{}, error) {
 }
 
 func (c *current) onCompoundType13(k, v interface{}) (interface{}, error) {
-	return types.MakeCompoundTypeRef("", types.MapKind, k.(types.TypeRef), v.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.MapKind, k.(types.TypeRef), v.(types.TypeRef)), nil
 }
 
 func (p *parser) callonCompoundType13() (interface{}, error) {
@@ -1429,7 +1429,7 @@ func (p *parser) callonCompoundType13() (interface{}, error) {
 }
 
 func (c *current) onCompoundType29(t interface{}) (interface{}, error) {
-	return types.MakeCompoundTypeRef("", types.SetKind, t.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.SetKind, t.(types.TypeRef)), nil
 }
 
 func (p *parser) callonCompoundType29() (interface{}, error) {
@@ -1439,7 +1439,7 @@ func (p *parser) callonCompoundType29() (interface{}, error) {
 }
 
 func (c *current) onCompoundType40(t interface{}) (interface{}, error) {
-	return types.MakeCompoundTypeRef("", types.RefKind, t.(types.TypeRef)), nil
+	return types.MakeCompoundTypeRef(types.RefKind, t.(types.TypeRef)), nil
 }
 
 func (p *parser) callonCompoundType40() (interface{}, error) {

--- a/nomdl/pkg/parse.go
+++ b/nomdl/pkg/parse.go
@@ -129,10 +129,10 @@ func resolveLocalOrdinals(p *intermediate) {
 
 		switch t.Kind() {
 		case types.ListKind, types.SetKind, types.RefKind:
-			return types.MakeCompoundTypeRef(t.Name(), t.Kind(), rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+			return types.MakeCompoundTypeRef(t.Kind(), rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
 		case types.MapKind:
 			elemTypes := t.Desc.(types.CompoundDesc).ElemTypes
-			return types.MakeCompoundTypeRef(t.Name(), t.Kind(), rec(elemTypes[0]), rec(elemTypes[1]))
+			return types.MakeCompoundTypeRef(t.Kind(), rec(elemTypes[0]), rec(elemTypes[1]))
 		case types.StructKind:
 			resolveFields(t.Desc.(types.StructDesc).Fields)
 			resolveFields(t.Desc.(types.StructDesc).Union)
@@ -174,10 +174,10 @@ func resolveNamespaces(p *intermediate, aliases map[string]ref.Ref, deps map[ref
 		}
 		switch t.Kind() {
 		case types.ListKind, types.SetKind, types.RefKind:
-			return types.MakeCompoundTypeRef(t.Name(), t.Kind(), rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+			return types.MakeCompoundTypeRef(t.Kind(), rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
 		case types.MapKind:
 			elemTypes := t.Desc.(types.CompoundDesc).ElemTypes
-			return types.MakeCompoundTypeRef(t.Name(), t.Kind(), rec(elemTypes[0]), rec(elemTypes[1]))
+			return types.MakeCompoundTypeRef(t.Kind(), rec(elemTypes[0]), rec(elemTypes[1]))
 		case types.StructKind:
 			resolveFields(t.Desc.(types.StructDesc).Fields)
 			resolveFields(t.Desc.(types.StructDesc).Union)

--- a/nomdl/pkg/parse_test.go
+++ b/nomdl/pkg/parse_test.go
@@ -204,14 +204,14 @@ type ParsedResultTestSuite struct {
 func (suite *ParsedResultTestSuite) SetupTest() {
 	suite.primField = testField{"a", types.MakePrimitiveTypeRef(types.Int64Kind), false}
 	suite.primOptionalField = testField{"b", types.MakePrimitiveTypeRef(types.Float64Kind), true}
-	suite.compoundField = testField{"set", types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false}
+	suite.compoundField = testField{"set", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false}
 	suite.compoundOfCompoundField = testField{
 		"listOfSet",
-		types.MakeCompoundTypeRef("", types.ListKind,
-			types.MakeCompoundTypeRef("", types.SetKind, types.MakePrimitiveTypeRef(types.StringKind))), false}
+		types.MakeCompoundTypeRef(types.ListKind,
+			types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind))), false}
 	suite.mapOfNamedTypeField = testField{
 		"mapOfStructToOther",
-		types.MakeCompoundTypeRef("", types.MapKind,
+		types.MakeCompoundTypeRef(types.MapKind,
 			types.MakeUnresolvedTypeRef("", "Struct"),
 			types.MakeUnresolvedTypeRef("Elsewhere", "Other"),
 		),

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -74,11 +74,11 @@ func (r *jsonArrayReader) readTypeRefAsTag() TypeRef {
 	switch kind {
 	case ListKind, SetKind, RefKind:
 		elemType := r.readTypeRefAsTag()
-		return MakeCompoundTypeRef("", kind, elemType)
+		return MakeCompoundTypeRef(kind, elemType)
 	case MapKind:
 		keyType := r.readTypeRefAsTag()
 		valueType := r.readTypeRefAsTag()
-		return MakeCompoundTypeRef("", kind, keyType, valueType)
+		return MakeCompoundTypeRef(kind, keyType, valueType)
 	case TypeRefKind:
 		return MakePrimitiveTypeRef(TypeRefKind)
 	case UnresolvedKind:
@@ -267,7 +267,7 @@ func (r *jsonArrayReader) readTypeRefAsValue(pkg *Package) TypeRef {
 			t := r2.readTypeRefAsValue(pkg)
 			elemTypes = append(elemTypes, t)
 		}
-		return MakeCompoundTypeRef("", k, elemTypes...)
+		return MakeCompoundTypeRef(k, elemTypes...)
 	case StructKind:
 		name := r.readString()
 
@@ -315,7 +315,7 @@ func fixupTypeRef(tr TypeRef, pkg *Package) TypeRef {
 		for i, elemType := range desc.ElemTypes {
 			elemTypes[i] = fixupTypeRef(elemType, pkg)
 		}
-		return MakeCompoundTypeRef(tr.Name(), tr.Kind(), elemTypes...)
+		return MakeCompoundTypeRef(tr.Kind(), elemTypes...)
 	case StructDesc:
 		fields := make([]Field, len(desc.Fields))
 		for i, f := range desc.Fields {

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -47,7 +47,7 @@ func TestReadTypeRefAsTag(t *testing.T) {
 
 	test(MakePrimitiveTypeRef(BoolKind), "[%d, true]", BoolKind)
 	test(MakePrimitiveTypeRef(TypeRefKind), "[%d, %d]", TypeRefKind, BoolKind)
-	test(MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(BoolKind)), "[%d, %d, true, false]", ListKind, BoolKind)
+	test(MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(BoolKind)), "[%d, %d, true, false]", ListKind, BoolKind)
 
 	pkgRef := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
 	test(MakeTypeRef(pkgRef, 42), `[%d, "%s", 42]`, UnresolvedKind, pkgRef.String())
@@ -95,7 +95,7 @@ func TestReadListOfInt32(t *testing.T) {
 	a := parseJson("[%d, %d, [0, 1, 2, 3]]", ListKind, Int32Kind)
 	r := newJsonArrayReader(a, cs)
 
-	tr := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int32Kind))
+	tr := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(Int32Kind))
 	RegisterFromValFunction(tr, func(v Value) Value {
 		return v
 	})
@@ -111,7 +111,7 @@ func TestReadListOfValue(t *testing.T) {
 	a := parseJson(`[%d, %d, [%d, 1, %d, "hi", %d, true]]`, ListKind, ValueKind, Int32Kind, StringKind, BoolKind)
 	r := newJsonArrayReader(a, cs)
 
-	listTr := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+	listTr := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
 	RegisterFromValFunction(listTr, func(v Value) Value {
 		return v
 	})
@@ -127,7 +127,7 @@ func TestReadValueListOfInt8(t *testing.T) {
 	a := parseJson(`[%d, %d, %d, [0, 1, 2]]`, ValueKind, ListKind, Int8Kind)
 	r := newJsonArrayReader(a, cs)
 
-	listTr := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int8Kind))
+	listTr := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(Int8Kind))
 	RegisterFromValFunction(listTr, func(v Value) Value {
 		return v
 	})
@@ -143,7 +143,7 @@ func TestReadMapOfInt64ToFloat64(t *testing.T) {
 	a := parseJson("[%d, %d, %d, [0, 1, 2, 3]]", MapKind, Int64Kind, Float64Kind)
 	r := newJsonArrayReader(a, cs)
 
-	tr := MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(Int64Kind), MakePrimitiveTypeRef(Float64Kind))
+	tr := MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(Int64Kind), MakePrimitiveTypeRef(Float64Kind))
 	RegisterFromValFunction(tr, func(v Value) Value {
 		return v
 	})
@@ -159,7 +159,7 @@ func TestReadValueMapOfUInt64ToUInt32(t *testing.T) {
 	a := parseJson("[%d, %d, %d, %d, [0, 1, 2, 3]]", ValueKind, MapKind, UInt64Kind, UInt32Kind)
 	r := newJsonArrayReader(a, cs)
 
-	mapTr := MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(UInt64Kind), MakePrimitiveTypeRef(UInt32Kind))
+	mapTr := MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(UInt64Kind), MakePrimitiveTypeRef(UInt32Kind))
 	RegisterFromValFunction(mapTr, func(v Value) Value {
 		return v
 	})
@@ -175,7 +175,7 @@ func TestReadSetOfUInt8(t *testing.T) {
 	a := parseJson("[%d, %d, [0, 1, 2, 3]]", SetKind, UInt8Kind)
 	r := newJsonArrayReader(a, cs)
 
-	tr := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(UInt8Kind))
+	tr := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(UInt8Kind))
 	RegisterFromValFunction(tr, func(v Value) Value {
 		return v
 	})
@@ -191,7 +191,7 @@ func TestReadValueSetOfUInt16(t *testing.T) {
 	a := parseJson("[%d, %d, %d, [0, 1, 2, 3]]", ValueKind, SetKind, UInt16Kind)
 	r := newJsonArrayReader(a, cs)
 
-	setTr := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(UInt16Kind))
+	setTr := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(UInt16Kind))
 	RegisterFromValFunction(setTr, func(v Value) Value {
 		return v
 	})
@@ -296,7 +296,7 @@ func TestReadStructWithList(t *testing.T) {
 
 	tref := MakeStructTypeRef("A4", []Field{
 		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
-		Field{"l", MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int32Kind)), false},
+		Field{"l", MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(Int32Kind)), false},
 		Field{"s", MakePrimitiveTypeRef(StringKind), false},
 	}, Choices{})
 	pkg := NewPackage([]TypeRef{tref}, []ref.Ref{})
@@ -310,7 +310,7 @@ func TestReadStructWithList(t *testing.T) {
 		return v
 	})
 
-	l32Tr := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int32Kind))
+	l32Tr := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(Int32Kind))
 	RegisterFromValFunction(l32Tr, func(v Value) Value {
 		return v
 	})
@@ -435,7 +435,7 @@ func TestReadRef(t *testing.T) {
 	a := parseJson(`[%d, %d, "%s"]`, RefKind, UInt32Kind, r.String())
 	reader := newJsonArrayReader(a, cs)
 
-	refTr := MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(UInt32Kind))
+	refTr := MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(UInt32Kind))
 	RegisterFromValFunction(refTr, func(v Value) Value {
 		return v
 	})
@@ -453,7 +453,7 @@ func TestReadValueRef(t *testing.T) {
 	a := parseJson(`[%d, %d, %d, "%s"]`, ValueKind, RefKind, UInt32Kind, r.String())
 	reader := newJsonArrayReader(a, cs)
 
-	refTypeRef := MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(UInt32Kind))
+	refTypeRef := MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(UInt32Kind))
 	RegisterFromValFunction(refTypeRef, func(v Value) Value {
 		return v
 	})
@@ -546,9 +546,9 @@ func TestReadTypeRefValue(t *testing.T) {
 
 	test(MakePrimitiveTypeRef(Int32Kind),
 		`[%d, %d]`, TypeRefKind, Int32Kind)
-	test(MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(BoolKind)),
+	test(MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(BoolKind)),
 		`[%d, %d, [%d]]`, TypeRefKind, ListKind, BoolKind)
-	test(MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(BoolKind), MakePrimitiveTypeRef(StringKind)),
+	test(MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(BoolKind), MakePrimitiveTypeRef(StringKind)),
 		`[%d, %d, [%d, %d]]`, TypeRefKind, MapKind, BoolKind, StringKind)
 	test(MakeEnumTypeRef("E", "a", "b", "c"),
 		`[%d, %d, "E", ["a", "b", "c"]]`, TypeRefKind, EnumKind)
@@ -613,7 +613,7 @@ func TestReadPackage2(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	rr := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
-	setTref := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(UInt32Kind))
+	setTref := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(UInt32Kind))
 	pkg := NewPackage([]TypeRef{setTref}, []ref.Ref{rr})
 
 	a := []interface{}{float64(PackageKind), []interface{}{float64(SetKind), []interface{}{float64(UInt32Kind)}}, []interface{}{rr.String()}}

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -54,7 +54,7 @@ func (l testList) InternalImplementation() List {
 func TestWriteList(t *testing.T) {
 	assert := assert.New(t)
 
-	tref := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int32Kind))
+	tref := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(Int32Kind))
 	v := NewList(Int32(0), Int32(1), Int32(2), Int32(3))
 
 	w := newJsonArrayWriter()
@@ -65,8 +65,8 @@ func TestWriteList(t *testing.T) {
 func TestWriteListOfList(t *testing.T) {
 	assert := assert.New(t)
 
-	it := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(Int16Kind))
-	tref := MakeCompoundTypeRef("", ListKind, it)
+	it := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(Int16Kind))
+	tref := MakeCompoundTypeRef(ListKind, it)
 	v := NewList(NewList(Int16(0)), NewList(Int16(1), Int16(2), Int16(3)))
 
 	w := newJsonArrayWriter()
@@ -91,7 +91,7 @@ func (s testSet) InternalImplementation() Set {
 func TestWriteSet(t *testing.T) {
 	assert := assert.New(t)
 
-	tref := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(UInt32Kind))
+	tref := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(UInt32Kind))
 	v := NewSet(UInt32(3), UInt32(1), UInt32(2), UInt32(0))
 
 	w := newJsonArrayWriter()
@@ -103,8 +103,8 @@ func TestWriteSet(t *testing.T) {
 func TestWriteSetOfSet(t *testing.T) {
 	assert := assert.New(t)
 
-	st := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(Int32Kind))
-	tref := MakeCompoundTypeRef("", SetKind, st)
+	st := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(Int32Kind))
+	tref := MakeCompoundTypeRef(SetKind, st)
 	v := NewSet(NewSet(Int32(0)), NewSet(Int32(1), Int32(2), Int32(3)))
 
 	w := newJsonArrayWriter()
@@ -129,7 +129,7 @@ func (m testMap) InternalImplementation() Map {
 func TestWriteMap(t *testing.T) {
 	assert := assert.New(t)
 
-	tref := MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(BoolKind))
+	tref := MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(BoolKind))
 	v := NewMap(NewString("a"), Bool(false), NewString("b"), Bool(true))
 
 	w := newJsonArrayWriter()
@@ -141,9 +141,9 @@ func TestWriteMap(t *testing.T) {
 func TestWriteMapOfMap(t *testing.T) {
 	assert := assert.New(t)
 
-	kt := MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(Int64Kind))
-	vt := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(BoolKind))
-	tref := MakeCompoundTypeRef("", MapKind, kt, vt)
+	kt := MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(StringKind), MakePrimitiveTypeRef(Int64Kind))
+	vt := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(BoolKind))
+	tref := MakeCompoundTypeRef(MapKind, kt, vt)
 	v := NewMap(NewMap(NewString("a"), Int64(0)), NewSet(Bool(true)))
 
 	w := newJsonArrayWriter()
@@ -236,7 +236,7 @@ func TestWriteStructWithList(t *testing.T) {
 
 	pkg := NewPackage([]TypeRef{
 		MakeStructTypeRef("S", []Field{
-			Field{"l", MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(StringKind)), false},
+			Field{"l", MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(StringKind)), false},
 		}, Choices{})}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	tref := MakeTypeRef(pkgRef, 0)
@@ -321,7 +321,7 @@ func TestWriteListOfEnum(t *testing.T) {
 		MakeEnumTypeRef("E", "a", "b", "c")}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	et := MakeTypeRef(pkgRef, 0)
-	tref := MakeCompoundTypeRef("", ListKind, et)
+	tref := MakeCompoundTypeRef(ListKind, et)
 	v := NewList(testEnum{UInt32(0), et}, testEnum{UInt32(1), et}, testEnum{UInt32(2), et})
 
 	w := newJsonArrayWriter()
@@ -332,7 +332,7 @@ func TestWriteListOfEnum(t *testing.T) {
 func TestWriteListOfValue(t *testing.T) {
 	assert := assert.New(t)
 
-	tref := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+	tref := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
 	blob, _ := NewBlob(bytes.NewBuffer([]byte{0x01}))
 	v := NewList(
 		Bool(true),
@@ -379,7 +379,7 @@ func TestWriteListOfValueWithStruct(t *testing.T) {
 		}, Choices{})}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
-	tref := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+	tref := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
 	st := MakeTypeRef(pkgRef, 0)
 	v := NewList(testMap{Map: NewMap(NewString("x"), Int32(42)), t: st})
 
@@ -397,7 +397,7 @@ func TestWriteListOfValueWithTypeRefs(t *testing.T) {
 		}, Choices{})}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
-	tref := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+	tref := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
 	v := NewList(
 		Bool(true),
 		MakePrimitiveTypeRef(Int32Kind),
@@ -431,7 +431,7 @@ func (r testRef) TargetRef() ref.Ref {
 func TestWriteRef(t *testing.T) {
 	assert := assert.New(t)
 
-	tref := MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(UInt32Kind))
+	tref := MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(UInt32Kind))
 	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
 	v := NewRef(r)
 
@@ -451,9 +451,9 @@ func TestWriteTypeRefValue(t *testing.T) {
 
 	test([]interface{}{TypeRefKind, Int32Kind}, MakePrimitiveTypeRef(Int32Kind))
 	test([]interface{}{TypeRefKind, ListKind, []interface{}{BoolKind}},
-		MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(BoolKind)))
+		MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(BoolKind)))
 	test([]interface{}{TypeRefKind, MapKind, []interface{}{BoolKind, StringKind}},
-		MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(BoolKind), MakePrimitiveTypeRef(StringKind)))
+		MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(BoolKind), MakePrimitiveTypeRef(StringKind)))
 	test([]interface{}{TypeRefKind, EnumKind, "E", []interface{}{"a", "b", "c"}},
 		MakeEnumTypeRef("E", "a", "b", "c"))
 
@@ -486,7 +486,7 @@ func TestWriteTypeRefValue(t *testing.T) {
 func TestWriteListOfTypeRefs(t *testing.T) {
 	assert := assert.New(t)
 
-	tref := MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(TypeRefKind))
+	tref := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(TypeRefKind))
 	v := NewList(MakePrimitiveTypeRef(BoolKind), MakeEnumTypeRef("E", "a", "b", "c"), MakePrimitiveTypeRef(StringKind))
 
 	w := newJsonArrayWriter()
@@ -530,7 +530,7 @@ func TestWritePackage(t *testing.T) {
 func TestWritePackage2(t *testing.T) {
 	assert := assert.New(t)
 
-	setTref := MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(UInt32Kind))
+	setTref := MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(UInt32Kind))
 	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
 	v := Package{[]TypeRef{setTref}, []ref.Ref{r}, &ref.Ref{}}
 

--- a/types/list.go
+++ b/types/list.go
@@ -51,7 +51,7 @@ func ListFromVal(v Value) List {
 	return v.(List)
 }
 
-var listTypeRef = MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))
+var listTypeRef = MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
 
 func init() {
 	RegisterFromValFunction(listTypeRef, func(v Value) Value {

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -341,7 +341,7 @@ func TestListIterAllP(t *testing.T) {
 func TestListTypeRef(t *testing.T) {
 	assert := assert.New(t)
 	l := NewList(Int32(0))
-	assert.True(l.TypeRef().Equals(MakeCompoundTypeRef("", ListKind, MakePrimitiveTypeRef(ValueKind))))
+	assert.True(l.TypeRef().Equals(MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))))
 }
 
 func TestListChunks(t *testing.T) {

--- a/types/map.go
+++ b/types/map.go
@@ -145,7 +145,7 @@ func (fm Map) Chunks() (futures []Future) {
 	return
 }
 
-var mapTypeRef = MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(ValueKind), MakePrimitiveTypeRef(ValueKind))
+var mapTypeRef = MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(ValueKind), MakePrimitiveTypeRef(ValueKind))
 
 func (fm Map) TypeRef() TypeRef {
 	return mapTypeRef

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -219,7 +219,7 @@ func TestMapFutures(t *testing.T) {
 func TestMapTypeRef(t *testing.T) {
 	assert := assert.New(t)
 	m := NewMap()
-	assert.True(m.TypeRef().Equals(MakeCompoundTypeRef("", MapKind, MakePrimitiveTypeRef(ValueKind), MakePrimitiveTypeRef(ValueKind))))
+	assert.True(m.TypeRef().Equals(MakeCompoundTypeRef(MapKind, MakePrimitiveTypeRef(ValueKind), MakePrimitiveTypeRef(ValueKind))))
 }
 
 func TestMapChunks(t *testing.T) {

--- a/types/package_set_of_ref.go
+++ b/types/package_set_of_ref.go
@@ -77,7 +77,7 @@ func (m SetOfRefOfPackage) TypeRef() TypeRef {
 }
 
 func init() {
-	__typeRefForSetOfRefOfPackage = MakeCompoundTypeRef("", SetKind, MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(PackageKind)))
+	__typeRefForSetOfRefOfPackage = MakeCompoundTypeRef(SetKind, MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(PackageKind)))
 	RegisterFromValFunction(__typeRefForSetOfRefOfPackage, func(v Value) Value {
 		return SetOfRefOfPackageFromVal(v)
 	})
@@ -205,7 +205,7 @@ func (m RefOfPackage) TypeRef() TypeRef {
 }
 
 func init() {
-	__typeRefForRefOfPackage = MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(PackageKind))
+	__typeRefForRefOfPackage = MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(PackageKind))
 	RegisterFromValFunction(__typeRefForRefOfPackage, func(v Value) Value {
 		return RefOfPackageFromVal(v)
 	})

--- a/types/ref.go
+++ b/types/ref.go
@@ -33,7 +33,7 @@ func (r Ref) TargetRef() ref.Ref {
 	return r.target
 }
 
-var refTypeRef = MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(ValueKind))
+var refTypeRef = MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(ValueKind))
 
 func (r Ref) TypeRef() TypeRef {
 	return refTypeRef

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -41,5 +41,5 @@ func TestRefTypeRef(t *testing.T) {
 	assert := assert.New(t)
 	l := NewList()
 	r := NewRef(l.Ref())
-	assert.True(r.TypeRef().Equals(MakeCompoundTypeRef("", RefKind, MakePrimitiveTypeRef(ValueKind))))
+	assert.True(r.TypeRef().Equals(MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(ValueKind))))
 }

--- a/types/set.go
+++ b/types/set.go
@@ -138,7 +138,7 @@ func (fs Set) Chunks() (futures []Future) {
 	return
 }
 
-var setTypeRef = MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(ValueKind))
+var setTypeRef = MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(ValueKind))
 
 func (fs Set) TypeRef() TypeRef {
 	return setTypeRef

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -188,7 +188,7 @@ func TestSetFilter(t *testing.T) {
 func TestSetTypeRef(t *testing.T) {
 	assert := assert.New(t)
 	s := NewSet()
-	assert.True(s.TypeRef().Equals(MakeCompoundTypeRef("", SetKind, MakePrimitiveTypeRef(ValueKind))))
+	assert.True(s.TypeRef().Equals(MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(ValueKind))))
 }
 
 func TestSetChunks(t *testing.T) {

--- a/types/type_ref_test.go
+++ b/types/type_ref_test.go
@@ -15,8 +15,8 @@ func TestTypes(t *testing.T) {
 	boolType := MakePrimitiveTypeRef(BoolKind)
 	uint8Type := MakePrimitiveTypeRef(UInt8Kind)
 	stringType := MakePrimitiveTypeRef(StringKind)
-	mapType := MakeCompoundTypeRef("MapOfStringToUInt8", MapKind, stringType, uint8Type)
-	setType := MakeCompoundTypeRef("SetOfString", SetKind, stringType)
+	mapType := MakeCompoundTypeRef(MapKind, stringType, uint8Type)
+	setType := MakeCompoundTypeRef(SetKind, stringType)
 	mahType := MakeStructTypeRef("MahStruct", []Field{
 		Field{"Field1", stringType, false},
 		Field{"Field2", boolType, true},


### PR DESCRIPTION
The name param of MakeCompoundTypeRef is always the empty string.

I didn't change the underlying storage or serialization.

Fixes #436, #477
