### PR TITLE
NomDL: Read Package from ChunkSource when decoding

### DIFF
--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -231,12 +231,17 @@ func (r *jsonArrayReader) readTypeRefKindToValue(t TypeRef, pkg *Package) Value 
 }
 
 func (r *jsonArrayReader) readUnresolvedKindToValue(t TypeRef, pkg *Package) Value {
+	// When we have a struct referencing another struct/enum in the same package the package ref is empty. In that case we use the package that is passed into this function.
 	d.Chk.True(t.IsUnresolved())
 	pkgRef := t.PackageRef()
 	ordinal := t.Ordinal()
-	pkg2 := LookupPackage(pkgRef)
-	if pkg2 != nil {
-		pkg = pkg2
+	if !pkgRef.IsEmpty() {
+		pkg2 := LookupPackage(pkgRef)
+		if pkg2 != nil {
+			pkg = pkg2
+		} else {
+			pkg = readPackage(pkgRef, r.cs)
+		}
 	}
 
 	d.Chk.NotNil(pkg, "Woah, got a nil pkg. pkgRef: %s, ordinal: %d\n", pkgRef, ordinal)

--- a/types/package_registry.go
+++ b/types/package_registry.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -23,6 +24,12 @@ func RegisterPackage(p *Package) (r ref.Ref) {
 	r = p.Ref()
 	packages[r] = p
 	return
+}
+
+func readPackage(r ref.Ref, cs chunks.ChunkSource) *Package {
+	p := ReadValue(r, cs).(Package)
+	RegisterPackage(&p)
+	return &p
 }
 
 func RegisterFromValFunction(t TypeRef, f toNomsValueFunc) {

--- a/types/type_ref.go
+++ b/types/type_ref.go
@@ -42,7 +42,7 @@ func (t TypeRef) IsUnresolved() bool {
 }
 
 func (t TypeRef) HasPackageRef() bool {
-	return t.IsUnresolved() && t.PackageRef() != ref.Ref{}
+	return t.IsUnresolved() && !t.PackageRef().IsEmpty()
 }
 
 // Describe() methods generate text that should parse into the struct being described.


### PR DESCRIPTION
Packages usually gets registered using RegisterPackage which is called
by generated code. However, if the data in the data store was created
using another binary it is unlikely that the current binary registered
the same Package.

When writing values that depends on Packages we write the Package to
the ChunkStore...

When we read a value that depends on a Package and the Package has
not been registered we now read the Package out of the the ChunkStore
and register it for future uses.
