### PR TITLE
Fixes #687.

### DIFF
--- a/clients/counter/counter.go
+++ b/clients/counter/counter.go
@@ -28,8 +28,8 @@ func main() {
 		lastVal = uint64(commit.Value().(types.Uint64))
 	}
 	newVal := lastVal + 1
-	_, ok := ds.Commit(types.Uint64(newVal))
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	_, err := ds.Commit(types.Uint64(newVal))
+	d.Exp.NoError(err)
 
 	fmt.Println(newVal)
 }

--- a/clients/crunchbase/importer/importer.go
+++ b/clients/crunchbase/importer/importer.go
@@ -66,13 +66,15 @@ func main() {
 		companiesRef = importCompanies(*ds, tempFile.Name())
 	}
 
-	// Commit ref of the companiesRef list
-	_, ok := ds.Commit(ImportDef{
+	imp := ImportDef{
 		ref.FromHash(h).String(),
 		DateDef{time.Now().Format(time.RFC3339)},
 		companiesRef,
-	}.New(ds.Store()))
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	}.New(ds.Store())
+
+	// Commit ref of the companiesRef list
+	_, err = ds.Commit(imp)
+	d.Exp.NoError(err)
 }
 
 func importCompanies(ds dataset.Dataset, fileName string) ref.Ref {

--- a/clients/crunchbase/index/index.go
+++ b/clients/crunchbase/index/index.go
@@ -115,8 +115,8 @@ func main() {
 		}
 
 		output := mapOfRefs.New(ds)
-		_, ok = outputDataset.Commit(output)
-		d.Exp.True(ok, "Could not commit due to conflicting edit")
+		_, err := outputDataset.Commit(output)
+		d.Exp.NoError(err)
 
 		util.MaybeWriteMemProfile()
 	})

--- a/clients/csv_importer/csv_importer.go
+++ b/clients/csv_importer/csv_importer.go
@@ -178,8 +178,8 @@ func main() {
 	listType := types.MakeCompoundType(types.ListKind, refType)
 
 	value := types.NewTypedList(ds.Store(), listType, refs...)
-	_, ok := ds.Commit(value)
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	_, err = ds.Commit(value)
+	d.Exp.NoError(err)
 }
 
 // Returns the rune contained in *delimiter or an error.

--- a/clients/flickr/flickr.go
+++ b/clients/flickr/flickr.go
@@ -325,10 +325,10 @@ func awaitOAuthResponse(l net.Listener, tempCred *oauth.Credentials) error {
 }
 
 func commitUser() {
-	ok := false
+	var err error
 	r := NewRefOfUser(types.WriteValue(user, ds.Store()))
-	*ds, ok = ds.Commit(r)
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	*ds, err = ds.Commit(r)
+	d.Exp.NoError(err)
 }
 
 func callFlickrAPI(method string, response interface{}, args *map[string]string) error {

--- a/clients/json_importer/json_importer.go
+++ b/clients/json_importer/json_importer.go
@@ -41,6 +41,6 @@ func main() {
 		log.Fatalln("Error decoding JSON: ", err)
 	}
 
-	_, ok := ds.Commit(util.NomsValueFromDecodedJSON(ds.Store(), jsonObject))
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	_, err = ds.Commit(util.NomsValueFromDecodedJSON(ds.Store(), jsonObject))
+	d.Exp.NoError(err)
 }

--- a/clients/music/mp3_importer/mp3_importer.go
+++ b/clients/music/mp3_importer/mp3_importer.go
@@ -39,11 +39,11 @@ func addMp3(ds *dataset.Dataset, filename string) {
 		Mp3:    types.NewBlob(bufio.NewReader(mp3_file), ds.Store()),
 	}.New(ds.Store())
 	songs := readSongsFromDataset(ds).Append(new_song)
-	if _, ok := ds.Commit(songs); ok {
+	if _, err := ds.Commit(songs); err == nil {
 		fmt.Println("Successfully committed", filename)
 		printSong(new_song)
 	} else {
-		log.Fatalln("Failed to commit", filename)
+		log.Fatalf("Failed to commit: %s, error: %s\n", filename, err)
 	}
 }
 

--- a/clients/picasa/picasa.go
+++ b/clients/picasa/picasa.go
@@ -86,8 +86,8 @@ func main() {
 	*user = user.SetRefreshToken(refreshToken)
 	userRef := types.WriteValue(user, ds.Store())
 	fmt.Printf("userRef: %s\n", userRef)
-	_, ok := ds.Commit(NewRefOfUser(userRef))
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	_, err := ds.Commit(NewRefOfUser(userRef))
+	d.Exp.NoError(err)
 }
 
 func picasaUsage() {

--- a/clients/pitchmap/index/index.go
+++ b/clients/pitchmap/index/index.go
@@ -166,8 +166,8 @@ func main() {
 		input := inputDataset.Head().Value().(ListOfRefOfMapOfStringToValue)
 		output := getIndex(input, ds)
 
-		_, ok := outputDataset.Commit(output)
-		d.Exp.True(ok, "Could not commit due to conflicting edit")
+		_, err := outputDataset.Commit(output)
+		d.Exp.NoError(err)
 
 		util.MaybeWriteMemProfile()
 	})

--- a/clients/quad_tree/main.go
+++ b/clients/quad_tree/main.go
@@ -132,8 +132,8 @@ func main() {
 	if !*quietFlag {
 		fmt.Printf("Calling Commit(), elapsed time: %.2f secs\n", SecsSince(start))
 	}
-	_, ok = dataset.Commit(types.NewRef(nomsQtRoot.Ref()))
-	d.Chk.True(ok, "Could not commit due to conflicting edit")
+	_, err = dataset.Commit(types.NewRef(nomsQtRoot.Ref()))
+	d.Exp.NoError(err)
 	if !*quietFlag {
 		fmt.Printf("Commit completed, elapsed time: %.2f secs\n", time.Now().Sub(start).Seconds())
 	}

--- a/clients/sfcrime_importer/sfcrime.go
+++ b/clients/sfcrime_importer/sfcrime.go
@@ -155,8 +155,8 @@ func main() {
 	}
 
 	ref := types.WriteValue(incidentRefs, ds.Store())
-	_, ok := ds.Commit(types.NewRef(ref))
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	_, err = ds.Commit(types.NewRef(ref))
+	d.Exp.NoError(err)
 
 	if !*quietFlag {
 		fmt.Printf("Commit completed, elaspsed time: %.2f secs\n", time.Now().Sub(start).Seconds())

--- a/clients/shove/shove.go
+++ b/clients/shove/shove.go
@@ -43,9 +43,11 @@ func main() {
 			sinkRef = ref.Parse(*sinkRefFlag)
 		}
 
-		*sink = sink.Pull(*source, int(*p), sinkRef)
+		var err error
+		*sink, err = sink.Pull(*source, int(*p), sinkRef)
 
 		util.MaybeWriteMemProfile()
+		d.Exp.NoError(err)
 	})
 
 	if err != nil {

--- a/clients/shove/shove_test.go
+++ b/clients/shove/shove_test.go
@@ -24,8 +24,8 @@ func (s *testSuite) TestShove() {
 	s.LdbFlagName = "-source-ldb"
 	cs := chunks.NewLevelDBStore(s.LdbDir, 1, false)
 	ds := dataset.NewDataset(datas.NewDataStore(cs), "foo")
-	ds, ok := ds.Commit(types.Int32(42))
-	s.True(ok)
+	ds, err := ds.Commit(types.Int32(42))
+	s.NoError(err)
 	ds.Close()
 
 	ldb2dir := path.Join(s.TempDir, "ldb2")

--- a/clients/tagdex/tagdex.go
+++ b/clients/tagdex/tagdex.go
@@ -74,8 +74,8 @@ func main() {
 		// AllP gives inconsistent results. BUG 604
 	}, 1)
 
-	_, ok = outputDS.Commit(out)
-	d.Exp.True(ok, "Could not commit due to conflicting edit")
+	_, err := outputDS.Commit(out)
+	d.Exp.NoError(err)
 
 	fmt.Printf("Indexed %v photos from %v values in %v\n", numPhotos, numValues, time.Now().Sub(t0))
 }

--- a/clients/tagdex/tagdex_test.go
+++ b/clients/tagdex/tagdex_test.go
@@ -47,9 +47,9 @@ func (s *testSuite) TestTagdex() {
 	inputRef := types.WriteValue(set, cs)
 	refVal := types.NewRef(inputRef)
 
-	var ok bool
-	inputDs, ok = inputDs.Commit(refVal)
-	s.True(ok)
+	var err error
+	inputDs, err = inputDs.Commit(refVal)
+	s.NoError(err)
 	inputDs.Close()
 
 	out := s.Run(main, []string{"-in", "input-test", "-out", "tagdex-test"})

--- a/clients/xml_importer/xml_importer.go
+++ b/clients/xml_importer/xml_importer.go
@@ -130,8 +130,8 @@ func main() {
 		}
 
 		if !*noIO {
-			_, ok := ds.Commit(refs.New(ds.Store()))
-			d.Exp.True(ok, "Could not commit due to conflicting edit")
+			_, err := ds.Commit(refs.New(ds.Store()))
+			d.Exp.NoError(err)
 		}
 
 		util.MaybeWriteMemProfile()

--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -18,8 +18,8 @@ type DataStore interface {
 	// Datasets returns the root of the datastore which is a MapOfStringToRefOfCommit where string is a datasetID.
 	Datasets() MapOfStringToRefOfCommit
 
-	// Commit updates the commit that a datastore points at. The new Commit is constructed using v and the current Head. If the update cannot be performed, e.g., because of a conflict, Commit returns 'false'. The newest snapshot of the datastore is always returned.
-	Commit(datasetID string, commit Commit) (DataStore, bool)
+	// Commit updates the commit that a datastore points at. The new Commit is constructed using v and the current Head. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the datastore is always returned.
+	Commit(datasetID string, commit Commit) (DataStore, error)
 
 	// Copies all chunks reachable from (and including)|r| but not reachable from (and including |exclude| in |source| to |sink|
 	CopyReachableChunksP(r, exclude ref.Ref, sink chunks.ChunkSink, concurrency int)

--- a/datas/local_datastore.go
+++ b/datas/local_datastore.go
@@ -22,9 +22,9 @@ func newLocalDataStore(cs chunks.ChunkStore) *LocalDataStore {
 	return &LocalDataStore{dataStoreCommon{cs, datasetsFromRef(rootRef, cs)}}
 }
 
-func (lds *LocalDataStore) Commit(datasetID string, commit Commit) (DataStore, bool) {
-	ok := lds.commit(datasetID, commit)
-	return newLocalDataStore(lds.ChunkStore), ok
+func (lds *LocalDataStore) Commit(datasetID string, commit Commit) (DataStore, error) {
+	err := lds.commit(datasetID, commit)
+	return newLocalDataStore(lds.ChunkStore), err
 }
 
 // Copies all chunks reachable from (and including)|sourceRef| but not reachable from (and including) |exclude| in |source| to |sink|

--- a/datas/remote_datastore.go
+++ b/datas/remote_datastore.go
@@ -32,9 +32,9 @@ func (lds *RemoteDataStore) host() *url.URL {
 	return lds.dataStoreCommon.ChunkStore.(*chunks.HttpStore).Host()
 }
 
-func (lds *RemoteDataStore) Commit(datasetID string, commit Commit) (DataStore, bool) {
-	ok := lds.commit(datasetID, commit)
-	return newRemoteDataStore(lds.ChunkStore), ok
+func (lds *RemoteDataStore) Commit(datasetID string, commit Commit) (DataStore, error) {
+	err := lds.commit(datasetID, commit)
+	return newRemoteDataStore(lds.ChunkStore), err
 }
 
 // Asks remote server to figure out which chunks need to be copied and return them.

--- a/dataset/pull_test.go
+++ b/dataset/pull_test.go
@@ -53,26 +53,26 @@ func pullTest(t *testing.T, topdown bool) {
 		types.NewString("first"), NewList(sink),
 		types.NewString("second"), NewList(sink, types.Int32(2)))
 
-	ok := false
-	source, ok = source.Commit(sourceInitialValue)
-	assert.True(ok)
-	sink, ok = sink.Commit(sinkInitialValue)
-	assert.True(ok)
+	var err error
+	source, err = source.Commit(sourceInitialValue)
+	assert.NoError(err)
+	sink, err = sink.Commit(sinkInitialValue)
+	assert.NoError(err)
 
 	// Add some new stuff to source.
 	updatedValue := sourceInitialValue.Set(
 		types.NewString("third"), NewList(source, types.Int32(3)))
-	source, ok = source.Commit(updatedValue)
-	assert.True(ok)
+	source, err = source.Commit(updatedValue)
+	assert.NoError(err)
 
 	// Add some more stuff, so that source isn't directly ahead of sink.
 	updatedValue = updatedValue.Set(
 		types.NewString("fourth"), NewList(source, types.Int32(4)))
-	source, ok = source.Commit(updatedValue)
-	assert.True(ok)
+	source, err = source.Commit(updatedValue)
+	assert.NoError(err)
 
-	sink = sink.pull(source, 1, topdown, ref.Ref{})
-	assert.True(ok)
+	sink, err = sink.pull(source, 1, topdown, ref.Ref{})
+	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }
 
@@ -97,10 +97,11 @@ func pullFirstCommit(t *testing.T, topdown bool) {
 	NewList(sink)
 	NewList(sink, types.Int32(2))
 
-	source, ok := source.Commit(sourceInitialValue)
-	assert.True(ok)
+	source, err := source.Commit(sourceInitialValue)
+	assert.NoError(err)
 
-	sink = sink.pull(source, 1, topdown, ref.Ref{})
+	sink, err = sink.pull(source, 1, topdown, ref.Ref{})
+	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }
 
@@ -123,10 +124,11 @@ func pullDeepRef(t *testing.T, topdown bool) {
 		types.NewSet(source.Store(), NewSet(source)),
 		types.NewMap(source.Store(), NewMap(source), NewMap(source)))
 
-	source, ok := source.Commit(sourceInitialValue)
-	assert.True(ok)
+	source, err := source.Commit(sourceInitialValue)
+	assert.NoError(err)
 
-	sink = sink.pull(source, 1, topdown, ref.Ref{})
+	sink, err = sink.pull(source, 1, topdown, ref.Ref{})
+	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }
 

--- a/nomdl/codegen/codegen.go
+++ b/nomdl/codegen/codegen.go
@@ -112,7 +112,8 @@ func generate(packageName, in, out, outDir string, written map[string]bool, pars
 	generateAndEmit(getBareFileName(in), out, written, deps, parsed)
 
 	// Since we're just building up a set of refs to all the packages in pkgDS, simply retrying is the logical response to commit failure.
-	for ok := false; !ok; pkgDS, ok = pkgDS.Commit(buildSetOfRefOfPackage(parsed, deps, pkgDS)) {
+	err := datas.ErrOptimisticLockFailed
+	for ; err == datas.ErrOptimisticLockFailed; pkgDS, err = pkgDS.Commit(buildSetOfRefOfPackage(parsed, deps, pkgDS)) {
 	}
 	return pkgDS
 }


### PR DESCRIPTION
Make dataStoreCommon.doCommit() return an error instead of boolean.
