### PR TITLE
Clean up registration of Ref values

### DIFF
--- a/clients/common/incident.noms.go
+++ b/clients/common/incident.noms.go
@@ -472,9 +472,11 @@ func (m RefOfIncident) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfIncident = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__commonPackageInFile_incident_CachedRef, 0))
-	types.RegisterFromValFunction(__typeRefForRefOfIncident, func(v types.Value) types.Value {
-		return NewRefOfIncident(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfIncident, builderForRefOfIncident)
+}
+
+func builderForRefOfIncident(r ref.Ref) types.Value {
+	return NewRefOfIncident(r)
 }
 
 func (r RefOfIncident) TargetValue(cs chunks.ChunkSource) Incident {

--- a/clients/common/quad_tree.noms.go
+++ b/clients/common/quad_tree.noms.go
@@ -538,9 +538,11 @@ func (m RefOfValue) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfValue = types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.ValueKind))
-	types.RegisterFromValFunction(__typeRefForRefOfValue, func(v types.Value) types.Value {
-		return NewRefOfValue(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfValue, builderForRefOfValue)
+}
+
+func builderForRefOfValue(r ref.Ref) types.Value {
+	return NewRefOfValue(r)
 }
 
 func (r RefOfValue) TargetValue(cs chunks.ChunkSource) types.Value {
@@ -1123,9 +1125,11 @@ func (m RefOfSQuadTree) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfSQuadTree = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__commonPackageInFile_quad_tree_CachedRef, 2))
-	types.RegisterFromValFunction(__typeRefForRefOfSQuadTree, func(v types.Value) types.Value {
-		return NewRefOfSQuadTree(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfSQuadTree, builderForRefOfSQuadTree)
+}
+
+func builderForRefOfSQuadTree(r ref.Ref) types.Value {
+	return NewRefOfSQuadTree(r)
 }
 
 func (r RefOfSQuadTree) TargetValue(cs chunks.ChunkSource) SQuadTree {

--- a/clients/flickr/types.noms.go
+++ b/clients/flickr/types.noms.go
@@ -477,9 +477,11 @@ func (m RefOfUser) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfUser = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__mainPackageInFile_types_CachedRef, 0))
-	types.RegisterFromValFunction(__typeRefForRefOfUser, func(v types.Value) types.Value {
-		return NewRefOfUser(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfUser, builderForRefOfUser)
+}
+
+func builderForRefOfUser(r ref.Ref) types.Value {
+	return NewRefOfUser(r)
 }
 
 func (r RefOfUser) TargetValue(cs chunks.ChunkSource) User {
@@ -528,9 +530,11 @@ func (m RefOfSetOfRefOfRemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfSetOfRefOfRemotePhoto = types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0))))
-	types.RegisterFromValFunction(__typeRefForRefOfSetOfRefOfRemotePhoto, func(v types.Value) types.Value {
-		return NewRefOfSetOfRefOfRemotePhoto(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfSetOfRefOfRemotePhoto, builderForRefOfSetOfRefOfRemotePhoto)
+}
+
+func builderForRefOfSetOfRefOfRemotePhoto(r ref.Ref) types.Value {
+	return NewRefOfSetOfRefOfRemotePhoto(r)
 }
 
 func (r RefOfSetOfRefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) SetOfRefOfRemotePhoto {
@@ -727,9 +731,11 @@ func (m RefOfRemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfRemotePhoto = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0))
-	types.RegisterFromValFunction(__typeRefForRefOfRemotePhoto, func(v types.Value) types.Value {
-		return NewRefOfRemotePhoto(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfRemotePhoto, builderForRefOfRemotePhoto)
+}
+
+func builderForRefOfRemotePhoto(r ref.Ref) types.Value {
+	return NewRefOfRemotePhoto(r)
 }
 
 func (r RefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) RemotePhoto {

--- a/clients/picasa/picasa.noms.go
+++ b/clients/picasa/picasa.noms.go
@@ -640,9 +640,11 @@ func (m RefOfUser) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfUser = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__mainPackageInFile_picasa_CachedRef, 0))
-	types.RegisterFromValFunction(__typeRefForRefOfUser, func(v types.Value) types.Value {
-		return NewRefOfUser(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfUser, builderForRefOfUser)
+}
+
+func builderForRefOfUser(r ref.Ref) types.Value {
+	return NewRefOfUser(r)
 }
 
 func (r RefOfUser) TargetValue(cs chunks.ChunkSource) User {
@@ -691,9 +693,11 @@ func (m RefOfSetOfRefOfRemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfSetOfRefOfRemotePhoto = types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0))))
-	types.RegisterFromValFunction(__typeRefForRefOfSetOfRefOfRemotePhoto, func(v types.Value) types.Value {
-		return NewRefOfSetOfRefOfRemotePhoto(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfSetOfRefOfRemotePhoto, builderForRefOfSetOfRefOfRemotePhoto)
+}
+
+func builderForRefOfSetOfRefOfRemotePhoto(r ref.Ref) types.Value {
+	return NewRefOfSetOfRefOfRemotePhoto(r)
 }
 
 func (r RefOfSetOfRefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) SetOfRefOfRemotePhoto {
@@ -890,9 +894,11 @@ func (m RefOfRemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfRemotePhoto = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0))
-	types.RegisterFromValFunction(__typeRefForRefOfRemotePhoto, func(v types.Value) types.Value {
-		return NewRefOfRemotePhoto(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfRemotePhoto, builderForRefOfRemotePhoto)
+}
+
+func builderForRefOfRemotePhoto(r ref.Ref) types.Value {
+	return NewRefOfRemotePhoto(r)
 }
 
 func (r RefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) RemotePhoto {

--- a/clients/tagdex/types.noms.go
+++ b/clients/tagdex/types.noms.go
@@ -320,9 +320,11 @@ func (m RefOfRemotePhoto) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfRemotePhoto = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(ref.Parse("sha1-00419ebbb418539af67238164b20341913efeb4d"), 0))
-	types.RegisterFromValFunction(__typeRefForRefOfRemotePhoto, func(v types.Value) types.Value {
-		return NewRefOfRemotePhoto(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfRemotePhoto, builderForRefOfRemotePhoto)
+}
+
+func builderForRefOfRemotePhoto(r ref.Ref) types.Value {
+	return NewRefOfRemotePhoto(r)
 }
 
 func (r RefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) RemotePhoto {

--- a/datas/types.noms.go
+++ b/datas/types.noms.go
@@ -442,9 +442,11 @@ func (m RefOfCommit) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfCommit = types.MakeCompoundTypeRef(types.RefKind, types.MakeTypeRef(__datasPackageInFile_types_CachedRef, 0))
-	types.RegisterFromValFunction(__typeRefForRefOfCommit, func(v types.Value) types.Value {
-		return NewRefOfCommit(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfCommit, builderForRefOfCommit)
+}
+
+func builderForRefOfCommit(r ref.Ref) types.Value {
+	return NewRefOfCommit(r)
 }
 
 func (r RefOfCommit) TargetValue(cs chunks.ChunkSource) Commit {

--- a/nomdl/codegen/ref.tmpl
+++ b/nomdl/codegen/ref.tmpl
@@ -38,9 +38,11 @@ func (m {{.Name}}) TypeRef() {{$typesPackage}}TypeRef {
 
 func init() {
 	__typeRefFor{{.Name}} = {{toTypesTypeRef .Type .FileID .PackageName}}
-	{{$typesPackage}}RegisterFromValFunction(__typeRefFor{{.Name}}, func(v {{$typesPackage}}Value) {{$typesPackage}}Value {
-		return New{{.Name}}(v.({{$typesPackage}}Ref).TargetRef())
-	})
+	{{$typesPackage}}RegisterRef(__typeRefFor{{.Name}}, builderFor{{.Name}})
+}
+
+func builderFor{{.Name}}(r ref.Ref) {{$typesPackage}}Value {
+	return New{{.Name}}(r)
 }
 
 func (r {{.Name}}) TargetValue(cs chunks.ChunkSource) {{userType .ElemType}} {

--- a/nomdl/codegen/test/gen/ref.noms.go
+++ b/nomdl/codegen/test/gen/ref.noms.go
@@ -149,9 +149,11 @@ func (m RefOfListOfString) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfListOfString = types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.ListKind, types.MakePrimitiveTypeRef(types.StringKind)))
-	types.RegisterFromValFunction(__typeRefForRefOfListOfString, func(v types.Value) types.Value {
-		return NewRefOfListOfString(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfListOfString, builderForRefOfListOfString)
+}
+
+func builderForRefOfListOfString(r ref.Ref) types.Value {
+	return NewRefOfListOfString(r)
 }
 
 func (r RefOfListOfString) TargetValue(cs chunks.ChunkSource) ListOfString {
@@ -341,9 +343,11 @@ func (m RefOfSetOfFloat32) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfSetOfFloat32 = types.MakeCompoundTypeRef(types.RefKind, types.MakeCompoundTypeRef(types.SetKind, types.MakePrimitiveTypeRef(types.Float32Kind)))
-	types.RegisterFromValFunction(__typeRefForRefOfSetOfFloat32, func(v types.Value) types.Value {
-		return NewRefOfSetOfFloat32(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfSetOfFloat32, builderForRefOfSetOfFloat32)
+}
+
+func builderForRefOfSetOfFloat32(r ref.Ref) types.Value {
+	return NewRefOfSetOfFloat32(r)
 }
 
 func (r RefOfSetOfFloat32) TargetValue(cs chunks.ChunkSource) SetOfFloat32 {
@@ -533,9 +537,11 @@ func (m RefOfFloat32) TypeRef() types.TypeRef {
 
 func init() {
 	__typeRefForRefOfFloat32 = types.MakeCompoundTypeRef(types.RefKind, types.MakePrimitiveTypeRef(types.Float32Kind))
-	types.RegisterFromValFunction(__typeRefForRefOfFloat32, func(v types.Value) types.Value {
-		return NewRefOfFloat32(v.(types.Ref).TargetRef())
-	})
+	types.RegisterRef(__typeRefForRefOfFloat32, builderForRefOfFloat32)
+}
+
+func builderForRefOfFloat32(r ref.Ref) types.Value {
+	return NewRefOfFloat32(r)
 }
 
 func (r RefOfFloat32) TargetValue(cs chunks.ChunkSource) float32 {

--- a/types/compound_blob_struct.noms.go
+++ b/types/compound_blob_struct.noms.go
@@ -449,9 +449,11 @@ func (m RefOfBlob) TypeRef() TypeRef {
 
 func init() {
 	__typeRefForRefOfBlob = MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(BlobKind))
-	RegisterFromValFunction(__typeRefForRefOfBlob, func(v Value) Value {
-		return NewRefOfBlob(v.(Ref).TargetRef())
-	})
+	RegisterRef(__typeRefForRefOfBlob, builderForRefOfBlob)
+}
+
+func builderForRefOfBlob(r ref.Ref) Value {
+	return NewRefOfBlob(r)
 }
 
 func (r RefOfBlob) TargetValue(cs chunks.ChunkSource) Blob {

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -158,9 +158,8 @@ func (r *jsonArrayReader) readPackage(t TypeRef, pkg *Package) Value {
 
 func (r *jsonArrayReader) readRefValue(t TypeRef, pkg *Package) Value {
 	ref := r.readRef()
-	v := NewRef(ref)
 	t = fixupTypeRef(t, pkg)
-	return ToNomsValueFromTypeRef(t, v)
+	return refFromTypeRef(ref, t)
 }
 
 func (r *jsonArrayReader) readTopLevelValue() Value {

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -109,14 +109,8 @@ func TestReadListOfValue(t *testing.T) {
 
 	a := parseJson(`[%d, %d, [%d, 1, %d, "hi", %d, true]]`, ListKind, ValueKind, Int32Kind, StringKind, BoolKind)
 	r := newJsonArrayReader(a, cs)
-
-	listTr := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
-	RegisterFromValFunction(listTr, func(v Value) Value {
-		return v
-	})
-
 	l := r.readTopLevelValue()
-	assert.EqualValues(NewList(Int32(1), NewString("hi"), Bool(true)), l)
+	assert.True(NewList(Int32(1), NewString("hi"), Bool(true)).Equals(l))
 }
 
 func TestReadValueListOfInt8(t *testing.T) {
@@ -390,15 +384,8 @@ func TestReadRef(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	r := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
-
 	a := parseJson(`[%d, %d, "%s"]`, RefKind, UInt32Kind, r.String())
 	reader := newJsonArrayReader(a, cs)
-
-	refTr := MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(UInt32Kind))
-	RegisterFromValFunction(refTr, func(v Value) Value {
-		return v
-	})
-
 	v := reader.readTopLevelValue()
 	assert.True(NewRef(r).Equals(v))
 }
@@ -408,15 +395,8 @@ func TestReadValueRef(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	r := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
-
 	a := parseJson(`[%d, %d, %d, "%s"]`, ValueKind, RefKind, UInt32Kind, r.String())
 	reader := newJsonArrayReader(a, cs)
-
-	refTypeRef := MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(UInt32Kind))
-	RegisterFromValFunction(refTypeRef, func(v Value) Value {
-		return v
-	})
-
 	v := reader.readTopLevelValue()
 	assert.True(NewRef(r).Equals(v))
 }
@@ -446,13 +426,7 @@ func TestReadStructWithEnum(t *testing.T) {
 
 	a := parseJson(`[%d, "%s", 0, 42, 1, true]`, UnresolvedKind, pkgRef.String())
 	r := newJsonArrayReader(a, cs)
-
-	structTr := MakeTypeRef(pkgRef, 0)
-	RegisterFromValFunction(structTr, func(v Value) Value {
-		return v
-	})
 	enumTr := MakeTypeRef(pkgRef, 1)
-
 	v := r.readTopLevelValue().(Struct)
 
 	assert.True(v.Get("x").Equals(Int16(42)))

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -104,7 +104,7 @@ func (w *jsonArrayWriter) writeValue(v Value, tr TypeRef, pkg *Package) {
 		}
 		w.write(w3.toArray())
 	case RefKind:
-		w.writeRef(getRefFromRefKind(v))
+		w.writeRef(v.(RefBase).TargetRef())
 	case SetKind:
 		w2 := newJsonArrayWriter(w.cs)
 		elemType := tr.Desc.(CompoundDesc).ElemTypes[0]
@@ -129,15 +129,6 @@ func (w *jsonArrayWriter) writeValue(v Value, tr TypeRef, pkg *Package) {
 	default:
 		d.Chk.Fail("Unknown NomsKind")
 	}
-}
-
-// TODO: This is ugly. BUG 452
-type refImplementation interface {
-	TargetRef() ref.Ref
-}
-
-func getRefFromRefKind(v Value) ref.Ref {
-	return v.(refImplementation).TargetRef()
 }
 
 func (w *jsonArrayWriter) writeTypeRefAsValue(v TypeRef) {

--- a/types/list.go
+++ b/types/list.go
@@ -20,12 +20,6 @@ type MapFunc func(v Value, index uint64) interface{}
 
 var listTypeRef = MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
 
-func init() {
-	RegisterFromValFunction(listTypeRef, func(v Value) Value {
-		return v.(List)
-	})
-}
-
 func NewList(v ...Value) List {
 	// Copy because Noms values are supposed to be immutable and Go allows v to be reused (thus mutable).
 	values := make([]Value, len(v))

--- a/types/map.go
+++ b/types/map.go
@@ -142,12 +142,6 @@ func (m Map) elemTypes() []TypeRef {
 	return m.t.Desc.(CompoundDesc).ElemTypes
 }
 
-func init() {
-	RegisterFromValFunction(mapTypeRef, func(v Value) Value {
-		return v.(Map)
-	})
-}
-
 type mapEntry struct {
 	key   Value
 	value Value

--- a/types/package_set_of_ref.go
+++ b/types/package_set_of_ref.go
@@ -188,9 +188,11 @@ func (m RefOfPackage) TypeRef() TypeRef {
 
 func init() {
 	__typeRefForRefOfPackage = MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(PackageKind))
-	RegisterFromValFunction(__typeRefForRefOfPackage, func(v Value) Value {
-		return NewRefOfPackage(v.(Ref).TargetRef())
-	})
+	RegisterRef(__typeRefForRefOfPackage, builderForRefOfPackage)
+}
+
+func builderForRefOfPackage(r ref.Ref) Value {
+	return NewRefOfPackage(r)
 }
 
 func (r RefOfPackage) TargetValue(cs chunks.ChunkSource) Package {

--- a/types/ref.go
+++ b/types/ref.go
@@ -11,6 +11,10 @@ type Ref struct {
 	ref    *ref.Ref
 }
 
+type RefBase interface {
+	TargetRef() ref.Ref
+}
+
 func NewRef(target ref.Ref) Ref {
 	return newRef(target, refTypeRef)
 }
@@ -39,12 +43,6 @@ var refTypeRef = MakeCompoundTypeRef(RefKind, MakePrimitiveTypeRef(ValueKind))
 
 func (r Ref) TypeRef() TypeRef {
 	return r.t
-}
-
-func init() {
-	RegisterFromValFunction(refTypeRef, func(v Value) Value {
-		return v.(Ref)
-	})
 }
 
 func (r Ref) TargetValue(cs chunks.ChunkSource) Value {

--- a/types/set.go
+++ b/types/set.go
@@ -22,12 +22,6 @@ type setFilterCallback func(v Value) (keep bool)
 
 var setTypeRef = MakeCompoundTypeRef(SetKind, MakePrimitiveTypeRef(ValueKind))
 
-func init() {
-	RegisterFromValFunction(setTypeRef, func(v Value) Value {
-		return v.(Set)
-	})
-}
-
 func NewSet(v ...Value) Set {
 	return newSetFromData(buildSetData(setData{}, v), setTypeRef)
 }


### PR DESCRIPTION
Ref values use the TargetRef to get the internal implementation

RegisterFromValFunction and ToNomsValueFromTypeRef were only used by
ref values at this point so these were renamed and simplified to be
more specific for ref values
