### PR TITLE
NomDL: Remove extra write of the Package type refs

### DIFF
--- a/types/write_value.go
+++ b/types/write_value.go
@@ -58,9 +58,6 @@ func encCompoundBlobFromCompoundBlob(cb compoundBlob, cs chunks.ChunkSink) inter
 }
 
 func processPackageChildren(p Package, cs chunks.ChunkSink) {
-	for _, t := range p.types {
-		writeChildValueInternal(t, cs)
-	}
 	for _, r := range p.dependencies {
 		p := LookupPackage(r)
 		if p != nil {


### PR DESCRIPTION
When writing a Package we were writing the type refs describing the
types in Package. These are never referenced from anywhere and the
information is embedded into the Package chunk.
