### PR TITLE
Fix import of goleveldb package to point into Godeps/_workspace

### DIFF
--- a/datas/datastore_common.go
+++ b/datas/datastore_common.go
@@ -6,7 +6,7 @@ import (
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 	"github.com/attic-labs/noms/walk"
-	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/attic-labs/noms/Godeps/_workspace/src/github.com/syndtr/goleveldb/leveldb/errors"
 )
 
 type dataStoreCommon struct {


### PR DESCRIPTION
Need to keep our dependencies hermetic and pinned.
