### PR TITLE
JS: No need to go through dist when testing

### DIFF
--- a/js2/package.json
+++ b/js2/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "babel -w src/ -d dist/",
     "build": "babel src/ -d dist/",
-    "pretest": "eslint src/ && flow src/ && babel src/ -d dist/",
-    "test": "mocha --ui tdd dist/"
+    "pretest": "eslint src/ && flow src/",
+    "test": "mocha --ui tdd --reporter dot --compilers js:babel/register src/"
   }
 }


### PR DESCRIPTION
Instead use `--compilers` flag to mocha.
