### PR TITLE
JS: Add support for writing Ref

### DIFF
--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -194,6 +194,8 @@ class JsonArrayReader {
       case Kind.Package:
         return Promise.resolve(this.readPackage(t, pkg));
       case Kind.Ref:
+        // TODO: This is not aligned with Go. In Go we have a dedicated Value
+        // for refs.
         return Promise.resolve(this.readRef());
       case Kind.Set: {
         let r2 = new JsonArrayReader(this.readArray(), this._cs);

--- a/js/src/encode.js
+++ b/js/src/encode.js
@@ -130,6 +130,13 @@ class JsonArrayWriter {
         this.write(w3.array);
         break;
       }
+      case Kind.Ref: {
+        // TODO: This is not aligned with Go. In Go we have a dedicated Value
+        // for refs.
+        invariant(v instanceof Ref);
+        this.writeRef(v);
+        break;
+      }
       case Kind.Set: {
         invariant(v instanceof Set);
         let w2 = new JsonArrayWriter(this._cs);

--- a/js/src/encode_test.js
+++ b/js/src/encode_test.js
@@ -329,4 +329,13 @@ suite('Encode', () => {
     assert.equal(buffer2.byteLength, chunk2.data.buffer.byteLength);
     assert.deepEqual(buffer2, chunk2.data.buffer);
   });
+
+  test('write ref', async () => {
+    let ms = new MemoryStore();
+    let w = new JsonArrayWriter(ms);
+    let ref = Ref.parse('sha1-0123456789abcdef0123456789abcdef01234567');
+    let t = makeCompoundType(Kind.Ref, makePrimitiveType(Kind.Blob));
+    w.writeTopLevel(t, ref);
+    assert.deepEqual([Kind.Ref, Kind.Blob, ref.toString()], w.array);
+  });
 });


### PR DESCRIPTION
Reading an writing ref values return Ref. This is different from
Go but it gets us unblocked.

Towards #599
