### PR TITLE
JS: Don't compile native features

### DIFF
--- a/js2/.babelrc
+++ b/js2/.babelrc
@@ -1,3 +1,11 @@
 {
-  "optional": ["asyncToGenerator"]
+  "optional": ["asyncToGenerator"],
+  "blacklist": [
+    "es6.blockScoping",
+    "es6.constants",
+    "es6.forOf",
+    "es6.properties.computed",
+    "es6.properties.shorthand",
+    "es6.templateLiterals"
+  ]
 }


### PR DESCRIPTION
This disables compiling features that Node and browsers support.

We will most likely need to tweak this in the future to match the
browsers we want to support.
