### PR TITLE
Make List TypeRef per instance

### DIFF
--- a/types/list_test.go
+++ b/types/list_test.go
@@ -337,6 +337,23 @@ func TestListTypeRef(t *testing.T) {
 	assert := assert.New(t)
 	l := NewList(Int32(0))
 	assert.True(l.TypeRef().Equals(MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))))
+
+	tr := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(UInt8Kind))
+	l2 := newListLeafNoCopy([]Value{UInt8(0), UInt8(1)}, tr)
+	assert.Equal(tr, l2.TypeRef())
+	l2 = l2.Slice(0, 1)
+	assert.Equal(tr, l2.TypeRef())
+	l2 = l2.Set(0, UInt8(11))
+	assert.Equal(tr, l2.TypeRef())
+	l2 = l2.Append(UInt8(2))
+	assert.Equal(tr, l2.TypeRef())
+	l2 = l2.Insert(0, UInt8(3))
+	assert.Equal(tr, l2.TypeRef())
+	l2 = l2.Remove(0, 1)
+	assert.Equal(tr, l2.TypeRef())
+	l2 = l2.RemoveAt(0)
+	assert.Equal(tr, l2.TypeRef())
+
 }
 
 func TestListChunks(t *testing.T) {


### PR DESCRIPTION
This is so that we can use type.List for "unknown" list types when
decoding chunks.
