### PR TITLE
Make sure we write packages to the store

### DIFF
--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -239,6 +239,8 @@ func (r *jsonArrayReader) readUnresolvedKindToValue(t TypeRef, pkg *Package) Val
 		pkg = pkg2
 	}
 
+	d.Chk.NotNil(pkg, "Woah, got a nil pkg. pkgRef: %s, ordinal: %d\n", pkgRef, ordinal)
+
 	typeDef := pkg.types[ordinal]
 
 	if typeDef.Kind() == EnumKind {


### PR DESCRIPTION
When we write a value that has a TypeRef with a package we need to
write that package.

When we write a package that has dependencies we need to write the
dependent packages too.
