### PR TITLE
Add types.Struct and improve typed structs

### DIFF
--- a/clients/common/geo.noms.go
+++ b/clients/common/geo.noms.go
@@ -35,15 +35,19 @@ func init() {
 // Geoposition
 
 type Geoposition struct {
-	m   types.Map
+	_Latitude  float32
+	_Longitude float32
+
 	ref *ref.Ref
 }
 
 func NewGeoposition() Geoposition {
-	return Geoposition{types.NewMap(
-		types.NewString("Latitude"), types.Float32(0),
-		types.NewString("Longitude"), types.Float32(0),
-	), &ref.Ref{}}
+	return Geoposition{
+		_Latitude:  float32(0),
+		_Longitude: float32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeopositionDef struct {
@@ -53,19 +57,20 @@ type GeopositionDef struct {
 
 func (def GeopositionDef) New() Geoposition {
 	return Geoposition{
-		types.NewMap(
-			types.NewString("Latitude"), types.Float32(def.Latitude),
-			types.NewString("Longitude"), types.Float32(def.Longitude),
-		), &ref.Ref{}}
+		_Latitude:  def.Latitude,
+		_Longitude: def.Longitude,
+		ref:        &ref.Ref{},
+	}
 }
 
 func (s Geoposition) Def() (d GeopositionDef) {
-	d.Latitude = float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
-	d.Longitude = float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	d.Latitude = s._Latitude
+	d.Longitude = s._Longitude
 	return
 }
 
 var __typeRefForGeoposition types.TypeRef
+var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -73,22 +78,35 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForGeoposition, func(v types.Value) types.Value {
-		return GeopositionFromVal(v)
-	})
+	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
+		[]types.Field{
+			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
 }
 
-func GeopositionFromVal(val types.Value) Geoposition {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Geoposition); ok {
-		return val
+func (s Geoposition) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Latitude":  types.Float32(s._Latitude),
+		"Longitude": types.Float32(s._Longitude),
 	}
-	// TODO: Validate here
-	return Geoposition{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
 }
 
-func (s Geoposition) InternalImplementation() types.Map {
-	return s.m
+func builderForGeoposition() chan types.Value {
+	c := make(chan types.Value)
+	s := Geoposition{ref: &ref.Ref{}}
+	go func() {
+		s._Latitude = float32((<-c).(types.Float32))
+		s._Longitude = float32((<-c).(types.Float32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Geoposition) Equals(other types.Value) bool {
@@ -100,39 +118,46 @@ func (s Geoposition) Ref() ref.Ref {
 }
 
 func (s Geoposition) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeoposition.Chunks()...)
 	return
 }
 
 func (s Geoposition) Latitude() float32 {
-	return float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
+	return s._Latitude
 }
 
 func (s Geoposition) SetLatitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Latitude"), types.Float32(val)), &ref.Ref{}}
+	s._Latitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Geoposition) Longitude() float32 {
-	return float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	return s._Longitude
 }
 
 func (s Geoposition) SetLongitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Longitude"), types.Float32(val)), &ref.Ref{}}
+	s._Longitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Georectangle
 
 type Georectangle struct {
-	m   types.Map
+	_TopLeft     Geoposition
+	_BottomRight Geoposition
+
 	ref *ref.Ref
 }
 
 func NewGeorectangle() Georectangle {
-	return Georectangle{types.NewMap(
-		types.NewString("TopLeft"), NewGeoposition(),
-		types.NewString("BottomRight"), NewGeoposition(),
-	), &ref.Ref{}}
+	return Georectangle{
+		_TopLeft:     NewGeoposition(),
+		_BottomRight: NewGeoposition(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeorectangleDef struct {
@@ -142,19 +167,20 @@ type GeorectangleDef struct {
 
 func (def GeorectangleDef) New() Georectangle {
 	return Georectangle{
-		types.NewMap(
-			types.NewString("TopLeft"), def.TopLeft.New(),
-			types.NewString("BottomRight"), def.BottomRight.New(),
-		), &ref.Ref{}}
+		_TopLeft:     def.TopLeft.New(),
+		_BottomRight: def.BottomRight.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s Georectangle) Def() (d GeorectangleDef) {
-	d.TopLeft = s.m.Get(types.NewString("TopLeft")).(Geoposition).Def()
-	d.BottomRight = s.m.Get(types.NewString("BottomRight")).(Geoposition).Def()
+	d.TopLeft = s._TopLeft.Def()
+	d.BottomRight = s._BottomRight.Def()
 	return
 }
 
 var __typeRefForGeorectangle types.TypeRef
+var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -162,22 +188,35 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForGeorectangle, func(v types.Value) types.Value {
-		return GeorectangleFromVal(v)
-	})
+	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
+		[]types.Field{
+			types.Field{"TopLeft", types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 0), false},
+			types.Field{"BottomRight", types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
 }
 
-func GeorectangleFromVal(val types.Value) Georectangle {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Georectangle); ok {
-		return val
+func (s Georectangle) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"TopLeft":     s._TopLeft,
+		"BottomRight": s._BottomRight,
 	}
-	// TODO: Validate here
-	return Georectangle{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
 }
 
-func (s Georectangle) InternalImplementation() types.Map {
-	return s.m
+func builderForGeorectangle() chan types.Value {
+	c := make(chan types.Value)
+	s := Georectangle{ref: &ref.Ref{}}
+	go func() {
+		s._TopLeft = (<-c).(Geoposition)
+		s._BottomRight = (<-c).(Geoposition)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Georectangle) Equals(other types.Value) bool {
@@ -189,23 +228,28 @@ func (s Georectangle) Ref() ref.Ref {
 }
 
 func (s Georectangle) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeorectangle.Chunks()...)
+	chunks = append(chunks, s._TopLeft.Chunks()...)
+	chunks = append(chunks, s._BottomRight.Chunks()...)
 	return
 }
 
 func (s Georectangle) TopLeft() Geoposition {
-	return s.m.Get(types.NewString("TopLeft")).(Geoposition)
+	return s._TopLeft
 }
 
 func (s Georectangle) SetTopLeft(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("TopLeft"), val), &ref.Ref{}}
+	s._TopLeft = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Georectangle) BottomRight() Geoposition {
-	return s.m.Get(types.NewString("BottomRight")).(Geoposition)
+	return s._BottomRight
 }
 
 func (s Georectangle) SetBottomRight(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("BottomRight"), val), &ref.Ref{}}
+	s._BottomRight = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/clients/common/incident.noms.go
+++ b/clients/common/incident.noms.go
@@ -40,24 +40,37 @@ func init() {
 // Incident
 
 type Incident struct {
-	m   types.Map
+	_ID          int64
+	_Category    string
+	_Description string
+	_DayOfWeek   string
+	_Date        string
+	_Time        string
+	_PdDistrict  string
+	_Resolution  string
+	_Address     string
+	_Geoposition Geoposition
+	_PdID        string
+
 	ref *ref.Ref
 }
 
 func NewIncident() Incident {
-	return Incident{types.NewMap(
-		types.NewString("ID"), types.Int64(0),
-		types.NewString("Category"), types.NewString(""),
-		types.NewString("Description"), types.NewString(""),
-		types.NewString("DayOfWeek"), types.NewString(""),
-		types.NewString("Date"), types.NewString(""),
-		types.NewString("Time"), types.NewString(""),
-		types.NewString("PdDistrict"), types.NewString(""),
-		types.NewString("Resolution"), types.NewString(""),
-		types.NewString("Address"), types.NewString(""),
-		types.NewString("Geoposition"), NewGeoposition(),
-		types.NewString("PdID"), types.NewString(""),
-	), &ref.Ref{}}
+	return Incident{
+		_ID:          int64(0),
+		_Category:    "",
+		_Description: "",
+		_DayOfWeek:   "",
+		_Date:        "",
+		_Time:        "",
+		_PdDistrict:  "",
+		_Resolution:  "",
+		_Address:     "",
+		_Geoposition: NewGeoposition(),
+		_PdID:        "",
+
+		ref: &ref.Ref{},
+	}
 }
 
 type IncidentDef struct {
@@ -76,37 +89,38 @@ type IncidentDef struct {
 
 func (def IncidentDef) New() Incident {
 	return Incident{
-		types.NewMap(
-			types.NewString("ID"), types.Int64(def.ID),
-			types.NewString("Category"), types.NewString(def.Category),
-			types.NewString("Description"), types.NewString(def.Description),
-			types.NewString("DayOfWeek"), types.NewString(def.DayOfWeek),
-			types.NewString("Date"), types.NewString(def.Date),
-			types.NewString("Time"), types.NewString(def.Time),
-			types.NewString("PdDistrict"), types.NewString(def.PdDistrict),
-			types.NewString("Resolution"), types.NewString(def.Resolution),
-			types.NewString("Address"), types.NewString(def.Address),
-			types.NewString("Geoposition"), def.Geoposition.New(),
-			types.NewString("PdID"), types.NewString(def.PdID),
-		), &ref.Ref{}}
+		_ID:          def.ID,
+		_Category:    def.Category,
+		_Description: def.Description,
+		_DayOfWeek:   def.DayOfWeek,
+		_Date:        def.Date,
+		_Time:        def.Time,
+		_PdDistrict:  def.PdDistrict,
+		_Resolution:  def.Resolution,
+		_Address:     def.Address,
+		_Geoposition: def.Geoposition.New(),
+		_PdID:        def.PdID,
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s Incident) Def() (d IncidentDef) {
-	d.ID = int64(s.m.Get(types.NewString("ID")).(types.Int64))
-	d.Category = s.m.Get(types.NewString("Category")).(types.String).String()
-	d.Description = s.m.Get(types.NewString("Description")).(types.String).String()
-	d.DayOfWeek = s.m.Get(types.NewString("DayOfWeek")).(types.String).String()
-	d.Date = s.m.Get(types.NewString("Date")).(types.String).String()
-	d.Time = s.m.Get(types.NewString("Time")).(types.String).String()
-	d.PdDistrict = s.m.Get(types.NewString("PdDistrict")).(types.String).String()
-	d.Resolution = s.m.Get(types.NewString("Resolution")).(types.String).String()
-	d.Address = s.m.Get(types.NewString("Address")).(types.String).String()
-	d.Geoposition = s.m.Get(types.NewString("Geoposition")).(Geoposition).Def()
-	d.PdID = s.m.Get(types.NewString("PdID")).(types.String).String()
+	d.ID = s._ID
+	d.Category = s._Category
+	d.Description = s._Description
+	d.DayOfWeek = s._DayOfWeek
+	d.Date = s._Date
+	d.Time = s._Time
+	d.PdDistrict = s._PdDistrict
+	d.Resolution = s._Resolution
+	d.Address = s._Address
+	d.Geoposition = s._Geoposition.Def()
+	d.PdID = s._PdID
 	return
 }
 
 var __typeRefForIncident types.TypeRef
+var __typeDefForIncident types.TypeRef
 
 func (m Incident) TypeRef() types.TypeRef {
 	return __typeRefForIncident
@@ -114,22 +128,62 @@ func (m Incident) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForIncident = types.MakeTypeRef(__commonPackageInFile_incident_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForIncident, func(v types.Value) types.Value {
-		return IncidentFromVal(v)
-	})
+	__typeDefForIncident = types.MakeStructTypeRef("Incident",
+		[]types.Field{
+			types.Field{"ID", types.MakePrimitiveTypeRef(types.Int64Kind), false},
+			types.Field{"Category", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Description", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"DayOfWeek", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Date", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Time", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"PdDistrict", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Resolution", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Address", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
+			types.Field{"PdID", types.MakePrimitiveTypeRef(types.StringKind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForIncident, builderForIncident)
 }
 
-func IncidentFromVal(val types.Value) Incident {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Incident); ok {
-		return val
+func (s Incident) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"ID":          types.Int64(s._ID),
+		"Category":    types.NewString(s._Category),
+		"Description": types.NewString(s._Description),
+		"DayOfWeek":   types.NewString(s._DayOfWeek),
+		"Date":        types.NewString(s._Date),
+		"Time":        types.NewString(s._Time),
+		"PdDistrict":  types.NewString(s._PdDistrict),
+		"Resolution":  types.NewString(s._Resolution),
+		"Address":     types.NewString(s._Address),
+		"Geoposition": s._Geoposition,
+		"PdID":        types.NewString(s._PdID),
 	}
-	// TODO: Validate here
-	return Incident{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForIncident, __typeDefForIncident, m)
 }
 
-func (s Incident) InternalImplementation() types.Map {
-	return s.m
+func builderForIncident() chan types.Value {
+	c := make(chan types.Value)
+	s := Incident{ref: &ref.Ref{}}
+	go func() {
+		s._ID = int64((<-c).(types.Int64))
+		s._Category = (<-c).(types.String).String()
+		s._Description = (<-c).(types.String).String()
+		s._DayOfWeek = (<-c).(types.String).String()
+		s._Date = (<-c).(types.String).String()
+		s._Time = (<-c).(types.String).String()
+		s._PdDistrict = (<-c).(types.String).String()
+		s._Resolution = (<-c).(types.String).String()
+		s._Address = (<-c).(types.String).String()
+		s._Geoposition = (<-c).(Geoposition)
+		s._PdID = (<-c).(types.String).String()
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Incident) Equals(other types.Value) bool {
@@ -141,97 +195,119 @@ func (s Incident) Ref() ref.Ref {
 }
 
 func (s Incident) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForIncident.Chunks()...)
+	chunks = append(chunks, s._Geoposition.Chunks()...)
 	return
 }
 
 func (s Incident) ID() int64 {
-	return int64(s.m.Get(types.NewString("ID")).(types.Int64))
+	return s._ID
 }
 
 func (s Incident) SetID(val int64) Incident {
-	return Incident{s.m.Set(types.NewString("ID"), types.Int64(val)), &ref.Ref{}}
+	s._ID = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Category() string {
-	return s.m.Get(types.NewString("Category")).(types.String).String()
+	return s._Category
 }
 
 func (s Incident) SetCategory(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Category"), types.NewString(val)), &ref.Ref{}}
+	s._Category = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Description() string {
-	return s.m.Get(types.NewString("Description")).(types.String).String()
+	return s._Description
 }
 
 func (s Incident) SetDescription(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Description"), types.NewString(val)), &ref.Ref{}}
+	s._Description = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) DayOfWeek() string {
-	return s.m.Get(types.NewString("DayOfWeek")).(types.String).String()
+	return s._DayOfWeek
 }
 
 func (s Incident) SetDayOfWeek(val string) Incident {
-	return Incident{s.m.Set(types.NewString("DayOfWeek"), types.NewString(val)), &ref.Ref{}}
+	s._DayOfWeek = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Date() string {
-	return s.m.Get(types.NewString("Date")).(types.String).String()
+	return s._Date
 }
 
 func (s Incident) SetDate(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Date"), types.NewString(val)), &ref.Ref{}}
+	s._Date = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Time() string {
-	return s.m.Get(types.NewString("Time")).(types.String).String()
+	return s._Time
 }
 
 func (s Incident) SetTime(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Time"), types.NewString(val)), &ref.Ref{}}
+	s._Time = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) PdDistrict() string {
-	return s.m.Get(types.NewString("PdDistrict")).(types.String).String()
+	return s._PdDistrict
 }
 
 func (s Incident) SetPdDistrict(val string) Incident {
-	return Incident{s.m.Set(types.NewString("PdDistrict"), types.NewString(val)), &ref.Ref{}}
+	s._PdDistrict = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Resolution() string {
-	return s.m.Get(types.NewString("Resolution")).(types.String).String()
+	return s._Resolution
 }
 
 func (s Incident) SetResolution(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Resolution"), types.NewString(val)), &ref.Ref{}}
+	s._Resolution = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Address() string {
-	return s.m.Get(types.NewString("Address")).(types.String).String()
+	return s._Address
 }
 
 func (s Incident) SetAddress(val string) Incident {
-	return Incident{s.m.Set(types.NewString("Address"), types.NewString(val)), &ref.Ref{}}
+	s._Address = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) Geoposition() Geoposition {
-	return s.m.Get(types.NewString("Geoposition")).(Geoposition)
+	return s._Geoposition
 }
 
 func (s Incident) SetGeoposition(val Geoposition) Incident {
-	return Incident{s.m.Set(types.NewString("Geoposition"), val), &ref.Ref{}}
+	s._Geoposition = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Incident) PdID() string {
-	return s.m.Get(types.NewString("PdID")).(types.String).String()
+	return s._PdID
 }
 
 func (s Incident) SetPdID(val string) Incident {
-	return Incident{s.m.Set(types.NewString("PdID"), types.NewString(val)), &ref.Ref{}}
+	s._PdID = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // ListOfRefOfIncident

--- a/clients/common/photo.noms.go
+++ b/clients/common/photo.noms.go
@@ -41,19 +41,27 @@ func init() {
 // RemotePhoto
 
 type RemotePhoto struct {
-	m   types.Map
+	_Id          string
+	_Title       string
+	_Url         string
+	_Geoposition Geoposition
+	_Sizes       MapOfSizeToString
+	_Tags        SetOfString
+
 	ref *ref.Ref
 }
 
 func NewRemotePhoto() RemotePhoto {
-	return RemotePhoto{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Url"), types.NewString(""),
-		types.NewString("Geoposition"), NewGeoposition(),
-		types.NewString("Sizes"), NewMapOfSizeToString(),
-		types.NewString("Tags"), NewSetOfString(),
-	), &ref.Ref{}}
+	return RemotePhoto{
+		_Id:          "",
+		_Title:       "",
+		_Url:         "",
+		_Geoposition: NewGeoposition(),
+		_Sizes:       NewMapOfSizeToString(),
+		_Tags:        NewSetOfString(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type RemotePhotoDef struct {
@@ -67,27 +75,28 @@ type RemotePhotoDef struct {
 
 func (def RemotePhotoDef) New() RemotePhoto {
 	return RemotePhoto{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Url"), types.NewString(def.Url),
-			types.NewString("Geoposition"), def.Geoposition.New(),
-			types.NewString("Sizes"), def.Sizes.New(),
-			types.NewString("Tags"), def.Tags.New(),
-		), &ref.Ref{}}
+		_Id:          def.Id,
+		_Title:       def.Title,
+		_Url:         def.Url,
+		_Geoposition: def.Geoposition.New(),
+		_Sizes:       def.Sizes.New(),
+		_Tags:        def.Tags.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s RemotePhoto) Def() (d RemotePhotoDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Url = s.m.Get(types.NewString("Url")).(types.String).String()
-	d.Geoposition = s.m.Get(types.NewString("Geoposition")).(Geoposition).Def()
-	d.Sizes = s.m.Get(types.NewString("Sizes")).(MapOfSizeToString).Def()
-	d.Tags = s.m.Get(types.NewString("Tags")).(SetOfString).Def()
+	d.Id = s._Id
+	d.Title = s._Title
+	d.Url = s._Url
+	d.Geoposition = s._Geoposition.Def()
+	d.Sizes = s._Sizes.Def()
+	d.Tags = s._Tags.Def()
 	return
 }
 
 var __typeRefForRemotePhoto types.TypeRef
+var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -95,22 +104,47 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__commonPackageInFile_photo_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForRemotePhoto, func(v types.Value) types.Value {
-		return RemotePhotoFromVal(v)
-	})
+	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
+			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__commonPackageInFile_photo_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
+			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
 }
 
-func RemotePhotoFromVal(val types.Value) RemotePhoto {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(RemotePhoto); ok {
-		return val
+func (s RemotePhoto) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":          types.NewString(s._Id),
+		"Title":       types.NewString(s._Title),
+		"Url":         types.NewString(s._Url),
+		"Geoposition": s._Geoposition,
+		"Sizes":       s._Sizes,
+		"Tags":        s._Tags,
 	}
-	// TODO: Validate here
-	return RemotePhoto{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
 }
 
-func (s RemotePhoto) InternalImplementation() types.Map {
-	return s.m
+func builderForRemotePhoto() chan types.Value {
+	c := make(chan types.Value)
+	s := RemotePhoto{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Title = (<-c).(types.String).String()
+		s._Url = (<-c).(types.String).String()
+		s._Geoposition = (<-c).(Geoposition)
+		s._Sizes = (<-c).(MapOfSizeToString)
+		s._Tags = (<-c).(SetOfString)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s RemotePhoto) Equals(other types.Value) bool {
@@ -122,71 +156,89 @@ func (s RemotePhoto) Ref() ref.Ref {
 }
 
 func (s RemotePhoto) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForRemotePhoto.Chunks()...)
+	chunks = append(chunks, s._Geoposition.Chunks()...)
+	chunks = append(chunks, s._Sizes.Chunks()...)
+	chunks = append(chunks, s._Tags.Chunks()...)
 	return
 }
 
 func (s RemotePhoto) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s RemotePhoto) SetId(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s RemotePhoto) SetTitle(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Url() string {
-	return s.m.Get(types.NewString("Url")).(types.String).String()
+	return s._Url
 }
 
 func (s RemotePhoto) SetUrl(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Url"), types.NewString(val)), &ref.Ref{}}
+	s._Url = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Geoposition() Geoposition {
-	return s.m.Get(types.NewString("Geoposition")).(Geoposition)
+	return s._Geoposition
 }
 
 func (s RemotePhoto) SetGeoposition(val Geoposition) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Geoposition"), val), &ref.Ref{}}
+	s._Geoposition = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Sizes() MapOfSizeToString {
-	return s.m.Get(types.NewString("Sizes")).(MapOfSizeToString)
+	return s._Sizes
 }
 
 func (s RemotePhoto) SetSizes(val MapOfSizeToString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Sizes"), val), &ref.Ref{}}
+	s._Sizes = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Tags() SetOfString {
-	return s.m.Get(types.NewString("Tags")).(SetOfString)
+	return s._Tags
 }
 
 func (s RemotePhoto) SetTags(val SetOfString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Tags"), val), &ref.Ref{}}
+	s._Tags = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Size
 
 type Size struct {
-	m   types.Map
+	_Width  uint32
+	_Height uint32
+
 	ref *ref.Ref
 }
 
 func NewSize() Size {
-	return Size{types.NewMap(
-		types.NewString("Width"), types.UInt32(0),
-		types.NewString("Height"), types.UInt32(0),
-	), &ref.Ref{}}
+	return Size{
+		_Width:  uint32(0),
+		_Height: uint32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type SizeDef struct {
@@ -196,19 +248,20 @@ type SizeDef struct {
 
 func (def SizeDef) New() Size {
 	return Size{
-		types.NewMap(
-			types.NewString("Width"), types.UInt32(def.Width),
-			types.NewString("Height"), types.UInt32(def.Height),
-		), &ref.Ref{}}
+		_Width:  def.Width,
+		_Height: def.Height,
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s Size) Def() (d SizeDef) {
-	d.Width = uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
-	d.Height = uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	d.Width = s._Width
+	d.Height = s._Height
 	return
 }
 
 var __typeRefForSize types.TypeRef
+var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -216,22 +269,35 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__commonPackageInFile_photo_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForSize, func(v types.Value) types.Value {
-		return SizeFromVal(v)
-	})
+	__typeDefForSize = types.MakeStructTypeRef("Size",
+		[]types.Field{
+			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
 }
 
-func SizeFromVal(val types.Value) Size {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Size); ok {
-		return val
+func (s Size) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Width":  types.UInt32(s._Width),
+		"Height": types.UInt32(s._Height),
 	}
-	// TODO: Validate here
-	return Size{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
 }
 
-func (s Size) InternalImplementation() types.Map {
-	return s.m
+func builderForSize() chan types.Value {
+	c := make(chan types.Value)
+	s := Size{ref: &ref.Ref{}}
+	go func() {
+		s._Width = uint32((<-c).(types.UInt32))
+		s._Height = uint32((<-c).(types.UInt32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Size) Equals(other types.Value) bool {
@@ -243,25 +309,28 @@ func (s Size) Ref() ref.Ref {
 }
 
 func (s Size) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForSize.Chunks()...)
 	return
 }
 
 func (s Size) Width() uint32 {
-	return uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
+	return s._Width
 }
 
 func (s Size) SetWidth(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Width"), types.UInt32(val)), &ref.Ref{}}
+	s._Width = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Size) Height() uint32 {
-	return uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	return s._Height
 }
 
 func (s Size) SetHeight(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Height"), types.UInt32(val)), &ref.Ref{}}
+	s._Height = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // MapOfSizeToString

--- a/clients/flickr/sha1_00419eb.go
+++ b/clients/flickr/sha1_00419eb.go
@@ -41,19 +41,27 @@ func init() {
 // RemotePhoto
 
 type RemotePhoto struct {
-	m   types.Map
+	_Id          string
+	_Title       string
+	_Url         string
+	_Geoposition Geoposition
+	_Sizes       MapOfSizeToString
+	_Tags        SetOfString
+
 	ref *ref.Ref
 }
 
 func NewRemotePhoto() RemotePhoto {
-	return RemotePhoto{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Url"), types.NewString(""),
-		types.NewString("Geoposition"), NewGeoposition(),
-		types.NewString("Sizes"), NewMapOfSizeToString(),
-		types.NewString("Tags"), NewSetOfString(),
-	), &ref.Ref{}}
+	return RemotePhoto{
+		_Id:          "",
+		_Title:       "",
+		_Url:         "",
+		_Geoposition: NewGeoposition(),
+		_Sizes:       NewMapOfSizeToString(),
+		_Tags:        NewSetOfString(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type RemotePhotoDef struct {
@@ -67,27 +75,28 @@ type RemotePhotoDef struct {
 
 func (def RemotePhotoDef) New() RemotePhoto {
 	return RemotePhoto{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Url"), types.NewString(def.Url),
-			types.NewString("Geoposition"), def.Geoposition.New(),
-			types.NewString("Sizes"), def.Sizes.New(),
-			types.NewString("Tags"), def.Tags.New(),
-		), &ref.Ref{}}
+		_Id:          def.Id,
+		_Title:       def.Title,
+		_Url:         def.Url,
+		_Geoposition: def.Geoposition.New(),
+		_Sizes:       def.Sizes.New(),
+		_Tags:        def.Tags.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s RemotePhoto) Def() (d RemotePhotoDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Url = s.m.Get(types.NewString("Url")).(types.String).String()
-	d.Geoposition = s.m.Get(types.NewString("Geoposition")).(Geoposition).Def()
-	d.Sizes = s.m.Get(types.NewString("Sizes")).(MapOfSizeToString).Def()
-	d.Tags = s.m.Get(types.NewString("Tags")).(SetOfString).Def()
+	d.Id = s._Id
+	d.Title = s._Title
+	d.Url = s._Url
+	d.Geoposition = s._Geoposition.Def()
+	d.Sizes = s._Sizes.Def()
+	d.Tags = s._Tags.Def()
 	return
 }
 
 var __typeRefForRemotePhoto types.TypeRef
+var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -95,22 +104,47 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForRemotePhoto, func(v types.Value) types.Value {
-		return RemotePhotoFromVal(v)
-	})
+	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
+			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
+			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
 }
 
-func RemotePhotoFromVal(val types.Value) RemotePhoto {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(RemotePhoto); ok {
-		return val
+func (s RemotePhoto) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":          types.NewString(s._Id),
+		"Title":       types.NewString(s._Title),
+		"Url":         types.NewString(s._Url),
+		"Geoposition": s._Geoposition,
+		"Sizes":       s._Sizes,
+		"Tags":        s._Tags,
 	}
-	// TODO: Validate here
-	return RemotePhoto{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
 }
 
-func (s RemotePhoto) InternalImplementation() types.Map {
-	return s.m
+func builderForRemotePhoto() chan types.Value {
+	c := make(chan types.Value)
+	s := RemotePhoto{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Title = (<-c).(types.String).String()
+		s._Url = (<-c).(types.String).String()
+		s._Geoposition = (<-c).(Geoposition)
+		s._Sizes = (<-c).(MapOfSizeToString)
+		s._Tags = (<-c).(SetOfString)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s RemotePhoto) Equals(other types.Value) bool {
@@ -122,71 +156,89 @@ func (s RemotePhoto) Ref() ref.Ref {
 }
 
 func (s RemotePhoto) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForRemotePhoto.Chunks()...)
+	chunks = append(chunks, s._Geoposition.Chunks()...)
+	chunks = append(chunks, s._Sizes.Chunks()...)
+	chunks = append(chunks, s._Tags.Chunks()...)
 	return
 }
 
 func (s RemotePhoto) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s RemotePhoto) SetId(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s RemotePhoto) SetTitle(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Url() string {
-	return s.m.Get(types.NewString("Url")).(types.String).String()
+	return s._Url
 }
 
 func (s RemotePhoto) SetUrl(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Url"), types.NewString(val)), &ref.Ref{}}
+	s._Url = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Geoposition() Geoposition {
-	return s.m.Get(types.NewString("Geoposition")).(Geoposition)
+	return s._Geoposition
 }
 
 func (s RemotePhoto) SetGeoposition(val Geoposition) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Geoposition"), val), &ref.Ref{}}
+	s._Geoposition = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Sizes() MapOfSizeToString {
-	return s.m.Get(types.NewString("Sizes")).(MapOfSizeToString)
+	return s._Sizes
 }
 
 func (s RemotePhoto) SetSizes(val MapOfSizeToString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Sizes"), val), &ref.Ref{}}
+	s._Sizes = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Tags() SetOfString {
-	return s.m.Get(types.NewString("Tags")).(SetOfString)
+	return s._Tags
 }
 
 func (s RemotePhoto) SetTags(val SetOfString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Tags"), val), &ref.Ref{}}
+	s._Tags = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Size
 
 type Size struct {
-	m   types.Map
+	_Width  uint32
+	_Height uint32
+
 	ref *ref.Ref
 }
 
 func NewSize() Size {
-	return Size{types.NewMap(
-		types.NewString("Width"), types.UInt32(0),
-		types.NewString("Height"), types.UInt32(0),
-	), &ref.Ref{}}
+	return Size{
+		_Width:  uint32(0),
+		_Height: uint32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type SizeDef struct {
@@ -196,19 +248,20 @@ type SizeDef struct {
 
 func (def SizeDef) New() Size {
 	return Size{
-		types.NewMap(
-			types.NewString("Width"), types.UInt32(def.Width),
-			types.NewString("Height"), types.UInt32(def.Height),
-		), &ref.Ref{}}
+		_Width:  def.Width,
+		_Height: def.Height,
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s Size) Def() (d SizeDef) {
-	d.Width = uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
-	d.Height = uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	d.Width = s._Width
+	d.Height = s._Height
 	return
 }
 
 var __typeRefForSize types.TypeRef
+var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -216,22 +269,35 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForSize, func(v types.Value) types.Value {
-		return SizeFromVal(v)
-	})
+	__typeDefForSize = types.MakeStructTypeRef("Size",
+		[]types.Field{
+			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
 }
 
-func SizeFromVal(val types.Value) Size {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Size); ok {
-		return val
+func (s Size) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Width":  types.UInt32(s._Width),
+		"Height": types.UInt32(s._Height),
 	}
-	// TODO: Validate here
-	return Size{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
 }
 
-func (s Size) InternalImplementation() types.Map {
-	return s.m
+func builderForSize() chan types.Value {
+	c := make(chan types.Value)
+	s := Size{ref: &ref.Ref{}}
+	go func() {
+		s._Width = uint32((<-c).(types.UInt32))
+		s._Height = uint32((<-c).(types.UInt32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Size) Equals(other types.Value) bool {
@@ -243,25 +309,28 @@ func (s Size) Ref() ref.Ref {
 }
 
 func (s Size) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForSize.Chunks()...)
 	return
 }
 
 func (s Size) Width() uint32 {
-	return uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
+	return s._Width
 }
 
 func (s Size) SetWidth(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Width"), types.UInt32(val)), &ref.Ref{}}
+	s._Width = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Size) Height() uint32 {
-	return uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	return s._Height
 }
 
 func (s Size) SetHeight(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Height"), types.UInt32(val)), &ref.Ref{}}
+	s._Height = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // MapOfSizeToString

--- a/clients/flickr/sha1_6d5e1c5.go
+++ b/clients/flickr/sha1_6d5e1c5.go
@@ -35,15 +35,19 @@ func init() {
 // Geoposition
 
 type Geoposition struct {
-	m   types.Map
+	_Latitude  float32
+	_Longitude float32
+
 	ref *ref.Ref
 }
 
 func NewGeoposition() Geoposition {
-	return Geoposition{types.NewMap(
-		types.NewString("Latitude"), types.Float32(0),
-		types.NewString("Longitude"), types.Float32(0),
-	), &ref.Ref{}}
+	return Geoposition{
+		_Latitude:  float32(0),
+		_Longitude: float32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeopositionDef struct {
@@ -53,19 +57,20 @@ type GeopositionDef struct {
 
 func (def GeopositionDef) New() Geoposition {
 	return Geoposition{
-		types.NewMap(
-			types.NewString("Latitude"), types.Float32(def.Latitude),
-			types.NewString("Longitude"), types.Float32(def.Longitude),
-		), &ref.Ref{}}
+		_Latitude:  def.Latitude,
+		_Longitude: def.Longitude,
+		ref:        &ref.Ref{},
+	}
 }
 
 func (s Geoposition) Def() (d GeopositionDef) {
-	d.Latitude = float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
-	d.Longitude = float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	d.Latitude = s._Latitude
+	d.Longitude = s._Longitude
 	return
 }
 
 var __typeRefForGeoposition types.TypeRef
+var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -73,22 +78,35 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForGeoposition, func(v types.Value) types.Value {
-		return GeopositionFromVal(v)
-	})
+	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
+		[]types.Field{
+			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
 }
 
-func GeopositionFromVal(val types.Value) Geoposition {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Geoposition); ok {
-		return val
+func (s Geoposition) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Latitude":  types.Float32(s._Latitude),
+		"Longitude": types.Float32(s._Longitude),
 	}
-	// TODO: Validate here
-	return Geoposition{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
 }
 
-func (s Geoposition) InternalImplementation() types.Map {
-	return s.m
+func builderForGeoposition() chan types.Value {
+	c := make(chan types.Value)
+	s := Geoposition{ref: &ref.Ref{}}
+	go func() {
+		s._Latitude = float32((<-c).(types.Float32))
+		s._Longitude = float32((<-c).(types.Float32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Geoposition) Equals(other types.Value) bool {
@@ -100,39 +118,46 @@ func (s Geoposition) Ref() ref.Ref {
 }
 
 func (s Geoposition) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeoposition.Chunks()...)
 	return
 }
 
 func (s Geoposition) Latitude() float32 {
-	return float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
+	return s._Latitude
 }
 
 func (s Geoposition) SetLatitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Latitude"), types.Float32(val)), &ref.Ref{}}
+	s._Latitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Geoposition) Longitude() float32 {
-	return float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	return s._Longitude
 }
 
 func (s Geoposition) SetLongitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Longitude"), types.Float32(val)), &ref.Ref{}}
+	s._Longitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Georectangle
 
 type Georectangle struct {
-	m   types.Map
+	_TopLeft     Geoposition
+	_BottomRight Geoposition
+
 	ref *ref.Ref
 }
 
 func NewGeorectangle() Georectangle {
-	return Georectangle{types.NewMap(
-		types.NewString("TopLeft"), NewGeoposition(),
-		types.NewString("BottomRight"), NewGeoposition(),
-	), &ref.Ref{}}
+	return Georectangle{
+		_TopLeft:     NewGeoposition(),
+		_BottomRight: NewGeoposition(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeorectangleDef struct {
@@ -142,19 +167,20 @@ type GeorectangleDef struct {
 
 func (def GeorectangleDef) New() Georectangle {
 	return Georectangle{
-		types.NewMap(
-			types.NewString("TopLeft"), def.TopLeft.New(),
-			types.NewString("BottomRight"), def.BottomRight.New(),
-		), &ref.Ref{}}
+		_TopLeft:     def.TopLeft.New(),
+		_BottomRight: def.BottomRight.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s Georectangle) Def() (d GeorectangleDef) {
-	d.TopLeft = s.m.Get(types.NewString("TopLeft")).(Geoposition).Def()
-	d.BottomRight = s.m.Get(types.NewString("BottomRight")).(Geoposition).Def()
+	d.TopLeft = s._TopLeft.Def()
+	d.BottomRight = s._BottomRight.Def()
 	return
 }
 
 var __typeRefForGeorectangle types.TypeRef
+var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -162,22 +188,35 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForGeorectangle, func(v types.Value) types.Value {
-		return GeorectangleFromVal(v)
-	})
+	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
+		[]types.Field{
+			types.Field{"TopLeft", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
+			types.Field{"BottomRight", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
 }
 
-func GeorectangleFromVal(val types.Value) Georectangle {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Georectangle); ok {
-		return val
+func (s Georectangle) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"TopLeft":     s._TopLeft,
+		"BottomRight": s._BottomRight,
 	}
-	// TODO: Validate here
-	return Georectangle{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
 }
 
-func (s Georectangle) InternalImplementation() types.Map {
-	return s.m
+func builderForGeorectangle() chan types.Value {
+	c := make(chan types.Value)
+	s := Georectangle{ref: &ref.Ref{}}
+	go func() {
+		s._TopLeft = (<-c).(Geoposition)
+		s._BottomRight = (<-c).(Geoposition)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Georectangle) Equals(other types.Value) bool {
@@ -189,23 +228,28 @@ func (s Georectangle) Ref() ref.Ref {
 }
 
 func (s Georectangle) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeorectangle.Chunks()...)
+	chunks = append(chunks, s._TopLeft.Chunks()...)
+	chunks = append(chunks, s._BottomRight.Chunks()...)
 	return
 }
 
 func (s Georectangle) TopLeft() Geoposition {
-	return s.m.Get(types.NewString("TopLeft")).(Geoposition)
+	return s._TopLeft
 }
 
 func (s Georectangle) SetTopLeft(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("TopLeft"), val), &ref.Ref{}}
+	s._TopLeft = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Georectangle) BottomRight() Geoposition {
-	return s.m.Get(types.NewString("BottomRight")).(Geoposition)
+	return s._BottomRight
 }
 
 func (s Georectangle) SetBottomRight(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("BottomRight"), val), &ref.Ref{}}
+	s._BottomRight = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/clients/flickr/types.noms.go
+++ b/clients/flickr/types.noms.go
@@ -42,18 +42,25 @@ func init() {
 // User
 
 type User struct {
-	m   types.Map
+	_Id          string
+	_Name        string
+	_OAuthToken  string
+	_OAuthSecret string
+	_Albums      MapOfStringToAlbum
+
 	ref *ref.Ref
 }
 
 func NewUser() User {
-	return User{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Name"), types.NewString(""),
-		types.NewString("OAuthToken"), types.NewString(""),
-		types.NewString("OAuthSecret"), types.NewString(""),
-		types.NewString("Albums"), NewMapOfStringToAlbum(),
-	), &ref.Ref{}}
+	return User{
+		_Id:          "",
+		_Name:        "",
+		_OAuthToken:  "",
+		_OAuthSecret: "",
+		_Albums:      NewMapOfStringToAlbum(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type UserDef struct {
@@ -66,25 +73,26 @@ type UserDef struct {
 
 func (def UserDef) New() User {
 	return User{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Name"), types.NewString(def.Name),
-			types.NewString("OAuthToken"), types.NewString(def.OAuthToken),
-			types.NewString("OAuthSecret"), types.NewString(def.OAuthSecret),
-			types.NewString("Albums"), def.Albums.New(),
-		), &ref.Ref{}}
+		_Id:          def.Id,
+		_Name:        def.Name,
+		_OAuthToken:  def.OAuthToken,
+		_OAuthSecret: def.OAuthSecret,
+		_Albums:      def.Albums.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s User) Def() (d UserDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Name = s.m.Get(types.NewString("Name")).(types.String).String()
-	d.OAuthToken = s.m.Get(types.NewString("OAuthToken")).(types.String).String()
-	d.OAuthSecret = s.m.Get(types.NewString("OAuthSecret")).(types.String).String()
-	d.Albums = s.m.Get(types.NewString("Albums")).(MapOfStringToAlbum).Def()
+	d.Id = s._Id
+	d.Name = s._Name
+	d.OAuthToken = s._OAuthToken
+	d.OAuthSecret = s._OAuthSecret
+	d.Albums = s._Albums.Def()
 	return
 }
 
 var __typeRefForUser types.TypeRef
+var __typeDefForUser types.TypeRef
 
 func (m User) TypeRef() types.TypeRef {
 	return __typeRefForUser
@@ -92,22 +100,44 @@ func (m User) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForUser = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForUser, func(v types.Value) types.Value {
-		return UserFromVal(v)
-	})
+	__typeDefForUser = types.MakeStructTypeRef("User",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Name", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"OAuthToken", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"OAuthSecret", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Albums", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1)), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForUser, builderForUser)
 }
 
-func UserFromVal(val types.Value) User {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(User); ok {
-		return val
+func (s User) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":          types.NewString(s._Id),
+		"Name":        types.NewString(s._Name),
+		"OAuthToken":  types.NewString(s._OAuthToken),
+		"OAuthSecret": types.NewString(s._OAuthSecret),
+		"Albums":      s._Albums,
 	}
-	// TODO: Validate here
-	return User{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForUser, __typeDefForUser, m)
 }
 
-func (s User) InternalImplementation() types.Map {
-	return s.m
+func builderForUser() chan types.Value {
+	c := make(chan types.Value)
+	s := User{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Name = (<-c).(types.String).String()
+		s._OAuthToken = (<-c).(types.String).String()
+		s._OAuthSecret = (<-c).(types.String).String()
+		s._Albums = (<-c).(MapOfStringToAlbum)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s User) Equals(other types.Value) bool {
@@ -119,64 +149,79 @@ func (s User) Ref() ref.Ref {
 }
 
 func (s User) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForUser.Chunks()...)
+	chunks = append(chunks, s._Albums.Chunks()...)
 	return
 }
 
 func (s User) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s User) SetId(val string) User {
-	return User{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) Name() string {
-	return s.m.Get(types.NewString("Name")).(types.String).String()
+	return s._Name
 }
 
 func (s User) SetName(val string) User {
-	return User{s.m.Set(types.NewString("Name"), types.NewString(val)), &ref.Ref{}}
+	s._Name = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) OAuthToken() string {
-	return s.m.Get(types.NewString("OAuthToken")).(types.String).String()
+	return s._OAuthToken
 }
 
 func (s User) SetOAuthToken(val string) User {
-	return User{s.m.Set(types.NewString("OAuthToken"), types.NewString(val)), &ref.Ref{}}
+	s._OAuthToken = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) OAuthSecret() string {
-	return s.m.Get(types.NewString("OAuthSecret")).(types.String).String()
+	return s._OAuthSecret
 }
 
 func (s User) SetOAuthSecret(val string) User {
-	return User{s.m.Set(types.NewString("OAuthSecret"), types.NewString(val)), &ref.Ref{}}
+	s._OAuthSecret = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) Albums() MapOfStringToAlbum {
-	return s.m.Get(types.NewString("Albums")).(MapOfStringToAlbum)
+	return s._Albums
 }
 
 func (s User) SetAlbums(val MapOfStringToAlbum) User {
-	return User{s.m.Set(types.NewString("Albums"), val), &ref.Ref{}}
+	s._Albums = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Album
 
 type Album struct {
-	m   types.Map
+	_Id     string
+	_Title  string
+	_Photos RefOfSetOfRefOfRemotePhoto
+
 	ref *ref.Ref
 }
 
 func NewAlbum() Album {
-	return Album{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Photos"), NewRefOfSetOfRefOfRemotePhoto(ref.Ref{}),
-	), &ref.Ref{}}
+	return Album{
+		_Id:     "",
+		_Title:  "",
+		_Photos: NewRefOfSetOfRefOfRemotePhoto(ref.Ref{}),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type AlbumDef struct {
@@ -187,21 +232,22 @@ type AlbumDef struct {
 
 func (def AlbumDef) New() Album {
 	return Album{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Photos"), NewRefOfSetOfRefOfRemotePhoto(def.Photos),
-		), &ref.Ref{}}
+		_Id:     def.Id,
+		_Title:  def.Title,
+		_Photos: NewRefOfSetOfRefOfRemotePhoto(def.Photos),
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s Album) Def() (d AlbumDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Photos = s.m.Get(types.NewString("Photos")).(RefOfSetOfRefOfRemotePhoto).TargetRef()
+	d.Id = s._Id
+	d.Title = s._Title
+	d.Photos = s._Photos.TargetRef()
 	return
 }
 
 var __typeRefForAlbum types.TypeRef
+var __typeDefForAlbum types.TypeRef
 
 func (m Album) TypeRef() types.TypeRef {
 	return __typeRefForAlbum
@@ -209,22 +255,38 @@ func (m Album) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForAlbum = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForAlbum, func(v types.Value) types.Value {
-		return AlbumFromVal(v)
-	})
+	__typeDefForAlbum = types.MakeStructTypeRef("Album",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Photos", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0)))), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForAlbum, builderForAlbum)
 }
 
-func AlbumFromVal(val types.Value) Album {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Album); ok {
-		return val
+func (s Album) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":     types.NewString(s._Id),
+		"Title":  types.NewString(s._Title),
+		"Photos": s._Photos,
 	}
-	// TODO: Validate here
-	return Album{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForAlbum, __typeDefForAlbum, m)
 }
 
-func (s Album) InternalImplementation() types.Map {
-	return s.m
+func builderForAlbum() chan types.Value {
+	c := make(chan types.Value)
+	s := Album{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Title = (<-c).(types.String).String()
+		s._Photos = (<-c).(RefOfSetOfRefOfRemotePhoto)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Album) Equals(other types.Value) bool {
@@ -236,33 +298,39 @@ func (s Album) Ref() ref.Ref {
 }
 
 func (s Album) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForAlbum.Chunks()...)
+	chunks = append(chunks, s._Photos.Chunks()...)
 	return
 }
 
 func (s Album) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s Album) SetId(val string) Album {
-	return Album{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Album) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s Album) SetTitle(val string) Album {
-	return Album{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Album) Photos() RefOfSetOfRefOfRemotePhoto {
-	return s.m.Get(types.NewString("Photos")).(RefOfSetOfRefOfRemotePhoto)
+	return s._Photos
 }
 
 func (s Album) SetPhotos(val RefOfSetOfRefOfRemotePhoto) Album {
-	return Album{s.m.Set(types.NewString("Photos"), val), &ref.Ref{}}
+	s._Photos = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // MapOfStringToAlbum

--- a/clients/music/mp3_importer/types.noms.go
+++ b/clients/music/mp3_importer/types.noms.go
@@ -31,18 +31,25 @@ func init() {
 // Song
 
 type Song struct {
-	m   types.Map
+	_Title  string
+	_Artist string
+	_Album  string
+	_Year   string
+	_Mp3    types.Blob
+
 	ref *ref.Ref
 }
 
 func NewSong() Song {
-	return Song{types.NewMap(
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Artist"), types.NewString(""),
-		types.NewString("Album"), types.NewString(""),
-		types.NewString("Year"), types.NewString(""),
-		types.NewString("Mp3"), types.NewEmptyBlob(),
-	), &ref.Ref{}}
+	return Song{
+		_Title:  "",
+		_Artist: "",
+		_Album:  "",
+		_Year:   "",
+		_Mp3:    types.NewEmptyBlob(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type SongDef struct {
@@ -55,25 +62,26 @@ type SongDef struct {
 
 func (def SongDef) New() Song {
 	return Song{
-		types.NewMap(
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Artist"), types.NewString(def.Artist),
-			types.NewString("Album"), types.NewString(def.Album),
-			types.NewString("Year"), types.NewString(def.Year),
-			types.NewString("Mp3"), def.Mp3,
-		), &ref.Ref{}}
+		_Title:  def.Title,
+		_Artist: def.Artist,
+		_Album:  def.Album,
+		_Year:   def.Year,
+		_Mp3:    def.Mp3,
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s Song) Def() (d SongDef) {
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Artist = s.m.Get(types.NewString("Artist")).(types.String).String()
-	d.Album = s.m.Get(types.NewString("Album")).(types.String).String()
-	d.Year = s.m.Get(types.NewString("Year")).(types.String).String()
-	d.Mp3 = s.m.Get(types.NewString("Mp3")).(types.Blob)
+	d.Title = s._Title
+	d.Artist = s._Artist
+	d.Album = s._Album
+	d.Year = s._Year
+	d.Mp3 = s._Mp3
 	return
 }
 
 var __typeRefForSong types.TypeRef
+var __typeDefForSong types.TypeRef
 
 func (m Song) TypeRef() types.TypeRef {
 	return __typeRefForSong
@@ -81,22 +89,44 @@ func (m Song) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSong = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForSong, func(v types.Value) types.Value {
-		return SongFromVal(v)
-	})
+	__typeDefForSong = types.MakeStructTypeRef("Song",
+		[]types.Field{
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Artist", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Album", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Year", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Mp3", types.MakePrimitiveTypeRef(types.BlobKind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForSong, builderForSong)
 }
 
-func SongFromVal(val types.Value) Song {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Song); ok {
-		return val
+func (s Song) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Title":  types.NewString(s._Title),
+		"Artist": types.NewString(s._Artist),
+		"Album":  types.NewString(s._Album),
+		"Year":   types.NewString(s._Year),
+		"Mp3":    s._Mp3,
 	}
-	// TODO: Validate here
-	return Song{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForSong, __typeDefForSong, m)
 }
 
-func (s Song) InternalImplementation() types.Map {
-	return s.m
+func builderForSong() chan types.Value {
+	c := make(chan types.Value)
+	s := Song{ref: &ref.Ref{}}
+	go func() {
+		s._Title = (<-c).(types.String).String()
+		s._Artist = (<-c).(types.String).String()
+		s._Album = (<-c).(types.String).String()
+		s._Year = (<-c).(types.String).String()
+		s._Mp3 = (<-c).(types.Blob)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Song) Equals(other types.Value) bool {
@@ -108,49 +138,59 @@ func (s Song) Ref() ref.Ref {
 }
 
 func (s Song) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForSong.Chunks()...)
+	chunks = append(chunks, s._Mp3.Chunks()...)
 	return
 }
 
 func (s Song) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s Song) SetTitle(val string) Song {
-	return Song{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Song) Artist() string {
-	return s.m.Get(types.NewString("Artist")).(types.String).String()
+	return s._Artist
 }
 
 func (s Song) SetArtist(val string) Song {
-	return Song{s.m.Set(types.NewString("Artist"), types.NewString(val)), &ref.Ref{}}
+	s._Artist = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Song) Album() string {
-	return s.m.Get(types.NewString("Album")).(types.String).String()
+	return s._Album
 }
 
 func (s Song) SetAlbum(val string) Song {
-	return Song{s.m.Set(types.NewString("Album"), types.NewString(val)), &ref.Ref{}}
+	s._Album = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Song) Year() string {
-	return s.m.Get(types.NewString("Year")).(types.String).String()
+	return s._Year
 }
 
 func (s Song) SetYear(val string) Song {
-	return Song{s.m.Set(types.NewString("Year"), types.NewString(val)), &ref.Ref{}}
+	s._Year = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Song) Mp3() types.Blob {
-	return s.m.Get(types.NewString("Mp3")).(types.Blob)
+	return s._Mp3
 }
 
 func (s Song) SetMp3(val types.Blob) Song {
-	return Song{s.m.Set(types.NewString("Mp3"), val), &ref.Ref{}}
+	s._Mp3 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // ListOfSong

--- a/clients/picasa/picasa.noms.go
+++ b/clients/picasa/picasa.noms.go
@@ -44,19 +44,27 @@ func init() {
 // User
 
 type User struct {
-	m   types.Map
+	_Id           string
+	_Name         string
+	_Albums       MapOfStringToAlbum
+	_RefreshToken string
+	_OAuthToken   string
+	_OAuthSecret  string
+
 	ref *ref.Ref
 }
 
 func NewUser() User {
-	return User{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Name"), types.NewString(""),
-		types.NewString("Albums"), NewMapOfStringToAlbum(),
-		types.NewString("RefreshToken"), types.NewString(""),
-		types.NewString("OAuthToken"), types.NewString(""),
-		types.NewString("OAuthSecret"), types.NewString(""),
-	), &ref.Ref{}}
+	return User{
+		_Id:           "",
+		_Name:         "",
+		_Albums:       NewMapOfStringToAlbum(),
+		_RefreshToken: "",
+		_OAuthToken:   "",
+		_OAuthSecret:  "",
+
+		ref: &ref.Ref{},
+	}
 }
 
 type UserDef struct {
@@ -70,27 +78,28 @@ type UserDef struct {
 
 func (def UserDef) New() User {
 	return User{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Name"), types.NewString(def.Name),
-			types.NewString("Albums"), def.Albums.New(),
-			types.NewString("RefreshToken"), types.NewString(def.RefreshToken),
-			types.NewString("OAuthToken"), types.NewString(def.OAuthToken),
-			types.NewString("OAuthSecret"), types.NewString(def.OAuthSecret),
-		), &ref.Ref{}}
+		_Id:           def.Id,
+		_Name:         def.Name,
+		_Albums:       def.Albums.New(),
+		_RefreshToken: def.RefreshToken,
+		_OAuthToken:   def.OAuthToken,
+		_OAuthSecret:  def.OAuthSecret,
+		ref:           &ref.Ref{},
+	}
 }
 
 func (s User) Def() (d UserDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Name = s.m.Get(types.NewString("Name")).(types.String).String()
-	d.Albums = s.m.Get(types.NewString("Albums")).(MapOfStringToAlbum).Def()
-	d.RefreshToken = s.m.Get(types.NewString("RefreshToken")).(types.String).String()
-	d.OAuthToken = s.m.Get(types.NewString("OAuthToken")).(types.String).String()
-	d.OAuthSecret = s.m.Get(types.NewString("OAuthSecret")).(types.String).String()
+	d.Id = s._Id
+	d.Name = s._Name
+	d.Albums = s._Albums.Def()
+	d.RefreshToken = s._RefreshToken
+	d.OAuthToken = s._OAuthToken
+	d.OAuthSecret = s._OAuthSecret
 	return
 }
 
 var __typeRefForUser types.TypeRef
+var __typeDefForUser types.TypeRef
 
 func (m User) TypeRef() types.TypeRef {
 	return __typeRefForUser
@@ -98,22 +107,47 @@ func (m User) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForUser = types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForUser, func(v types.Value) types.Value {
-		return UserFromVal(v)
-	})
+	__typeDefForUser = types.MakeStructTypeRef("User",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Name", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Albums", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 1)), false},
+			types.Field{"RefreshToken", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"OAuthToken", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"OAuthSecret", types.MakePrimitiveTypeRef(types.StringKind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForUser, builderForUser)
 }
 
-func UserFromVal(val types.Value) User {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(User); ok {
-		return val
+func (s User) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":           types.NewString(s._Id),
+		"Name":         types.NewString(s._Name),
+		"Albums":       s._Albums,
+		"RefreshToken": types.NewString(s._RefreshToken),
+		"OAuthToken":   types.NewString(s._OAuthToken),
+		"OAuthSecret":  types.NewString(s._OAuthSecret),
 	}
-	// TODO: Validate here
-	return User{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForUser, __typeDefForUser, m)
 }
 
-func (s User) InternalImplementation() types.Map {
-	return s.m
+func builderForUser() chan types.Value {
+	c := make(chan types.Value)
+	s := User{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Name = (<-c).(types.String).String()
+		s._Albums = (<-c).(MapOfStringToAlbum)
+		s._RefreshToken = (<-c).(types.String).String()
+		s._OAuthToken = (<-c).(types.String).String()
+		s._OAuthSecret = (<-c).(types.String).String()
+
+		c <- s
+	}()
+	return c
 }
 
 func (s User) Equals(other types.Value) bool {
@@ -125,73 +159,91 @@ func (s User) Ref() ref.Ref {
 }
 
 func (s User) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForUser.Chunks()...)
+	chunks = append(chunks, s._Albums.Chunks()...)
 	return
 }
 
 func (s User) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s User) SetId(val string) User {
-	return User{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) Name() string {
-	return s.m.Get(types.NewString("Name")).(types.String).String()
+	return s._Name
 }
 
 func (s User) SetName(val string) User {
-	return User{s.m.Set(types.NewString("Name"), types.NewString(val)), &ref.Ref{}}
+	s._Name = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) Albums() MapOfStringToAlbum {
-	return s.m.Get(types.NewString("Albums")).(MapOfStringToAlbum)
+	return s._Albums
 }
 
 func (s User) SetAlbums(val MapOfStringToAlbum) User {
-	return User{s.m.Set(types.NewString("Albums"), val), &ref.Ref{}}
+	s._Albums = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) RefreshToken() string {
-	return s.m.Get(types.NewString("RefreshToken")).(types.String).String()
+	return s._RefreshToken
 }
 
 func (s User) SetRefreshToken(val string) User {
-	return User{s.m.Set(types.NewString("RefreshToken"), types.NewString(val)), &ref.Ref{}}
+	s._RefreshToken = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) OAuthToken() string {
-	return s.m.Get(types.NewString("OAuthToken")).(types.String).String()
+	return s._OAuthToken
 }
 
 func (s User) SetOAuthToken(val string) User {
-	return User{s.m.Set(types.NewString("OAuthToken"), types.NewString(val)), &ref.Ref{}}
+	s._OAuthToken = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s User) OAuthSecret() string {
-	return s.m.Get(types.NewString("OAuthSecret")).(types.String).String()
+	return s._OAuthSecret
 }
 
 func (s User) SetOAuthSecret(val string) User {
-	return User{s.m.Set(types.NewString("OAuthSecret"), types.NewString(val)), &ref.Ref{}}
+	s._OAuthSecret = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Album
 
 type Album struct {
-	m   types.Map
+	_Id        string
+	_Title     string
+	_NumPhotos uint32
+	_Photos    RefOfSetOfRefOfRemotePhoto
+
 	ref *ref.Ref
 }
 
 func NewAlbum() Album {
-	return Album{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("NumPhotos"), types.UInt32(0),
-		types.NewString("Photos"), NewRefOfSetOfRefOfRemotePhoto(ref.Ref{}),
-	), &ref.Ref{}}
+	return Album{
+		_Id:        "",
+		_Title:     "",
+		_NumPhotos: uint32(0),
+		_Photos:    NewRefOfSetOfRefOfRemotePhoto(ref.Ref{}),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type AlbumDef struct {
@@ -203,23 +255,24 @@ type AlbumDef struct {
 
 func (def AlbumDef) New() Album {
 	return Album{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("NumPhotos"), types.UInt32(def.NumPhotos),
-			types.NewString("Photos"), NewRefOfSetOfRefOfRemotePhoto(def.Photos),
-		), &ref.Ref{}}
+		_Id:        def.Id,
+		_Title:     def.Title,
+		_NumPhotos: def.NumPhotos,
+		_Photos:    NewRefOfSetOfRefOfRemotePhoto(def.Photos),
+		ref:        &ref.Ref{},
+	}
 }
 
 func (s Album) Def() (d AlbumDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.NumPhotos = uint32(s.m.Get(types.NewString("NumPhotos")).(types.UInt32))
-	d.Photos = s.m.Get(types.NewString("Photos")).(RefOfSetOfRefOfRemotePhoto).TargetRef()
+	d.Id = s._Id
+	d.Title = s._Title
+	d.NumPhotos = s._NumPhotos
+	d.Photos = s._Photos.TargetRef()
 	return
 }
 
 var __typeRefForAlbum types.TypeRef
+var __typeDefForAlbum types.TypeRef
 
 func (m Album) TypeRef() types.TypeRef {
 	return __typeRefForAlbum
@@ -227,22 +280,41 @@ func (m Album) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForAlbum = types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForAlbum, func(v types.Value) types.Value {
-		return AlbumFromVal(v)
-	})
+	__typeDefForAlbum = types.MakeStructTypeRef("Album",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"NumPhotos", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+			types.Field{"Photos", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0)))), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForAlbum, builderForAlbum)
 }
 
-func AlbumFromVal(val types.Value) Album {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Album); ok {
-		return val
+func (s Album) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":        types.NewString(s._Id),
+		"Title":     types.NewString(s._Title),
+		"NumPhotos": types.UInt32(s._NumPhotos),
+		"Photos":    s._Photos,
 	}
-	// TODO: Validate here
-	return Album{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForAlbum, __typeDefForAlbum, m)
 }
 
-func (s Album) InternalImplementation() types.Map {
-	return s.m
+func builderForAlbum() chan types.Value {
+	c := make(chan types.Value)
+	s := Album{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Title = (<-c).(types.String).String()
+		s._NumPhotos = uint32((<-c).(types.UInt32))
+		s._Photos = (<-c).(RefOfSetOfRefOfRemotePhoto)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Album) Equals(other types.Value) bool {
@@ -254,41 +326,49 @@ func (s Album) Ref() ref.Ref {
 }
 
 func (s Album) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForAlbum.Chunks()...)
+	chunks = append(chunks, s._Photos.Chunks()...)
 	return
 }
 
 func (s Album) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s Album) SetId(val string) Album {
-	return Album{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Album) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s Album) SetTitle(val string) Album {
-	return Album{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Album) NumPhotos() uint32 {
-	return uint32(s.m.Get(types.NewString("NumPhotos")).(types.UInt32))
+	return s._NumPhotos
 }
 
 func (s Album) SetNumPhotos(val uint32) Album {
-	return Album{s.m.Set(types.NewString("NumPhotos"), types.UInt32(val)), &ref.Ref{}}
+	s._NumPhotos = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Album) Photos() RefOfSetOfRefOfRemotePhoto {
-	return s.m.Get(types.NewString("Photos")).(RefOfSetOfRefOfRemotePhoto)
+	return s._Photos
 }
 
 func (s Album) SetPhotos(val RefOfSetOfRefOfRemotePhoto) Album {
-	return Album{s.m.Set(types.NewString("Photos"), val), &ref.Ref{}}
+	s._Photos = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // MapOfStringToAlbum

--- a/clients/picasa/sha1_00419eb.go
+++ b/clients/picasa/sha1_00419eb.go
@@ -41,19 +41,27 @@ func init() {
 // RemotePhoto
 
 type RemotePhoto struct {
-	m   types.Map
+	_Id          string
+	_Title       string
+	_Url         string
+	_Geoposition Geoposition
+	_Sizes       MapOfSizeToString
+	_Tags        SetOfString
+
 	ref *ref.Ref
 }
 
 func NewRemotePhoto() RemotePhoto {
-	return RemotePhoto{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Url"), types.NewString(""),
-		types.NewString("Geoposition"), NewGeoposition(),
-		types.NewString("Sizes"), NewMapOfSizeToString(),
-		types.NewString("Tags"), NewSetOfString(),
-	), &ref.Ref{}}
+	return RemotePhoto{
+		_Id:          "",
+		_Title:       "",
+		_Url:         "",
+		_Geoposition: NewGeoposition(),
+		_Sizes:       NewMapOfSizeToString(),
+		_Tags:        NewSetOfString(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type RemotePhotoDef struct {
@@ -67,27 +75,28 @@ type RemotePhotoDef struct {
 
 func (def RemotePhotoDef) New() RemotePhoto {
 	return RemotePhoto{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Url"), types.NewString(def.Url),
-			types.NewString("Geoposition"), def.Geoposition.New(),
-			types.NewString("Sizes"), def.Sizes.New(),
-			types.NewString("Tags"), def.Tags.New(),
-		), &ref.Ref{}}
+		_Id:          def.Id,
+		_Title:       def.Title,
+		_Url:         def.Url,
+		_Geoposition: def.Geoposition.New(),
+		_Sizes:       def.Sizes.New(),
+		_Tags:        def.Tags.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s RemotePhoto) Def() (d RemotePhotoDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Url = s.m.Get(types.NewString("Url")).(types.String).String()
-	d.Geoposition = s.m.Get(types.NewString("Geoposition")).(Geoposition).Def()
-	d.Sizes = s.m.Get(types.NewString("Sizes")).(MapOfSizeToString).Def()
-	d.Tags = s.m.Get(types.NewString("Tags")).(SetOfString).Def()
+	d.Id = s._Id
+	d.Title = s._Title
+	d.Url = s._Url
+	d.Geoposition = s._Geoposition.Def()
+	d.Sizes = s._Sizes.Def()
+	d.Tags = s._Tags.Def()
 	return
 }
 
 var __typeRefForRemotePhoto types.TypeRef
+var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -95,22 +104,47 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForRemotePhoto, func(v types.Value) types.Value {
-		return RemotePhotoFromVal(v)
-	})
+	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
+			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
+			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
 }
 
-func RemotePhotoFromVal(val types.Value) RemotePhoto {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(RemotePhoto); ok {
-		return val
+func (s RemotePhoto) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":          types.NewString(s._Id),
+		"Title":       types.NewString(s._Title),
+		"Url":         types.NewString(s._Url),
+		"Geoposition": s._Geoposition,
+		"Sizes":       s._Sizes,
+		"Tags":        s._Tags,
 	}
-	// TODO: Validate here
-	return RemotePhoto{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
 }
 
-func (s RemotePhoto) InternalImplementation() types.Map {
-	return s.m
+func builderForRemotePhoto() chan types.Value {
+	c := make(chan types.Value)
+	s := RemotePhoto{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Title = (<-c).(types.String).String()
+		s._Url = (<-c).(types.String).String()
+		s._Geoposition = (<-c).(Geoposition)
+		s._Sizes = (<-c).(MapOfSizeToString)
+		s._Tags = (<-c).(SetOfString)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s RemotePhoto) Equals(other types.Value) bool {
@@ -122,71 +156,89 @@ func (s RemotePhoto) Ref() ref.Ref {
 }
 
 func (s RemotePhoto) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForRemotePhoto.Chunks()...)
+	chunks = append(chunks, s._Geoposition.Chunks()...)
+	chunks = append(chunks, s._Sizes.Chunks()...)
+	chunks = append(chunks, s._Tags.Chunks()...)
 	return
 }
 
 func (s RemotePhoto) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s RemotePhoto) SetId(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s RemotePhoto) SetTitle(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Url() string {
-	return s.m.Get(types.NewString("Url")).(types.String).String()
+	return s._Url
 }
 
 func (s RemotePhoto) SetUrl(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Url"), types.NewString(val)), &ref.Ref{}}
+	s._Url = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Geoposition() Geoposition {
-	return s.m.Get(types.NewString("Geoposition")).(Geoposition)
+	return s._Geoposition
 }
 
 func (s RemotePhoto) SetGeoposition(val Geoposition) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Geoposition"), val), &ref.Ref{}}
+	s._Geoposition = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Sizes() MapOfSizeToString {
-	return s.m.Get(types.NewString("Sizes")).(MapOfSizeToString)
+	return s._Sizes
 }
 
 func (s RemotePhoto) SetSizes(val MapOfSizeToString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Sizes"), val), &ref.Ref{}}
+	s._Sizes = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Tags() SetOfString {
-	return s.m.Get(types.NewString("Tags")).(SetOfString)
+	return s._Tags
 }
 
 func (s RemotePhoto) SetTags(val SetOfString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Tags"), val), &ref.Ref{}}
+	s._Tags = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Size
 
 type Size struct {
-	m   types.Map
+	_Width  uint32
+	_Height uint32
+
 	ref *ref.Ref
 }
 
 func NewSize() Size {
-	return Size{types.NewMap(
-		types.NewString("Width"), types.UInt32(0),
-		types.NewString("Height"), types.UInt32(0),
-	), &ref.Ref{}}
+	return Size{
+		_Width:  uint32(0),
+		_Height: uint32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type SizeDef struct {
@@ -196,19 +248,20 @@ type SizeDef struct {
 
 func (def SizeDef) New() Size {
 	return Size{
-		types.NewMap(
-			types.NewString("Width"), types.UInt32(def.Width),
-			types.NewString("Height"), types.UInt32(def.Height),
-		), &ref.Ref{}}
+		_Width:  def.Width,
+		_Height: def.Height,
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s Size) Def() (d SizeDef) {
-	d.Width = uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
-	d.Height = uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	d.Width = s._Width
+	d.Height = s._Height
 	return
 }
 
 var __typeRefForSize types.TypeRef
+var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -216,22 +269,35 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForSize, func(v types.Value) types.Value {
-		return SizeFromVal(v)
-	})
+	__typeDefForSize = types.MakeStructTypeRef("Size",
+		[]types.Field{
+			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
 }
 
-func SizeFromVal(val types.Value) Size {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Size); ok {
-		return val
+func (s Size) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Width":  types.UInt32(s._Width),
+		"Height": types.UInt32(s._Height),
 	}
-	// TODO: Validate here
-	return Size{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
 }
 
-func (s Size) InternalImplementation() types.Map {
-	return s.m
+func builderForSize() chan types.Value {
+	c := make(chan types.Value)
+	s := Size{ref: &ref.Ref{}}
+	go func() {
+		s._Width = uint32((<-c).(types.UInt32))
+		s._Height = uint32((<-c).(types.UInt32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Size) Equals(other types.Value) bool {
@@ -243,25 +309,28 @@ func (s Size) Ref() ref.Ref {
 }
 
 func (s Size) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForSize.Chunks()...)
 	return
 }
 
 func (s Size) Width() uint32 {
-	return uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
+	return s._Width
 }
 
 func (s Size) SetWidth(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Width"), types.UInt32(val)), &ref.Ref{}}
+	s._Width = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Size) Height() uint32 {
-	return uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	return s._Height
 }
 
 func (s Size) SetHeight(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Height"), types.UInt32(val)), &ref.Ref{}}
+	s._Height = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // MapOfSizeToString

--- a/clients/picasa/sha1_6d5e1c5.go
+++ b/clients/picasa/sha1_6d5e1c5.go
@@ -35,15 +35,19 @@ func init() {
 // Geoposition
 
 type Geoposition struct {
-	m   types.Map
+	_Latitude  float32
+	_Longitude float32
+
 	ref *ref.Ref
 }
 
 func NewGeoposition() Geoposition {
-	return Geoposition{types.NewMap(
-		types.NewString("Latitude"), types.Float32(0),
-		types.NewString("Longitude"), types.Float32(0),
-	), &ref.Ref{}}
+	return Geoposition{
+		_Latitude:  float32(0),
+		_Longitude: float32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeopositionDef struct {
@@ -53,19 +57,20 @@ type GeopositionDef struct {
 
 func (def GeopositionDef) New() Geoposition {
 	return Geoposition{
-		types.NewMap(
-			types.NewString("Latitude"), types.Float32(def.Latitude),
-			types.NewString("Longitude"), types.Float32(def.Longitude),
-		), &ref.Ref{}}
+		_Latitude:  def.Latitude,
+		_Longitude: def.Longitude,
+		ref:        &ref.Ref{},
+	}
 }
 
 func (s Geoposition) Def() (d GeopositionDef) {
-	d.Latitude = float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
-	d.Longitude = float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	d.Latitude = s._Latitude
+	d.Longitude = s._Longitude
 	return
 }
 
 var __typeRefForGeoposition types.TypeRef
+var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -73,22 +78,35 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForGeoposition, func(v types.Value) types.Value {
-		return GeopositionFromVal(v)
-	})
+	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
+		[]types.Field{
+			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
 }
 
-func GeopositionFromVal(val types.Value) Geoposition {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Geoposition); ok {
-		return val
+func (s Geoposition) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Latitude":  types.Float32(s._Latitude),
+		"Longitude": types.Float32(s._Longitude),
 	}
-	// TODO: Validate here
-	return Geoposition{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
 }
 
-func (s Geoposition) InternalImplementation() types.Map {
-	return s.m
+func builderForGeoposition() chan types.Value {
+	c := make(chan types.Value)
+	s := Geoposition{ref: &ref.Ref{}}
+	go func() {
+		s._Latitude = float32((<-c).(types.Float32))
+		s._Longitude = float32((<-c).(types.Float32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Geoposition) Equals(other types.Value) bool {
@@ -100,39 +118,46 @@ func (s Geoposition) Ref() ref.Ref {
 }
 
 func (s Geoposition) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeoposition.Chunks()...)
 	return
 }
 
 func (s Geoposition) Latitude() float32 {
-	return float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
+	return s._Latitude
 }
 
 func (s Geoposition) SetLatitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Latitude"), types.Float32(val)), &ref.Ref{}}
+	s._Latitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Geoposition) Longitude() float32 {
-	return float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	return s._Longitude
 }
 
 func (s Geoposition) SetLongitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Longitude"), types.Float32(val)), &ref.Ref{}}
+	s._Longitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Georectangle
 
 type Georectangle struct {
-	m   types.Map
+	_TopLeft     Geoposition
+	_BottomRight Geoposition
+
 	ref *ref.Ref
 }
 
 func NewGeorectangle() Georectangle {
-	return Georectangle{types.NewMap(
-		types.NewString("TopLeft"), NewGeoposition(),
-		types.NewString("BottomRight"), NewGeoposition(),
-	), &ref.Ref{}}
+	return Georectangle{
+		_TopLeft:     NewGeoposition(),
+		_BottomRight: NewGeoposition(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeorectangleDef struct {
@@ -142,19 +167,20 @@ type GeorectangleDef struct {
 
 func (def GeorectangleDef) New() Georectangle {
 	return Georectangle{
-		types.NewMap(
-			types.NewString("TopLeft"), def.TopLeft.New(),
-			types.NewString("BottomRight"), def.BottomRight.New(),
-		), &ref.Ref{}}
+		_TopLeft:     def.TopLeft.New(),
+		_BottomRight: def.BottomRight.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s Georectangle) Def() (d GeorectangleDef) {
-	d.TopLeft = s.m.Get(types.NewString("TopLeft")).(Geoposition).Def()
-	d.BottomRight = s.m.Get(types.NewString("BottomRight")).(Geoposition).Def()
+	d.TopLeft = s._TopLeft.Def()
+	d.BottomRight = s._BottomRight.Def()
 	return
 }
 
 var __typeRefForGeorectangle types.TypeRef
+var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -162,22 +188,35 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForGeorectangle, func(v types.Value) types.Value {
-		return GeorectangleFromVal(v)
-	})
+	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
+		[]types.Field{
+			types.Field{"TopLeft", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
+			types.Field{"BottomRight", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
 }
 
-func GeorectangleFromVal(val types.Value) Georectangle {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Georectangle); ok {
-		return val
+func (s Georectangle) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"TopLeft":     s._TopLeft,
+		"BottomRight": s._BottomRight,
 	}
-	// TODO: Validate here
-	return Georectangle{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
 }
 
-func (s Georectangle) InternalImplementation() types.Map {
-	return s.m
+func builderForGeorectangle() chan types.Value {
+	c := make(chan types.Value)
+	s := Georectangle{ref: &ref.Ref{}}
+	go func() {
+		s._TopLeft = (<-c).(Geoposition)
+		s._BottomRight = (<-c).(Geoposition)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Georectangle) Equals(other types.Value) bool {
@@ -189,23 +228,28 @@ func (s Georectangle) Ref() ref.Ref {
 }
 
 func (s Georectangle) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeorectangle.Chunks()...)
+	chunks = append(chunks, s._TopLeft.Chunks()...)
+	chunks = append(chunks, s._BottomRight.Chunks()...)
 	return
 }
 
 func (s Georectangle) TopLeft() Geoposition {
-	return s.m.Get(types.NewString("TopLeft")).(Geoposition)
+	return s._TopLeft
 }
 
 func (s Georectangle) SetTopLeft(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("TopLeft"), val), &ref.Ref{}}
+	s._TopLeft = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Georectangle) BottomRight() Geoposition {
-	return s.m.Get(types.NewString("BottomRight")).(Geoposition)
+	return s._BottomRight
 }
 
 func (s Georectangle) SetBottomRight(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("BottomRight"), val), &ref.Ref{}}
+	s._BottomRight = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/clients/pitchmap/index/types.noms.go
+++ b/clients/pitchmap/index/types.noms.go
@@ -28,15 +28,19 @@ func init() {
 // Pitch
 
 type Pitch struct {
-	m   types.Map
+	_X float64
+	_Z float64
+
 	ref *ref.Ref
 }
 
 func NewPitch() Pitch {
-	return Pitch{types.NewMap(
-		types.NewString("X"), types.Float64(0),
-		types.NewString("Z"), types.Float64(0),
-	), &ref.Ref{}}
+	return Pitch{
+		_X: float64(0),
+		_Z: float64(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type PitchDef struct {
@@ -46,19 +50,20 @@ type PitchDef struct {
 
 func (def PitchDef) New() Pitch {
 	return Pitch{
-		types.NewMap(
-			types.NewString("X"), types.Float64(def.X),
-			types.NewString("Z"), types.Float64(def.Z),
-		), &ref.Ref{}}
+		_X:  def.X,
+		_Z:  def.Z,
+		ref: &ref.Ref{},
+	}
 }
 
 func (s Pitch) Def() (d PitchDef) {
-	d.X = float64(s.m.Get(types.NewString("X")).(types.Float64))
-	d.Z = float64(s.m.Get(types.NewString("Z")).(types.Float64))
+	d.X = s._X
+	d.Z = s._Z
 	return
 }
 
 var __typeRefForPitch types.TypeRef
+var __typeDefForPitch types.TypeRef
 
 func (m Pitch) TypeRef() types.TypeRef {
 	return __typeRefForPitch
@@ -66,22 +71,35 @@ func (m Pitch) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForPitch = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForPitch, func(v types.Value) types.Value {
-		return PitchFromVal(v)
-	})
+	__typeDefForPitch = types.MakeStructTypeRef("Pitch",
+		[]types.Field{
+			types.Field{"X", types.MakePrimitiveTypeRef(types.Float64Kind), false},
+			types.Field{"Z", types.MakePrimitiveTypeRef(types.Float64Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForPitch, builderForPitch)
 }
 
-func PitchFromVal(val types.Value) Pitch {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Pitch); ok {
-		return val
+func (s Pitch) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"X": types.Float64(s._X),
+		"Z": types.Float64(s._Z),
 	}
-	// TODO: Validate here
-	return Pitch{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForPitch, __typeDefForPitch, m)
 }
 
-func (s Pitch) InternalImplementation() types.Map {
-	return s.m
+func builderForPitch() chan types.Value {
+	c := make(chan types.Value)
+	s := Pitch{ref: &ref.Ref{}}
+	go func() {
+		s._X = float64((<-c).(types.Float64))
+		s._Z = float64((<-c).(types.Float64))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Pitch) Equals(other types.Value) bool {
@@ -93,25 +111,28 @@ func (s Pitch) Ref() ref.Ref {
 }
 
 func (s Pitch) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForPitch.Chunks()...)
 	return
 }
 
 func (s Pitch) X() float64 {
-	return float64(s.m.Get(types.NewString("X")).(types.Float64))
+	return s._X
 }
 
 func (s Pitch) SetX(val float64) Pitch {
-	return Pitch{s.m.Set(types.NewString("X"), types.Float64(val)), &ref.Ref{}}
+	s._X = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Pitch) Z() float64 {
-	return float64(s.m.Get(types.NewString("Z")).(types.Float64))
+	return s._Z
 }
 
 func (s Pitch) SetZ(val float64) Pitch {
-	return Pitch{s.m.Set(types.NewString("Z"), types.Float64(val)), &ref.Ref{}}
+	s._Z = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // ListOfMapOfStringToValue

--- a/clients/tagdex/sha1_00419eb.go
+++ b/clients/tagdex/sha1_00419eb.go
@@ -41,19 +41,27 @@ func init() {
 // RemotePhoto
 
 type RemotePhoto struct {
-	m   types.Map
+	_Id          string
+	_Title       string
+	_Url         string
+	_Geoposition Geoposition
+	_Sizes       MapOfSizeToString
+	_Tags        SetOfString
+
 	ref *ref.Ref
 }
 
 func NewRemotePhoto() RemotePhoto {
-	return RemotePhoto{types.NewMap(
-		types.NewString("Id"), types.NewString(""),
-		types.NewString("Title"), types.NewString(""),
-		types.NewString("Url"), types.NewString(""),
-		types.NewString("Geoposition"), NewGeoposition(),
-		types.NewString("Sizes"), NewMapOfSizeToString(),
-		types.NewString("Tags"), NewSetOfString(),
-	), &ref.Ref{}}
+	return RemotePhoto{
+		_Id:          "",
+		_Title:       "",
+		_Url:         "",
+		_Geoposition: NewGeoposition(),
+		_Sizes:       NewMapOfSizeToString(),
+		_Tags:        NewSetOfString(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type RemotePhotoDef struct {
@@ -67,27 +75,28 @@ type RemotePhotoDef struct {
 
 func (def RemotePhotoDef) New() RemotePhoto {
 	return RemotePhoto{
-		types.NewMap(
-			types.NewString("Id"), types.NewString(def.Id),
-			types.NewString("Title"), types.NewString(def.Title),
-			types.NewString("Url"), types.NewString(def.Url),
-			types.NewString("Geoposition"), def.Geoposition.New(),
-			types.NewString("Sizes"), def.Sizes.New(),
-			types.NewString("Tags"), def.Tags.New(),
-		), &ref.Ref{}}
+		_Id:          def.Id,
+		_Title:       def.Title,
+		_Url:         def.Url,
+		_Geoposition: def.Geoposition.New(),
+		_Sizes:       def.Sizes.New(),
+		_Tags:        def.Tags.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s RemotePhoto) Def() (d RemotePhotoDef) {
-	d.Id = s.m.Get(types.NewString("Id")).(types.String).String()
-	d.Title = s.m.Get(types.NewString("Title")).(types.String).String()
-	d.Url = s.m.Get(types.NewString("Url")).(types.String).String()
-	d.Geoposition = s.m.Get(types.NewString("Geoposition")).(Geoposition).Def()
-	d.Sizes = s.m.Get(types.NewString("Sizes")).(MapOfSizeToString).Def()
-	d.Tags = s.m.Get(types.NewString("Tags")).(SetOfString).Def()
+	d.Id = s._Id
+	d.Title = s._Title
+	d.Url = s._Url
+	d.Geoposition = s._Geoposition.Def()
+	d.Sizes = s._Sizes.Def()
+	d.Tags = s._Tags.Def()
 	return
 }
 
 var __typeRefForRemotePhoto types.TypeRef
+var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -95,22 +104,47 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForRemotePhoto, func(v types.Value) types.Value {
-		return RemotePhotoFromVal(v)
-	})
+	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
+		[]types.Field{
+			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
+			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
+			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
 }
 
-func RemotePhotoFromVal(val types.Value) RemotePhoto {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(RemotePhoto); ok {
-		return val
+func (s RemotePhoto) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Id":          types.NewString(s._Id),
+		"Title":       types.NewString(s._Title),
+		"Url":         types.NewString(s._Url),
+		"Geoposition": s._Geoposition,
+		"Sizes":       s._Sizes,
+		"Tags":        s._Tags,
 	}
-	// TODO: Validate here
-	return RemotePhoto{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
 }
 
-func (s RemotePhoto) InternalImplementation() types.Map {
-	return s.m
+func builderForRemotePhoto() chan types.Value {
+	c := make(chan types.Value)
+	s := RemotePhoto{ref: &ref.Ref{}}
+	go func() {
+		s._Id = (<-c).(types.String).String()
+		s._Title = (<-c).(types.String).String()
+		s._Url = (<-c).(types.String).String()
+		s._Geoposition = (<-c).(Geoposition)
+		s._Sizes = (<-c).(MapOfSizeToString)
+		s._Tags = (<-c).(SetOfString)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s RemotePhoto) Equals(other types.Value) bool {
@@ -122,71 +156,89 @@ func (s RemotePhoto) Ref() ref.Ref {
 }
 
 func (s RemotePhoto) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForRemotePhoto.Chunks()...)
+	chunks = append(chunks, s._Geoposition.Chunks()...)
+	chunks = append(chunks, s._Sizes.Chunks()...)
+	chunks = append(chunks, s._Tags.Chunks()...)
 	return
 }
 
 func (s RemotePhoto) Id() string {
-	return s.m.Get(types.NewString("Id")).(types.String).String()
+	return s._Id
 }
 
 func (s RemotePhoto) SetId(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Id"), types.NewString(val)), &ref.Ref{}}
+	s._Id = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Title() string {
-	return s.m.Get(types.NewString("Title")).(types.String).String()
+	return s._Title
 }
 
 func (s RemotePhoto) SetTitle(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Title"), types.NewString(val)), &ref.Ref{}}
+	s._Title = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Url() string {
-	return s.m.Get(types.NewString("Url")).(types.String).String()
+	return s._Url
 }
 
 func (s RemotePhoto) SetUrl(val string) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Url"), types.NewString(val)), &ref.Ref{}}
+	s._Url = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Geoposition() Geoposition {
-	return s.m.Get(types.NewString("Geoposition")).(Geoposition)
+	return s._Geoposition
 }
 
 func (s RemotePhoto) SetGeoposition(val Geoposition) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Geoposition"), val), &ref.Ref{}}
+	s._Geoposition = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Sizes() MapOfSizeToString {
-	return s.m.Get(types.NewString("Sizes")).(MapOfSizeToString)
+	return s._Sizes
 }
 
 func (s RemotePhoto) SetSizes(val MapOfSizeToString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Sizes"), val), &ref.Ref{}}
+	s._Sizes = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s RemotePhoto) Tags() SetOfString {
-	return s.m.Get(types.NewString("Tags")).(SetOfString)
+	return s._Tags
 }
 
 func (s RemotePhoto) SetTags(val SetOfString) RemotePhoto {
-	return RemotePhoto{s.m.Set(types.NewString("Tags"), val), &ref.Ref{}}
+	s._Tags = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Size
 
 type Size struct {
-	m   types.Map
+	_Width  uint32
+	_Height uint32
+
 	ref *ref.Ref
 }
 
 func NewSize() Size {
-	return Size{types.NewMap(
-		types.NewString("Width"), types.UInt32(0),
-		types.NewString("Height"), types.UInt32(0),
-	), &ref.Ref{}}
+	return Size{
+		_Width:  uint32(0),
+		_Height: uint32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type SizeDef struct {
@@ -196,19 +248,20 @@ type SizeDef struct {
 
 func (def SizeDef) New() Size {
 	return Size{
-		types.NewMap(
-			types.NewString("Width"), types.UInt32(def.Width),
-			types.NewString("Height"), types.UInt32(def.Height),
-		), &ref.Ref{}}
+		_Width:  def.Width,
+		_Height: def.Height,
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s Size) Def() (d SizeDef) {
-	d.Width = uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
-	d.Height = uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	d.Width = s._Width
+	d.Height = s._Height
 	return
 }
 
 var __typeRefForSize types.TypeRef
+var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -216,22 +269,35 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForSize, func(v types.Value) types.Value {
-		return SizeFromVal(v)
-	})
+	__typeDefForSize = types.MakeStructTypeRef("Size",
+		[]types.Field{
+			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
 }
 
-func SizeFromVal(val types.Value) Size {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Size); ok {
-		return val
+func (s Size) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Width":  types.UInt32(s._Width),
+		"Height": types.UInt32(s._Height),
 	}
-	// TODO: Validate here
-	return Size{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
 }
 
-func (s Size) InternalImplementation() types.Map {
-	return s.m
+func builderForSize() chan types.Value {
+	c := make(chan types.Value)
+	s := Size{ref: &ref.Ref{}}
+	go func() {
+		s._Width = uint32((<-c).(types.UInt32))
+		s._Height = uint32((<-c).(types.UInt32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Size) Equals(other types.Value) bool {
@@ -243,25 +309,28 @@ func (s Size) Ref() ref.Ref {
 }
 
 func (s Size) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForSize.Chunks()...)
 	return
 }
 
 func (s Size) Width() uint32 {
-	return uint32(s.m.Get(types.NewString("Width")).(types.UInt32))
+	return s._Width
 }
 
 func (s Size) SetWidth(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Width"), types.UInt32(val)), &ref.Ref{}}
+	s._Width = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Size) Height() uint32 {
-	return uint32(s.m.Get(types.NewString("Height")).(types.UInt32))
+	return s._Height
 }
 
 func (s Size) SetHeight(val uint32) Size {
-	return Size{s.m.Set(types.NewString("Height"), types.UInt32(val)), &ref.Ref{}}
+	s._Height = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // MapOfSizeToString

--- a/clients/tagdex/sha1_6d5e1c5.go
+++ b/clients/tagdex/sha1_6d5e1c5.go
@@ -35,15 +35,19 @@ func init() {
 // Geoposition
 
 type Geoposition struct {
-	m   types.Map
+	_Latitude  float32
+	_Longitude float32
+
 	ref *ref.Ref
 }
 
 func NewGeoposition() Geoposition {
-	return Geoposition{types.NewMap(
-		types.NewString("Latitude"), types.Float32(0),
-		types.NewString("Longitude"), types.Float32(0),
-	), &ref.Ref{}}
+	return Geoposition{
+		_Latitude:  float32(0),
+		_Longitude: float32(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeopositionDef struct {
@@ -53,19 +57,20 @@ type GeopositionDef struct {
 
 func (def GeopositionDef) New() Geoposition {
 	return Geoposition{
-		types.NewMap(
-			types.NewString("Latitude"), types.Float32(def.Latitude),
-			types.NewString("Longitude"), types.Float32(def.Longitude),
-		), &ref.Ref{}}
+		_Latitude:  def.Latitude,
+		_Longitude: def.Longitude,
+		ref:        &ref.Ref{},
+	}
 }
 
 func (s Geoposition) Def() (d GeopositionDef) {
-	d.Latitude = float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
-	d.Longitude = float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	d.Latitude = s._Latitude
+	d.Longitude = s._Longitude
 	return
 }
 
 var __typeRefForGeoposition types.TypeRef
+var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -73,22 +78,35 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForGeoposition, func(v types.Value) types.Value {
-		return GeopositionFromVal(v)
-	})
+	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
+		[]types.Field{
+			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
 }
 
-func GeopositionFromVal(val types.Value) Geoposition {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Geoposition); ok {
-		return val
+func (s Geoposition) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Latitude":  types.Float32(s._Latitude),
+		"Longitude": types.Float32(s._Longitude),
 	}
-	// TODO: Validate here
-	return Geoposition{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
 }
 
-func (s Geoposition) InternalImplementation() types.Map {
-	return s.m
+func builderForGeoposition() chan types.Value {
+	c := make(chan types.Value)
+	s := Geoposition{ref: &ref.Ref{}}
+	go func() {
+		s._Latitude = float32((<-c).(types.Float32))
+		s._Longitude = float32((<-c).(types.Float32))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Geoposition) Equals(other types.Value) bool {
@@ -100,39 +118,46 @@ func (s Geoposition) Ref() ref.Ref {
 }
 
 func (s Geoposition) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeoposition.Chunks()...)
 	return
 }
 
 func (s Geoposition) Latitude() float32 {
-	return float32(s.m.Get(types.NewString("Latitude")).(types.Float32))
+	return s._Latitude
 }
 
 func (s Geoposition) SetLatitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Latitude"), types.Float32(val)), &ref.Ref{}}
+	s._Latitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Geoposition) Longitude() float32 {
-	return float32(s.m.Get(types.NewString("Longitude")).(types.Float32))
+	return s._Longitude
 }
 
 func (s Geoposition) SetLongitude(val float32) Geoposition {
-	return Geoposition{s.m.Set(types.NewString("Longitude"), types.Float32(val)), &ref.Ref{}}
+	s._Longitude = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // Georectangle
 
 type Georectangle struct {
-	m   types.Map
+	_TopLeft     Geoposition
+	_BottomRight Geoposition
+
 	ref *ref.Ref
 }
 
 func NewGeorectangle() Georectangle {
-	return Georectangle{types.NewMap(
-		types.NewString("TopLeft"), NewGeoposition(),
-		types.NewString("BottomRight"), NewGeoposition(),
-	), &ref.Ref{}}
+	return Georectangle{
+		_TopLeft:     NewGeoposition(),
+		_BottomRight: NewGeoposition(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type GeorectangleDef struct {
@@ -142,19 +167,20 @@ type GeorectangleDef struct {
 
 func (def GeorectangleDef) New() Georectangle {
 	return Georectangle{
-		types.NewMap(
-			types.NewString("TopLeft"), def.TopLeft.New(),
-			types.NewString("BottomRight"), def.BottomRight.New(),
-		), &ref.Ref{}}
+		_TopLeft:     def.TopLeft.New(),
+		_BottomRight: def.BottomRight.New(),
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s Georectangle) Def() (d GeorectangleDef) {
-	d.TopLeft = s.m.Get(types.NewString("TopLeft")).(Geoposition).Def()
-	d.BottomRight = s.m.Get(types.NewString("BottomRight")).(Geoposition).Def()
+	d.TopLeft = s._TopLeft.Def()
+	d.BottomRight = s._BottomRight.Def()
 	return
 }
 
 var __typeRefForGeorectangle types.TypeRef
+var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -162,22 +188,35 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForGeorectangle, func(v types.Value) types.Value {
-		return GeorectangleFromVal(v)
-	})
+	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
+		[]types.Field{
+			types.Field{"TopLeft", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
+			types.Field{"BottomRight", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
 }
 
-func GeorectangleFromVal(val types.Value) Georectangle {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(Georectangle); ok {
-		return val
+func (s Georectangle) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"TopLeft":     s._TopLeft,
+		"BottomRight": s._BottomRight,
 	}
-	// TODO: Validate here
-	return Georectangle{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
 }
 
-func (s Georectangle) InternalImplementation() types.Map {
-	return s.m
+func builderForGeorectangle() chan types.Value {
+	c := make(chan types.Value)
+	s := Georectangle{ref: &ref.Ref{}}
+	go func() {
+		s._TopLeft = (<-c).(Geoposition)
+		s._BottomRight = (<-c).(Geoposition)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s Georectangle) Equals(other types.Value) bool {
@@ -189,23 +228,28 @@ func (s Georectangle) Ref() ref.Ref {
 }
 
 func (s Georectangle) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForGeorectangle.Chunks()...)
+	chunks = append(chunks, s._TopLeft.Chunks()...)
+	chunks = append(chunks, s._BottomRight.Chunks()...)
 	return
 }
 
 func (s Georectangle) TopLeft() Geoposition {
-	return s.m.Get(types.NewString("TopLeft")).(Geoposition)
+	return s._TopLeft
 }
 
 func (s Georectangle) SetTopLeft(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("TopLeft"), val), &ref.Ref{}}
+	s._TopLeft = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s Georectangle) BottomRight() Geoposition {
-	return s.m.Get(types.NewString("BottomRight")).(Geoposition)
+	return s._BottomRight
 }
 
 func (s Georectangle) SetBottomRight(val Geoposition) Georectangle {
-	return Georectangle{s.m.Set(types.NewString("BottomRight"), val), &ref.Ref{}}
+	s._BottomRight = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -85,7 +85,7 @@ func (ds *Dataset) validateRefAsCommit(r ref.Ref) datas.Commit {
 		}
 	}()
 
-	return datas.CommitFromVal(v)
+	return v.(datas.Commit)
 }
 
 // SetNewHead takes the Ref of the desired new Head of ds, the chunk for which should already exist in the Dataset. It validates that the Ref points to an existing chunk that decodes to the correct type of value and then commits it to ds, returning a new Dataset with newHeadRef set and ok set to true. In the event that the commit fails, ok is set to false and a new up-to-date Dataset is returned WITHOUT newHeadRef in it. The caller should try again using this new Dataset.

--- a/nomdl/codegen/code/generate.go
+++ b/nomdl/codegen/code/generate.go
@@ -90,6 +90,30 @@ func (gen Generator) DefToValue(val string, t types.TypeRef) string {
 	panic("unreachable")
 }
 
+// DefToUser returns a string containing Go code to convert an instance of a Def type (named val) to a User type described by t.
+func (gen Generator) DefToUser(val string, t types.TypeRef) string {
+	rt := gen.R.Resolve(t)
+	switch rt.Kind() {
+	case types.BlobKind, types.BoolKind, types.EnumKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.PackageKind, types.StringKind, types.TypeRefKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind, types.ValueKind:
+		return val
+	case types.ListKind, types.MapKind, types.RefKind, types.SetKind, types.StructKind:
+		return gen.DefToValue(val, rt)
+	}
+	panic("unreachable")
+}
+
+// MayHaveChunks returns whether the type (t) may contain more chunks.
+func (gen Generator) MayHaveChunks(t types.TypeRef) bool {
+	rt := gen.R.Resolve(t)
+	switch rt.Kind() {
+	case types.BlobKind, types.ListKind, types.MapKind, types.PackageKind, types.RefKind, types.SetKind, types.StructKind, types.TypeRefKind, types.ValueKind:
+		return true
+	case types.BoolKind, types.EnumKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.StringKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind:
+		return false
+	}
+	panic("unreachable")
+}
+
 // ValueToDef returns a string containing Go code to convert an instance of a types.Value (val) into the Def type appropriate for t.
 func (gen Generator) ValueToDef(val string, t types.TypeRef) string {
 	rt := gen.R.Resolve(t)
@@ -106,6 +130,20 @@ func (gen Generator) ValueToDef(val string, t types.TypeRef) string {
 		return fmt.Sprintf("%s.TargetRef()", gen.ValueToUser(val, t))
 	case types.ValueKind:
 		return val // Value is already a Value
+	}
+	panic("unreachable")
+}
+
+// UserToDef returns a string containing Go code to convert an User value (val) into the Def type appropriate for t.
+func (gen Generator) UserToDef(val string, t types.TypeRef) string {
+	rt := gen.R.Resolve(t)
+	switch rt.Kind() {
+	case types.BlobKind, types.EnumKind, types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.PackageKind, types.StringKind, types.TypeRefKind, types.UInt16Kind, types.UInt32Kind, types.UInt64Kind, types.UInt8Kind, types.ValueKind:
+		return val
+	case types.ListKind, types.MapKind, types.SetKind, types.StructKind:
+		return fmt.Sprintf("%s.Def()", val)
+	case types.RefKind:
+		return fmt.Sprintf("%s.TargetRef()", val)
 	}
 	panic("unreachable")
 }

--- a/nomdl/codegen/codegen.go
+++ b/nomdl/codegen/codegen.go
@@ -245,9 +245,12 @@ func (gen *codeGen) readTemplates() *template.Template {
 		template.FuncMap{
 			"defType":        gen.generator.DefType,
 			"defToValue":     gen.generator.DefToValue,
+			"defToUser":      gen.generator.DefToUser,
+			"mayHaveChunks":  gen.generator.MayHaveChunks,
 			"valueToDef":     gen.generator.ValueToDef,
 			"userType":       gen.generator.UserType,
 			"userToValue":    gen.generator.UserToValue,
+			"userToDef":      gen.generator.UserToDef,
 			"valueToUser":    gen.generator.ValueToUser,
 			"userZero":       gen.generator.UserZero,
 			"valueZero":      gen.generator.ValueZero,

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -3,64 +3,50 @@
 // {{.Name}}
 
 type {{.Name}} struct {
-	m   {{$typesPackage}}Map
+	{{range .Fields}}_{{.Name}} {{userType .T}}
+	{{if .Optional}}__optional{{.Name}} bool
+	{{end}}{{end}}{{if .HasUnion}}__unionIndex uint32
+	__unionValue {{$typesPackage}}Value{{end}}
 	ref *ref.Ref
 }
 
 func New{{.Name}}() {{.Name}} {
-	return {{.Name}}{ {{$typesPackage}}NewMap(
-			{{range .Fields}}{{if (not .Optional)}}{{$typesPackage}}NewString("{{.Name}}"), {{valueZero .T}},
-			{{end}}{{end}}{{if .HasUnion}}{{$typesPackage}}NewString("$unionIndex"), {{$typesPackage}}UInt32(0),
-			{{$typesPackage}}NewString("$unionValue"), {{valueZero .UnionZeroType}},{{end}}
-		), &ref.Ref{}}
+	return {{.Name}}{
+		{{range .Fields}}{{if (not .Optional)}}_{{.Name}}: {{userZero .T}},
+		{{end}}{{end}}{{if .HasUnion}}__unionIndex: 0,
+		__unionValue: {{valueZero .UnionZeroType}},{{end}}
+		ref: &ref.Ref{},
+	}
 }
 
 {{if .CanUseDef}}
 	type {{.Name}}Def struct {
 		{{range .Fields}}{{title .Name}} {{defType .T}}
 		{{end}}{{if .HasUnion}}__unionIndex uint32
-		__unionValue interface{}
+		__unionValue {{$typesPackage}}Value
 	{{end}}}
 
 	func (def {{.Name}}Def) New() {{.Name}} {
 		return {{.Name}}{
-			{{$typesPackage}}NewMap(
-				{{range .Fields}}{{$typesPackage}}NewString("{{.Name}}"), {{defToValue (print "def." (title .Name)) .T}},
-				{{end}}{{if .HasUnion}}{{$typesPackage}}NewString("$unionIndex"), {{$typesPackage}}UInt32(def.__unionIndex),
-				{{$typesPackage}}NewString("$unionValue"), def.__unionDefToValue(),
-			{{end}}
-		), &ref.Ref{}}
+			{{range .Fields}}_{{.Name}}: {{defToUser (print "def." (title .Name)) .T}},
+			{{if .Optional}}__optional{{.Name}}: true,
+			{{end}}{{end}}{{if .HasUnion}}__unionIndex: def.__unionIndex,
+			__unionValue: def.__unionValue,
+			{{end}}ref: &ref.Ref{},
+		}
 	}
 
 	func (s {{.Name}}) Def() (d {{.Name}}Def) {
-		{{range .Fields}}{{if .Optional}}if v, ok := s.m.MaybeGet({{$typesPackage}}NewString("{{.Name}}")); ok {
-				d.{{title .Name}} = {{valueToDef "v" .T}}
-			}{{else}}d.{{title .Name}} = {{valueToDef (printf `s.m.Get(%sNewString("%s"))` $typesPackage .Name) .T}}{{end}}
-		{{end}}{{if .HasUnion}}d.__unionIndex = uint32(s.m.Get({{$typesPackage}}NewString("$unionIndex")).({{$typesPackage}}UInt32))
-			d.__unionValue = s.__unionValueToDef()
+		{{range .Fields}}{{if .Optional}}if s.__optional{{.Name}}{ {{end}}d.{{title .Name}} = {{userToDef (printf `s._%s` .Name) .T}}
+		{{if .Optional}} }
+		{{end}}{{end}}{{if .HasUnion}}d.__unionIndex = s.__unionIndex
+		d.__unionValue = s.__unionValue
 		{{end}}return
 	}
-
-	{{if .HasUnion}}
-		func (def {{.Name}}Def) __unionDefToValue() {{$typesPackage}}Value {
-			switch def.__unionIndex {
-			{{range $index, $field := .Choices}}case {{$index}}:
-				return {{defToValue (printf "def.__unionValue.(%s)" (defType .T)) .T}}
-			{{end}}}
-			panic("unreachable")
-		}
-
-		func (s {{.Name}}) __unionValueToDef() interface{} {
-			switch uint32(s.m.Get({{$typesPackage}}NewString("$unionIndex")).({{$typesPackage}}UInt32)) {
-			{{range $index, $field := .Choices}}case {{$index}}:
-				return {{valueToDef (printf `s.m.Get(%sNewString("$unionValue"))` $typesPackage) .T}}
-			{{end}}}
-			panic("unreachable")
-		}
-	{{end}}
 {{end}}
 
 var __typeRefFor{{.Name}} {{$typesPackage}}TypeRef
+var __typeDefFor{{.Name}} {{$typesPackage}}TypeRef
 
 func (m {{.Name}}) TypeRef() {{$typesPackage}}TypeRef {
 	return __typeRefFor{{.Name}}
@@ -68,22 +54,37 @@ func (m {{.Name}}) TypeRef() {{$typesPackage}}TypeRef {
 
 func init() {
 	__typeRefFor{{.Name}} = {{$typesPackage}}MakeTypeRef(__{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef, {{.Ordinal}})
-	{{$typesPackage}}RegisterFromValFunction(__typeRefFor{{.Name}}, func(v {{$typesPackage}}Value) {{$typesPackage}}Value {
-		return {{.Name}}FromVal(v)
-	})
+	__typeDefFor{{.Name}} = {{toTypesTypeRef .Type .FileID .PackageName}}
+	{{$typesPackage}}RegisterStructBuilder(__typeRefFor{{.Name}}, builderFor{{.Name}})
 }
 
-func {{.Name}}FromVal(val {{$typesPackage}}Value) {{.Name}} {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.({{.Name}}); ok {
-		return val
-	}
-	// TODO: Validate here
-	return {{.Name}}{val.({{$typesPackage}}Map), &ref.Ref{}}
+func (s {{.Name}}) InternalImplementation() {{$typesPackage}}Struct {
+	// TODO: Remove this
+	m := map[string]{{$typesPackage}}Value{
+		{{range .Fields}}{{if (not .Optional)}}"{{.Name}}": {{userToValue (printf "s._%s" .Name) .T}},
+		{{end}}{{end}}
+	}{{range .Fields}}{{if .Optional}}
+	if s.__optional{{.Name}} {
+		m["{{.Name}}"] = {{userToValue (printf "s._%s" .Name) .T}}
+	}{{end}}{{end}}{{if .HasUnion}}
+	m[__typeDefFor{{.Name}}.Desc.({{$typesPackage}}StructDesc).Union[s.__unionIndex].Name] = s.__unionValue{{end}}
+	return {{$typesPackage}}NewStruct(__typeRefFor{{.Name}}, __typeDefFor{{.Name}}, m)
 }
 
-func (s {{.Name}}) InternalImplementation() {{$typesPackage}}Map {
-	return s.m
+func builderFor{{.Name}}() chan {{$typesPackage}}Value {
+	c := make(chan {{$typesPackage}}Value)
+	s := {{.Name}}{ref: &ref.Ref{}}
+	go func() { {{range .Fields}}{{if .Optional}}
+		s.__optional{{.Name}} = bool((<-c).({{$typesPackage}}Bool))
+		if s.__optional{{.Name}} {
+			s._{{.Name}} = {{valueToUser "(<-c)" .T}}
+		}{{else}}
+		s._{{.Name}} = {{valueToUser "(<-c)" .T}}{{end}}{{end}}
+		{{if .HasUnion}}s.__unionIndex = uint32((<-c).({{$typesPackage}}UInt32))
+		s.__unionValue = <-c{{end}}
+		c <- s	
+	}()
+	return c	
 }
 
 func (s {{.Name}}) Equals(other {{$typesPackage}}Value) bool {
@@ -95,42 +96,50 @@ func (s {{.Name}}) Ref() ref.Ref {
 }
 
 func (s {{.Name}}) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
-	return
+	chunks = append(chunks, __typeRefFor{{.Name}}.Chunks()...)
+	{{range .Fields}}{{if mayHaveChunks .T}}{{if .Optional}}if s.__optional{{.Name}} {
+		{{end}}chunks = append(chunks, s._{{.Name}}.Chunks()...)
+		{{if .Optional}} }
+	{{end}}{{end}}{{end}}{{if .HasUnion}}chunks = append(chunks, s.__unionValue.Chunks()...)
+	{{end}}return
 }
 
 {{$name := .Name}}
 {{range $index, $field := .Fields}}
 {{if .Optional}}
 func (s {{$name}}) {{title .Name}}() (v {{userType .T}}, ok bool) {
-	var vv {{$typesPackage}}Value
-	if vv, ok = s.m.MaybeGet({{$typesPackage}}NewString("{{.Name}}")); ok {
-		v = {{valueToUser "vv" .T}}
+	if s.__optional{{.Name}} {
+		return s._{{.Name}}, true
 	}
 	return
 }
 {{else}}
 func (s {{$name}}) {{title .Name}}() {{userType .T}} {
-	return {{valueToUser (printf `s.m.Get(%sNewString("%s"))` $typesPackage .Name) .T}}
+	return s._{{.Name}}
 }
 {{end}}
 func (s {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
-	return {{$name}}{s.m.Set({{$typesPackage}}NewString("{{.Name}}"), {{userToValue "val" .T}}), &ref.Ref{}}
+	{{if .Optional}}s.__optional{{.Name}} = true
+	{{end}}s._{{.Name}} = val
+	s.ref = &ref.Ref{}
+	return s
 }
 {{end}}
 
 {{$canUseDef := .CanUseDef}}
 {{range $index, $field := .Choices}}
 	func (s {{$name}}) {{title .Name}}() (val {{userType .T}}, ok bool) {
-		if s.m.Get({{$typesPackage}}NewString("$unionIndex")).({{$typesPackage}}UInt32) != {{$index}} {
+		if s.__unionIndex != {{$index}} {
 			return
 		}
-		return {{valueToUser (printf `s.m.Get(%sNewString("$unionValue"))` $typesPackage) .T}}, true
+		return {{valueToUser "s.__unionValue" .T}}, true
 	}
 
 	func (s {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
-		return {{$name}}{s.m.Set({{$typesPackage}}NewString("$unionIndex"), {{$typesPackage}}UInt32({{$index}})).Set({{$typesPackage}}NewString("$unionValue"), {{userToValue "val" .T}}), &ref.Ref{}}
+		s.__unionIndex = {{$index}}
+		s.__unionValue = {{userToValue "val" .T}}
+		s.ref = &ref.Ref{}
+		return s
 	}
 
 	{{if $canUseDef}}
@@ -138,12 +147,12 @@ func (s {{$name}}) Set{{title .Name}}(val {{userType .T}}) {{$name}} {
 			if def.__unionIndex != {{$index}} {
 				return
 			}
-			return def.__unionValue.({{defType .T}}), true
+			return {{valueToDef "def.__unionValue" .T}}, true
 		}
 
 		func (def {{$name}}Def) Set{{title .Name}}(val {{defType .T}}) {{$name}}Def {
 			def.__unionIndex = {{$index}}
-			def.__unionValue = val
+			def.__unionValue = {{defToValue "val" .T}}
 			return def
 		}
 	{{end}}

--- a/nomdl/codegen/test/enum_struct_test.go
+++ b/nomdl/codegen/test/enum_struct_test.go
@@ -31,9 +31,9 @@ func TestEnumValue(t *testing.T) {
 	assert := assert.New(t)
 
 	def := gen.EnumStructDef{gen.Switch}
-	st := def.New()
-	val := st
-	st2 := gen.EnumStructFromVal(val)
+	var st types.Value
+	st = def.New()
+	st2 := st.(gen.EnumStruct)
 	assert.True(st.Equals(st2))
 }
 

--- a/nomdl/codegen/test/gen/enum_struct.noms.go
+++ b/nomdl/codegen/test/gen/enum_struct.noms.go
@@ -72,14 +72,17 @@ func (e Handedness) Chunks() []ref.Ref {
 // EnumStruct
 
 type EnumStruct struct {
-	m   types.Map
+	_hand Handedness
+
 	ref *ref.Ref
 }
 
 func NewEnumStruct() EnumStruct {
-	return EnumStruct{types.NewMap(
-		types.NewString("hand"), NewHandedness(),
-	), &ref.Ref{}}
+	return EnumStruct{
+		_hand: NewHandedness(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type EnumStructDef struct {
@@ -88,17 +91,18 @@ type EnumStructDef struct {
 
 func (def EnumStructDef) New() EnumStruct {
 	return EnumStruct{
-		types.NewMap(
-			types.NewString("hand"), def.Hand,
-		), &ref.Ref{}}
+		_hand: def.Hand,
+		ref:   &ref.Ref{},
+	}
 }
 
 func (s EnumStruct) Def() (d EnumStructDef) {
-	d.Hand = s.m.Get(types.NewString("hand")).(Handedness)
+	d.Hand = s._hand
 	return
 }
 
 var __typeRefForEnumStruct types.TypeRef
+var __typeDefForEnumStruct types.TypeRef
 
 func (m EnumStruct) TypeRef() types.TypeRef {
 	return __typeRefForEnumStruct
@@ -106,22 +110,32 @@ func (m EnumStruct) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForEnumStruct = types.MakeTypeRef(__genPackageInFile_enum_struct_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForEnumStruct, func(v types.Value) types.Value {
-		return EnumStructFromVal(v)
-	})
+	__typeDefForEnumStruct = types.MakeStructTypeRef("EnumStruct",
+		[]types.Field{
+			types.Field{"hand", types.MakeTypeRef(__genPackageInFile_enum_struct_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForEnumStruct, builderForEnumStruct)
 }
 
-func EnumStructFromVal(val types.Value) EnumStruct {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(EnumStruct); ok {
-		return val
+func (s EnumStruct) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"hand": s._hand,
 	}
-	// TODO: Validate here
-	return EnumStruct{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForEnumStruct, __typeDefForEnumStruct, m)
 }
 
-func (s EnumStruct) InternalImplementation() types.Map {
-	return s.m
+func builderForEnumStruct() chan types.Value {
+	c := make(chan types.Value)
+	s := EnumStruct{ref: &ref.Ref{}}
+	go func() {
+		s._hand = (<-c).(Handedness)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s EnumStruct) Equals(other types.Value) bool {
@@ -133,15 +147,16 @@ func (s EnumStruct) Ref() ref.Ref {
 }
 
 func (s EnumStruct) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForEnumStruct.Chunks()...)
 	return
 }
 
 func (s EnumStruct) Hand() Handedness {
-	return s.m.Get(types.NewString("hand")).(Handedness)
+	return s._hand
 }
 
 func (s EnumStruct) SetHand(val Handedness) EnumStruct {
-	return EnumStruct{s.m.Set(types.NewString("hand"), val), &ref.Ref{}}
+	s._hand = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/nomdl/codegen/test/gen/ref.noms.go
+++ b/nomdl/codegen/test/gen/ref.noms.go
@@ -28,14 +28,17 @@ func init() {
 // StructWithRef
 
 type StructWithRef struct {
-	m   types.Map
+	_r RefOfSetOfFloat32
+
 	ref *ref.Ref
 }
 
 func NewStructWithRef() StructWithRef {
-	return StructWithRef{types.NewMap(
-		types.NewString("r"), NewRefOfSetOfFloat32(ref.Ref{}),
-	), &ref.Ref{}}
+	return StructWithRef{
+		_r: NewRefOfSetOfFloat32(ref.Ref{}),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type StructWithRefDef struct {
@@ -44,17 +47,18 @@ type StructWithRefDef struct {
 
 func (def StructWithRefDef) New() StructWithRef {
 	return StructWithRef{
-		types.NewMap(
-			types.NewString("r"), NewRefOfSetOfFloat32(def.R),
-		), &ref.Ref{}}
+		_r:  NewRefOfSetOfFloat32(def.R),
+		ref: &ref.Ref{},
+	}
 }
 
 func (s StructWithRef) Def() (d StructWithRefDef) {
-	d.R = s.m.Get(types.NewString("r")).(RefOfSetOfFloat32).TargetRef()
+	d.R = s._r.TargetRef()
 	return
 }
 
 var __typeRefForStructWithRef types.TypeRef
+var __typeDefForStructWithRef types.TypeRef
 
 func (m StructWithRef) TypeRef() types.TypeRef {
 	return __typeRefForStructWithRef
@@ -62,22 +66,32 @@ func (m StructWithRef) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithRef = types.MakeTypeRef(__genPackageInFile_ref_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForStructWithRef, func(v types.Value) types.Value {
-		return StructWithRefFromVal(v)
-	})
+	__typeDefForStructWithRef = types.MakeStructTypeRef("StructWithRef",
+		[]types.Field{
+			types.Field{"r", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForStructWithRef, builderForStructWithRef)
 }
 
-func StructWithRefFromVal(val types.Value) StructWithRef {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(StructWithRef); ok {
-		return val
+func (s StructWithRef) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"r": s._r,
 	}
-	// TODO: Validate here
-	return StructWithRef{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForStructWithRef, __typeDefForStructWithRef, m)
 }
 
-func (s StructWithRef) InternalImplementation() types.Map {
-	return s.m
+func builderForStructWithRef() chan types.Value {
+	c := make(chan types.Value)
+	s := StructWithRef{ref: &ref.Ref{}}
+	go func() {
+		s._r = (<-c).(RefOfSetOfFloat32)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s StructWithRef) Equals(other types.Value) bool {
@@ -89,17 +103,19 @@ func (s StructWithRef) Ref() ref.Ref {
 }
 
 func (s StructWithRef) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForStructWithRef.Chunks()...)
+	chunks = append(chunks, s._r.Chunks()...)
 	return
 }
 
 func (s StructWithRef) R() RefOfSetOfFloat32 {
-	return s.m.Get(types.NewString("r")).(RefOfSetOfFloat32)
+	return s._r
 }
 
 func (s StructWithRef) SetR(val RefOfSetOfFloat32) StructWithRef {
-	return StructWithRef{s.m.Set(types.NewString("r"), val), &ref.Ref{}}
+	s._r = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // RefOfListOfString

--- a/nomdl/codegen/test/gen/sha1_09d2fdd.go
+++ b/nomdl/codegen/test/gen/sha1_09d2fdd.go
@@ -36,15 +36,19 @@ func init() {
 // D
 
 type D struct {
-	m   types.Map
+	_structField S
+	_enumField   E
+
 	ref *ref.Ref
 }
 
 func NewD() D {
-	return D{types.NewMap(
-		types.NewString("structField"), NewS(),
-		types.NewString("enumField"), NewE(),
-	), &ref.Ref{}}
+	return D{
+		_structField: NewS(),
+		_enumField:   NewE(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type DDef struct {
@@ -54,19 +58,20 @@ type DDef struct {
 
 func (def DDef) New() D {
 	return D{
-		types.NewMap(
-			types.NewString("structField"), def.StructField.New(),
-			types.NewString("enumField"), def.EnumField,
-		), &ref.Ref{}}
+		_structField: def.StructField.New(),
+		_enumField:   def.EnumField,
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s D) Def() (d DDef) {
-	d.StructField = s.m.Get(types.NewString("structField")).(S).Def()
-	d.EnumField = s.m.Get(types.NewString("enumField")).(E)
+	d.StructField = s._structField.Def()
+	d.EnumField = s._enumField
 	return
 }
 
 var __typeRefForD types.TypeRef
+var __typeDefForD types.TypeRef
 
 func (m D) TypeRef() types.TypeRef {
 	return __typeRefForD
@@ -74,22 +79,35 @@ func (m D) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForD = types.MakeTypeRef(__genPackageInFile_sha1_09d2fdd_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForD, func(v types.Value) types.Value {
-		return DFromVal(v)
-	})
+	__typeDefForD = types.MakeStructTypeRef("D",
+		[]types.Field{
+			types.Field{"structField", types.MakeTypeRef(ref.Parse("sha1-1c216c6f1d6989e4ede5f78b7689214948dabeef"), 0), false},
+			types.Field{"enumField", types.MakeTypeRef(ref.Parse("sha1-1c216c6f1d6989e4ede5f78b7689214948dabeef"), 1), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForD, builderForD)
 }
 
-func DFromVal(val types.Value) D {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(D); ok {
-		return val
+func (s D) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"structField": s._structField,
+		"enumField":   s._enumField,
 	}
-	// TODO: Validate here
-	return D{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForD, __typeDefForD, m)
 }
 
-func (s D) InternalImplementation() types.Map {
-	return s.m
+func builderForD() chan types.Value {
+	c := make(chan types.Value)
+	s := D{ref: &ref.Ref{}}
+	go func() {
+		s._structField = (<-c).(S)
+		s._enumField = (<-c).(E)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s D) Equals(other types.Value) bool {
@@ -101,38 +119,45 @@ func (s D) Ref() ref.Ref {
 }
 
 func (s D) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForD.Chunks()...)
+	chunks = append(chunks, s._structField.Chunks()...)
 	return
 }
 
 func (s D) StructField() S {
-	return s.m.Get(types.NewString("structField")).(S)
+	return s._structField
 }
 
 func (s D) SetStructField(val S) D {
-	return D{s.m.Set(types.NewString("structField"), val), &ref.Ref{}}
+	s._structField = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s D) EnumField() E {
-	return s.m.Get(types.NewString("enumField")).(E)
+	return s._enumField
 }
 
 func (s D) SetEnumField(val E) D {
-	return D{s.m.Set(types.NewString("enumField"), val), &ref.Ref{}}
+	s._enumField = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // DUser
 
 type DUser struct {
-	m   types.Map
+	_Dfield D
+
 	ref *ref.Ref
 }
 
 func NewDUser() DUser {
-	return DUser{types.NewMap(
-		types.NewString("Dfield"), NewD(),
-	), &ref.Ref{}}
+	return DUser{
+		_Dfield: NewD(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type DUserDef struct {
@@ -141,17 +166,18 @@ type DUserDef struct {
 
 func (def DUserDef) New() DUser {
 	return DUser{
-		types.NewMap(
-			types.NewString("Dfield"), def.Dfield.New(),
-		), &ref.Ref{}}
+		_Dfield: def.Dfield.New(),
+		ref:     &ref.Ref{},
+	}
 }
 
 func (s DUser) Def() (d DUserDef) {
-	d.Dfield = s.m.Get(types.NewString("Dfield")).(D).Def()
+	d.Dfield = s._Dfield.Def()
 	return
 }
 
 var __typeRefForDUser types.TypeRef
+var __typeDefForDUser types.TypeRef
 
 func (m DUser) TypeRef() types.TypeRef {
 	return __typeRefForDUser
@@ -159,22 +185,32 @@ func (m DUser) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForDUser = types.MakeTypeRef(__genPackageInFile_sha1_09d2fdd_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForDUser, func(v types.Value) types.Value {
-		return DUserFromVal(v)
-	})
+	__typeDefForDUser = types.MakeStructTypeRef("DUser",
+		[]types.Field{
+			types.Field{"Dfield", types.MakeTypeRef(__genPackageInFile_sha1_09d2fdd_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForDUser, builderForDUser)
 }
 
-func DUserFromVal(val types.Value) DUser {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(DUser); ok {
-		return val
+func (s DUser) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"Dfield": s._Dfield,
 	}
-	// TODO: Validate here
-	return DUser{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForDUser, __typeDefForDUser, m)
 }
 
-func (s DUser) InternalImplementation() types.Map {
-	return s.m
+func builderForDUser() chan types.Value {
+	c := make(chan types.Value)
+	s := DUser{ref: &ref.Ref{}}
+	go func() {
+		s._Dfield = (<-c).(D)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s DUser) Equals(other types.Value) bool {
@@ -186,15 +222,17 @@ func (s DUser) Ref() ref.Ref {
 }
 
 func (s DUser) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForDUser.Chunks()...)
+	chunks = append(chunks, s._Dfield.Chunks()...)
 	return
 }
 
 func (s DUser) Dfield() D {
-	return s.m.Get(types.NewString("Dfield")).(D)
+	return s._Dfield
 }
 
 func (s DUser) SetDfield(val D) DUser {
-	return DUser{s.m.Set(types.NewString("Dfield"), val), &ref.Ref{}}
+	s._Dfield = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/nomdl/codegen/test/gen/sha1_1c216c6.go
+++ b/nomdl/codegen/test/gen/sha1_1c216c6.go
@@ -29,15 +29,19 @@ func init() {
 // S
 
 type S struct {
-	m   types.Map
+	_s string
+	_b bool
+
 	ref *ref.Ref
 }
 
 func NewS() S {
-	return S{types.NewMap(
-		types.NewString("s"), types.NewString(""),
-		types.NewString("b"), types.Bool(false),
-	), &ref.Ref{}}
+	return S{
+		_s: "",
+		_b: false,
+
+		ref: &ref.Ref{},
+	}
 }
 
 type SDef struct {
@@ -47,19 +51,20 @@ type SDef struct {
 
 func (def SDef) New() S {
 	return S{
-		types.NewMap(
-			types.NewString("s"), types.NewString(def.S),
-			types.NewString("b"), types.Bool(def.B),
-		), &ref.Ref{}}
+		_s:  def.S,
+		_b:  def.B,
+		ref: &ref.Ref{},
+	}
 }
 
 func (s S) Def() (d SDef) {
-	d.S = s.m.Get(types.NewString("s")).(types.String).String()
-	d.B = bool(s.m.Get(types.NewString("b")).(types.Bool))
+	d.S = s._s
+	d.B = s._b
 	return
 }
 
 var __typeRefForS types.TypeRef
+var __typeDefForS types.TypeRef
 
 func (m S) TypeRef() types.TypeRef {
 	return __typeRefForS
@@ -67,22 +72,35 @@ func (m S) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForS = types.MakeTypeRef(__genPackageInFile_sha1_1c216c6_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForS, func(v types.Value) types.Value {
-		return SFromVal(v)
-	})
+	__typeDefForS = types.MakeStructTypeRef("S",
+		[]types.Field{
+			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForS, builderForS)
 }
 
-func SFromVal(val types.Value) S {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(S); ok {
-		return val
+func (s S) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"s": types.NewString(s._s),
+		"b": types.Bool(s._b),
 	}
-	// TODO: Validate here
-	return S{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForS, __typeDefForS, m)
 }
 
-func (s S) InternalImplementation() types.Map {
-	return s.m
+func builderForS() chan types.Value {
+	c := make(chan types.Value)
+	s := S{ref: &ref.Ref{}}
+	go func() {
+		s._s = (<-c).(types.String).String()
+		s._b = bool((<-c).(types.Bool))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s S) Equals(other types.Value) bool {
@@ -94,25 +112,28 @@ func (s S) Ref() ref.Ref {
 }
 
 func (s S) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForS.Chunks()...)
 	return
 }
 
 func (s S) S() string {
-	return s.m.Get(types.NewString("s")).(types.String).String()
+	return s._s
 }
 
 func (s S) SetS(val string) S {
-	return S{s.m.Set(types.NewString("s"), types.NewString(val)), &ref.Ref{}}
+	s._s = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s S) B() bool {
-	return bool(s.m.Get(types.NewString("b")).(types.Bool))
+	return s._b
 }
 
 func (s S) SetB(val bool) S {
-	return S{s.m.Set(types.NewString("b"), types.Bool(val)), &ref.Ref{}}
+	s._b = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // E

--- a/nomdl/codegen/test/gen/struct_optional.noms.go
+++ b/nomdl/codegen/test/gen/struct_optional.noms.go
@@ -28,12 +28,19 @@ func init() {
 // OptionalStruct
 
 type OptionalStruct struct {
-	m   types.Map
+	_s          string
+	__optionals bool
+	_b          bool
+	__optionalb bool
+
 	ref *ref.Ref
 }
 
 func NewOptionalStruct() OptionalStruct {
-	return OptionalStruct{types.NewMap(), &ref.Ref{}}
+	return OptionalStruct{
+
+		ref: &ref.Ref{},
+	}
 }
 
 type OptionalStructDef struct {
@@ -43,23 +50,26 @@ type OptionalStructDef struct {
 
 func (def OptionalStructDef) New() OptionalStruct {
 	return OptionalStruct{
-		types.NewMap(
-			types.NewString("s"), types.NewString(def.S),
-			types.NewString("b"), types.Bool(def.B),
-		), &ref.Ref{}}
+		_s:          def.S,
+		__optionals: true,
+		_b:          def.B,
+		__optionalb: true,
+		ref:         &ref.Ref{},
+	}
 }
 
 func (s OptionalStruct) Def() (d OptionalStructDef) {
-	if v, ok := s.m.MaybeGet(types.NewString("s")); ok {
-		d.S = v.(types.String).String()
+	if s.__optionals {
+		d.S = s._s
 	}
-	if v, ok := s.m.MaybeGet(types.NewString("b")); ok {
-		d.B = bool(v.(types.Bool))
+	if s.__optionalb {
+		d.B = s._b
 	}
 	return
 }
 
 var __typeRefForOptionalStruct types.TypeRef
+var __typeDefForOptionalStruct types.TypeRef
 
 func (m OptionalStruct) TypeRef() types.TypeRef {
 	return __typeRefForOptionalStruct
@@ -67,22 +77,44 @@ func (m OptionalStruct) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForOptionalStruct = types.MakeTypeRef(__genPackageInFile_struct_optional_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForOptionalStruct, func(v types.Value) types.Value {
-		return OptionalStructFromVal(v)
-	})
+	__typeDefForOptionalStruct = types.MakeStructTypeRef("OptionalStruct",
+		[]types.Field{
+			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), true},
+			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), true},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForOptionalStruct, builderForOptionalStruct)
 }
 
-func OptionalStructFromVal(val types.Value) OptionalStruct {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(OptionalStruct); ok {
-		return val
+func (s OptionalStruct) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{}
+	if s.__optionals {
+		m["s"] = types.NewString(s._s)
 	}
-	// TODO: Validate here
-	return OptionalStruct{val.(types.Map), &ref.Ref{}}
+	if s.__optionalb {
+		m["b"] = types.Bool(s._b)
+	}
+	return types.NewStruct(__typeRefForOptionalStruct, __typeDefForOptionalStruct, m)
 }
 
-func (s OptionalStruct) InternalImplementation() types.Map {
-	return s.m
+func builderForOptionalStruct() chan types.Value {
+	c := make(chan types.Value)
+	s := OptionalStruct{ref: &ref.Ref{}}
+	go func() {
+		s.__optionals = bool((<-c).(types.Bool))
+		if s.__optionals {
+			s._s = (<-c).(types.String).String()
+		}
+		s.__optionalb = bool((<-c).(types.Bool))
+		if s.__optionalb {
+			s._b = bool((<-c).(types.Bool))
+		}
+
+		c <- s
+	}()
+	return c
 }
 
 func (s OptionalStruct) Equals(other types.Value) bool {
@@ -94,31 +126,34 @@ func (s OptionalStruct) Ref() ref.Ref {
 }
 
 func (s OptionalStruct) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForOptionalStruct.Chunks()...)
 	return
 }
 
 func (s OptionalStruct) S() (v string, ok bool) {
-	var vv types.Value
-	if vv, ok = s.m.MaybeGet(types.NewString("s")); ok {
-		v = vv.(types.String).String()
+	if s.__optionals {
+		return s._s, true
 	}
 	return
 }
 
 func (s OptionalStruct) SetS(val string) OptionalStruct {
-	return OptionalStruct{s.m.Set(types.NewString("s"), types.NewString(val)), &ref.Ref{}}
+	s.__optionals = true
+	s._s = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s OptionalStruct) B() (v bool, ok bool) {
-	var vv types.Value
-	if vv, ok = s.m.MaybeGet(types.NewString("b")); ok {
-		v = bool(vv.(types.Bool))
+	if s.__optionalb {
+		return s._b, true
 	}
 	return
 }
 
 func (s OptionalStruct) SetB(val bool) OptionalStruct {
-	return OptionalStruct{s.m.Set(types.NewString("b"), types.Bool(val)), &ref.Ref{}}
+	s.__optionalb = true
+	s._b = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/nomdl/codegen/test/gen/struct_primitives.noms.go
+++ b/nomdl/codegen/test/gen/struct_primitives.noms.go
@@ -40,27 +40,43 @@ func init() {
 // StructPrimitives
 
 type StructPrimitives struct {
-	m   types.Map
+	_uint64  uint64
+	_uint32  uint32
+	_uint16  uint16
+	_uint8   uint8
+	_int64   int64
+	_int32   int32
+	_int16   int16
+	_int8    int8
+	_float64 float64
+	_float32 float32
+	_bool    bool
+	_string  string
+	_blob    types.Blob
+	_value   types.Value
+
 	ref *ref.Ref
 }
 
 func NewStructPrimitives() StructPrimitives {
-	return StructPrimitives{types.NewMap(
-		types.NewString("uint64"), types.UInt64(0),
-		types.NewString("uint32"), types.UInt32(0),
-		types.NewString("uint16"), types.UInt16(0),
-		types.NewString("uint8"), types.UInt8(0),
-		types.NewString("int64"), types.Int64(0),
-		types.NewString("int32"), types.Int32(0),
-		types.NewString("int16"), types.Int16(0),
-		types.NewString("int8"), types.Int8(0),
-		types.NewString("float64"), types.Float64(0),
-		types.NewString("float32"), types.Float32(0),
-		types.NewString("bool"), types.Bool(false),
-		types.NewString("string"), types.NewString(""),
-		types.NewString("blob"), types.NewEmptyBlob(),
-		types.NewString("value"), types.Bool(false),
-	), &ref.Ref{}}
+	return StructPrimitives{
+		_uint64:  uint64(0),
+		_uint32:  uint32(0),
+		_uint16:  uint16(0),
+		_uint8:   uint8(0),
+		_int64:   int64(0),
+		_int32:   int32(0),
+		_int16:   int16(0),
+		_int8:    int8(0),
+		_float64: float64(0),
+		_float32: float32(0),
+		_bool:    false,
+		_string:  "",
+		_blob:    types.NewEmptyBlob(),
+		_value:   types.Bool(false),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type StructPrimitivesDef struct {
@@ -82,43 +98,44 @@ type StructPrimitivesDef struct {
 
 func (def StructPrimitivesDef) New() StructPrimitives {
 	return StructPrimitives{
-		types.NewMap(
-			types.NewString("uint64"), types.UInt64(def.Uint64),
-			types.NewString("uint32"), types.UInt32(def.Uint32),
-			types.NewString("uint16"), types.UInt16(def.Uint16),
-			types.NewString("uint8"), types.UInt8(def.Uint8),
-			types.NewString("int64"), types.Int64(def.Int64),
-			types.NewString("int32"), types.Int32(def.Int32),
-			types.NewString("int16"), types.Int16(def.Int16),
-			types.NewString("int8"), types.Int8(def.Int8),
-			types.NewString("float64"), types.Float64(def.Float64),
-			types.NewString("float32"), types.Float32(def.Float32),
-			types.NewString("bool"), types.Bool(def.Bool),
-			types.NewString("string"), types.NewString(def.String),
-			types.NewString("blob"), def.Blob,
-			types.NewString("value"), def.Value,
-		), &ref.Ref{}}
+		_uint64:  def.Uint64,
+		_uint32:  def.Uint32,
+		_uint16:  def.Uint16,
+		_uint8:   def.Uint8,
+		_int64:   def.Int64,
+		_int32:   def.Int32,
+		_int16:   def.Int16,
+		_int8:    def.Int8,
+		_float64: def.Float64,
+		_float32: def.Float32,
+		_bool:    def.Bool,
+		_string:  def.String,
+		_blob:    def.Blob,
+		_value:   def.Value,
+		ref:      &ref.Ref{},
+	}
 }
 
 func (s StructPrimitives) Def() (d StructPrimitivesDef) {
-	d.Uint64 = uint64(s.m.Get(types.NewString("uint64")).(types.UInt64))
-	d.Uint32 = uint32(s.m.Get(types.NewString("uint32")).(types.UInt32))
-	d.Uint16 = uint16(s.m.Get(types.NewString("uint16")).(types.UInt16))
-	d.Uint8 = uint8(s.m.Get(types.NewString("uint8")).(types.UInt8))
-	d.Int64 = int64(s.m.Get(types.NewString("int64")).(types.Int64))
-	d.Int32 = int32(s.m.Get(types.NewString("int32")).(types.Int32))
-	d.Int16 = int16(s.m.Get(types.NewString("int16")).(types.Int16))
-	d.Int8 = int8(s.m.Get(types.NewString("int8")).(types.Int8))
-	d.Float64 = float64(s.m.Get(types.NewString("float64")).(types.Float64))
-	d.Float32 = float32(s.m.Get(types.NewString("float32")).(types.Float32))
-	d.Bool = bool(s.m.Get(types.NewString("bool")).(types.Bool))
-	d.String = s.m.Get(types.NewString("string")).(types.String).String()
-	d.Blob = s.m.Get(types.NewString("blob")).(types.Blob)
-	d.Value = s.m.Get(types.NewString("value"))
+	d.Uint64 = s._uint64
+	d.Uint32 = s._uint32
+	d.Uint16 = s._uint16
+	d.Uint8 = s._uint8
+	d.Int64 = s._int64
+	d.Int32 = s._int32
+	d.Int16 = s._int16
+	d.Int8 = s._int8
+	d.Float64 = s._float64
+	d.Float32 = s._float32
+	d.Bool = s._bool
+	d.String = s._string
+	d.Blob = s._blob
+	d.Value = s._value
 	return
 }
 
 var __typeRefForStructPrimitives types.TypeRef
+var __typeDefForStructPrimitives types.TypeRef
 
 func (m StructPrimitives) TypeRef() types.TypeRef {
 	return __typeRefForStructPrimitives
@@ -126,22 +143,71 @@ func (m StructPrimitives) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructPrimitives = types.MakeTypeRef(__genPackageInFile_struct_primitives_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForStructPrimitives, func(v types.Value) types.Value {
-		return StructPrimitivesFromVal(v)
-	})
+	__typeDefForStructPrimitives = types.MakeStructTypeRef("StructPrimitives",
+		[]types.Field{
+			types.Field{"uint64", types.MakePrimitiveTypeRef(types.UInt64Kind), false},
+			types.Field{"uint32", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
+			types.Field{"uint16", types.MakePrimitiveTypeRef(types.UInt16Kind), false},
+			types.Field{"uint8", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
+			types.Field{"int64", types.MakePrimitiveTypeRef(types.Int64Kind), false},
+			types.Field{"int32", types.MakePrimitiveTypeRef(types.Int32Kind), false},
+			types.Field{"int16", types.MakePrimitiveTypeRef(types.Int16Kind), false},
+			types.Field{"int8", types.MakePrimitiveTypeRef(types.Int8Kind), false},
+			types.Field{"float64", types.MakePrimitiveTypeRef(types.Float64Kind), false},
+			types.Field{"float32", types.MakePrimitiveTypeRef(types.Float32Kind), false},
+			types.Field{"bool", types.MakePrimitiveTypeRef(types.BoolKind), false},
+			types.Field{"string", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"blob", types.MakePrimitiveTypeRef(types.BlobKind), false},
+			types.Field{"value", types.MakePrimitiveTypeRef(types.ValueKind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForStructPrimitives, builderForStructPrimitives)
 }
 
-func StructPrimitivesFromVal(val types.Value) StructPrimitives {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(StructPrimitives); ok {
-		return val
+func (s StructPrimitives) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"uint64":  types.UInt64(s._uint64),
+		"uint32":  types.UInt32(s._uint32),
+		"uint16":  types.UInt16(s._uint16),
+		"uint8":   types.UInt8(s._uint8),
+		"int64":   types.Int64(s._int64),
+		"int32":   types.Int32(s._int32),
+		"int16":   types.Int16(s._int16),
+		"int8":    types.Int8(s._int8),
+		"float64": types.Float64(s._float64),
+		"float32": types.Float32(s._float32),
+		"bool":    types.Bool(s._bool),
+		"string":  types.NewString(s._string),
+		"blob":    s._blob,
+		"value":   s._value,
 	}
-	// TODO: Validate here
-	return StructPrimitives{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForStructPrimitives, __typeDefForStructPrimitives, m)
 }
 
-func (s StructPrimitives) InternalImplementation() types.Map {
-	return s.m
+func builderForStructPrimitives() chan types.Value {
+	c := make(chan types.Value)
+	s := StructPrimitives{ref: &ref.Ref{}}
+	go func() {
+		s._uint64 = uint64((<-c).(types.UInt64))
+		s._uint32 = uint32((<-c).(types.UInt32))
+		s._uint16 = uint16((<-c).(types.UInt16))
+		s._uint8 = uint8((<-c).(types.UInt8))
+		s._int64 = int64((<-c).(types.Int64))
+		s._int32 = int32((<-c).(types.Int32))
+		s._int16 = int16((<-c).(types.Int16))
+		s._int8 = int8((<-c).(types.Int8))
+		s._float64 = float64((<-c).(types.Float64))
+		s._float32 = float32((<-c).(types.Float32))
+		s._bool = bool((<-c).(types.Bool))
+		s._string = (<-c).(types.String).String()
+		s._blob = (<-c).(types.Blob)
+		s._value = (<-c)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s StructPrimitives) Equals(other types.Value) bool {
@@ -153,119 +219,148 @@ func (s StructPrimitives) Ref() ref.Ref {
 }
 
 func (s StructPrimitives) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForStructPrimitives.Chunks()...)
+	chunks = append(chunks, s._blob.Chunks()...)
+	chunks = append(chunks, s._value.Chunks()...)
 	return
 }
 
 func (s StructPrimitives) Uint64() uint64 {
-	return uint64(s.m.Get(types.NewString("uint64")).(types.UInt64))
+	return s._uint64
 }
 
 func (s StructPrimitives) SetUint64(val uint64) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("uint64"), types.UInt64(val)), &ref.Ref{}}
+	s._uint64 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Uint32() uint32 {
-	return uint32(s.m.Get(types.NewString("uint32")).(types.UInt32))
+	return s._uint32
 }
 
 func (s StructPrimitives) SetUint32(val uint32) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("uint32"), types.UInt32(val)), &ref.Ref{}}
+	s._uint32 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Uint16() uint16 {
-	return uint16(s.m.Get(types.NewString("uint16")).(types.UInt16))
+	return s._uint16
 }
 
 func (s StructPrimitives) SetUint16(val uint16) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("uint16"), types.UInt16(val)), &ref.Ref{}}
+	s._uint16 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Uint8() uint8 {
-	return uint8(s.m.Get(types.NewString("uint8")).(types.UInt8))
+	return s._uint8
 }
 
 func (s StructPrimitives) SetUint8(val uint8) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("uint8"), types.UInt8(val)), &ref.Ref{}}
+	s._uint8 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Int64() int64 {
-	return int64(s.m.Get(types.NewString("int64")).(types.Int64))
+	return s._int64
 }
 
 func (s StructPrimitives) SetInt64(val int64) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("int64"), types.Int64(val)), &ref.Ref{}}
+	s._int64 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Int32() int32 {
-	return int32(s.m.Get(types.NewString("int32")).(types.Int32))
+	return s._int32
 }
 
 func (s StructPrimitives) SetInt32(val int32) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("int32"), types.Int32(val)), &ref.Ref{}}
+	s._int32 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Int16() int16 {
-	return int16(s.m.Get(types.NewString("int16")).(types.Int16))
+	return s._int16
 }
 
 func (s StructPrimitives) SetInt16(val int16) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("int16"), types.Int16(val)), &ref.Ref{}}
+	s._int16 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Int8() int8 {
-	return int8(s.m.Get(types.NewString("int8")).(types.Int8))
+	return s._int8
 }
 
 func (s StructPrimitives) SetInt8(val int8) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("int8"), types.Int8(val)), &ref.Ref{}}
+	s._int8 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Float64() float64 {
-	return float64(s.m.Get(types.NewString("float64")).(types.Float64))
+	return s._float64
 }
 
 func (s StructPrimitives) SetFloat64(val float64) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("float64"), types.Float64(val)), &ref.Ref{}}
+	s._float64 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Float32() float32 {
-	return float32(s.m.Get(types.NewString("float32")).(types.Float32))
+	return s._float32
 }
 
 func (s StructPrimitives) SetFloat32(val float32) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("float32"), types.Float32(val)), &ref.Ref{}}
+	s._float32 = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Bool() bool {
-	return bool(s.m.Get(types.NewString("bool")).(types.Bool))
+	return s._bool
 }
 
 func (s StructPrimitives) SetBool(val bool) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("bool"), types.Bool(val)), &ref.Ref{}}
+	s._bool = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) String() string {
-	return s.m.Get(types.NewString("string")).(types.String).String()
+	return s._string
 }
 
 func (s StructPrimitives) SetString(val string) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("string"), types.NewString(val)), &ref.Ref{}}
+	s._string = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Blob() types.Blob {
-	return s.m.Get(types.NewString("blob")).(types.Blob)
+	return s._blob
 }
 
 func (s StructPrimitives) SetBlob(val types.Blob) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("blob"), val), &ref.Ref{}}
+	s._blob = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructPrimitives) Value() types.Value {
-	return s.m.Get(types.NewString("value"))
+	return s._value
 }
 
 func (s StructPrimitives) SetValue(val types.Value) StructPrimitives {
-	return StructPrimitives{s.m.Set(types.NewString("value"), val), &ref.Ref{}}
+	s._value = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/nomdl/codegen/test/gen/struct_with_dup_list.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_dup_list.noms.go
@@ -27,14 +27,17 @@ func init() {
 // StructWithDupList
 
 type StructWithDupList struct {
-	m   types.Map
+	_l ListOfUInt8
+
 	ref *ref.Ref
 }
 
 func NewStructWithDupList() StructWithDupList {
-	return StructWithDupList{types.NewMap(
-		types.NewString("l"), NewListOfUInt8(),
-	), &ref.Ref{}}
+	return StructWithDupList{
+		_l: NewListOfUInt8(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type StructWithDupListDef struct {
@@ -43,17 +46,18 @@ type StructWithDupListDef struct {
 
 func (def StructWithDupListDef) New() StructWithDupList {
 	return StructWithDupList{
-		types.NewMap(
-			types.NewString("l"), def.L.New(),
-		), &ref.Ref{}}
+		_l:  def.L.New(),
+		ref: &ref.Ref{},
+	}
 }
 
 func (s StructWithDupList) Def() (d StructWithDupListDef) {
-	d.L = s.m.Get(types.NewString("l")).(ListOfUInt8).Def()
+	d.L = s._l.Def()
 	return
 }
 
 var __typeRefForStructWithDupList types.TypeRef
+var __typeDefForStructWithDupList types.TypeRef
 
 func (m StructWithDupList) TypeRef() types.TypeRef {
 	return __typeRefForStructWithDupList
@@ -61,22 +65,32 @@ func (m StructWithDupList) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithDupList = types.MakeTypeRef(__genPackageInFile_struct_with_dup_list_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForStructWithDupList, func(v types.Value) types.Value {
-		return StructWithDupListFromVal(v)
-	})
+	__typeDefForStructWithDupList = types.MakeStructTypeRef("StructWithDupList",
+		[]types.Field{
+			types.Field{"l", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForStructWithDupList, builderForStructWithDupList)
 }
 
-func StructWithDupListFromVal(val types.Value) StructWithDupList {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(StructWithDupList); ok {
-		return val
+func (s StructWithDupList) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"l": s._l,
 	}
-	// TODO: Validate here
-	return StructWithDupList{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForStructWithDupList, __typeDefForStructWithDupList, m)
 }
 
-func (s StructWithDupList) InternalImplementation() types.Map {
-	return s.m
+func builderForStructWithDupList() chan types.Value {
+	c := make(chan types.Value)
+	s := StructWithDupList{ref: &ref.Ref{}}
+	go func() {
+		s._l = (<-c).(ListOfUInt8)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s StructWithDupList) Equals(other types.Value) bool {
@@ -88,17 +102,19 @@ func (s StructWithDupList) Ref() ref.Ref {
 }
 
 func (s StructWithDupList) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForStructWithDupList.Chunks()...)
+	chunks = append(chunks, s._l.Chunks()...)
 	return
 }
 
 func (s StructWithDupList) L() ListOfUInt8 {
-	return s.m.Get(types.NewString("l")).(ListOfUInt8)
+	return s._l
 }
 
 func (s StructWithDupList) SetL(val ListOfUInt8) StructWithDupList {
-	return StructWithDupList{s.m.Set(types.NewString("l"), val), &ref.Ref{}}
+	s._l = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // ListOfUInt8

--- a/nomdl/codegen/test/gen/struct_with_imports.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_imports.noms.go
@@ -74,15 +74,19 @@ func (e LocalE) Chunks() []ref.Ref {
 // ImportUser
 
 type ImportUser struct {
-	m   types.Map
+	_importedStruct D
+	_enum           LocalE
+
 	ref *ref.Ref
 }
 
 func NewImportUser() ImportUser {
-	return ImportUser{types.NewMap(
-		types.NewString("importedStruct"), NewD(),
-		types.NewString("enum"), NewLocalE(),
-	), &ref.Ref{}}
+	return ImportUser{
+		_importedStruct: NewD(),
+		_enum:           NewLocalE(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type ImportUserDef struct {
@@ -92,19 +96,20 @@ type ImportUserDef struct {
 
 func (def ImportUserDef) New() ImportUser {
 	return ImportUser{
-		types.NewMap(
-			types.NewString("importedStruct"), def.ImportedStruct.New(),
-			types.NewString("enum"), def.Enum,
-		), &ref.Ref{}}
+		_importedStruct: def.ImportedStruct.New(),
+		_enum:           def.Enum,
+		ref:             &ref.Ref{},
+	}
 }
 
 func (s ImportUser) Def() (d ImportUserDef) {
-	d.ImportedStruct = s.m.Get(types.NewString("importedStruct")).(D).Def()
-	d.Enum = s.m.Get(types.NewString("enum")).(LocalE)
+	d.ImportedStruct = s._importedStruct.Def()
+	d.Enum = s._enum
 	return
 }
 
 var __typeRefForImportUser types.TypeRef
+var __typeDefForImportUser types.TypeRef
 
 func (m ImportUser) TypeRef() types.TypeRef {
 	return __typeRefForImportUser
@@ -112,22 +117,35 @@ func (m ImportUser) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForImportUser = types.MakeTypeRef(__genPackageInFile_struct_with_imports_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefForImportUser, func(v types.Value) types.Value {
-		return ImportUserFromVal(v)
-	})
+	__typeDefForImportUser = types.MakeStructTypeRef("ImportUser",
+		[]types.Field{
+			types.Field{"importedStruct", types.MakeTypeRef(ref.Parse("sha1-09d2fdd9743c4daec6deebbbc1a38f75ad088eca"), 0), false},
+			types.Field{"enum", types.MakeTypeRef(__genPackageInFile_struct_with_imports_CachedRef, 0), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForImportUser, builderForImportUser)
 }
 
-func ImportUserFromVal(val types.Value) ImportUser {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(ImportUser); ok {
-		return val
+func (s ImportUser) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"importedStruct": s._importedStruct,
+		"enum":           s._enum,
 	}
-	// TODO: Validate here
-	return ImportUser{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForImportUser, __typeDefForImportUser, m)
 }
 
-func (s ImportUser) InternalImplementation() types.Map {
-	return s.m
+func builderForImportUser() chan types.Value {
+	c := make(chan types.Value)
+	s := ImportUser{ref: &ref.Ref{}}
+	go func() {
+		s._importedStruct = (<-c).(D)
+		s._enum = (<-c).(LocalE)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s ImportUser) Equals(other types.Value) bool {
@@ -139,25 +157,29 @@ func (s ImportUser) Ref() ref.Ref {
 }
 
 func (s ImportUser) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForImportUser.Chunks()...)
+	chunks = append(chunks, s._importedStruct.Chunks()...)
 	return
 }
 
 func (s ImportUser) ImportedStruct() D {
-	return s.m.Get(types.NewString("importedStruct")).(D)
+	return s._importedStruct
 }
 
 func (s ImportUser) SetImportedStruct(val D) ImportUser {
-	return ImportUser{s.m.Set(types.NewString("importedStruct"), val), &ref.Ref{}}
+	s._importedStruct = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s ImportUser) Enum() LocalE {
-	return s.m.Get(types.NewString("enum")).(LocalE)
+	return s._enum
 }
 
 func (s ImportUser) SetEnum(val LocalE) ImportUser {
-	return ImportUser{s.m.Set(types.NewString("enum"), val), &ref.Ref{}}
+	s._enum = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // ListOfD

--- a/nomdl/codegen/test/gen/struct_with_list.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_list.noms.go
@@ -30,17 +30,23 @@ func init() {
 // StructWithList
 
 type StructWithList struct {
-	m   types.Map
+	_l ListOfUInt8
+	_b bool
+	_s string
+	_i int64
+
 	ref *ref.Ref
 }
 
 func NewStructWithList() StructWithList {
-	return StructWithList{types.NewMap(
-		types.NewString("l"), NewListOfUInt8(),
-		types.NewString("b"), types.Bool(false),
-		types.NewString("s"), types.NewString(""),
-		types.NewString("i"), types.Int64(0),
-	), &ref.Ref{}}
+	return StructWithList{
+		_l: NewListOfUInt8(),
+		_b: false,
+		_s: "",
+		_i: int64(0),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type StructWithListDef struct {
@@ -52,23 +58,24 @@ type StructWithListDef struct {
 
 func (def StructWithListDef) New() StructWithList {
 	return StructWithList{
-		types.NewMap(
-			types.NewString("l"), def.L.New(),
-			types.NewString("b"), types.Bool(def.B),
-			types.NewString("s"), types.NewString(def.S),
-			types.NewString("i"), types.Int64(def.I),
-		), &ref.Ref{}}
+		_l:  def.L.New(),
+		_b:  def.B,
+		_s:  def.S,
+		_i:  def.I,
+		ref: &ref.Ref{},
+	}
 }
 
 func (s StructWithList) Def() (d StructWithListDef) {
-	d.L = s.m.Get(types.NewString("l")).(ListOfUInt8).Def()
-	d.B = bool(s.m.Get(types.NewString("b")).(types.Bool))
-	d.S = s.m.Get(types.NewString("s")).(types.String).String()
-	d.I = int64(s.m.Get(types.NewString("i")).(types.Int64))
+	d.L = s._l.Def()
+	d.B = s._b
+	d.S = s._s
+	d.I = s._i
 	return
 }
 
 var __typeRefForStructWithList types.TypeRef
+var __typeDefForStructWithList types.TypeRef
 
 func (m StructWithList) TypeRef() types.TypeRef {
 	return __typeRefForStructWithList
@@ -76,22 +83,41 @@ func (m StructWithList) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithList = types.MakeTypeRef(__genPackageInFile_struct_with_list_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForStructWithList, func(v types.Value) types.Value {
-		return StructWithListFromVal(v)
-	})
+	__typeDefForStructWithList = types.MakeStructTypeRef("StructWithList",
+		[]types.Field{
+			types.Field{"l", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
+			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
+			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
+			types.Field{"i", types.MakePrimitiveTypeRef(types.Int64Kind), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForStructWithList, builderForStructWithList)
 }
 
-func StructWithListFromVal(val types.Value) StructWithList {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(StructWithList); ok {
-		return val
+func (s StructWithList) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"l": s._l,
+		"b": types.Bool(s._b),
+		"s": types.NewString(s._s),
+		"i": types.Int64(s._i),
 	}
-	// TODO: Validate here
-	return StructWithList{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForStructWithList, __typeDefForStructWithList, m)
 }
 
-func (s StructWithList) InternalImplementation() types.Map {
-	return s.m
+func builderForStructWithList() chan types.Value {
+	c := make(chan types.Value)
+	s := StructWithList{ref: &ref.Ref{}}
+	go func() {
+		s._l = (<-c).(ListOfUInt8)
+		s._b = bool((<-c).(types.Bool))
+		s._s = (<-c).(types.String).String()
+		s._i = int64((<-c).(types.Int64))
+
+		c <- s
+	}()
+	return c
 }
 
 func (s StructWithList) Equals(other types.Value) bool {
@@ -103,39 +129,47 @@ func (s StructWithList) Ref() ref.Ref {
 }
 
 func (s StructWithList) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForStructWithList.Chunks()...)
+	chunks = append(chunks, s._l.Chunks()...)
 	return
 }
 
 func (s StructWithList) L() ListOfUInt8 {
-	return s.m.Get(types.NewString("l")).(ListOfUInt8)
+	return s._l
 }
 
 func (s StructWithList) SetL(val ListOfUInt8) StructWithList {
-	return StructWithList{s.m.Set(types.NewString("l"), val), &ref.Ref{}}
+	s._l = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructWithList) B() bool {
-	return bool(s.m.Get(types.NewString("b")).(types.Bool))
+	return s._b
 }
 
 func (s StructWithList) SetB(val bool) StructWithList {
-	return StructWithList{s.m.Set(types.NewString("b"), types.Bool(val)), &ref.Ref{}}
+	s._b = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructWithList) S() string {
-	return s.m.Get(types.NewString("s")).(types.String).String()
+	return s._s
 }
 
 func (s StructWithList) SetS(val string) StructWithList {
-	return StructWithList{s.m.Set(types.NewString("s"), types.NewString(val)), &ref.Ref{}}
+	s._s = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructWithList) I() int64 {
-	return int64(s.m.Get(types.NewString("i")).(types.Int64))
+	return s._i
 }
 
 func (s StructWithList) SetI(val int64) StructWithList {
-	return StructWithList{s.m.Set(types.NewString("i"), types.Int64(val)), &ref.Ref{}}
+	s._i = val
+	s.ref = &ref.Ref{}
+	return s
 }

--- a/nomdl/codegen/test/gen/struct_with_unions.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_unions.noms.go
@@ -42,15 +42,19 @@ func init() {
 // StructWithUnions
 
 type StructWithUnions struct {
-	m   types.Map
+	_a __unionOfBOfFloat64AndCOfString
+	_d __unionOfEOfFloat64AndFOfString
+
 	ref *ref.Ref
 }
 
 func NewStructWithUnions() StructWithUnions {
-	return StructWithUnions{types.NewMap(
-		types.NewString("a"), New__unionOfBOfFloat64AndCOfString(),
-		types.NewString("d"), New__unionOfEOfFloat64AndFOfString(),
-	), &ref.Ref{}}
+	return StructWithUnions{
+		_a: New__unionOfBOfFloat64AndCOfString(),
+		_d: New__unionOfEOfFloat64AndFOfString(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type StructWithUnionsDef struct {
@@ -60,19 +64,20 @@ type StructWithUnionsDef struct {
 
 func (def StructWithUnionsDef) New() StructWithUnions {
 	return StructWithUnions{
-		types.NewMap(
-			types.NewString("a"), def.A.New(),
-			types.NewString("d"), def.D.New(),
-		), &ref.Ref{}}
+		_a:  def.A.New(),
+		_d:  def.D.New(),
+		ref: &ref.Ref{},
+	}
 }
 
 func (s StructWithUnions) Def() (d StructWithUnionsDef) {
-	d.A = s.m.Get(types.NewString("a")).(__unionOfBOfFloat64AndCOfString).Def()
-	d.D = s.m.Get(types.NewString("d")).(__unionOfEOfFloat64AndFOfString).Def()
+	d.A = s._a.Def()
+	d.D = s._d.Def()
 	return
 }
 
 var __typeRefForStructWithUnions types.TypeRef
+var __typeDefForStructWithUnions types.TypeRef
 
 func (m StructWithUnions) TypeRef() types.TypeRef {
 	return __typeRefForStructWithUnions
@@ -80,22 +85,35 @@ func (m StructWithUnions) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithUnions = types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 0)
-	types.RegisterFromValFunction(__typeRefForStructWithUnions, func(v types.Value) types.Value {
-		return StructWithUnionsFromVal(v)
-	})
+	__typeDefForStructWithUnions = types.MakeStructTypeRef("StructWithUnions",
+		[]types.Field{
+			types.Field{"a", types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 1), false},
+			types.Field{"d", types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 2), false},
+		},
+		types.Choices{},
+	)
+	types.RegisterStructBuilder(__typeRefForStructWithUnions, builderForStructWithUnions)
 }
 
-func StructWithUnionsFromVal(val types.Value) StructWithUnions {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(StructWithUnions); ok {
-		return val
+func (s StructWithUnions) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{
+		"a": s._a,
+		"d": s._d,
 	}
-	// TODO: Validate here
-	return StructWithUnions{val.(types.Map), &ref.Ref{}}
+	return types.NewStruct(__typeRefForStructWithUnions, __typeDefForStructWithUnions, m)
 }
 
-func (s StructWithUnions) InternalImplementation() types.Map {
-	return s.m
+func builderForStructWithUnions() chan types.Value {
+	c := make(chan types.Value)
+	s := StructWithUnions{ref: &ref.Ref{}}
+	go func() {
+		s._a = (<-c).(__unionOfBOfFloat64AndCOfString)
+		s._d = (<-c).(__unionOfEOfFloat64AndFOfString)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s StructWithUnions) Equals(other types.Value) bool {
@@ -107,81 +125,69 @@ func (s StructWithUnions) Ref() ref.Ref {
 }
 
 func (s StructWithUnions) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForStructWithUnions.Chunks()...)
+	chunks = append(chunks, s._a.Chunks()...)
+	chunks = append(chunks, s._d.Chunks()...)
 	return
 }
 
 func (s StructWithUnions) A() __unionOfBOfFloat64AndCOfString {
-	return s.m.Get(types.NewString("a")).(__unionOfBOfFloat64AndCOfString)
+	return s._a
 }
 
 func (s StructWithUnions) SetA(val __unionOfBOfFloat64AndCOfString) StructWithUnions {
-	return StructWithUnions{s.m.Set(types.NewString("a"), val), &ref.Ref{}}
+	s._a = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s StructWithUnions) D() __unionOfEOfFloat64AndFOfString {
-	return s.m.Get(types.NewString("d")).(__unionOfEOfFloat64AndFOfString)
+	return s._d
 }
 
 func (s StructWithUnions) SetD(val __unionOfEOfFloat64AndFOfString) StructWithUnions {
-	return StructWithUnions{s.m.Set(types.NewString("d"), val), &ref.Ref{}}
+	s._d = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // __unionOfBOfFloat64AndCOfString
 
 type __unionOfBOfFloat64AndCOfString struct {
-	m   types.Map
-	ref *ref.Ref
+	__unionIndex uint32
+	__unionValue types.Value
+	ref          *ref.Ref
 }
 
 func New__unionOfBOfFloat64AndCOfString() __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfString{types.NewMap(
-		types.NewString("$unionIndex"), types.UInt32(0),
-		types.NewString("$unionValue"), types.Float64(0),
-	), &ref.Ref{}}
+	return __unionOfBOfFloat64AndCOfString{
+		__unionIndex: 0,
+		__unionValue: types.Float64(0),
+		ref:          &ref.Ref{},
+	}
 }
 
 type __unionOfBOfFloat64AndCOfStringDef struct {
 	__unionIndex uint32
-	__unionValue interface{}
+	__unionValue types.Value
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) New() __unionOfBOfFloat64AndCOfString {
 	return __unionOfBOfFloat64AndCOfString{
-		types.NewMap(
-			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
-			types.NewString("$unionValue"), def.__unionDefToValue(),
-		), &ref.Ref{}}
+		__unionIndex: def.__unionIndex,
+		__unionValue: def.__unionValue,
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s __unionOfBOfFloat64AndCOfString) Def() (d __unionOfBOfFloat64AndCOfStringDef) {
-	d.__unionIndex = uint32(s.m.Get(types.NewString("$unionIndex")).(types.UInt32))
-	d.__unionValue = s.__unionValueToDef()
+	d.__unionIndex = s.__unionIndex
+	d.__unionValue = s.__unionValue
 	return
 }
 
-func (def __unionOfBOfFloat64AndCOfStringDef) __unionDefToValue() types.Value {
-	switch def.__unionIndex {
-	case 0:
-		return types.Float64(def.__unionValue.(float64))
-	case 1:
-		return types.NewString(def.__unionValue.(string))
-	}
-	panic("unreachable")
-}
-
-func (s __unionOfBOfFloat64AndCOfString) __unionValueToDef() interface{} {
-	switch uint32(s.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
-	case 0:
-		return float64(s.m.Get(types.NewString("$unionValue")).(types.Float64))
-	case 1:
-		return s.m.Get(types.NewString("$unionValue")).(types.String).String()
-	}
-	panic("unreachable")
-}
-
 var __typeRefFor__unionOfBOfFloat64AndCOfString types.TypeRef
+var __typeDefFor__unionOfBOfFloat64AndCOfString types.TypeRef
 
 func (m __unionOfBOfFloat64AndCOfString) TypeRef() types.TypeRef {
 	return __typeRefFor__unionOfBOfFloat64AndCOfString
@@ -189,22 +195,32 @@ func (m __unionOfBOfFloat64AndCOfString) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefFor__unionOfBOfFloat64AndCOfString = types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 1)
-	types.RegisterFromValFunction(__typeRefFor__unionOfBOfFloat64AndCOfString, func(v types.Value) types.Value {
-		return __unionOfBOfFloat64AndCOfStringFromVal(v)
-	})
+	__typeDefFor__unionOfBOfFloat64AndCOfString = types.MakeStructTypeRef("",
+		[]types.Field{},
+		types.Choices{
+			types.Field{"b", types.MakePrimitiveTypeRef(types.Float64Kind), false},
+			types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind), false},
+		},
+	)
+	types.RegisterStructBuilder(__typeRefFor__unionOfBOfFloat64AndCOfString, builderFor__unionOfBOfFloat64AndCOfString)
 }
 
-func __unionOfBOfFloat64AndCOfStringFromVal(val types.Value) __unionOfBOfFloat64AndCOfString {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(__unionOfBOfFloat64AndCOfString); ok {
-		return val
-	}
-	// TODO: Validate here
-	return __unionOfBOfFloat64AndCOfString{val.(types.Map), &ref.Ref{}}
+func (s __unionOfBOfFloat64AndCOfString) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{}
+	m[__typeDefFor__unionOfBOfFloat64AndCOfString.Desc.(types.StructDesc).Union[s.__unionIndex].Name] = s.__unionValue
+	return types.NewStruct(__typeRefFor__unionOfBOfFloat64AndCOfString, __typeDefFor__unionOfBOfFloat64AndCOfString, m)
 }
 
-func (s __unionOfBOfFloat64AndCOfString) InternalImplementation() types.Map {
-	return s.m
+func builderFor__unionOfBOfFloat64AndCOfString() chan types.Value {
+	c := make(chan types.Value)
+	s := __unionOfBOfFloat64AndCOfString{ref: &ref.Ref{}}
+	go func() {
+		s.__unionIndex = uint32((<-c).(types.UInt32))
+		s.__unionValue = <-c
+		c <- s
+	}()
+	return c
 }
 
 func (s __unionOfBOfFloat64AndCOfString) Equals(other types.Value) bool {
@@ -216,113 +232,102 @@ func (s __unionOfBOfFloat64AndCOfString) Ref() ref.Ref {
 }
 
 func (s __unionOfBOfFloat64AndCOfString) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefFor__unionOfBOfFloat64AndCOfString.Chunks()...)
+	chunks = append(chunks, s.__unionValue.Chunks()...)
 	return
 }
 
 func (s __unionOfBOfFloat64AndCOfString) B() (val float64, ok bool) {
-	if s.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 0 {
+	if s.__unionIndex != 0 {
 		return
 	}
-	return float64(s.m.Get(types.NewString("$unionValue")).(types.Float64)), true
+	return float64(s.__unionValue.(types.Float64)), true
 }
 
 func (s __unionOfBOfFloat64AndCOfString) SetB(val float64) __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfString{s.m.Set(types.NewString("$unionIndex"), types.UInt32(0)).Set(types.NewString("$unionValue"), types.Float64(val)), &ref.Ref{}}
+	s.__unionIndex = 0
+	s.__unionValue = types.Float64(val)
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) B() (val float64, ok bool) {
 	if def.__unionIndex != 0 {
 		return
 	}
-	return def.__unionValue.(float64), true
+	return float64(def.__unionValue.(types.Float64)), true
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) SetB(val float64) __unionOfBOfFloat64AndCOfStringDef {
 	def.__unionIndex = 0
-	def.__unionValue = val
+	def.__unionValue = types.Float64(val)
 	return def
 }
 
 func (s __unionOfBOfFloat64AndCOfString) C() (val string, ok bool) {
-	if s.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 1 {
+	if s.__unionIndex != 1 {
 		return
 	}
-	return s.m.Get(types.NewString("$unionValue")).(types.String).String(), true
+	return s.__unionValue.(types.String).String(), true
 }
 
 func (s __unionOfBOfFloat64AndCOfString) SetC(val string) __unionOfBOfFloat64AndCOfString {
-	return __unionOfBOfFloat64AndCOfString{s.m.Set(types.NewString("$unionIndex"), types.UInt32(1)).Set(types.NewString("$unionValue"), types.NewString(val)), &ref.Ref{}}
+	s.__unionIndex = 1
+	s.__unionValue = types.NewString(val)
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) C() (val string, ok bool) {
 	if def.__unionIndex != 1 {
 		return
 	}
-	return def.__unionValue.(string), true
+	return def.__unionValue.(types.String).String(), true
 }
 
 func (def __unionOfBOfFloat64AndCOfStringDef) SetC(val string) __unionOfBOfFloat64AndCOfStringDef {
 	def.__unionIndex = 1
-	def.__unionValue = val
+	def.__unionValue = types.NewString(val)
 	return def
 }
 
 // __unionOfEOfFloat64AndFOfString
 
 type __unionOfEOfFloat64AndFOfString struct {
-	m   types.Map
-	ref *ref.Ref
+	__unionIndex uint32
+	__unionValue types.Value
+	ref          *ref.Ref
 }
 
 func New__unionOfEOfFloat64AndFOfString() __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfString{types.NewMap(
-		types.NewString("$unionIndex"), types.UInt32(0),
-		types.NewString("$unionValue"), types.Float64(0),
-	), &ref.Ref{}}
+	return __unionOfEOfFloat64AndFOfString{
+		__unionIndex: 0,
+		__unionValue: types.Float64(0),
+		ref:          &ref.Ref{},
+	}
 }
 
 type __unionOfEOfFloat64AndFOfStringDef struct {
 	__unionIndex uint32
-	__unionValue interface{}
+	__unionValue types.Value
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) New() __unionOfEOfFloat64AndFOfString {
 	return __unionOfEOfFloat64AndFOfString{
-		types.NewMap(
-			types.NewString("$unionIndex"), types.UInt32(def.__unionIndex),
-			types.NewString("$unionValue"), def.__unionDefToValue(),
-		), &ref.Ref{}}
+		__unionIndex: def.__unionIndex,
+		__unionValue: def.__unionValue,
+		ref:          &ref.Ref{},
+	}
 }
 
 func (s __unionOfEOfFloat64AndFOfString) Def() (d __unionOfEOfFloat64AndFOfStringDef) {
-	d.__unionIndex = uint32(s.m.Get(types.NewString("$unionIndex")).(types.UInt32))
-	d.__unionValue = s.__unionValueToDef()
+	d.__unionIndex = s.__unionIndex
+	d.__unionValue = s.__unionValue
 	return
 }
 
-func (def __unionOfEOfFloat64AndFOfStringDef) __unionDefToValue() types.Value {
-	switch def.__unionIndex {
-	case 0:
-		return types.Float64(def.__unionValue.(float64))
-	case 1:
-		return types.NewString(def.__unionValue.(string))
-	}
-	panic("unreachable")
-}
-
-func (s __unionOfEOfFloat64AndFOfString) __unionValueToDef() interface{} {
-	switch uint32(s.m.Get(types.NewString("$unionIndex")).(types.UInt32)) {
-	case 0:
-		return float64(s.m.Get(types.NewString("$unionValue")).(types.Float64))
-	case 1:
-		return s.m.Get(types.NewString("$unionValue")).(types.String).String()
-	}
-	panic("unreachable")
-}
-
 var __typeRefFor__unionOfEOfFloat64AndFOfString types.TypeRef
+var __typeDefFor__unionOfEOfFloat64AndFOfString types.TypeRef
 
 func (m __unionOfEOfFloat64AndFOfString) TypeRef() types.TypeRef {
 	return __typeRefFor__unionOfEOfFloat64AndFOfString
@@ -330,22 +335,32 @@ func (m __unionOfEOfFloat64AndFOfString) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefFor__unionOfEOfFloat64AndFOfString = types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 2)
-	types.RegisterFromValFunction(__typeRefFor__unionOfEOfFloat64AndFOfString, func(v types.Value) types.Value {
-		return __unionOfEOfFloat64AndFOfStringFromVal(v)
-	})
+	__typeDefFor__unionOfEOfFloat64AndFOfString = types.MakeStructTypeRef("",
+		[]types.Field{},
+		types.Choices{
+			types.Field{"e", types.MakePrimitiveTypeRef(types.Float64Kind), false},
+			types.Field{"f", types.MakePrimitiveTypeRef(types.StringKind), false},
+		},
+	)
+	types.RegisterStructBuilder(__typeRefFor__unionOfEOfFloat64AndFOfString, builderFor__unionOfEOfFloat64AndFOfString)
 }
 
-func __unionOfEOfFloat64AndFOfStringFromVal(val types.Value) __unionOfEOfFloat64AndFOfString {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(__unionOfEOfFloat64AndFOfString); ok {
-		return val
-	}
-	// TODO: Validate here
-	return __unionOfEOfFloat64AndFOfString{val.(types.Map), &ref.Ref{}}
+func (s __unionOfEOfFloat64AndFOfString) InternalImplementation() types.Struct {
+	// TODO: Remove this
+	m := map[string]types.Value{}
+	m[__typeDefFor__unionOfEOfFloat64AndFOfString.Desc.(types.StructDesc).Union[s.__unionIndex].Name] = s.__unionValue
+	return types.NewStruct(__typeRefFor__unionOfEOfFloat64AndFOfString, __typeDefFor__unionOfEOfFloat64AndFOfString, m)
 }
 
-func (s __unionOfEOfFloat64AndFOfString) InternalImplementation() types.Map {
-	return s.m
+func builderFor__unionOfEOfFloat64AndFOfString() chan types.Value {
+	c := make(chan types.Value)
+	s := __unionOfEOfFloat64AndFOfString{ref: &ref.Ref{}}
+	go func() {
+		s.__unionIndex = uint32((<-c).(types.UInt32))
+		s.__unionValue = <-c
+		c <- s
+	}()
+	return c
 }
 
 func (s __unionOfEOfFloat64AndFOfString) Equals(other types.Value) bool {
@@ -357,55 +372,61 @@ func (s __unionOfEOfFloat64AndFOfString) Ref() ref.Ref {
 }
 
 func (s __unionOfEOfFloat64AndFOfString) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefFor__unionOfEOfFloat64AndFOfString.Chunks()...)
+	chunks = append(chunks, s.__unionValue.Chunks()...)
 	return
 }
 
 func (s __unionOfEOfFloat64AndFOfString) E() (val float64, ok bool) {
-	if s.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 0 {
+	if s.__unionIndex != 0 {
 		return
 	}
-	return float64(s.m.Get(types.NewString("$unionValue")).(types.Float64)), true
+	return float64(s.__unionValue.(types.Float64)), true
 }
 
 func (s __unionOfEOfFloat64AndFOfString) SetE(val float64) __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfString{s.m.Set(types.NewString("$unionIndex"), types.UInt32(0)).Set(types.NewString("$unionValue"), types.Float64(val)), &ref.Ref{}}
+	s.__unionIndex = 0
+	s.__unionValue = types.Float64(val)
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) E() (val float64, ok bool) {
 	if def.__unionIndex != 0 {
 		return
 	}
-	return def.__unionValue.(float64), true
+	return float64(def.__unionValue.(types.Float64)), true
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) SetE(val float64) __unionOfEOfFloat64AndFOfStringDef {
 	def.__unionIndex = 0
-	def.__unionValue = val
+	def.__unionValue = types.Float64(val)
 	return def
 }
 
 func (s __unionOfEOfFloat64AndFOfString) F() (val string, ok bool) {
-	if s.m.Get(types.NewString("$unionIndex")).(types.UInt32) != 1 {
+	if s.__unionIndex != 1 {
 		return
 	}
-	return s.m.Get(types.NewString("$unionValue")).(types.String).String(), true
+	return s.__unionValue.(types.String).String(), true
 }
 
 func (s __unionOfEOfFloat64AndFOfString) SetF(val string) __unionOfEOfFloat64AndFOfString {
-	return __unionOfEOfFloat64AndFOfString{s.m.Set(types.NewString("$unionIndex"), types.UInt32(1)).Set(types.NewString("$unionValue"), types.NewString(val)), &ref.Ref{}}
+	s.__unionIndex = 1
+	s.__unionValue = types.NewString(val)
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) F() (val string, ok bool) {
 	if def.__unionIndex != 1 {
 		return
 	}
-	return def.__unionValue.(string), true
+	return def.__unionValue.(types.String).String(), true
 }
 
 func (def __unionOfEOfFloat64AndFOfStringDef) SetF(val string) __unionOfEOfFloat64AndFOfStringDef {
 	def.__unionIndex = 1
-	def.__unionValue = val
+	def.__unionValue = types.NewString(val)
 	return def
 }

--- a/nomdl/codegen/test/struct_primitives_test.go
+++ b/nomdl/codegen/test/struct_primitives_test.go
@@ -123,5 +123,5 @@ func TestStructBackingMapKeyNames(t *testing.T) {
 
 	s := gen.NewStructPrimitives().SetBool(true)
 
-	assert.True(bool(s.InternalImplementation().Get(types.NewString("bool")).(types.Bool)))
+	assert.True(bool(s.InternalImplementation().Get("bool").(types.Bool)))
 }

--- a/nomdl/codegen/test/struct_test.go
+++ b/nomdl/codegen/test/struct_test.go
@@ -30,9 +30,9 @@ func TestValue(t *testing.T) {
 	assert := assert.New(t)
 
 	def := gen.StructDef{"hi", true}
-	st := def.New()
-	val := st
-	st2 := gen.StructFromVal(val)
+	var st types.Value
+	st = def.New()
+	st2 := st.(gen.Struct)
 	assert.True(st.Equals(st2))
 }
 

--- a/types/assert.go
+++ b/types/assert.go
@@ -5,7 +5,7 @@ import "github.com/attic-labs/noms/d"
 func assertType(t TypeRef, v ...Value) {
 	if t.Kind() != ValueKind {
 		for _, v := range v {
-			d.Chk.True(t.Equals(v.TypeRef()))
+			d.Chk.True(t.Equals(v.TypeRef()), "Invalid type. Expected: %s, found: %s", t.Describe(), v.TypeRef().Describe())
 		}
 	}
 }

--- a/types/compound_blob_struct.noms.go
+++ b/types/compound_blob_struct.noms.go
@@ -28,15 +28,19 @@ func init() {
 // compoundBlobStruct
 
 type compoundBlobStruct struct {
-	m   Map
+	_Offsets ListOfUInt64
+	_Blobs   ListOfRefOfBlob
+
 	ref *ref.Ref
 }
 
 func NewcompoundBlobStruct() compoundBlobStruct {
-	return compoundBlobStruct{NewMap(
-		NewString("Offsets"), NewListOfUInt64(),
-		NewString("Blobs"), NewListOfRefOfBlob(),
-	), &ref.Ref{}}
+	return compoundBlobStruct{
+		_Offsets: NewListOfUInt64(),
+		_Blobs:   NewListOfRefOfBlob(),
+
+		ref: &ref.Ref{},
+	}
 }
 
 type compoundBlobStructDef struct {
@@ -46,19 +50,20 @@ type compoundBlobStructDef struct {
 
 func (def compoundBlobStructDef) New() compoundBlobStruct {
 	return compoundBlobStruct{
-		NewMap(
-			NewString("Offsets"), def.Offsets.New(),
-			NewString("Blobs"), def.Blobs.New(),
-		), &ref.Ref{}}
+		_Offsets: def.Offsets.New(),
+		_Blobs:   def.Blobs.New(),
+		ref:      &ref.Ref{},
+	}
 }
 
 func (s compoundBlobStruct) Def() (d compoundBlobStructDef) {
-	d.Offsets = s.m.Get(NewString("Offsets")).(ListOfUInt64).Def()
-	d.Blobs = s.m.Get(NewString("Blobs")).(ListOfRefOfBlob).Def()
+	d.Offsets = s._Offsets.Def()
+	d.Blobs = s._Blobs.Def()
 	return
 }
 
 var __typeRefForcompoundBlobStruct TypeRef
+var __typeDefForcompoundBlobStruct TypeRef
 
 func (m compoundBlobStruct) TypeRef() TypeRef {
 	return __typeRefForcompoundBlobStruct
@@ -66,22 +71,35 @@ func (m compoundBlobStruct) TypeRef() TypeRef {
 
 func init() {
 	__typeRefForcompoundBlobStruct = MakeTypeRef(__typesPackageInFile_compound_blob_struct_CachedRef, 0)
-	RegisterFromValFunction(__typeRefForcompoundBlobStruct, func(v Value) Value {
-		return compoundBlobStructFromVal(v)
-	})
+	__typeDefForcompoundBlobStruct = MakeStructTypeRef("compoundBlobStruct",
+		[]Field{
+			Field{"Offsets", MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(UInt64Kind)), false},
+			Field{"Blobs", MakeCompoundTypeRef(ListKind, MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(BlobKind))), false},
+		},
+		Choices{},
+	)
+	RegisterStructBuilder(__typeRefForcompoundBlobStruct, builderForcompoundBlobStruct)
 }
 
-func compoundBlobStructFromVal(val Value) compoundBlobStruct {
-	// TODO: Do we still need FromVal?
-	if val, ok := val.(compoundBlobStruct); ok {
-		return val
+func (s compoundBlobStruct) InternalImplementation() Struct {
+	// TODO: Remove this
+	m := map[string]Value{
+		"Offsets": s._Offsets,
+		"Blobs":   s._Blobs,
 	}
-	// TODO: Validate here
-	return compoundBlobStruct{val.(Map), &ref.Ref{}}
+	return NewStruct(__typeRefForcompoundBlobStruct, __typeDefForcompoundBlobStruct, m)
 }
 
-func (s compoundBlobStruct) InternalImplementation() Map {
-	return s.m
+func builderForcompoundBlobStruct() chan Value {
+	c := make(chan Value)
+	s := compoundBlobStruct{ref: &ref.Ref{}}
+	go func() {
+		s._Offsets = (<-c).(ListOfUInt64)
+		s._Blobs = (<-c).(ListOfRefOfBlob)
+
+		c <- s
+	}()
+	return c
 }
 
 func (s compoundBlobStruct) Equals(other Value) bool {
@@ -93,25 +111,30 @@ func (s compoundBlobStruct) Ref() ref.Ref {
 }
 
 func (s compoundBlobStruct) Chunks() (chunks []ref.Ref) {
-	chunks = append(chunks, s.TypeRef().Chunks()...)
-	chunks = append(chunks, s.m.Chunks()...)
+	chunks = append(chunks, __typeRefForcompoundBlobStruct.Chunks()...)
+	chunks = append(chunks, s._Offsets.Chunks()...)
+	chunks = append(chunks, s._Blobs.Chunks()...)
 	return
 }
 
 func (s compoundBlobStruct) Offsets() ListOfUInt64 {
-	return s.m.Get(NewString("Offsets")).(ListOfUInt64)
+	return s._Offsets
 }
 
 func (s compoundBlobStruct) SetOffsets(val ListOfUInt64) compoundBlobStruct {
-	return compoundBlobStruct{s.m.Set(NewString("Offsets"), val), &ref.Ref{}}
+	s._Offsets = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 func (s compoundBlobStruct) Blobs() ListOfRefOfBlob {
-	return s.m.Get(NewString("Blobs")).(ListOfRefOfBlob)
+	return s._Blobs
 }
 
 func (s compoundBlobStruct) SetBlobs(val ListOfRefOfBlob) compoundBlobStruct {
-	return compoundBlobStruct{s.m.Set(NewString("Blobs"), val), &ref.Ref{}}
+	s._Blobs = val
+	s.ref = &ref.Ref{}
+	return s
 }
 
 // ListOfUInt64

--- a/types/struct.go
+++ b/types/struct.go
@@ -1,0 +1,187 @@
+package types
+
+import (
+	"github.com/attic-labs/noms/d"
+	"github.com/attic-labs/noms/ref"
+)
+
+type structData map[string]Value
+
+type Struct struct {
+	data       structData
+	t          TypeRef
+	typeDef    TypeRef
+	unionIndex uint32
+	unionValue Value
+	ref        *ref.Ref
+}
+
+func newStructFromData(data structData, unionIndex uint32, unionValue Value, typeRef, typeDef TypeRef) Struct {
+	d.Chk.Equal(typeRef.Kind(), UnresolvedKind)
+	d.Chk.True(typeRef.HasPackageRef())
+	d.Chk.True(typeRef.HasOrdinal())
+	d.Chk.Equal(typeDef.Kind(), StructKind)
+	return Struct{data, typeRef, typeDef, unionIndex, unionValue, &ref.Ref{}}
+}
+
+func NewStruct(typeRef, typeDef TypeRef, data structData) Struct {
+	newData := make(structData)
+	unionIndex := uint32(0)
+	var unionValue Value
+
+	desc := typeDef.Desc.(StructDesc)
+	for _, f := range desc.Fields {
+		v, ok := data[f.Name]
+		if ok {
+			newData[f.Name] = v
+		} else {
+			d.Chk.True(f.Optional, "Missing required field %s", f.Name)
+		}
+	}
+	for i, f := range desc.Union {
+		v, ok := data[f.Name]
+		if ok {
+			unionIndex = uint32(i)
+			unionValue = v
+			break
+		}
+	}
+	return newStructFromData(newData, unionIndex, unionValue, typeRef, typeDef)
+}
+
+func (s Struct) Equals(other Value) bool {
+	return other != nil && s.t.Equals(other.TypeRef()) && s.Ref() == other.Ref()
+}
+
+func (s Struct) Ref() ref.Ref {
+	return EnsureRef(s.ref, s)
+}
+
+func (s Struct) Chunks() (chunks []ref.Ref) {
+	chunks = append(chunks, s.t.Chunks()...)
+	for _, f := range s.desc().Fields {
+		if v, ok := s.data[f.Name]; ok {
+			chunks = append(chunks, v.Chunks()...)
+		} else {
+			d.Chk.True(f.Optional)
+		}
+	}
+
+	if s.hasUnion() {
+		chunks = append(chunks, s.unionValue.Chunks()...)
+	}
+
+	return
+}
+
+func (s Struct) TypeRef() TypeRef {
+	return s.t
+}
+
+func (s Struct) desc() StructDesc {
+	return s.typeDef.Desc.(StructDesc)
+}
+
+func (s Struct) hasUnion() bool {
+	return len(s.desc().Union) > 0
+}
+
+func (s Struct) MaybeGet(n string) (Value, bool) {
+	_, idx, ok := s.findField(n)
+	if !ok {
+		return nil, false
+	}
+	if idx == -1 {
+		v, ok := s.data[n]
+		return v, ok
+	}
+	if s.unionIndex != uint32(idx) {
+		return nil, false
+	}
+	return s.unionValue, true
+}
+
+func (s Struct) Get(n string) Value {
+	_, idx, ok := s.findField(n)
+	d.Chk.True(ok, `Struct has no field "%s"`, n)
+	if idx == -1 {
+		v, ok := s.data[n]
+		d.Chk.True(ok)
+		return v
+	}
+	d.Chk.Equal(s.unionIndex, uint32(idx), `Union field "%s" is not set`, n)
+	return s.unionValue
+}
+
+func (s Struct) Set(n string, v Value) Struct {
+	f, idx, ok := s.findField(n)
+	d.Chk.True(ok, "Struct has no field %s", n)
+	assertType(f.T, v)
+	data := make(structData, len(s.data))
+	unionIndex := s.unionIndex
+	unionValue := s.unionValue
+	for k, v := range s.data {
+		data[k] = v
+	}
+
+	if idx == -1 {
+		data[n] = v
+	} else {
+		unionIndex = uint32(idx)
+		unionValue = v
+	}
+
+	return newStructFromData(data, unionIndex, unionValue, s.t, s.typeDef)
+}
+
+func (s Struct) UnionIndex() uint32 {
+	return s.unionIndex
+}
+
+func (s Struct) UnionValue() Value {
+	return s.unionValue
+}
+
+func (s Struct) findField(n string) (Field, int32, bool) {
+	for _, f := range s.desc().Fields {
+		if f.Name == n {
+			return f, -1, true
+		}
+	}
+	for i, f := range s.desc().Union {
+		if f.Name == n {
+			return f, int32(i), true
+		}
+	}
+	return Field{}, -1, false
+}
+
+func structBuilder(typeRef, typeDef TypeRef) chan Value {
+	c := make(chan Value)
+
+	go func() {
+		desc := typeDef.Desc.(StructDesc)
+		data := structData{}
+		unionIndex := uint32(0)
+		var unionValue Value
+
+		for _, f := range desc.Fields {
+			if f.Optional {
+				b := bool((<-c).(Bool))
+				if b {
+					data[f.Name] = <-c
+				}
+			} else {
+				data[f.Name] = <-c
+			}
+		}
+		if len(desc.Union) > 0 {
+			unionIndex = uint32((<-c).(UInt32))
+			unionValue = <-c
+		}
+
+		c <- newStructFromData(data, unionIndex, unionValue, typeRef, typeDef)
+	}()
+
+	return c
+}

--- a/types/struct_test.go
+++ b/types/struct_test.go
@@ -1,0 +1,188 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/attic-labs/noms/ref"
+)
+
+func TestGenericStructEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S1", []Field{
+		Field{"x", MakePrimitiveTypeRef(BoolKind), false},
+		Field{"o", MakePrimitiveTypeRef(StringKind), true},
+	}, Choices{})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	data1 := structData{"x": Bool(true)}
+	s1 := newStructFromData(data1, 0, nil, typeRef, typeDef)
+	data2 := structData{"x": Bool(true), "extra": NewString("is ignored")}
+	s2 := newStructFromData(data2, 0, nil, typeRef, typeDef)
+
+	assert.True(s1.Equals(s2))
+	assert.True(s2.Equals(s1))
+}
+
+func TestGenericStructChunks(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S1", []Field{
+		Field{"r", MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(BoolKind)), false},
+	}, Choices{})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	b := Bool(true)
+
+	data1 := structData{"r": NewRef(b.Ref())}
+	s1 := newStructFromData(data1, 0, nil, typeRef, typeDef)
+
+	assert.Len(s1.Chunks(), 2)
+	assert.Equal(pkgRef, s1.Chunks()[0])
+	assert.Equal(b.Ref(), s1.Chunks()[1])
+}
+
+func TestGenericStructChunksOptional(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S1", []Field{
+		Field{"r", MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(BoolKind)), true},
+	}, Choices{})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	b := Bool(true)
+
+	data1 := structData{}
+	s1 := newStructFromData(data1, 0, nil, typeRef, typeDef)
+
+	assert.Len(s1.Chunks(), 1)
+	assert.Equal(pkgRef, s1.Chunks()[0])
+
+	data2 := structData{"r": NewRef(b.Ref())}
+	s2 := newStructFromData(data2, 0, nil, typeRef, typeDef)
+
+	assert.Len(s2.Chunks(), 2)
+	assert.Equal(pkgRef, s2.Chunks()[0])
+	assert.Equal(b.Ref(), s2.Chunks()[1])
+}
+
+func TestGenericStructChunksUnion(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S1", []Field{}, Choices{
+		Field{"r", MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(BoolKind)), false},
+		Field{"s", MakePrimitiveTypeRef(StringKind), false},
+	})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	b := Bool(true)
+
+	s1 := NewStruct(typeRef, typeDef, structData{"s": NewString("hi")})
+
+	assert.Len(s1.Chunks(), 1)
+	assert.Equal(pkgRef, s1.Chunks()[0])
+
+	s2 := NewStruct(typeRef, typeDef, structData{"r": NewRef(b.Ref())})
+
+	assert.Len(s2.Chunks(), 2)
+	assert.Equal(pkgRef, s2.Chunks()[0])
+	assert.Equal(b.Ref(), s2.Chunks()[1])
+}
+
+func TestGenericStructNew(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S2", []Field{
+		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
+		Field{"o", MakePrimitiveTypeRef(StringKind), true},
+	}, Choices{})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	s := NewStruct(typeRef, typeDef, map[string]Value{"b": Bool(true)})
+	assert.True(s.Get("b").Equals(Bool(true)))
+	_, ok := s.MaybeGet("o")
+	assert.False(ok)
+
+	_, ok = s.MaybeGet("x")
+	assert.False(ok)
+
+	s2 := NewStruct(typeRef, typeDef, map[string]Value{"b": Bool(false), "o": NewString("hi")})
+	assert.True(s2.Get("b").Equals(Bool(false)))
+	o, ok := s2.MaybeGet("o")
+	assert.True(ok)
+	assert.True(NewString("hi").Equals(o))
+
+	assert.Panics(func() { NewStruct(typeRef, typeDef, nil) })
+	assert.Panics(func() { NewStruct(typeRef, typeDef, map[string]Value{"o": NewString("hi")}) })
+}
+
+func TestGenericStructNewUnion(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S3", []Field{}, Choices{
+		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
+		Field{"o", MakePrimitiveTypeRef(StringKind), false},
+	})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	s := NewStruct(typeRef, typeDef, map[string]Value{"b": Bool(true)})
+	assert.True(s.Get("b").Equals(Bool(true)))
+	_, ok := s.MaybeGet("o")
+	assert.False(ok)
+}
+
+func TestGenericStructSet(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S3", []Field{
+		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
+		Field{"o", MakePrimitiveTypeRef(StringKind), true},
+	}, Choices{})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	s := NewStruct(typeRef, typeDef, map[string]Value{"b": Bool(true)})
+	s2 := s.Set("b", Bool(false))
+
+	assert.Panics(func() { s.Set("b", Int32(1)) })
+	assert.Panics(func() { s.Set("x", Int32(1)) })
+
+	s3 := s2.Set("b", Bool(true))
+	assert.True(s.Equals(s3))
+}
+
+func TestGenericStructSetUnion(t *testing.T) {
+	assert := assert.New(t)
+
+	typeDef := MakeStructTypeRef("S3", []Field{}, Choices{
+		Field{"b", MakePrimitiveTypeRef(BoolKind), false},
+		Field{"s", MakePrimitiveTypeRef(StringKind), false},
+	})
+	pkg := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
+	pkgRef := RegisterPackage(&pkg)
+	typeRef := MakeTypeRef(pkgRef, 0)
+
+	s := NewStruct(typeRef, typeDef, map[string]Value{"b": Bool(true)})
+	assert.Equal(uint32(0), s.UnionIndex())
+	assert.True(Bool(true).Equals(s.UnionValue()))
+	s2 := s.Set("s", NewString("hi"))
+	assert.Equal(uint32(1), s2.UnionIndex())
+	assert.True(NewString("hi").Equals(s2.UnionValue()))
+
+	s3 := s2.Set("b", Bool(true))
+	assert.True(s.Equals(s3))
+}

--- a/types/write_value_test.go
+++ b/types/write_value_test.go
@@ -65,17 +65,16 @@ func TestWritePackageWhenValueIsWritten(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewMemoryStore()
 
-	pkg1 := NewPackage([]TypeRef{
-		MakeStructTypeRef("S", []Field{
-			Field{"X", MakePrimitiveTypeRef(Int32Kind), false},
-		}, Choices{}),
-	}, []ref.Ref{})
+	typeDef := MakeStructTypeRef("S", []Field{
+		Field{"X", MakePrimitiveTypeRef(Int32Kind), false},
+	}, Choices{})
+	pkg1 := NewPackage([]TypeRef{typeDef}, []ref.Ref{})
 	// Don't write package
 	pkgRef1 := RegisterPackage(&pkg1)
+	typeRef := MakeTypeRef(pkgRef1, 0)
 
-	m := NewMap(NewString("X"), Int32(42))
-	tref := MakeTypeRef(pkgRef1, 0)
-	WriteValue(testMap{Map: m, t: tref}, cs)
+	s := NewStruct(typeRef, typeDef, structData{"X": Int32(42)})
+	WriteValue(s, cs)
 
 	pkg2 := ReadValue(pkgRef1, cs)
 	assert.True(pkg1.Equals(pkg2))


### PR DESCRIPTION
The generated code for typed structs now uses a Go struct which
implements Value directly. The fields in this struct uses the "user"
type. (The union value still uses types.Value though.)

When a typed struct is created by the decoder, it asks for a struct
builder which returns a channel that the values of the fields of the
struct are sent to.
