### PR TITLE
Make sure that we call fixupTypeRef before we use the Ref

### DIFF
--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -261,7 +261,6 @@ func (w *jsonArrayWriter) writeBlob(b Blob) {
 
 func (w *jsonArrayWriter) writeStruct(v Value, typeRef, typeDef TypeRef, pkg *Package) {
 	typeRef = fixupTypeRef(typeRef, pkg)
-	typeDef = fixupTypeRef(typeDef, pkg)
 
 	c := structReaderForTypeRef(v, typeRef, typeDef)
 	desc := typeDef.Desc.(StructDesc)


### PR DESCRIPTION
The Ref of a TypeRef is used in a maps and then it is important that
we fix all empty refs to point at the current package.

Remove unneeded calls to fixupTypeRef and make sure we call it just
before using the TypeRef as a key in a map.
