### PR TITLE
Remove InternalImplementation from structs

### DIFF
--- a/clients/common/geo.noms.go
+++ b/clients/common/geo.noms.go
@@ -70,7 +70,6 @@ func (s Geoposition) Def() (d GeopositionDef) {
 }
 
 var __typeRefForGeoposition types.TypeRef
-var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -78,33 +77,26 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 0)
-	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
-		[]types.Field{
-			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
-}
-
-func (s Geoposition) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Latitude":  types.Float32(s._Latitude),
-		"Longitude": types.Float32(s._Longitude),
-	}
-	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
+	types.RegisterStruct(__typeRefForGeoposition, builderForGeoposition, readerForGeoposition)
 }
 
 func builderForGeoposition() chan types.Value {
 	c := make(chan types.Value)
-	s := Geoposition{ref: &ref.Ref{}}
 	go func() {
+		s := Geoposition{ref: &ref.Ref{}}
 		s._Latitude = float32((<-c).(types.Float32))
 		s._Longitude = float32((<-c).(types.Float32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeoposition(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Geoposition)
+		c <- types.Float32(s._Latitude)
+		c <- types.Float32(s._Longitude)
 	}()
 	return c
 }
@@ -180,7 +172,6 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 }
 
 var __typeRefForGeorectangle types.TypeRef
-var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -188,33 +179,26 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 1)
-	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
-		[]types.Field{
-			types.Field{"TopLeft", types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 0), false},
-			types.Field{"BottomRight", types.MakeTypeRef(__commonPackageInFile_geo_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
-}
-
-func (s Georectangle) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"TopLeft":     s._TopLeft,
-		"BottomRight": s._BottomRight,
-	}
-	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
+	types.RegisterStruct(__typeRefForGeorectangle, builderForGeorectangle, readerForGeorectangle)
 }
 
 func builderForGeorectangle() chan types.Value {
 	c := make(chan types.Value)
-	s := Georectangle{ref: &ref.Ref{}}
 	go func() {
+		s := Georectangle{ref: &ref.Ref{}}
 		s._TopLeft = (<-c).(Geoposition)
 		s._BottomRight = (<-c).(Geoposition)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeorectangle(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Georectangle)
+		c <- s._TopLeft
+		c <- s._BottomRight
 	}()
 	return c
 }

--- a/clients/common/incident.noms.go
+++ b/clients/common/incident.noms.go
@@ -120,7 +120,6 @@ func (s Incident) Def() (d IncidentDef) {
 }
 
 var __typeRefForIncident types.TypeRef
-var __typeDefForIncident types.TypeRef
 
 func (m Incident) TypeRef() types.TypeRef {
 	return __typeRefForIncident
@@ -128,47 +127,13 @@ func (m Incident) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForIncident = types.MakeTypeRef(__commonPackageInFile_incident_CachedRef, 0)
-	__typeDefForIncident = types.MakeStructTypeRef("Incident",
-		[]types.Field{
-			types.Field{"ID", types.MakePrimitiveTypeRef(types.Int64Kind), false},
-			types.Field{"Category", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Description", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"DayOfWeek", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Date", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Time", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"PdDistrict", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Resolution", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Address", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
-			types.Field{"PdID", types.MakePrimitiveTypeRef(types.StringKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForIncident, builderForIncident)
-}
-
-func (s Incident) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"ID":          types.Int64(s._ID),
-		"Category":    types.NewString(s._Category),
-		"Description": types.NewString(s._Description),
-		"DayOfWeek":   types.NewString(s._DayOfWeek),
-		"Date":        types.NewString(s._Date),
-		"Time":        types.NewString(s._Time),
-		"PdDistrict":  types.NewString(s._PdDistrict),
-		"Resolution":  types.NewString(s._Resolution),
-		"Address":     types.NewString(s._Address),
-		"Geoposition": s._Geoposition,
-		"PdID":        types.NewString(s._PdID),
-	}
-	return types.NewStruct(__typeRefForIncident, __typeDefForIncident, m)
+	types.RegisterStruct(__typeRefForIncident, builderForIncident, readerForIncident)
 }
 
 func builderForIncident() chan types.Value {
 	c := make(chan types.Value)
-	s := Incident{ref: &ref.Ref{}}
 	go func() {
+		s := Incident{ref: &ref.Ref{}}
 		s._ID = int64((<-c).(types.Int64))
 		s._Category = (<-c).(types.String).String()
 		s._Description = (<-c).(types.String).String()
@@ -180,8 +145,26 @@ func builderForIncident() chan types.Value {
 		s._Address = (<-c).(types.String).String()
 		s._Geoposition = (<-c).(Geoposition)
 		s._PdID = (<-c).(types.String).String()
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForIncident(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Incident)
+		c <- types.Int64(s._ID)
+		c <- types.NewString(s._Category)
+		c <- types.NewString(s._Description)
+		c <- types.NewString(s._DayOfWeek)
+		c <- types.NewString(s._Date)
+		c <- types.NewString(s._Time)
+		c <- types.NewString(s._PdDistrict)
+		c <- types.NewString(s._Resolution)
+		c <- types.NewString(s._Address)
+		c <- s._Geoposition
+		c <- types.NewString(s._PdID)
 	}()
 	return c
 }

--- a/clients/common/photo.noms.go
+++ b/clients/common/photo.noms.go
@@ -96,7 +96,6 @@ func (s RemotePhoto) Def() (d RemotePhotoDef) {
 }
 
 var __typeRefForRemotePhoto types.TypeRef
-var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -104,45 +103,34 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__commonPackageInFile_photo_CachedRef, 0)
-	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
-			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__commonPackageInFile_photo_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
-			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
-}
-
-func (s RemotePhoto) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":          types.NewString(s._Id),
-		"Title":       types.NewString(s._Title),
-		"Url":         types.NewString(s._Url),
-		"Geoposition": s._Geoposition,
-		"Sizes":       s._Sizes,
-		"Tags":        s._Tags,
-	}
-	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
+	types.RegisterStruct(__typeRefForRemotePhoto, builderForRemotePhoto, readerForRemotePhoto)
 }
 
 func builderForRemotePhoto() chan types.Value {
 	c := make(chan types.Value)
-	s := RemotePhoto{ref: &ref.Ref{}}
 	go func() {
+		s := RemotePhoto{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Title = (<-c).(types.String).String()
 		s._Url = (<-c).(types.String).String()
 		s._Geoposition = (<-c).(Geoposition)
 		s._Sizes = (<-c).(MapOfSizeToString)
 		s._Tags = (<-c).(SetOfString)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForRemotePhoto(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(RemotePhoto)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Title)
+		c <- types.NewString(s._Url)
+		c <- s._Geoposition
+		c <- s._Sizes
+		c <- s._Tags
 	}()
 	return c
 }
@@ -261,7 +249,6 @@ func (s Size) Def() (d SizeDef) {
 }
 
 var __typeRefForSize types.TypeRef
-var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -269,33 +256,26 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__commonPackageInFile_photo_CachedRef, 1)
-	__typeDefForSize = types.MakeStructTypeRef("Size",
-		[]types.Field{
-			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
-}
-
-func (s Size) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Width":  types.UInt32(s._Width),
-		"Height": types.UInt32(s._Height),
-	}
-	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
+	types.RegisterStruct(__typeRefForSize, builderForSize, readerForSize)
 }
 
 func builderForSize() chan types.Value {
 	c := make(chan types.Value)
-	s := Size{ref: &ref.Ref{}}
 	go func() {
+		s := Size{ref: &ref.Ref{}}
 		s._Width = uint32((<-c).(types.UInt32))
 		s._Height = uint32((<-c).(types.UInt32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForSize(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Size)
+		c <- types.UInt32(s._Width)
+		c <- types.UInt32(s._Height)
 	}()
 	return c
 }

--- a/clients/common/quad_tree.noms.go
+++ b/clients/common/quad_tree.noms.go
@@ -88,7 +88,6 @@ func (s Node) Def() (d NodeDef) {
 }
 
 var __typeRefForNode types.TypeRef
-var __typeDefForNode types.TypeRef
 
 func (m Node) TypeRef() types.TypeRef {
 	return __typeRefForNode
@@ -96,33 +95,26 @@ func (m Node) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForNode = types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 0)
-	__typeDefForNode = types.MakeStructTypeRef("Node",
-		[]types.Field{
-			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
-			types.Field{"Reference", types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForNode, builderForNode)
-}
-
-func (s Node) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Geoposition": s._Geoposition,
-		"Reference":   s._Reference,
-	}
-	return types.NewStruct(__typeRefForNode, __typeDefForNode, m)
+	types.RegisterStruct(__typeRefForNode, builderForNode, readerForNode)
 }
 
 func builderForNode() chan types.Value {
 	c := make(chan types.Value)
-	s := Node{ref: &ref.Ref{}}
 	go func() {
+		s := Node{ref: &ref.Ref{}}
 		s._Geoposition = (<-c).(Geoposition)
 		s._Reference = (<-c).(RefOfValue)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForNode(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Node)
+		c <- s._Geoposition
+		c <- s._Reference
 	}()
 	return c
 }
@@ -220,7 +212,6 @@ func (s QuadTree) Def() (d QuadTreeDef) {
 }
 
 var __typeRefForQuadTree types.TypeRef
-var __typeDefForQuadTree types.TypeRef
 
 func (m QuadTree) TypeRef() types.TypeRef {
 	return __typeRefForQuadTree
@@ -228,45 +219,34 @@ func (m QuadTree) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForQuadTree = types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 1)
-	__typeDefForQuadTree = types.MakeStructTypeRef("QuadTree",
-		[]types.Field{
-			types.Field{"Nodes", types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 0)), false},
-			types.Field{"Tiles", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 1)), false},
-			types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
-			types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Georectangle", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 1), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForQuadTree, builderForQuadTree)
-}
-
-func (s QuadTree) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Nodes":          s._Nodes,
-		"Tiles":          s._Tiles,
-		"Depth":          types.UInt8(s._Depth),
-		"NumDescendents": types.UInt32(s._NumDescendents),
-		"Path":           types.NewString(s._Path),
-		"Georectangle":   s._Georectangle,
-	}
-	return types.NewStruct(__typeRefForQuadTree, __typeDefForQuadTree, m)
+	types.RegisterStruct(__typeRefForQuadTree, builderForQuadTree, readerForQuadTree)
 }
 
 func builderForQuadTree() chan types.Value {
 	c := make(chan types.Value)
-	s := QuadTree{ref: &ref.Ref{}}
 	go func() {
+		s := QuadTree{ref: &ref.Ref{}}
 		s._Nodes = (<-c).(ListOfNode)
 		s._Tiles = (<-c).(MapOfStringToQuadTree)
 		s._Depth = uint8((<-c).(types.UInt8))
 		s._NumDescendents = uint32((<-c).(types.UInt32))
 		s._Path = (<-c).(types.String).String()
 		s._Georectangle = (<-c).(Georectangle)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForQuadTree(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(QuadTree)
+		c <- s._Nodes
+		c <- s._Tiles
+		c <- types.UInt8(s._Depth)
+		c <- types.UInt32(s._NumDescendents)
+		c <- types.NewString(s._Path)
+		c <- s._Georectangle
 	}()
 	return c
 }
@@ -405,7 +385,6 @@ func (s SQuadTree) Def() (d SQuadTreeDef) {
 }
 
 var __typeRefForSQuadTree types.TypeRef
-var __typeDefForSQuadTree types.TypeRef
 
 func (m SQuadTree) TypeRef() types.TypeRef {
 	return __typeRefForSQuadTree
@@ -413,45 +392,34 @@ func (m SQuadTree) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSQuadTree = types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 2)
-	__typeDefForSQuadTree = types.MakeStructTypeRef("SQuadTree",
-		[]types.Field{
-			types.Field{"Nodes", types.MakeCompoundTypeRef(types.ListKind, types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))), false},
-			types.Field{"Tiles", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 2))), false},
-			types.Field{"Depth", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
-			types.Field{"NumDescendents", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Path", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Georectangle", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 1), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForSQuadTree, builderForSQuadTree)
-}
-
-func (s SQuadTree) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Nodes":          s._Nodes,
-		"Tiles":          s._Tiles,
-		"Depth":          types.UInt8(s._Depth),
-		"NumDescendents": types.UInt32(s._NumDescendents),
-		"Path":           types.NewString(s._Path),
-		"Georectangle":   s._Georectangle,
-	}
-	return types.NewStruct(__typeRefForSQuadTree, __typeDefForSQuadTree, m)
+	types.RegisterStruct(__typeRefForSQuadTree, builderForSQuadTree, readerForSQuadTree)
 }
 
 func builderForSQuadTree() chan types.Value {
 	c := make(chan types.Value)
-	s := SQuadTree{ref: &ref.Ref{}}
 	go func() {
+		s := SQuadTree{ref: &ref.Ref{}}
 		s._Nodes = (<-c).(ListOfRefOfValue)
 		s._Tiles = (<-c).(MapOfStringToRefOfSQuadTree)
 		s._Depth = uint8((<-c).(types.UInt8))
 		s._NumDescendents = uint32((<-c).(types.UInt32))
 		s._Path = (<-c).(types.String).String()
 		s._Georectangle = (<-c).(Georectangle)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForSQuadTree(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(SQuadTree)
+		c <- s._Nodes
+		c <- s._Tiles
+		c <- types.UInt8(s._Depth)
+		c <- types.UInt32(s._NumDescendents)
+		c <- types.NewString(s._Path)
+		c <- s._Georectangle
 	}()
 	return c
 }

--- a/clients/flickr/sha1_00419eb.go
+++ b/clients/flickr/sha1_00419eb.go
@@ -96,7 +96,6 @@ func (s RemotePhoto) Def() (d RemotePhotoDef) {
 }
 
 var __typeRefForRemotePhoto types.TypeRef
-var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -104,45 +103,34 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 0)
-	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
-			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
-			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
-}
-
-func (s RemotePhoto) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":          types.NewString(s._Id),
-		"Title":       types.NewString(s._Title),
-		"Url":         types.NewString(s._Url),
-		"Geoposition": s._Geoposition,
-		"Sizes":       s._Sizes,
-		"Tags":        s._Tags,
-	}
-	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
+	types.RegisterStruct(__typeRefForRemotePhoto, builderForRemotePhoto, readerForRemotePhoto)
 }
 
 func builderForRemotePhoto() chan types.Value {
 	c := make(chan types.Value)
-	s := RemotePhoto{ref: &ref.Ref{}}
 	go func() {
+		s := RemotePhoto{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Title = (<-c).(types.String).String()
 		s._Url = (<-c).(types.String).String()
 		s._Geoposition = (<-c).(Geoposition)
 		s._Sizes = (<-c).(MapOfSizeToString)
 		s._Tags = (<-c).(SetOfString)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForRemotePhoto(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(RemotePhoto)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Title)
+		c <- types.NewString(s._Url)
+		c <- s._Geoposition
+		c <- s._Sizes
+		c <- s._Tags
 	}()
 	return c
 }
@@ -261,7 +249,6 @@ func (s Size) Def() (d SizeDef) {
 }
 
 var __typeRefForSize types.TypeRef
-var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -269,33 +256,26 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1)
-	__typeDefForSize = types.MakeStructTypeRef("Size",
-		[]types.Field{
-			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
-}
-
-func (s Size) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Width":  types.UInt32(s._Width),
-		"Height": types.UInt32(s._Height),
-	}
-	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
+	types.RegisterStruct(__typeRefForSize, builderForSize, readerForSize)
 }
 
 func builderForSize() chan types.Value {
 	c := make(chan types.Value)
-	s := Size{ref: &ref.Ref{}}
 	go func() {
+		s := Size{ref: &ref.Ref{}}
 		s._Width = uint32((<-c).(types.UInt32))
 		s._Height = uint32((<-c).(types.UInt32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForSize(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Size)
+		c <- types.UInt32(s._Width)
+		c <- types.UInt32(s._Height)
 	}()
 	return c
 }

--- a/clients/flickr/sha1_6d5e1c5.go
+++ b/clients/flickr/sha1_6d5e1c5.go
@@ -70,7 +70,6 @@ func (s Geoposition) Def() (d GeopositionDef) {
 }
 
 var __typeRefForGeoposition types.TypeRef
-var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -78,33 +77,26 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0)
-	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
-		[]types.Field{
-			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
-}
-
-func (s Geoposition) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Latitude":  types.Float32(s._Latitude),
-		"Longitude": types.Float32(s._Longitude),
-	}
-	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
+	types.RegisterStruct(__typeRefForGeoposition, builderForGeoposition, readerForGeoposition)
 }
 
 func builderForGeoposition() chan types.Value {
 	c := make(chan types.Value)
-	s := Geoposition{ref: &ref.Ref{}}
 	go func() {
+		s := Geoposition{ref: &ref.Ref{}}
 		s._Latitude = float32((<-c).(types.Float32))
 		s._Longitude = float32((<-c).(types.Float32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeoposition(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Geoposition)
+		c <- types.Float32(s._Latitude)
+		c <- types.Float32(s._Longitude)
 	}()
 	return c
 }
@@ -180,7 +172,6 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 }
 
 var __typeRefForGeorectangle types.TypeRef
-var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -188,33 +179,26 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 1)
-	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
-		[]types.Field{
-			types.Field{"TopLeft", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
-			types.Field{"BottomRight", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
-}
-
-func (s Georectangle) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"TopLeft":     s._TopLeft,
-		"BottomRight": s._BottomRight,
-	}
-	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
+	types.RegisterStruct(__typeRefForGeorectangle, builderForGeorectangle, readerForGeorectangle)
 }
 
 func builderForGeorectangle() chan types.Value {
 	c := make(chan types.Value)
-	s := Georectangle{ref: &ref.Ref{}}
 	go func() {
+		s := Georectangle{ref: &ref.Ref{}}
 		s._TopLeft = (<-c).(Geoposition)
 		s._BottomRight = (<-c).(Geoposition)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeorectangle(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Georectangle)
+		c <- s._TopLeft
+		c <- s._BottomRight
 	}()
 	return c
 }

--- a/clients/flickr/types.noms.go
+++ b/clients/flickr/types.noms.go
@@ -92,7 +92,6 @@ func (s User) Def() (d UserDef) {
 }
 
 var __typeRefForUser types.TypeRef
-var __typeDefForUser types.TypeRef
 
 func (m User) TypeRef() types.TypeRef {
 	return __typeRefForUser
@@ -100,42 +99,32 @@ func (m User) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForUser = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-	__typeDefForUser = types.MakeStructTypeRef("User",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Name", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"OAuthToken", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"OAuthSecret", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Albums", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForUser, builderForUser)
-}
-
-func (s User) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":          types.NewString(s._Id),
-		"Name":        types.NewString(s._Name),
-		"OAuthToken":  types.NewString(s._OAuthToken),
-		"OAuthSecret": types.NewString(s._OAuthSecret),
-		"Albums":      s._Albums,
-	}
-	return types.NewStruct(__typeRefForUser, __typeDefForUser, m)
+	types.RegisterStruct(__typeRefForUser, builderForUser, readerForUser)
 }
 
 func builderForUser() chan types.Value {
 	c := make(chan types.Value)
-	s := User{ref: &ref.Ref{}}
 	go func() {
+		s := User{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Name = (<-c).(types.String).String()
 		s._OAuthToken = (<-c).(types.String).String()
 		s._OAuthSecret = (<-c).(types.String).String()
 		s._Albums = (<-c).(MapOfStringToAlbum)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForUser(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(User)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Name)
+		c <- types.NewString(s._OAuthToken)
+		c <- types.NewString(s._OAuthSecret)
+		c <- s._Albums
 	}()
 	return c
 }
@@ -247,7 +236,6 @@ func (s Album) Def() (d AlbumDef) {
 }
 
 var __typeRefForAlbum types.TypeRef
-var __typeDefForAlbum types.TypeRef
 
 func (m Album) TypeRef() types.TypeRef {
 	return __typeRefForAlbum
@@ -255,36 +243,28 @@ func (m Album) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForAlbum = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 1)
-	__typeDefForAlbum = types.MakeStructTypeRef("Album",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Photos", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0)))), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForAlbum, builderForAlbum)
-}
-
-func (s Album) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":     types.NewString(s._Id),
-		"Title":  types.NewString(s._Title),
-		"Photos": s._Photos,
-	}
-	return types.NewStruct(__typeRefForAlbum, __typeDefForAlbum, m)
+	types.RegisterStruct(__typeRefForAlbum, builderForAlbum, readerForAlbum)
 }
 
 func builderForAlbum() chan types.Value {
 	c := make(chan types.Value)
-	s := Album{ref: &ref.Ref{}}
 	go func() {
+		s := Album{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Title = (<-c).(types.String).String()
 		s._Photos = (<-c).(RefOfSetOfRefOfRemotePhoto)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForAlbum(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Album)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Title)
+		c <- s._Photos
 	}()
 	return c
 }

--- a/clients/music/mp3_importer/types.noms.go
+++ b/clients/music/mp3_importer/types.noms.go
@@ -81,7 +81,6 @@ func (s Song) Def() (d SongDef) {
 }
 
 var __typeRefForSong types.TypeRef
-var __typeDefForSong types.TypeRef
 
 func (m Song) TypeRef() types.TypeRef {
 	return __typeRefForSong
@@ -89,42 +88,32 @@ func (m Song) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSong = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-	__typeDefForSong = types.MakeStructTypeRef("Song",
-		[]types.Field{
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Artist", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Album", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Year", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Mp3", types.MakePrimitiveTypeRef(types.BlobKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForSong, builderForSong)
-}
-
-func (s Song) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Title":  types.NewString(s._Title),
-		"Artist": types.NewString(s._Artist),
-		"Album":  types.NewString(s._Album),
-		"Year":   types.NewString(s._Year),
-		"Mp3":    s._Mp3,
-	}
-	return types.NewStruct(__typeRefForSong, __typeDefForSong, m)
+	types.RegisterStruct(__typeRefForSong, builderForSong, readerForSong)
 }
 
 func builderForSong() chan types.Value {
 	c := make(chan types.Value)
-	s := Song{ref: &ref.Ref{}}
 	go func() {
+		s := Song{ref: &ref.Ref{}}
 		s._Title = (<-c).(types.String).String()
 		s._Artist = (<-c).(types.String).String()
 		s._Album = (<-c).(types.String).String()
 		s._Year = (<-c).(types.String).String()
 		s._Mp3 = (<-c).(types.Blob)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForSong(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Song)
+		c <- types.NewString(s._Title)
+		c <- types.NewString(s._Artist)
+		c <- types.NewString(s._Album)
+		c <- types.NewString(s._Year)
+		c <- s._Mp3
 	}()
 	return c
 }

--- a/clients/picasa/picasa.noms.go
+++ b/clients/picasa/picasa.noms.go
@@ -99,7 +99,6 @@ func (s User) Def() (d UserDef) {
 }
 
 var __typeRefForUser types.TypeRef
-var __typeDefForUser types.TypeRef
 
 func (m User) TypeRef() types.TypeRef {
 	return __typeRefForUser
@@ -107,45 +106,34 @@ func (m User) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForUser = types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 0)
-	__typeDefForUser = types.MakeStructTypeRef("User",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Name", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Albums", types.MakeCompoundTypeRef(types.MapKind, types.MakePrimitiveTypeRef(types.StringKind), types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 1)), false},
-			types.Field{"RefreshToken", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"OAuthToken", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"OAuthSecret", types.MakePrimitiveTypeRef(types.StringKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForUser, builderForUser)
-}
-
-func (s User) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":           types.NewString(s._Id),
-		"Name":         types.NewString(s._Name),
-		"Albums":       s._Albums,
-		"RefreshToken": types.NewString(s._RefreshToken),
-		"OAuthToken":   types.NewString(s._OAuthToken),
-		"OAuthSecret":  types.NewString(s._OAuthSecret),
-	}
-	return types.NewStruct(__typeRefForUser, __typeDefForUser, m)
+	types.RegisterStruct(__typeRefForUser, builderForUser, readerForUser)
 }
 
 func builderForUser() chan types.Value {
 	c := make(chan types.Value)
-	s := User{ref: &ref.Ref{}}
 	go func() {
+		s := User{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Name = (<-c).(types.String).String()
 		s._Albums = (<-c).(MapOfStringToAlbum)
 		s._RefreshToken = (<-c).(types.String).String()
 		s._OAuthToken = (<-c).(types.String).String()
 		s._OAuthSecret = (<-c).(types.String).String()
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForUser(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(User)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Name)
+		c <- s._Albums
+		c <- types.NewString(s._RefreshToken)
+		c <- types.NewString(s._OAuthToken)
+		c <- types.NewString(s._OAuthSecret)
 	}()
 	return c
 }
@@ -272,7 +260,6 @@ func (s Album) Def() (d AlbumDef) {
 }
 
 var __typeRefForAlbum types.TypeRef
-var __typeDefForAlbum types.TypeRef
 
 func (m Album) TypeRef() types.TypeRef {
 	return __typeRefForAlbum
@@ -280,39 +267,30 @@ func (m Album) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForAlbum = types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 1)
-	__typeDefForAlbum = types.MakeStructTypeRef("Album",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"NumPhotos", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Photos", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0)))), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForAlbum, builderForAlbum)
-}
-
-func (s Album) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":        types.NewString(s._Id),
-		"Title":     types.NewString(s._Title),
-		"NumPhotos": types.UInt32(s._NumPhotos),
-		"Photos":    s._Photos,
-	}
-	return types.NewStruct(__typeRefForAlbum, __typeDefForAlbum, m)
+	types.RegisterStruct(__typeRefForAlbum, builderForAlbum, readerForAlbum)
 }
 
 func builderForAlbum() chan types.Value {
 	c := make(chan types.Value)
-	s := Album{ref: &ref.Ref{}}
 	go func() {
+		s := Album{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Title = (<-c).(types.String).String()
 		s._NumPhotos = uint32((<-c).(types.UInt32))
 		s._Photos = (<-c).(RefOfSetOfRefOfRemotePhoto)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForAlbum(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Album)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Title)
+		c <- types.UInt32(s._NumPhotos)
+		c <- s._Photos
 	}()
 	return c
 }

--- a/clients/picasa/sha1_00419eb.go
+++ b/clients/picasa/sha1_00419eb.go
@@ -96,7 +96,6 @@ func (s RemotePhoto) Def() (d RemotePhotoDef) {
 }
 
 var __typeRefForRemotePhoto types.TypeRef
-var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -104,45 +103,34 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 0)
-	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
-			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
-			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
-}
-
-func (s RemotePhoto) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":          types.NewString(s._Id),
-		"Title":       types.NewString(s._Title),
-		"Url":         types.NewString(s._Url),
-		"Geoposition": s._Geoposition,
-		"Sizes":       s._Sizes,
-		"Tags":        s._Tags,
-	}
-	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
+	types.RegisterStruct(__typeRefForRemotePhoto, builderForRemotePhoto, readerForRemotePhoto)
 }
 
 func builderForRemotePhoto() chan types.Value {
 	c := make(chan types.Value)
-	s := RemotePhoto{ref: &ref.Ref{}}
 	go func() {
+		s := RemotePhoto{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Title = (<-c).(types.String).String()
 		s._Url = (<-c).(types.String).String()
 		s._Geoposition = (<-c).(Geoposition)
 		s._Sizes = (<-c).(MapOfSizeToString)
 		s._Tags = (<-c).(SetOfString)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForRemotePhoto(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(RemotePhoto)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Title)
+		c <- types.NewString(s._Url)
+		c <- s._Geoposition
+		c <- s._Sizes
+		c <- s._Tags
 	}()
 	return c
 }
@@ -261,7 +249,6 @@ func (s Size) Def() (d SizeDef) {
 }
 
 var __typeRefForSize types.TypeRef
-var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -269,33 +256,26 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1)
-	__typeDefForSize = types.MakeStructTypeRef("Size",
-		[]types.Field{
-			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
-}
-
-func (s Size) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Width":  types.UInt32(s._Width),
-		"Height": types.UInt32(s._Height),
-	}
-	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
+	types.RegisterStruct(__typeRefForSize, builderForSize, readerForSize)
 }
 
 func builderForSize() chan types.Value {
 	c := make(chan types.Value)
-	s := Size{ref: &ref.Ref{}}
 	go func() {
+		s := Size{ref: &ref.Ref{}}
 		s._Width = uint32((<-c).(types.UInt32))
 		s._Height = uint32((<-c).(types.UInt32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForSize(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Size)
+		c <- types.UInt32(s._Width)
+		c <- types.UInt32(s._Height)
 	}()
 	return c
 }

--- a/clients/picasa/sha1_6d5e1c5.go
+++ b/clients/picasa/sha1_6d5e1c5.go
@@ -70,7 +70,6 @@ func (s Geoposition) Def() (d GeopositionDef) {
 }
 
 var __typeRefForGeoposition types.TypeRef
-var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -78,33 +77,26 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0)
-	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
-		[]types.Field{
-			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
-}
-
-func (s Geoposition) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Latitude":  types.Float32(s._Latitude),
-		"Longitude": types.Float32(s._Longitude),
-	}
-	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
+	types.RegisterStruct(__typeRefForGeoposition, builderForGeoposition, readerForGeoposition)
 }
 
 func builderForGeoposition() chan types.Value {
 	c := make(chan types.Value)
-	s := Geoposition{ref: &ref.Ref{}}
 	go func() {
+		s := Geoposition{ref: &ref.Ref{}}
 		s._Latitude = float32((<-c).(types.Float32))
 		s._Longitude = float32((<-c).(types.Float32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeoposition(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Geoposition)
+		c <- types.Float32(s._Latitude)
+		c <- types.Float32(s._Longitude)
 	}()
 	return c
 }
@@ -180,7 +172,6 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 }
 
 var __typeRefForGeorectangle types.TypeRef
-var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -188,33 +179,26 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 1)
-	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
-		[]types.Field{
-			types.Field{"TopLeft", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
-			types.Field{"BottomRight", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
-}
-
-func (s Georectangle) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"TopLeft":     s._TopLeft,
-		"BottomRight": s._BottomRight,
-	}
-	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
+	types.RegisterStruct(__typeRefForGeorectangle, builderForGeorectangle, readerForGeorectangle)
 }
 
 func builderForGeorectangle() chan types.Value {
 	c := make(chan types.Value)
-	s := Georectangle{ref: &ref.Ref{}}
 	go func() {
+		s := Georectangle{ref: &ref.Ref{}}
 		s._TopLeft = (<-c).(Geoposition)
 		s._BottomRight = (<-c).(Geoposition)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeorectangle(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Georectangle)
+		c <- s._TopLeft
+		c <- s._BottomRight
 	}()
 	return c
 }

--- a/clients/pitchmap/index/types.noms.go
+++ b/clients/pitchmap/index/types.noms.go
@@ -63,7 +63,6 @@ func (s Pitch) Def() (d PitchDef) {
 }
 
 var __typeRefForPitch types.TypeRef
-var __typeDefForPitch types.TypeRef
 
 func (m Pitch) TypeRef() types.TypeRef {
 	return __typeRefForPitch
@@ -71,33 +70,26 @@ func (m Pitch) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForPitch = types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0)
-	__typeDefForPitch = types.MakeStructTypeRef("Pitch",
-		[]types.Field{
-			types.Field{"X", types.MakePrimitiveTypeRef(types.Float64Kind), false},
-			types.Field{"Z", types.MakePrimitiveTypeRef(types.Float64Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForPitch, builderForPitch)
-}
-
-func (s Pitch) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"X": types.Float64(s._X),
-		"Z": types.Float64(s._Z),
-	}
-	return types.NewStruct(__typeRefForPitch, __typeDefForPitch, m)
+	types.RegisterStruct(__typeRefForPitch, builderForPitch, readerForPitch)
 }
 
 func builderForPitch() chan types.Value {
 	c := make(chan types.Value)
-	s := Pitch{ref: &ref.Ref{}}
 	go func() {
+		s := Pitch{ref: &ref.Ref{}}
 		s._X = float64((<-c).(types.Float64))
 		s._Z = float64((<-c).(types.Float64))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForPitch(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Pitch)
+		c <- types.Float64(s._X)
+		c <- types.Float64(s._Z)
 	}()
 	return c
 }

--- a/clients/tagdex/sha1_00419eb.go
+++ b/clients/tagdex/sha1_00419eb.go
@@ -96,7 +96,6 @@ func (s RemotePhoto) Def() (d RemotePhotoDef) {
 }
 
 var __typeRefForRemotePhoto types.TypeRef
-var __typeDefForRemotePhoto types.TypeRef
 
 func (m RemotePhoto) TypeRef() types.TypeRef {
 	return __typeRefForRemotePhoto
@@ -104,45 +103,34 @@ func (m RemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRemotePhoto = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 0)
-	__typeDefForRemotePhoto = types.MakeStructTypeRef("RemotePhoto",
-		[]types.Field{
-			types.Field{"Id", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Title", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Url", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"Geoposition", types.MakeTypeRef(ref.Parse("sha1-6d5e1c54214264058be9f61f4b4ece0368c8c678"), 0), false},
-			types.Field{"Sizes", types.MakeCompoundTypeRef(types.MapKind, types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1), types.MakePrimitiveTypeRef(types.StringKind)), false},
-			types.Field{"Tags", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.StringKind)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForRemotePhoto, builderForRemotePhoto)
-}
-
-func (s RemotePhoto) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Id":          types.NewString(s._Id),
-		"Title":       types.NewString(s._Title),
-		"Url":         types.NewString(s._Url),
-		"Geoposition": s._Geoposition,
-		"Sizes":       s._Sizes,
-		"Tags":        s._Tags,
-	}
-	return types.NewStruct(__typeRefForRemotePhoto, __typeDefForRemotePhoto, m)
+	types.RegisterStruct(__typeRefForRemotePhoto, builderForRemotePhoto, readerForRemotePhoto)
 }
 
 func builderForRemotePhoto() chan types.Value {
 	c := make(chan types.Value)
-	s := RemotePhoto{ref: &ref.Ref{}}
 	go func() {
+		s := RemotePhoto{ref: &ref.Ref{}}
 		s._Id = (<-c).(types.String).String()
 		s._Title = (<-c).(types.String).String()
 		s._Url = (<-c).(types.String).String()
 		s._Geoposition = (<-c).(Geoposition)
 		s._Sizes = (<-c).(MapOfSizeToString)
 		s._Tags = (<-c).(SetOfString)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForRemotePhoto(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(RemotePhoto)
+		c <- types.NewString(s._Id)
+		c <- types.NewString(s._Title)
+		c <- types.NewString(s._Url)
+		c <- s._Geoposition
+		c <- s._Sizes
+		c <- s._Tags
 	}()
 	return c
 }
@@ -261,7 +249,6 @@ func (s Size) Def() (d SizeDef) {
 }
 
 var __typeRefForSize types.TypeRef
-var __typeDefForSize types.TypeRef
 
 func (m Size) TypeRef() types.TypeRef {
 	return __typeRefForSize
@@ -269,33 +256,26 @@ func (m Size) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForSize = types.MakeTypeRef(__mainPackageInFile_sha1_00419eb_CachedRef, 1)
-	__typeDefForSize = types.MakeStructTypeRef("Size",
-		[]types.Field{
-			types.Field{"Width", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"Height", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForSize, builderForSize)
-}
-
-func (s Size) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Width":  types.UInt32(s._Width),
-		"Height": types.UInt32(s._Height),
-	}
-	return types.NewStruct(__typeRefForSize, __typeDefForSize, m)
+	types.RegisterStruct(__typeRefForSize, builderForSize, readerForSize)
 }
 
 func builderForSize() chan types.Value {
 	c := make(chan types.Value)
-	s := Size{ref: &ref.Ref{}}
 	go func() {
+		s := Size{ref: &ref.Ref{}}
 		s._Width = uint32((<-c).(types.UInt32))
 		s._Height = uint32((<-c).(types.UInt32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForSize(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Size)
+		c <- types.UInt32(s._Width)
+		c <- types.UInt32(s._Height)
 	}()
 	return c
 }

--- a/clients/tagdex/sha1_6d5e1c5.go
+++ b/clients/tagdex/sha1_6d5e1c5.go
@@ -70,7 +70,6 @@ func (s Geoposition) Def() (d GeopositionDef) {
 }
 
 var __typeRefForGeoposition types.TypeRef
-var __typeDefForGeoposition types.TypeRef
 
 func (m Geoposition) TypeRef() types.TypeRef {
 	return __typeRefForGeoposition
@@ -78,33 +77,26 @@ func (m Geoposition) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeoposition = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0)
-	__typeDefForGeoposition = types.MakeStructTypeRef("Geoposition",
-		[]types.Field{
-			types.Field{"Latitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-			types.Field{"Longitude", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeoposition, builderForGeoposition)
-}
-
-func (s Geoposition) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Latitude":  types.Float32(s._Latitude),
-		"Longitude": types.Float32(s._Longitude),
-	}
-	return types.NewStruct(__typeRefForGeoposition, __typeDefForGeoposition, m)
+	types.RegisterStruct(__typeRefForGeoposition, builderForGeoposition, readerForGeoposition)
 }
 
 func builderForGeoposition() chan types.Value {
 	c := make(chan types.Value)
-	s := Geoposition{ref: &ref.Ref{}}
 	go func() {
+		s := Geoposition{ref: &ref.Ref{}}
 		s._Latitude = float32((<-c).(types.Float32))
 		s._Longitude = float32((<-c).(types.Float32))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeoposition(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Geoposition)
+		c <- types.Float32(s._Latitude)
+		c <- types.Float32(s._Longitude)
 	}()
 	return c
 }
@@ -180,7 +172,6 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 }
 
 var __typeRefForGeorectangle types.TypeRef
-var __typeDefForGeorectangle types.TypeRef
 
 func (m Georectangle) TypeRef() types.TypeRef {
 	return __typeRefForGeorectangle
@@ -188,33 +179,26 @@ func (m Georectangle) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForGeorectangle = types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 1)
-	__typeDefForGeorectangle = types.MakeStructTypeRef("Georectangle",
-		[]types.Field{
-			types.Field{"TopLeft", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
-			types.Field{"BottomRight", types.MakeTypeRef(__mainPackageInFile_sha1_6d5e1c5_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForGeorectangle, builderForGeorectangle)
-}
-
-func (s Georectangle) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"TopLeft":     s._TopLeft,
-		"BottomRight": s._BottomRight,
-	}
-	return types.NewStruct(__typeRefForGeorectangle, __typeDefForGeorectangle, m)
+	types.RegisterStruct(__typeRefForGeorectangle, builderForGeorectangle, readerForGeorectangle)
 }
 
 func builderForGeorectangle() chan types.Value {
 	c := make(chan types.Value)
-	s := Georectangle{ref: &ref.Ref{}}
 	go func() {
+		s := Georectangle{ref: &ref.Ref{}}
 		s._TopLeft = (<-c).(Geoposition)
 		s._BottomRight = (<-c).(Geoposition)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForGeorectangle(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Georectangle)
+		c <- s._TopLeft
+		c <- s._BottomRight
 	}()
 	return c
 }

--- a/datas/types.noms.go
+++ b/datas/types.noms.go
@@ -64,7 +64,6 @@ func (s Commit) Def() (d CommitDef) {
 }
 
 var __typeRefForCommit types.TypeRef
-var __typeDefForCommit types.TypeRef
 
 func (m Commit) TypeRef() types.TypeRef {
 	return __typeRefForCommit
@@ -72,33 +71,26 @@ func (m Commit) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForCommit = types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0)
-	__typeDefForCommit = types.MakeStructTypeRef("Commit",
-		[]types.Field{
-			types.Field{"value", types.MakePrimitiveTypeRef(types.ValueKind), false},
-			types.Field{"parents", types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0))), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForCommit, builderForCommit)
-}
-
-func (s Commit) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"value":   s._value,
-		"parents": s._parents,
-	}
-	return types.NewStruct(__typeRefForCommit, __typeDefForCommit, m)
+	types.RegisterStruct(__typeRefForCommit, builderForCommit, readerForCommit)
 }
 
 func builderForCommit() chan types.Value {
 	c := make(chan types.Value)
-	s := Commit{ref: &ref.Ref{}}
 	go func() {
+		s := Commit{ref: &ref.Ref{}}
 		s._value = (<-c)
 		s._parents = (<-c).(SetOfRefOfCommit)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForCommit(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Commit)
+		c <- s._value
+		c <- s._parents
 	}()
 	return c
 }

--- a/nomdl/codegen/struct.tmpl
+++ b/nomdl/codegen/struct.tmpl
@@ -46,7 +46,6 @@ func New{{.Name}}() {{.Name}} {
 {{end}}
 
 var __typeRefFor{{.Name}} {{$typesPackage}}TypeRef
-var __typeDefFor{{.Name}} {{$typesPackage}}TypeRef
 
 func (m {{.Name}}) TypeRef() {{$typesPackage}}TypeRef {
 	return __typeRefFor{{.Name}}
@@ -54,37 +53,38 @@ func (m {{.Name}}) TypeRef() {{$typesPackage}}TypeRef {
 
 func init() {
 	__typeRefFor{{.Name}} = {{$typesPackage}}MakeTypeRef(__{{.PackageName}}PackageInFile_{{.FileID}}_CachedRef, {{.Ordinal}})
-	__typeDefFor{{.Name}} = {{toTypesTypeRef .Type .FileID .PackageName}}
-	{{$typesPackage}}RegisterStructBuilder(__typeRefFor{{.Name}}, builderFor{{.Name}})
-}
-
-func (s {{.Name}}) InternalImplementation() {{$typesPackage}}Struct {
-	// TODO: Remove this
-	m := map[string]{{$typesPackage}}Value{
-		{{range .Fields}}{{if (not .Optional)}}"{{.Name}}": {{userToValue (printf "s._%s" .Name) .T}},
-		{{end}}{{end}}
-	}{{range .Fields}}{{if .Optional}}
-	if s.__optional{{.Name}} {
-		m["{{.Name}}"] = {{userToValue (printf "s._%s" .Name) .T}}
-	}{{end}}{{end}}{{if .HasUnion}}
-	m[__typeDefFor{{.Name}}.Desc.({{$typesPackage}}StructDesc).Union[s.__unionIndex].Name] = s.__unionValue{{end}}
-	return {{$typesPackage}}NewStruct(__typeRefFor{{.Name}}, __typeDefFor{{.Name}}, m)
+	{{$typesPackage}}RegisterStruct(__typeRefFor{{.Name}}, builderFor{{.Name}}, readerFor{{.Name}})
 }
 
 func builderFor{{.Name}}() chan {{$typesPackage}}Value {
 	c := make(chan {{$typesPackage}}Value)
-	s := {{.Name}}{ref: &ref.Ref{}}
-	go func() { {{range .Fields}}{{if .Optional}}
+	go func() {
+		s := {{.Name}}{ref: &ref.Ref{}}{{range .Fields}}{{if .Optional}}
 		s.__optional{{.Name}} = bool((<-c).({{$typesPackage}}Bool))
 		if s.__optional{{.Name}} {
 			s._{{.Name}} = {{valueToUser "(<-c)" .T}}
 		}{{else}}
 		s._{{.Name}} = {{valueToUser "(<-c)" .T}}{{end}}{{end}}
 		{{if .HasUnion}}s.__unionIndex = uint32((<-c).({{$typesPackage}}UInt32))
-		s.__unionValue = <-c{{end}}
-		c <- s	
+		s.__unionValue = <-c
+		{{end}}c <- s
 	}()
-	return c	
+	return c
+}
+
+func readerFor{{.Name}}(v {{$typesPackage}}Value) chan {{$typesPackage}}Value {
+	c := make(chan {{$typesPackage}}Value)
+	go func() {
+		s := v.({{.Name}}){{range .Fields}}{{if .Optional}}
+		c <- {{$typesPackage}}Bool(s.__optional{{.Name}})
+		if s.__optional{{.Name}} {
+			c <- {{userToValue (printf "s._%s" .Name) .T}}
+		}{{else}}
+		c <- {{userToValue (printf "s._%s" .Name) .T}}{{end}}{{end}}
+		{{if .HasUnion}}c <- {{$typesPackage}}UInt32(s.__unionIndex)
+		c <- s.__unionValue
+	{{end}} }()
+	return c
 }
 
 func (s {{.Name}}) Equals(other {{$typesPackage}}Value) bool {

--- a/nomdl/codegen/test/gen/enum_struct.noms.go
+++ b/nomdl/codegen/test/gen/enum_struct.noms.go
@@ -102,7 +102,6 @@ func (s EnumStruct) Def() (d EnumStructDef) {
 }
 
 var __typeRefForEnumStruct types.TypeRef
-var __typeDefForEnumStruct types.TypeRef
 
 func (m EnumStruct) TypeRef() types.TypeRef {
 	return __typeRefForEnumStruct
@@ -110,30 +109,24 @@ func (m EnumStruct) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForEnumStruct = types.MakeTypeRef(__genPackageInFile_enum_struct_CachedRef, 1)
-	__typeDefForEnumStruct = types.MakeStructTypeRef("EnumStruct",
-		[]types.Field{
-			types.Field{"hand", types.MakeTypeRef(__genPackageInFile_enum_struct_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForEnumStruct, builderForEnumStruct)
-}
-
-func (s EnumStruct) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"hand": s._hand,
-	}
-	return types.NewStruct(__typeRefForEnumStruct, __typeDefForEnumStruct, m)
+	types.RegisterStruct(__typeRefForEnumStruct, builderForEnumStruct, readerForEnumStruct)
 }
 
 func builderForEnumStruct() chan types.Value {
 	c := make(chan types.Value)
-	s := EnumStruct{ref: &ref.Ref{}}
 	go func() {
+		s := EnumStruct{ref: &ref.Ref{}}
 		s._hand = (<-c).(Handedness)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForEnumStruct(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(EnumStruct)
+		c <- s._hand
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/ref.noms.go
+++ b/nomdl/codegen/test/gen/ref.noms.go
@@ -58,7 +58,6 @@ func (s StructWithRef) Def() (d StructWithRefDef) {
 }
 
 var __typeRefForStructWithRef types.TypeRef
-var __typeDefForStructWithRef types.TypeRef
 
 func (m StructWithRef) TypeRef() types.TypeRef {
 	return __typeRefForStructWithRef
@@ -66,30 +65,24 @@ func (m StructWithRef) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithRef = types.MakeTypeRef(__genPackageInFile_ref_CachedRef, 0)
-	__typeDefForStructWithRef = types.MakeStructTypeRef("StructWithRef",
-		[]types.Field{
-			types.Field{"r", types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind))), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForStructWithRef, builderForStructWithRef)
-}
-
-func (s StructWithRef) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"r": s._r,
-	}
-	return types.NewStruct(__typeRefForStructWithRef, __typeDefForStructWithRef, m)
+	types.RegisterStruct(__typeRefForStructWithRef, builderForStructWithRef, readerForStructWithRef)
 }
 
 func builderForStructWithRef() chan types.Value {
 	c := make(chan types.Value)
-	s := StructWithRef{ref: &ref.Ref{}}
 	go func() {
+		s := StructWithRef{ref: &ref.Ref{}}
 		s._r = (<-c).(RefOfSetOfFloat32)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForStructWithRef(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(StructWithRef)
+		c <- s._r
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/sha1_09d2fdd.go
+++ b/nomdl/codegen/test/gen/sha1_09d2fdd.go
@@ -71,7 +71,6 @@ func (s D) Def() (d DDef) {
 }
 
 var __typeRefForD types.TypeRef
-var __typeDefForD types.TypeRef
 
 func (m D) TypeRef() types.TypeRef {
 	return __typeRefForD
@@ -79,33 +78,26 @@ func (m D) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForD = types.MakeTypeRef(__genPackageInFile_sha1_09d2fdd_CachedRef, 0)
-	__typeDefForD = types.MakeStructTypeRef("D",
-		[]types.Field{
-			types.Field{"structField", types.MakeTypeRef(ref.Parse("sha1-1c216c6f1d6989e4ede5f78b7689214948dabeef"), 0), false},
-			types.Field{"enumField", types.MakeTypeRef(ref.Parse("sha1-1c216c6f1d6989e4ede5f78b7689214948dabeef"), 1), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForD, builderForD)
-}
-
-func (s D) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"structField": s._structField,
-		"enumField":   s._enumField,
-	}
-	return types.NewStruct(__typeRefForD, __typeDefForD, m)
+	types.RegisterStruct(__typeRefForD, builderForD, readerForD)
 }
 
 func builderForD() chan types.Value {
 	c := make(chan types.Value)
-	s := D{ref: &ref.Ref{}}
 	go func() {
+		s := D{ref: &ref.Ref{}}
 		s._structField = (<-c).(S)
 		s._enumField = (<-c).(E)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForD(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(D)
+		c <- s._structField
+		c <- s._enumField
 	}()
 	return c
 }
@@ -177,7 +169,6 @@ func (s DUser) Def() (d DUserDef) {
 }
 
 var __typeRefForDUser types.TypeRef
-var __typeDefForDUser types.TypeRef
 
 func (m DUser) TypeRef() types.TypeRef {
 	return __typeRefForDUser
@@ -185,30 +176,24 @@ func (m DUser) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForDUser = types.MakeTypeRef(__genPackageInFile_sha1_09d2fdd_CachedRef, 1)
-	__typeDefForDUser = types.MakeStructTypeRef("DUser",
-		[]types.Field{
-			types.Field{"Dfield", types.MakeTypeRef(__genPackageInFile_sha1_09d2fdd_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForDUser, builderForDUser)
-}
-
-func (s DUser) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"Dfield": s._Dfield,
-	}
-	return types.NewStruct(__typeRefForDUser, __typeDefForDUser, m)
+	types.RegisterStruct(__typeRefForDUser, builderForDUser, readerForDUser)
 }
 
 func builderForDUser() chan types.Value {
 	c := make(chan types.Value)
-	s := DUser{ref: &ref.Ref{}}
 	go func() {
+		s := DUser{ref: &ref.Ref{}}
 		s._Dfield = (<-c).(D)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForDUser(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(DUser)
+		c <- s._Dfield
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/sha1_1c216c6.go
+++ b/nomdl/codegen/test/gen/sha1_1c216c6.go
@@ -64,7 +64,6 @@ func (s S) Def() (d SDef) {
 }
 
 var __typeRefForS types.TypeRef
-var __typeDefForS types.TypeRef
 
 func (m S) TypeRef() types.TypeRef {
 	return __typeRefForS
@@ -72,33 +71,26 @@ func (m S) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForS = types.MakeTypeRef(__genPackageInFile_sha1_1c216c6_CachedRef, 0)
-	__typeDefForS = types.MakeStructTypeRef("S",
-		[]types.Field{
-			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForS, builderForS)
-}
-
-func (s S) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"s": types.NewString(s._s),
-		"b": types.Bool(s._b),
-	}
-	return types.NewStruct(__typeRefForS, __typeDefForS, m)
+	types.RegisterStruct(__typeRefForS, builderForS, readerForS)
 }
 
 func builderForS() chan types.Value {
 	c := make(chan types.Value)
-	s := S{ref: &ref.Ref{}}
 	go func() {
+		s := S{ref: &ref.Ref{}}
 		s._s = (<-c).(types.String).String()
 		s._b = bool((<-c).(types.Bool))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForS(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(S)
+		c <- types.NewString(s._s)
+		c <- types.Bool(s._b)
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct.noms.go
+++ b/nomdl/codegen/test/gen/struct.noms.go
@@ -63,7 +63,6 @@ func (s Struct) Def() (d StructDef) {
 }
 
 var __typeRefForStruct types.TypeRef
-var __typeDefForStruct types.TypeRef
 
 func (m Struct) TypeRef() types.TypeRef {
 	return __typeRefForStruct
@@ -71,33 +70,26 @@ func (m Struct) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStruct = types.MakeTypeRef(__genPackageInFile_struct_CachedRef, 0)
-	__typeDefForStruct = types.MakeStructTypeRef("Struct",
-		[]types.Field{
-			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForStruct, builderForStruct)
-}
-
-func (s Struct) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"s": types.NewString(s._s),
-		"b": types.Bool(s._b),
-	}
-	return types.NewStruct(__typeRefForStruct, __typeDefForStruct, m)
+	types.RegisterStruct(__typeRefForStruct, builderForStruct, readerForStruct)
 }
 
 func builderForStruct() chan types.Value {
 	c := make(chan types.Value)
-	s := Struct{ref: &ref.Ref{}}
 	go func() {
+		s := Struct{ref: &ref.Ref{}}
 		s._s = (<-c).(types.String).String()
 		s._b = bool((<-c).(types.Bool))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForStruct(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Struct)
+		c <- types.NewString(s._s)
+		c <- types.Bool(s._b)
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_optional.noms.go
+++ b/nomdl/codegen/test/gen/struct_optional.noms.go
@@ -69,7 +69,6 @@ func (s OptionalStruct) Def() (d OptionalStructDef) {
 }
 
 var __typeRefForOptionalStruct types.TypeRef
-var __typeDefForOptionalStruct types.TypeRef
 
 func (m OptionalStruct) TypeRef() types.TypeRef {
 	return __typeRefForOptionalStruct
@@ -77,32 +76,13 @@ func (m OptionalStruct) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForOptionalStruct = types.MakeTypeRef(__genPackageInFile_struct_optional_CachedRef, 0)
-	__typeDefForOptionalStruct = types.MakeStructTypeRef("OptionalStruct",
-		[]types.Field{
-			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), true},
-			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), true},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForOptionalStruct, builderForOptionalStruct)
-}
-
-func (s OptionalStruct) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{}
-	if s.__optionals {
-		m["s"] = types.NewString(s._s)
-	}
-	if s.__optionalb {
-		m["b"] = types.Bool(s._b)
-	}
-	return types.NewStruct(__typeRefForOptionalStruct, __typeDefForOptionalStruct, m)
+	types.RegisterStruct(__typeRefForOptionalStruct, builderForOptionalStruct, readerForOptionalStruct)
 }
 
 func builderForOptionalStruct() chan types.Value {
 	c := make(chan types.Value)
-	s := OptionalStruct{ref: &ref.Ref{}}
 	go func() {
+		s := OptionalStruct{ref: &ref.Ref{}}
 		s.__optionals = bool((<-c).(types.Bool))
 		if s.__optionals {
 			s._s = (<-c).(types.String).String()
@@ -111,8 +91,23 @@ func builderForOptionalStruct() chan types.Value {
 		if s.__optionalb {
 			s._b = bool((<-c).(types.Bool))
 		}
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForOptionalStruct(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(OptionalStruct)
+		c <- types.Bool(s.__optionals)
+		if s.__optionals {
+			c <- types.NewString(s._s)
+		}
+		c <- types.Bool(s.__optionalb)
+		if s.__optionalb {
+			c <- types.Bool(s._b)
+		}
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_primitives.noms.go
+++ b/nomdl/codegen/test/gen/struct_primitives.noms.go
@@ -135,7 +135,6 @@ func (s StructPrimitives) Def() (d StructPrimitivesDef) {
 }
 
 var __typeRefForStructPrimitives types.TypeRef
-var __typeDefForStructPrimitives types.TypeRef
 
 func (m StructPrimitives) TypeRef() types.TypeRef {
 	return __typeRefForStructPrimitives
@@ -143,53 +142,13 @@ func (m StructPrimitives) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructPrimitives = types.MakeTypeRef(__genPackageInFile_struct_primitives_CachedRef, 0)
-	__typeDefForStructPrimitives = types.MakeStructTypeRef("StructPrimitives",
-		[]types.Field{
-			types.Field{"uint64", types.MakePrimitiveTypeRef(types.UInt64Kind), false},
-			types.Field{"uint32", types.MakePrimitiveTypeRef(types.UInt32Kind), false},
-			types.Field{"uint16", types.MakePrimitiveTypeRef(types.UInt16Kind), false},
-			types.Field{"uint8", types.MakePrimitiveTypeRef(types.UInt8Kind), false},
-			types.Field{"int64", types.MakePrimitiveTypeRef(types.Int64Kind), false},
-			types.Field{"int32", types.MakePrimitiveTypeRef(types.Int32Kind), false},
-			types.Field{"int16", types.MakePrimitiveTypeRef(types.Int16Kind), false},
-			types.Field{"int8", types.MakePrimitiveTypeRef(types.Int8Kind), false},
-			types.Field{"float64", types.MakePrimitiveTypeRef(types.Float64Kind), false},
-			types.Field{"float32", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-			types.Field{"bool", types.MakePrimitiveTypeRef(types.BoolKind), false},
-			types.Field{"string", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"blob", types.MakePrimitiveTypeRef(types.BlobKind), false},
-			types.Field{"value", types.MakePrimitiveTypeRef(types.ValueKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForStructPrimitives, builderForStructPrimitives)
-}
-
-func (s StructPrimitives) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"uint64":  types.UInt64(s._uint64),
-		"uint32":  types.UInt32(s._uint32),
-		"uint16":  types.UInt16(s._uint16),
-		"uint8":   types.UInt8(s._uint8),
-		"int64":   types.Int64(s._int64),
-		"int32":   types.Int32(s._int32),
-		"int16":   types.Int16(s._int16),
-		"int8":    types.Int8(s._int8),
-		"float64": types.Float64(s._float64),
-		"float32": types.Float32(s._float32),
-		"bool":    types.Bool(s._bool),
-		"string":  types.NewString(s._string),
-		"blob":    s._blob,
-		"value":   s._value,
-	}
-	return types.NewStruct(__typeRefForStructPrimitives, __typeDefForStructPrimitives, m)
+	types.RegisterStruct(__typeRefForStructPrimitives, builderForStructPrimitives, readerForStructPrimitives)
 }
 
 func builderForStructPrimitives() chan types.Value {
 	c := make(chan types.Value)
-	s := StructPrimitives{ref: &ref.Ref{}}
 	go func() {
+		s := StructPrimitives{ref: &ref.Ref{}}
 		s._uint64 = uint64((<-c).(types.UInt64))
 		s._uint32 = uint32((<-c).(types.UInt32))
 		s._uint16 = uint16((<-c).(types.UInt16))
@@ -204,8 +163,29 @@ func builderForStructPrimitives() chan types.Value {
 		s._string = (<-c).(types.String).String()
 		s._blob = (<-c).(types.Blob)
 		s._value = (<-c)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForStructPrimitives(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(StructPrimitives)
+		c <- types.UInt64(s._uint64)
+		c <- types.UInt32(s._uint32)
+		c <- types.UInt16(s._uint16)
+		c <- types.UInt8(s._uint8)
+		c <- types.Int64(s._int64)
+		c <- types.Int32(s._int32)
+		c <- types.Int16(s._int16)
+		c <- types.Int8(s._int8)
+		c <- types.Float64(s._float64)
+		c <- types.Float32(s._float32)
+		c <- types.Bool(s._bool)
+		c <- types.NewString(s._string)
+		c <- s._blob
+		c <- s._value
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_recursive.noms.go
+++ b/nomdl/codegen/test/gen/struct_recursive.noms.go
@@ -57,7 +57,6 @@ func (s Tree) Def() (d TreeDef) {
 }
 
 var __typeRefForTree types.TypeRef
-var __typeDefForTree types.TypeRef
 
 func (m Tree) TypeRef() types.TypeRef {
 	return __typeRefForTree
@@ -65,30 +64,24 @@ func (m Tree) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForTree = types.MakeTypeRef(__genPackageInFile_struct_recursive_CachedRef, 0)
-	__typeDefForTree = types.MakeStructTypeRef("Tree",
-		[]types.Field{
-			types.Field{"children", types.MakeCompoundTypeRef(types.ListKind, types.MakeTypeRef(__genPackageInFile_struct_recursive_CachedRef, 0)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForTree, builderForTree)
-}
-
-func (s Tree) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"children": s._children,
-	}
-	return types.NewStruct(__typeRefForTree, __typeDefForTree, m)
+	types.RegisterStruct(__typeRefForTree, builderForTree, readerForTree)
 }
 
 func builderForTree() chan types.Value {
 	c := make(chan types.Value)
-	s := Tree{ref: &ref.Ref{}}
 	go func() {
+		s := Tree{ref: &ref.Ref{}}
 		s._children = (<-c).(ListOfTree)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForTree(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(Tree)
+		c <- s._children
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_with_dup_list.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_dup_list.noms.go
@@ -57,7 +57,6 @@ func (s StructWithDupList) Def() (d StructWithDupListDef) {
 }
 
 var __typeRefForStructWithDupList types.TypeRef
-var __typeDefForStructWithDupList types.TypeRef
 
 func (m StructWithDupList) TypeRef() types.TypeRef {
 	return __typeRefForStructWithDupList
@@ -65,30 +64,24 @@ func (m StructWithDupList) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithDupList = types.MakeTypeRef(__genPackageInFile_struct_with_dup_list_CachedRef, 0)
-	__typeDefForStructWithDupList = types.MakeStructTypeRef("StructWithDupList",
-		[]types.Field{
-			types.Field{"l", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForStructWithDupList, builderForStructWithDupList)
-}
-
-func (s StructWithDupList) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"l": s._l,
-	}
-	return types.NewStruct(__typeRefForStructWithDupList, __typeDefForStructWithDupList, m)
+	types.RegisterStruct(__typeRefForStructWithDupList, builderForStructWithDupList, readerForStructWithDupList)
 }
 
 func builderForStructWithDupList() chan types.Value {
 	c := make(chan types.Value)
-	s := StructWithDupList{ref: &ref.Ref{}}
 	go func() {
+		s := StructWithDupList{ref: &ref.Ref{}}
 		s._l = (<-c).(ListOfUInt8)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForStructWithDupList(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(StructWithDupList)
+		c <- s._l
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_with_imports.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_imports.noms.go
@@ -109,7 +109,6 @@ func (s ImportUser) Def() (d ImportUserDef) {
 }
 
 var __typeRefForImportUser types.TypeRef
-var __typeDefForImportUser types.TypeRef
 
 func (m ImportUser) TypeRef() types.TypeRef {
 	return __typeRefForImportUser
@@ -117,33 +116,26 @@ func (m ImportUser) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForImportUser = types.MakeTypeRef(__genPackageInFile_struct_with_imports_CachedRef, 1)
-	__typeDefForImportUser = types.MakeStructTypeRef("ImportUser",
-		[]types.Field{
-			types.Field{"importedStruct", types.MakeTypeRef(ref.Parse("sha1-09d2fdd9743c4daec6deebbbc1a38f75ad088eca"), 0), false},
-			types.Field{"enum", types.MakeTypeRef(__genPackageInFile_struct_with_imports_CachedRef, 0), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForImportUser, builderForImportUser)
-}
-
-func (s ImportUser) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"importedStruct": s._importedStruct,
-		"enum":           s._enum,
-	}
-	return types.NewStruct(__typeRefForImportUser, __typeDefForImportUser, m)
+	types.RegisterStruct(__typeRefForImportUser, builderForImportUser, readerForImportUser)
 }
 
 func builderForImportUser() chan types.Value {
 	c := make(chan types.Value)
-	s := ImportUser{ref: &ref.Ref{}}
 	go func() {
+		s := ImportUser{ref: &ref.Ref{}}
 		s._importedStruct = (<-c).(D)
 		s._enum = (<-c).(LocalE)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForImportUser(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(ImportUser)
+		c <- s._importedStruct
+		c <- s._enum
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_with_list.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_list.noms.go
@@ -75,7 +75,6 @@ func (s StructWithList) Def() (d StructWithListDef) {
 }
 
 var __typeRefForStructWithList types.TypeRef
-var __typeDefForStructWithList types.TypeRef
 
 func (m StructWithList) TypeRef() types.TypeRef {
 	return __typeRefForStructWithList
@@ -83,39 +82,30 @@ func (m StructWithList) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithList = types.MakeTypeRef(__genPackageInFile_struct_with_list_CachedRef, 0)
-	__typeDefForStructWithList = types.MakeStructTypeRef("StructWithList",
-		[]types.Field{
-			types.Field{"l", types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
-			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
-			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"i", types.MakePrimitiveTypeRef(types.Int64Kind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForStructWithList, builderForStructWithList)
-}
-
-func (s StructWithList) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"l": s._l,
-		"b": types.Bool(s._b),
-		"s": types.NewString(s._s),
-		"i": types.Int64(s._i),
-	}
-	return types.NewStruct(__typeRefForStructWithList, __typeDefForStructWithList, m)
+	types.RegisterStruct(__typeRefForStructWithList, builderForStructWithList, readerForStructWithList)
 }
 
 func builderForStructWithList() chan types.Value {
 	c := make(chan types.Value)
-	s := StructWithList{ref: &ref.Ref{}}
 	go func() {
+		s := StructWithList{ref: &ref.Ref{}}
 		s._l = (<-c).(ListOfUInt8)
 		s._b = bool((<-c).(types.Bool))
 		s._s = (<-c).(types.String).String()
 		s._i = int64((<-c).(types.Int64))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForStructWithList(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(StructWithList)
+		c <- s._l
+		c <- types.Bool(s._b)
+		c <- types.NewString(s._s)
+		c <- types.Int64(s._i)
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_with_union_field.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_union_field.noms.go
@@ -71,7 +71,6 @@ func (s StructWithUnionField) Def() (d StructWithUnionFieldDef) {
 }
 
 var __typeRefForStructWithUnionField types.TypeRef
-var __typeDefForStructWithUnionField types.TypeRef
 
 func (m StructWithUnionField) TypeRef() types.TypeRef {
 	return __typeRefForStructWithUnionField
@@ -79,38 +78,28 @@ func (m StructWithUnionField) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithUnionField = types.MakeTypeRef(__genPackageInFile_struct_with_union_field_CachedRef, 0)
-	__typeDefForStructWithUnionField = types.MakeStructTypeRef("StructWithUnionField",
-		[]types.Field{
-			types.Field{"a", types.MakePrimitiveTypeRef(types.Float32Kind), false},
-		},
-		types.Choices{
-			types.Field{"b", types.MakePrimitiveTypeRef(types.Float64Kind), false},
-			types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"d", types.MakePrimitiveTypeRef(types.BlobKind), false},
-			types.Field{"e", types.MakePrimitiveTypeRef(types.ValueKind), false},
-			types.Field{"f", types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.UInt8Kind)), false},
-		},
-	)
-	types.RegisterStructBuilder(__typeRefForStructWithUnionField, builderForStructWithUnionField)
-}
-
-func (s StructWithUnionField) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"a": types.Float32(s._a),
-	}
-	m[__typeDefForStructWithUnionField.Desc.(types.StructDesc).Union[s.__unionIndex].Name] = s.__unionValue
-	return types.NewStruct(__typeRefForStructWithUnionField, __typeDefForStructWithUnionField, m)
+	types.RegisterStruct(__typeRefForStructWithUnionField, builderForStructWithUnionField, readerForStructWithUnionField)
 }
 
 func builderForStructWithUnionField() chan types.Value {
 	c := make(chan types.Value)
-	s := StructWithUnionField{ref: &ref.Ref{}}
 	go func() {
+		s := StructWithUnionField{ref: &ref.Ref{}}
 		s._a = float32((<-c).(types.Float32))
 		s.__unionIndex = uint32((<-c).(types.UInt32))
 		s.__unionValue = <-c
 		c <- s
+	}()
+	return c
+}
+
+func readerForStructWithUnionField(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(StructWithUnionField)
+		c <- types.Float32(s._a)
+		c <- types.UInt32(s.__unionIndex)
+		c <- s.__unionValue
 	}()
 	return c
 }

--- a/nomdl/codegen/test/gen/struct_with_unions.noms.go
+++ b/nomdl/codegen/test/gen/struct_with_unions.noms.go
@@ -77,7 +77,6 @@ func (s StructWithUnions) Def() (d StructWithUnionsDef) {
 }
 
 var __typeRefForStructWithUnions types.TypeRef
-var __typeDefForStructWithUnions types.TypeRef
 
 func (m StructWithUnions) TypeRef() types.TypeRef {
 	return __typeRefForStructWithUnions
@@ -85,33 +84,26 @@ func (m StructWithUnions) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForStructWithUnions = types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 0)
-	__typeDefForStructWithUnions = types.MakeStructTypeRef("StructWithUnions",
-		[]types.Field{
-			types.Field{"a", types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 1), false},
-			types.Field{"d", types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 2), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForStructWithUnions, builderForStructWithUnions)
-}
-
-func (s StructWithUnions) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"a": s._a,
-		"d": s._d,
-	}
-	return types.NewStruct(__typeRefForStructWithUnions, __typeDefForStructWithUnions, m)
+	types.RegisterStruct(__typeRefForStructWithUnions, builderForStructWithUnions, readerForStructWithUnions)
 }
 
 func builderForStructWithUnions() chan types.Value {
 	c := make(chan types.Value)
-	s := StructWithUnions{ref: &ref.Ref{}}
 	go func() {
+		s := StructWithUnions{ref: &ref.Ref{}}
 		s._a = (<-c).(__unionOfBOfFloat64AndCOfString)
 		s._d = (<-c).(__unionOfEOfFloat64AndFOfString)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForStructWithUnions(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(StructWithUnions)
+		c <- s._a
+		c <- s._d
 	}()
 	return c
 }
@@ -187,7 +179,6 @@ func (s __unionOfBOfFloat64AndCOfString) Def() (d __unionOfBOfFloat64AndCOfStrin
 }
 
 var __typeRefFor__unionOfBOfFloat64AndCOfString types.TypeRef
-var __typeDefFor__unionOfBOfFloat64AndCOfString types.TypeRef
 
 func (m __unionOfBOfFloat64AndCOfString) TypeRef() types.TypeRef {
 	return __typeRefFor__unionOfBOfFloat64AndCOfString
@@ -195,30 +186,26 @@ func (m __unionOfBOfFloat64AndCOfString) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefFor__unionOfBOfFloat64AndCOfString = types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 1)
-	__typeDefFor__unionOfBOfFloat64AndCOfString = types.MakeStructTypeRef("",
-		[]types.Field{},
-		types.Choices{
-			types.Field{"b", types.MakePrimitiveTypeRef(types.Float64Kind), false},
-			types.Field{"c", types.MakePrimitiveTypeRef(types.StringKind), false},
-		},
-	)
-	types.RegisterStructBuilder(__typeRefFor__unionOfBOfFloat64AndCOfString, builderFor__unionOfBOfFloat64AndCOfString)
-}
-
-func (s __unionOfBOfFloat64AndCOfString) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{}
-	m[__typeDefFor__unionOfBOfFloat64AndCOfString.Desc.(types.StructDesc).Union[s.__unionIndex].Name] = s.__unionValue
-	return types.NewStruct(__typeRefFor__unionOfBOfFloat64AndCOfString, __typeDefFor__unionOfBOfFloat64AndCOfString, m)
+	types.RegisterStruct(__typeRefFor__unionOfBOfFloat64AndCOfString, builderFor__unionOfBOfFloat64AndCOfString, readerFor__unionOfBOfFloat64AndCOfString)
 }
 
 func builderFor__unionOfBOfFloat64AndCOfString() chan types.Value {
 	c := make(chan types.Value)
-	s := __unionOfBOfFloat64AndCOfString{ref: &ref.Ref{}}
 	go func() {
+		s := __unionOfBOfFloat64AndCOfString{ref: &ref.Ref{}}
 		s.__unionIndex = uint32((<-c).(types.UInt32))
 		s.__unionValue = <-c
 		c <- s
+	}()
+	return c
+}
+
+func readerFor__unionOfBOfFloat64AndCOfString(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(__unionOfBOfFloat64AndCOfString)
+		c <- types.UInt32(s.__unionIndex)
+		c <- s.__unionValue
 	}()
 	return c
 }
@@ -327,7 +314,6 @@ func (s __unionOfEOfFloat64AndFOfString) Def() (d __unionOfEOfFloat64AndFOfStrin
 }
 
 var __typeRefFor__unionOfEOfFloat64AndFOfString types.TypeRef
-var __typeDefFor__unionOfEOfFloat64AndFOfString types.TypeRef
 
 func (m __unionOfEOfFloat64AndFOfString) TypeRef() types.TypeRef {
 	return __typeRefFor__unionOfEOfFloat64AndFOfString
@@ -335,30 +321,26 @@ func (m __unionOfEOfFloat64AndFOfString) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefFor__unionOfEOfFloat64AndFOfString = types.MakeTypeRef(__genPackageInFile_struct_with_unions_CachedRef, 2)
-	__typeDefFor__unionOfEOfFloat64AndFOfString = types.MakeStructTypeRef("",
-		[]types.Field{},
-		types.Choices{
-			types.Field{"e", types.MakePrimitiveTypeRef(types.Float64Kind), false},
-			types.Field{"f", types.MakePrimitiveTypeRef(types.StringKind), false},
-		},
-	)
-	types.RegisterStructBuilder(__typeRefFor__unionOfEOfFloat64AndFOfString, builderFor__unionOfEOfFloat64AndFOfString)
-}
-
-func (s __unionOfEOfFloat64AndFOfString) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{}
-	m[__typeDefFor__unionOfEOfFloat64AndFOfString.Desc.(types.StructDesc).Union[s.__unionIndex].Name] = s.__unionValue
-	return types.NewStruct(__typeRefFor__unionOfEOfFloat64AndFOfString, __typeDefFor__unionOfEOfFloat64AndFOfString, m)
+	types.RegisterStruct(__typeRefFor__unionOfEOfFloat64AndFOfString, builderFor__unionOfEOfFloat64AndFOfString, readerFor__unionOfEOfFloat64AndFOfString)
 }
 
 func builderFor__unionOfEOfFloat64AndFOfString() chan types.Value {
 	c := make(chan types.Value)
-	s := __unionOfEOfFloat64AndFOfString{ref: &ref.Ref{}}
 	go func() {
+		s := __unionOfEOfFloat64AndFOfString{ref: &ref.Ref{}}
 		s.__unionIndex = uint32((<-c).(types.UInt32))
 		s.__unionValue = <-c
 		c <- s
+	}()
+	return c
+}
+
+func readerFor__unionOfEOfFloat64AndFOfString(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(__unionOfEOfFloat64AndFOfString)
+		c <- types.UInt32(s.__unionIndex)
+		c <- s.__unionValue
 	}()
 	return c
 }

--- a/nomdl/codegen/test/struct_primitives_test.go
+++ b/nomdl/codegen/test/struct_primitives_test.go
@@ -117,11 +117,3 @@ func TestAccessors(t *testing.T) {
 	st = st.SetValue(types.NewString("x"))
 	assert.True(st.Value().Equals(types.NewString("x")))
 }
-
-func TestStructBackingMapKeyNames(t *testing.T) {
-	assert := assert.New(t)
-
-	s := gen.NewStructPrimitives().SetBool(true)
-
-	assert.True(bool(s.InternalImplementation().Get("bool").(types.Bool)))
-}

--- a/nomdl/codegen/testDeps/leafDep/leafDep.noms.go
+++ b/nomdl/codegen/testDeps/leafDep/leafDep.noms.go
@@ -64,7 +64,6 @@ func (s S) Def() (d SDef) {
 }
 
 var __typeRefForS types.TypeRef
-var __typeDefForS types.TypeRef
 
 func (m S) TypeRef() types.TypeRef {
 	return __typeRefForS
@@ -72,33 +71,26 @@ func (m S) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForS = types.MakeTypeRef(__leafDepPackageInFile_leafDep_CachedRef, 0)
-	__typeDefForS = types.MakeStructTypeRef("S",
-		[]types.Field{
-			types.Field{"s", types.MakePrimitiveTypeRef(types.StringKind), false},
-			types.Field{"b", types.MakePrimitiveTypeRef(types.BoolKind), false},
-		},
-		types.Choices{},
-	)
-	types.RegisterStructBuilder(__typeRefForS, builderForS)
-}
-
-func (s S) InternalImplementation() types.Struct {
-	// TODO: Remove this
-	m := map[string]types.Value{
-		"s": types.NewString(s._s),
-		"b": types.Bool(s._b),
-	}
-	return types.NewStruct(__typeRefForS, __typeDefForS, m)
+	types.RegisterStruct(__typeRefForS, builderForS, readerForS)
 }
 
 func builderForS() chan types.Value {
 	c := make(chan types.Value)
-	s := S{ref: &ref.Ref{}}
 	go func() {
+		s := S{ref: &ref.Ref{}}
 		s._s = (<-c).(types.String).String()
 		s._b = bool((<-c).(types.Bool))
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForS(v types.Value) chan types.Value {
+	c := make(chan types.Value)
+	go func() {
+		s := v.(S)
+		c <- types.NewString(s._s)
+		c <- types.Bool(s._b)
 	}()
 	return c
 }

--- a/types/compound_blob_struct.noms.go
+++ b/types/compound_blob_struct.noms.go
@@ -63,7 +63,6 @@ func (s compoundBlobStruct) Def() (d compoundBlobStructDef) {
 }
 
 var __typeRefForcompoundBlobStruct TypeRef
-var __typeDefForcompoundBlobStruct TypeRef
 
 func (m compoundBlobStruct) TypeRef() TypeRef {
 	return __typeRefForcompoundBlobStruct
@@ -71,33 +70,26 @@ func (m compoundBlobStruct) TypeRef() TypeRef {
 
 func init() {
 	__typeRefForcompoundBlobStruct = MakeTypeRef(__typesPackageInFile_compound_blob_struct_CachedRef, 0)
-	__typeDefForcompoundBlobStruct = MakeStructTypeRef("compoundBlobStruct",
-		[]Field{
-			Field{"Offsets", MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(UInt64Kind)), false},
-			Field{"Blobs", MakeCompoundTypeRef(ListKind, MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(BlobKind))), false},
-		},
-		Choices{},
-	)
-	RegisterStructBuilder(__typeRefForcompoundBlobStruct, builderForcompoundBlobStruct)
-}
-
-func (s compoundBlobStruct) InternalImplementation() Struct {
-	// TODO: Remove this
-	m := map[string]Value{
-		"Offsets": s._Offsets,
-		"Blobs":   s._Blobs,
-	}
-	return NewStruct(__typeRefForcompoundBlobStruct, __typeDefForcompoundBlobStruct, m)
+	RegisterStruct(__typeRefForcompoundBlobStruct, builderForcompoundBlobStruct, readerForcompoundBlobStruct)
 }
 
 func builderForcompoundBlobStruct() chan Value {
 	c := make(chan Value)
-	s := compoundBlobStruct{ref: &ref.Ref{}}
 	go func() {
+		s := compoundBlobStruct{ref: &ref.Ref{}}
 		s._Offsets = (<-c).(ListOfUInt64)
 		s._Blobs = (<-c).(ListOfRefOfBlob)
-
 		c <- s
+	}()
+	return c
+}
+
+func readerForcompoundBlobStruct(v Value) chan Value {
+	c := make(chan Value)
+	go func() {
+		s := v.(compoundBlobStruct)
+		c <- s._Offsets
+		c <- s._Blobs
 	}()
 	return c
 }

--- a/types/struct.go
+++ b/types/struct.go
@@ -184,3 +184,29 @@ func structBuilder(typeRef, typeDef TypeRef) chan Value {
 
 	return c
 }
+
+func structReader(s Struct, typeRef, typeDef TypeRef) chan Value {
+	c := make(chan Value)
+
+	go func() {
+		desc := typeDef.Desc.(StructDesc)
+		for _, f := range desc.Fields {
+			v, ok := s.data[f.Name]
+			if f.Optional {
+				c <- Bool(ok)
+				if ok {
+					c <- v
+				}
+			} else {
+				d.Chk.True(ok)
+				c <- v
+			}
+		}
+		if len(desc.Union) > 0 {
+			c <- UInt32(s.unionIndex)
+			c <- s.unionValue
+		}
+	}()
+
+	return c
+}


### PR DESCRIPTION
By adding a reader to structs we can remove the function that exposes
the internal implementation details of a struct.
