### PR TITLE
Replace isometric-fetch

### DIFF
--- a/clients/splore/package.json
+++ b/clients/splore/package.json
@@ -17,8 +17,11 @@
     "watchify": "^3.6"
   },
   "scripts": {
-    "start": "NOMS_SERVER=http://localhost:8000 watchify -o out.js -t babelify -t envify -v -d main.js",
-    "build": "NOMS_SERVER=http://localhost:8000 NODE_ENV=production browserify main.js -t babelify -t envify > out.js",
+    "start": "NOMS_SERVER=http://localhost:8000 watchify -o out.js -v -d main.js",
+    "build": "NOMS_SERVER=http://localhost:8000 NODE_ENV=production browserify main.js > out.js",
     "test": "rm -f out.js && eslint *.js && flow"
+  },
+  "browserify": {
+    "transform": ["babelify", "envify"]
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -3,8 +3,7 @@
   "main": "dist/noms.js",
   "dependencies": {
     "rusha": "^0.8.3",
-    "text-encoding": "^0.5.2",
-    "isomorphic-fetch": "^2.2.0"
+    "text-encoding": "^0.5.2"
   },
   "devDependencies": {
     "babel": "~5.6.23",
@@ -20,5 +19,8 @@
     "build": "babel src/ -d dist/",
     "pretest": "eslint src/ && flow src/",
     "test": "mocha --ui tdd --reporter dot --compilers js:babel/register src/"
+  },
+  "browser": {
+    "./dist/fetch.js": "./dist/browser/fetch.js"
   }
 }

--- a/js/src/browser/fetch.js
+++ b/js/src/browser/fetch.js
@@ -1,0 +1,40 @@
+/* @flow */
+
+'use strict';
+
+type FetchOptions = {
+  method?: string,
+  body?: any,
+  headers?: {[key: string]: string}
+};
+
+function fetch<T>(url: string, responseType: string, options: FetchOptions = {}) : Promise<T> {
+  let xhr = new XMLHttpRequest();
+  xhr.responseType = responseType;
+  let method = options.method || 'GET';
+  xhr.open(method, url, true);
+  let p = new Promise((res, rej) => {
+    xhr.onloadend = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        res(xhr.response);
+      } else {
+        rej(xhr.status);
+      }
+    };
+  });
+  if (options.headers) {
+    for (let key in options.headers) {
+      xhr.setRequestHeader(key, options.headers[key]);
+    }
+  }
+  xhr.send(options.body);
+  return p;
+}
+
+export function fetchText(url: string, options: FetchOptions = {}) : Promise<string> {
+  return fetch(url, 'text', options);
+}
+
+export function fetchArrayBuffer(url: string, options: FetchOptions = {}) : Promise<ArrayBuffer> {
+  return fetch(url, 'arraybuffer', options);
+}

--- a/js/src/fetch.js
+++ b/js/src/fetch.js
@@ -1,0 +1,64 @@
+/* @flow */
+
+'use strict';
+
+import {request} from 'http';
+import {parse} from 'url';
+
+type FetchOptions = {
+  method?: string,
+  body?: any,
+  headers?: {[key: string]: string}
+};
+
+function fetch<T>(url: string, f: (buf: Buffer) => T, options: FetchOptions = {}) : Promise<T> {
+  let opts: any = parse(url);
+  opts.method = options.method || 'GET';
+  if (options.headers) {
+    opts.headers = options.headers;
+  }
+  return new Promise((resolve, reject) => {
+    let req = request(opts, res => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        reject(res.statusCode);
+        return;
+      }
+      let buf = new Buffer(0);
+      res.on('data', (chunk: Buffer) => {
+        buf = Buffer.concat([buf, chunk]);
+      });
+      res.on('end', () => {
+        resolve(f(buf));
+      });
+    });
+    req.on('error', err => {
+      reject(err);
+    });
+    if (options.body) {
+      req.write(options.body);
+    }
+    req.end();
+  });
+}
+
+function bufferToArrayBuffer(buf: Buffer) : ArrayBuffer {
+  let ab = new ArrayBuffer(buf.length);
+  let view = new Uint8Array(ab);
+  for (let i = 0; i < buf.length; i++) {
+    view[i] = buf[i];
+  }
+  return ab;
+}
+
+
+function bufferToString(buf: Buffer) : string {
+  return buf.toString();
+}
+
+export function fetchText(url: string, options: FetchOptions = {}) : Promise<string> {
+  return fetch(url, bufferToString, options);
+}
+
+export function fetchArrayBuffer(url: string, options: FetchOptions = {}) : Promise<ArrayBuffer> {
+  return fetch(url, bufferToArrayBuffer, options);
+}


### PR DESCRIPTION
This replaces the fetch polyfill with 2 more targetted functions:
fetchText and fetchArrayBuffer

There is one implementation for node and one for browsers. Browserify
picks the browser version by reading the value out of package.json

Towards #605
