### PR TITLE
Make types.Ref TypeRef per instance

### DIFF
--- a/types/ref.go
+++ b/types/ref.go
@@ -7,11 +7,16 @@ import (
 
 type Ref struct {
 	target ref.Ref
+	t      TypeRef
 	ref    *ref.Ref
 }
 
 func NewRef(target ref.Ref) Ref {
-	return Ref{target, &ref.Ref{}}
+	return newRef(target, refTypeRef)
+}
+
+func newRef(target ref.Ref, t TypeRef) Ref {
+	return Ref{target, t, &ref.Ref{}}
 }
 
 func (r Ref) Equals(other Value) bool {
@@ -36,7 +41,7 @@ func (r Ref) TargetRef() ref.Ref {
 var refTypeRef = MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(ValueKind))
 
 func (r Ref) TypeRef() TypeRef {
-	return refTypeRef
+	return r.t
 }
 
 func init() {
@@ -50,5 +55,5 @@ func (r Ref) TargetValue(cs chunks.ChunkSource) Value {
 }
 
 func (r Ref) SetTargetValue(val Value, cs chunks.ChunkSink) Ref {
-	return NewRef(WriteValue(val, cs))
+	return newRef(WriteValue(val, cs), r.t)
 }

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/attic-labs/noms/chunks"
 )
 
 func TestRefInList(t *testing.T) {
@@ -39,7 +40,15 @@ func TestRefInMap(t *testing.T) {
 
 func TestRefTypeRef(t *testing.T) {
 	assert := assert.New(t)
+
+	tr := MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(ValueKind))
+
 	l := NewList()
 	r := NewRef(l.Ref())
-	assert.True(r.TypeRef().Equals(MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(ValueKind))))
+	assert.True(r.TypeRef().Equals(tr))
+
+	cs := chunks.NewMemoryStore()
+	m := NewMap()
+	r2 := r.SetTargetValue(m, cs)
+	assert.True(r2.TypeRef().Equals(tr))
 }


### PR DESCRIPTION
This is so that we can use type.Ref for "unknown" ref types when
decoding chunks.
