### PR TITLE
JS: Remove invalid invariant about empty package ref

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -15,7 +15,7 @@
     "radix": 2,
     "semi": 2,
     "space-after-keywords": 2,
-    "space-before-function-paren": [2, "never"],
+    "space-before-function-paren": 0,
     "space-infix-ops": 2,
     "space-in-parens": [2, "never"]
   },

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -266,8 +266,6 @@ class JsonArrayReader {
         if (ordinal === -1) {
           let namespace = this.readString();
           let name = this.readString();
-          invariant(pkgRef.isEmpty(), 'Unresolved Types may not have a package ref');
-
           return makeUnresolvedType(namespace, name);
         }
 

--- a/js/src/type_test.js
+++ b/js/src/type_test.js
@@ -65,4 +65,12 @@ suite('Type', () => {
   test('type Type', () => {
     assert.isTrue(makePrimitiveType(Kind.Bool).type.equals(makePrimitiveType(Kind.Type)));
   });
+
+  test('empty package ref', async () => {
+    let ms = new MemoryStore();
+    let v = makeType(new Ref(), -1);
+    let r = writeValue(v, v.type, ms);
+    let v2 = await readValue(r, ms);
+    assert.isTrue(v.equals(v2));
+  });
 });


### PR DESCRIPTION
It is OK to have an empty package ref when serializing an
UnresolvedType. It can happen when a Package is serialized or if we
ask for the `ref` of an unresolved type.
