### PR TITLE
Implement a generic sequence chunker, and use it to create blobs.

### DIFF
--- a/clients/music/mp3_importer/mp3_importer.go
+++ b/clients/music/mp3_importer/mp3_importer.go
@@ -31,17 +31,12 @@ func addMp3(ds *dataset.Dataset, filename string) {
 	}
 	defer mp3_file.Close()
 
-	mp3_data, err := types.NewBlob(bufio.NewReader(mp3_file), ds.Store())
-	if err != nil {
-		log.Fatalf("Failed to read mp3 data from %s: %s\n", filename, err)
-	}
-
 	new_song := SongDef{
 		Title:  id3.Title(),
 		Artist: id3.Artist(),
 		Album:  id3.Album(),
 		Year:   id3.Year(),
-		Mp3:    mp3_data,
+		Mp3:    types.NewBlob(bufio.NewReader(mp3_file), ds.Store()),
 	}.New()
 	songs := readSongsFromDataset(ds).Append(new_song)
 	if _, ok := ds.Commit(songs); ok {

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -317,8 +317,7 @@ func isNilPtrOrNilInterface(v reflect.Value) bool {
 
 func readerEncoder(v reflect.Value) types.Value {
 	d.Chk.True(v.Type().Implements(readerType))
-	blob, err := types.NewMemoryBlob(v.Interface().(io.Reader))
-	d.Exp.NoError(err, "Failed to marshal reader into blob")
+	blob := types.NewMemoryBlob(v.Interface().(io.Reader))
 	return blob
 }
 
@@ -398,14 +397,9 @@ func newMapEncoder(t reflect.Type) encoderFunc {
 
 func encodeByteSlice(v reflect.Value) types.Value {
 	if v.IsNil() {
-		nom, _ := types.NewMemoryBlob(&bytes.Buffer{})
-		return nom
+		return types.NewMemoryBlob(&bytes.Buffer{})
 	}
-	nom, err := types.NewMemoryBlob(bytes.NewReader(v.Bytes()))
-	if err != nil {
-		panic(err)
-	}
-	return nom
+	return types.NewMemoryBlob(bytes.NewReader(v.Bytes()))
 }
 
 func newSliceEncoder(t reflect.Type) encoderFunc {

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -462,11 +462,7 @@ var pallValue = All{
 
 // Used in creating canned marshaled values below.
 func makeNewBlob(b []byte) types.Blob {
-	blob, err := types.NewMemoryBlob(bytes.NewBuffer(b))
-	if err != nil {
-		panic(err) // Sigh
-	}
-	return blob
+	return types.NewMemoryBlob(bytes.NewBuffer(b))
 }
 
 // Canned marshaled version of allValue

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -411,11 +411,7 @@ func byteSlice(b byte, times int) (out []byte) {
 }
 
 func blob(b ...byte) types.Blob {
-	blob, err := types.NewMemoryBlob(bytes.NewReader(b))
-	if err != nil {
-		panic(err)
-	}
-	return blob
+	return types.NewMemoryBlob(bytes.NewReader(b))
 }
 
 func list(l ...int) types.List {

--- a/nomdl/codegen/test/struct_primitives_test.go
+++ b/nomdl/codegen/test/struct_primitives_test.go
@@ -104,8 +104,7 @@ func TestAccessors(t *testing.T) {
 	assert.Equal("bye", st.String())
 
 	assert.True(st.Blob().Equals(types.NewEmptyBlob()))
-	b, err := types.NewMemoryBlob(strings.NewReader("hello"))
-	assert.NoError(err)
+	b := types.NewMemoryBlob(strings.NewReader("hello"))
 	st.SetBlob(b)
 	assert.True(st.Blob().Equals(types.NewEmptyBlob()))
 	st = st.SetBlob(b)

--- a/types/blob_test.go
+++ b/types/blob_test.go
@@ -20,21 +20,19 @@ func AssertSymNe(assert *assert.Assertions, a, b Value) {
 
 func TestBlobLen(t *testing.T) {
 	assert := assert.New(t)
-	b, err := NewMemoryBlob(&bytes.Buffer{})
-	assert.NoError(err)
+	b := NewMemoryBlob(&bytes.Buffer{})
 	assert.Equal(uint64(0), b.Len())
-	b, err = NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
-	assert.NoError(err)
+	b = NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
 	assert.Equal(uint64(1), b.Len())
 }
 
 func TestBlobEquals(t *testing.T) {
 	assert := assert.New(t)
-	b1, _ := NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
+	b1 := NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
 	b11 := b1
-	b12, _ := NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
-	b2, _ := NewMemoryBlob(bytes.NewBuffer([]byte{0x02}))
-	b3, _ := NewMemoryBlob(bytes.NewBuffer([]byte{0x02, 0x03}))
+	b12 := NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
+	b2 := NewMemoryBlob(bytes.NewBuffer([]byte{0x02}))
+	b3 := NewMemoryBlob(bytes.NewBuffer([]byte{0x02, 0x03}))
 	AssertSymEq(assert, b1, b11)
 	AssertSymEq(assert, b1, b12)
 	AssertSymNe(assert, b1, b2)
@@ -72,8 +70,7 @@ func TestBlobFromReaderThatReturnsDataAndError(t *testing.T) {
 	assert := assert.New(t)
 	tr := &testReader{buf: &bytes.Buffer{}}
 
-	b, err := NewMemoryBlob(tr)
-	assert.NoError(err)
+	b := NewMemoryBlob(tr)
 
 	actual := &bytes.Buffer{}
 	io.Copy(actual, b.Reader())

--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -18,7 +18,7 @@ func getTestCompoundBlob(datas ...string) compoundBlob {
 	length := uint64(0)
 	ms := chunks.NewMemoryStore()
 	for i, s := range datas {
-		b, _ := NewBlob(bytes.NewBufferString(s), ms)
+		b := NewBlob(bytes.NewBufferString(s), ms)
 		length += uint64(len(s))
 		tuples[i] = metaTuple{WriteValue(b, ms), UInt64(length)}
 	}
@@ -41,9 +41,7 @@ func getRandomBlob(t *testing.T) compoundBlob {
 		t.Skip("Skipping test in short mode.")
 	}
 	r := getRandomReader()
-	b, err := NewMemoryBlob(r)
-	assert.NoError(t, err)
-	return b.(compoundBlob)
+	return NewMemoryBlob(r).(compoundBlob)
 }
 
 func testByteRange(assert *assert.Assertions, offset, length int64, expect io.ReadSeeker, actual io.ReadSeeker) {
@@ -205,9 +203,7 @@ func TestCompoundBlobSameChunksWithPrefix(t *testing.T) {
 	buf := bytes.NewBufferString("prefix")
 	r := io.MultiReader(buf, rr)
 
-	b, err := NewMemoryBlob(r)
-	assert.NoError(err)
-	cb2 := b.(compoundBlob)
+	cb2 := NewMemoryBlob(r).(compoundBlob)
 
 	// cb1: chunks 2
 	//   chunks 21 - only first chunk is different
@@ -238,9 +234,7 @@ func TestCompoundBlobSameChunksWithSuffix(t *testing.T) {
 	buf := bytes.NewBufferString("suffix")
 	r := io.MultiReader(rr, buf)
 
-	b, err := NewMemoryBlob(r)
-	assert.NoError(err)
-	cb2 := b.(compoundBlob)
+	cb2 := NewMemoryBlob(r).(compoundBlob)
 
 	// cb1: chunks 2
 	//   chunks 21

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -83,8 +83,7 @@ func TestReadPrimitives(t *testing.T) {
 
 	test(NewString("hi"), `[%d, "hi"]`, StringKind)
 
-	blob, err := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
-	assert.NoError(err)
+	blob := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
 	test(blob, `[%d, "AAE="]`, BlobKind)
 }
 
@@ -471,8 +470,7 @@ func TestReadStructWithBlob(t *testing.T) {
 	r := newJsonArrayReader(a, cs)
 	v := r.readTopLevelValue().(Struct)
 
-	blob, err := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
-	assert.NoError(err)
+	blob := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
 	assert.True(v.Get("b").Equals(blob))
 }
 

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -35,8 +35,7 @@ func TestWritePrimitives(t *testing.T) {
 
 	f(StringKind, NewString("hi"), "hi")
 
-	blob, err := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
-	assert.NoError(err)
+	blob := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
 	f(BlobKind, blob, "AAE=")
 }
 
@@ -283,7 +282,7 @@ func TestWriteStructWithBlob(t *testing.T) {
 	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typeRef := MakeTypeRef(pkgRef, 0)
-	b, _ := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
+	b := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
 	v := NewStruct(typeRef, typeDef, structData{"b": b})
 
 	w := newJsonArrayWriter(cs)
@@ -327,7 +326,7 @@ func TestWriteListOfValue(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	tref := MakeCompoundTypeRef(ListKind, MakePrimitiveTypeRef(ValueKind))
-	blob, _ := NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
+	blob := NewMemoryBlob(bytes.NewBuffer([]byte{0x01}))
 	v := NewList(
 		Bool(true),
 		UInt8(1),

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -48,21 +48,18 @@ func TestValueEquals(t *testing.T) {
 		func() Value { return NewString("hi") },
 		func() Value { return NewString("bye") },
 		func() Value {
-			v, _ := NewMemoryBlob(&bytes.Buffer{})
-			return v
+			return NewMemoryBlob(&bytes.Buffer{})
 		},
 		func() Value {
-			v, _ := NewMemoryBlob(bytes.NewBufferString("hi"))
-			return v
+			return NewMemoryBlob(bytes.NewBufferString("hi"))
 		},
 		func() Value {
-			v, _ := NewMemoryBlob(bytes.NewBufferString("bye"))
-			return v
+			return NewMemoryBlob(bytes.NewBufferString("bye"))
 		},
 		func() Value {
 			ms := chunks.NewMemoryStore()
-			b1, _ := NewBlob(bytes.NewBufferString("hi"), ms)
-			b2, _ := NewBlob(bytes.NewBufferString("bye"), ms)
+			b1 := NewBlob(bytes.NewBufferString("hi"), ms)
+			b2 := NewBlob(bytes.NewBufferString("bye"), ms)
 			return newCompoundBlob([]metaTuple{{WriteValue(b1, ms), UInt64(uint64(2))}, {WriteValue(b2, ms), UInt64(uint64(5))}}, ms)
 		},
 		func() Value { return NewList() },

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -222,8 +222,8 @@ func TestMapEquals(t *testing.T) {
 
 func TestMapNotStringKeys(t *testing.T) {
 	assert := assert.New(t)
-	b1, _ := NewMemoryBlob(bytes.NewBufferString("blob1"))
-	b2, _ := NewMemoryBlob(bytes.NewBufferString("blob2"))
+	b1 := NewMemoryBlob(bytes.NewBufferString("blob1"))
+	b2 := NewMemoryBlob(bytes.NewBufferString("blob2"))
 	l := []Value{
 		Bool(true), NewString("true"),
 		Bool(false), NewString("false"),

--- a/types/read_value_test.go
+++ b/types/read_value_test.go
@@ -21,9 +21,7 @@ func TestReadValueBlobLeafDecode(t *testing.T) {
 
 	blobLeafDecode := func(r io.Reader) Value {
 		i := decode(r)
-		b, err := NewMemoryBlob(i.(io.Reader))
-		assert.NoError(err)
-		return b
+		return NewMemoryBlob(i.(io.Reader))
 	}
 
 	reader := bytes.NewBufferString("b ")

--- a/types/sequence_chunker.go
+++ b/types/sequence_chunker.go
@@ -1,0 +1,70 @@
+package types
+
+import "github.com/attic-labs/noms/d"
+
+type sequenceItem interface{}
+
+type sequenceChunker struct {
+	parent                       *sequenceChunker
+	current, pendingFirst        []sequenceItem
+	makeChunk, parentMakeChunk   makeChunkFn
+	isBoundary, parentIsBoundary isBoundaryFn
+}
+
+// makeChunkFn takes a sequence of items to chunk, and returns the result of chunking those items, a tuple of a reference to that chunk which can itself be chunked + its underlying value.
+type makeChunkFn func(values []sequenceItem) (sequenceItem, interface{})
+
+// isBoundaryFn takes an item and returns true if the sequence should chunk after this item, false if not.
+type isBoundaryFn func(value sequenceItem) bool
+
+func newSequenceChunker(makeChunk, parentMakeChunk makeChunkFn, isBoundary, parentIsBoundary isBoundaryFn) *sequenceChunker {
+	d.Chk.NotNil(makeChunk)
+	d.Chk.NotNil(parentMakeChunk)
+	d.Chk.NotNil(isBoundary)
+	d.Chk.NotNil(parentIsBoundary)
+	return &sequenceChunker{
+		nil,
+		[]sequenceItem{}, nil,
+		makeChunk, parentMakeChunk,
+		isBoundary, parentIsBoundary,
+	}
+}
+
+func (seq *sequenceChunker) Append(item sequenceItem) {
+	// Checking for seq.pendingFirst must happen immediately, because it's effectively a continuation from the last call to Append. Specifically, if the last call to Append created the first chunk boundary, delay creating the parent until absolutely necessary. Otherwise, we will be in a state where a parent has only a single item, which is invalid.
+	if seq.pendingFirst != nil {
+		d.Chk.True(seq.parent == nil)
+		seq.parent = newSequenceChunker(seq.parentMakeChunk, seq.parentMakeChunk, seq.parentIsBoundary, seq.parentIsBoundary)
+		chunk, _ := seq.makeChunk(seq.pendingFirst)
+		seq.parent.Append(chunk)
+		seq.pendingFirst = nil
+	}
+	seq.current = append(seq.current, item)
+	if seq.isBoundary(item) {
+		seq.handleChunkBoundary()
+	}
+}
+
+func (seq *sequenceChunker) handleChunkBoundary() {
+	if seq.parent == nil {
+		seq.pendingFirst = seq.current
+	} else {
+		chunk, _ := seq.makeChunk(seq.current)
+		seq.parent.Append(chunk)
+	}
+	seq.current = []sequenceItem{}
+}
+
+func (seq *sequenceChunker) Done() (sequenceItem, interface{}) {
+	if seq.pendingFirst != nil {
+		d.Chk.True(seq.parent == nil)
+		return seq.makeChunk(seq.pendingFirst)
+	}
+	if seq.parent != nil {
+		if len(seq.current) > 0 {
+			seq.handleChunkBoundary()
+		}
+		return seq.parent.Done()
+	}
+	return seq.makeChunk(seq.current)
+}

--- a/types/sequence_chunker_test.go
+++ b/types/sequence_chunker_test.go
@@ -1,0 +1,89 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+)
+
+func TestSequenceChunkerMod(t *testing.T) {
+	assert := assert.New(t)
+
+	sumChunker := func(items []sequenceItem) (sequenceItem, interface{}) {
+		sum := 0
+		for _, item := range items {
+			sum += item.(int)
+		}
+		return sum, items
+	}
+
+	modBounder := func(mod int) isBoundaryFn {
+		return func(item sequenceItem) bool {
+			return item.(int)%mod == 0
+		}
+	}
+
+	newTestSequenceChunker := func(from, to int) *sequenceChunker {
+		seq := newSequenceChunker(sumChunker, sumChunker, modBounder(3), modBounder(5))
+		for i := from; i <= to; i++ {
+			seq.Append(i)
+		}
+		return seq
+	}
+
+	intsFromSequenceItems := func(items interface{}) []int {
+		intSlice := []int{}
+		for _, item := range items.([]sequenceItem) {
+			intSlice = append(intSlice, item.(int))
+		}
+		return intSlice
+	}
+
+	// [1] is not a chunk boundary, so it won't chunk.
+	seq := newTestSequenceChunker(1, 1)
+	sum, items := seq.Done()
+	assert.Equal(1, sum)
+	assert.Equal([]int{1}, intsFromSequenceItems(items))
+
+	// [3] is a chunk boundary, but only a single chunk, so treat it as though it didn't chunk.
+	seq = newTestSequenceChunker(3, 3)
+	sum, items = seq.Done()
+	assert.Equal(3, sum)
+	assert.Equal([]int{3}, intsFromSequenceItems(items))
+
+	// None of [1, 2] is a chunk boundary, so it won't chunk.
+	seq = newTestSequenceChunker(1, 2)
+	sum, items = seq.Done()
+	assert.Equal(3, sum)
+	assert.Equal([]int{1, 2}, intsFromSequenceItems(items))
+
+	// [3, 4] has a chunk boundary on 3, so it should chunk as [3] [4].
+	seq = newTestSequenceChunker(3, 4)
+	sum, items = seq.Done()
+	assert.Equal(7, sum)
+	assert.Equal([]int{3, 4}, intsFromSequenceItems(items))
+
+	// [1, 2, 3] ends in a chunk boundary 3, but only a single chunk, so treat is as though it didn't chunk.
+	seq = newTestSequenceChunker(1, 3)
+	sum, items = seq.Done()
+	assert.Equal(6, sum)
+	assert.Equal([]int{1, 2, 3}, intsFromSequenceItems(items))
+
+	// [1, 2, 3, 4] has a chunk boundary on 3, so should chunk as [1, 2, 3] [4].
+	seq = newTestSequenceChunker(1, 4)
+	sum, items = seq.Done()
+	assert.Equal(10, sum)
+	assert.Equal([]int{6, 4}, intsFromSequenceItems(items))
+
+	// [1, 2, 3, 4, 5, 6] has a chunk boundary on 3 and 6, so should chunk as [1, 2, 3] [4, 5, 6]. Note also that the level above that ends in a chunk boundary 15 because 4+5+16=15 and 15%5 = 0, but like earlier, this shouldn't chunk because it's only a single chunk.
+	seq = newTestSequenceChunker(1, 6)
+	sum, items = seq.Done()
+	assert.Equal(21, sum)
+	assert.Equal([]int{6, 15}, intsFromSequenceItems(items))
+
+	// [1, 2, 3, 4, 5, 6, 7] will chunk as [1, 2, 3] [4, 5, 6] [7] producing meta chunks of [6, 15, 7] which chunks on 15, so we'll get 2 chunks [6, 15] [7].
+	seq = newTestSequenceChunker(1, 7)
+	sum, items = seq.Done()
+	assert.Equal(28, sum)
+	assert.Equal([]int{21, 7}, intsFromSequenceItems(items))
+}

--- a/types/write_value_test.go
+++ b/types/write_value_test.go
@@ -27,8 +27,7 @@ func TestWriteValue(t *testing.T) {
 
 	// Encoding details for each codec is tested elsewhere.
 	// Here we just want to make sure codecs are selected correctly.
-	b, err := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01, 0x02}))
-	assert.NoError(err)
+	b := NewMemoryBlob(bytes.NewBuffer([]byte{0x00, 0x01, 0x02}))
 	testEncode(string([]byte{'b', ' ', 0x00, 0x01, 0x02}), b)
 
 	testEncode(fmt.Sprintf("t [%d,\"hi\"]", StringKind), NewString("hi"))
@@ -43,8 +42,7 @@ func TestWriteBlobLeaf(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	buf := bytes.NewBuffer([]byte{})
-	b1, err := NewMemoryBlob(buf)
-	assert.NoError(err)
+	b1 := NewMemoryBlob(buf)
 	bl1, ok := b1.(blobLeaf)
 	assert.True(ok)
 	r1 := WriteValue(bl1, cs)
@@ -52,8 +50,7 @@ func TestWriteBlobLeaf(t *testing.T) {
 	assert.Equal("sha1-e1bc846440ec2fb557a5a271e785cd4c648883fa", r1.String())
 
 	buf = bytes.NewBufferString("Hello, World!")
-	b2, err := NewMemoryBlob(buf)
-	assert.NoError(err)
+	b2 := NewMemoryBlob(buf)
 	bl2, ok := b2.(blobLeaf)
 	assert.True(ok)
 	r2 := WriteValue(bl2, cs)


### PR DESCRIPTION
This takes raf's https://github.com/rafael-atticlabs/noms/tree/newChunker and modifies it to use a "push" rather than a "pull" model. The push model chains together sequence chunkers on demand.

The contents of types/sequence_chunker.go was written by me, half of the types/blob.go changes were by me and half by raf, and all other changes were by raf.
