### PR TITLE
Reduce size of test data in Set and Map IterAllP() tests

### DIFF
--- a/types/map_test.go
+++ b/types/map_test.go
@@ -186,9 +186,9 @@ func TestMapIterAllP(t *testing.T) {
 		assert.Equal(mapLen, numVisited, "IterAllP was not called with every map key")
 	}
 	testIter(0, 100)
-	testIter(10, 1000)
-	testIter(1, 100000)
-	testIter(64, 100000)
+	testIter(10, 100)
+	testIter(1, 100)
+	testIter(64, 200)
 }
 
 func TestMapFilter(t *testing.T) {

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -208,9 +208,9 @@ func TestSetIterAllP(t *testing.T) {
 		assert.Equal(setLen, numVisited, "IterAllP was not called with every index")
 	}
 	testIter(0, 100)
-	testIter(10, 1000)
-	testIter(1, 100000)
-	testIter(64, 100000)
+	testIter(10, 100)
+	testIter(1, 100)
+	testIter(64, 200)
 }
 
 func TestSetFilter(t *testing.T) {


### PR DESCRIPTION
Building up these big Sets and Maps is really slow, and the purpose of
this test is not to stress-test the code with huge data, but rather to
verify correctness. Since Set and Map are being replaced soon, it doesn't
make sense to improve the existing implementations.
