### PR TITLE
Change list/blob chunk values to be their length, not cumulative length.

### DIFF
--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -15,12 +15,10 @@ import (
 
 func getTestCompoundBlob(datas ...string) compoundBlob {
 	tuples := make([]metaTuple, len(datas))
-	length := uint64(0)
 	ms := chunks.NewMemoryStore()
 	for i, s := range datas {
 		b := NewBlob(bytes.NewBufferString(s), ms)
-		length += uint64(len(s))
-		tuples[i] = metaTuple{WriteValue(b, ms), Uint64(length)}
+		tuples[i] = metaTuple{WriteValue(b, ms), Uint64(len(s))}
 	}
 	return newCompoundBlob(tuples, ms)
 }
@@ -28,7 +26,7 @@ func getTestCompoundBlob(datas ...string) compoundBlob {
 func getRandomReader() io.ReadSeeker {
 	length := int(5e5)
 	s := rand.NewSource(42)
-	buff := make([]byte, 5e5, 5e5)
+	buff := make([]byte, length)
 	for i := 0; i < length; i++ {
 		buff[i] = byte(s.Int63() & 0xff)
 	}
@@ -132,7 +130,7 @@ func TestCompoundBlobReaderSeek(t *testing.T) {
 
 	n, err = r.Seek(-1, 1)
 	assert.NoError(err)
-	// assert.Equal(int64(3), n)
+	assert.Equal(int64(3), n)
 
 	n2, err = r.Read(p)
 	assert.NoError(err)

--- a/types/compound_map.go
+++ b/types/compound_map.go
@@ -47,20 +47,20 @@ func (cm compoundMap) Empty() bool {
 func (cm compoundMap) findLeaf(key Value) (*sequenceCursor, mapLeaf) {
 	cursor, leaf := newMetaSequenceCursor(cm, cm.cs)
 
-	var seekFn sequenceCursorSeekCompareFn
+	var seekFn sequenceCursorSeekBinaryCompareFn
 	if orderedSequenceByIndexedType(cm.t) {
 		orderedKey := key.(OrderedValue)
 
-		seekFn = func(carry interface{}, mt sequenceItem) bool {
+		seekFn = func(mt sequenceItem) bool {
 			return !mt.(metaTuple).value.(OrderedValue).Less(orderedKey)
 		}
 	} else {
-		seekFn = func(carry interface{}, mt sequenceItem) bool {
+		seekFn = func(mt sequenceItem) bool {
 			return !mt.(metaTuple).value.(Ref).TargetRef().Less(key.Ref())
 		}
 	}
 
-	cursor.seek(seekFn, nil, nil)
+	cursor.seekBinary(seekFn)
 
 	current := cursor.current().(metaTuple)
 	if current.ref != leaf.Ref() {

--- a/types/compound_set.go
+++ b/types/compound_set.go
@@ -71,20 +71,20 @@ func (cs compoundSet) Filter(cb setFilterCallback) Set {
 func (cs compoundSet) findLeaf(key Value) (*sequenceCursor, setLeaf) {
 	cursor, leaf := newMetaSequenceCursor(cs, cs.cs)
 
-	var seekFn sequenceCursorSeekCompareFn
+	var seekFn sequenceCursorSeekBinaryCompareFn
 	if orderedSequenceByIndexedType(cs.t) {
 		orderedKey := key.(OrderedValue)
 
-		seekFn = func(carry interface{}, mt sequenceItem) bool {
+		seekFn = func(mt sequenceItem) bool {
 			return !mt.(metaTuple).value.(OrderedValue).Less(orderedKey)
 		}
 	} else {
-		seekFn = func(carry interface{}, mt sequenceItem) bool {
+		seekFn = func(mt sequenceItem) bool {
 			return !mt.(metaTuple).value.(Ref).TargetRef().Less(key.Ref())
 		}
 	}
 
-	cursor.seek(seekFn, nil, nil)
+	cursor.seekBinary(seekFn)
 
 	current := cursor.current().(metaTuple)
 	if current.ref != leaf.Ref() {

--- a/types/meta_sequence_cursor_test.go
+++ b/types/meta_sequence_cursor_test.go
@@ -33,21 +33,21 @@ func TestMeta(t *testing.T) {
 
 	mtr := l0.Type()
 
-	m0 := compoundList{metaSequenceObject{metaSequenceData{{lr0, Uint64(1)}, {lr1, Uint64(2)}}, mtr}, &ref.Ref{}, cs}
+	m0 := compoundList{metaSequenceObject{metaSequenceData{{lr0, Uint64(1)}, {lr1, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
 	lm0 := WriteValue(m0, cs)
-	m1 := compoundList{metaSequenceObject{metaSequenceData{{lr2, Uint64(1)}, {lr3, Uint64(2)}}, mtr}, &ref.Ref{}, cs}
+	m1 := compoundList{metaSequenceObject{metaSequenceData{{lr2, Uint64(1)}, {lr3, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
 	lm1 := WriteValue(m1, cs)
-	m2 := compoundList{metaSequenceObject{metaSequenceData{{lr4, Uint64(1)}, {lr5, Uint64(2)}}, mtr}, &ref.Ref{}, cs}
+	m2 := compoundList{metaSequenceObject{metaSequenceData{{lr4, Uint64(1)}, {lr5, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
 	lm2 := WriteValue(m2, cs)
-	m3 := compoundList{metaSequenceObject{metaSequenceData{{lr6, Uint64(1)}, {lr7, Uint64(2)}}, mtr}, &ref.Ref{}, cs}
+	m3 := compoundList{metaSequenceObject{metaSequenceData{{lr6, Uint64(1)}, {lr7, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
 	lm3 := WriteValue(m3, cs)
 
-	m00 := compoundList{metaSequenceObject{metaSequenceData{{lm0, Uint64(2)}, {lm1, Uint64(4)}}, mtr}, &ref.Ref{}, cs}
+	m00 := compoundList{metaSequenceObject{metaSequenceData{{lm0, Uint64(2)}, {lm1, Uint64(4)}}, mtr}, 0, &ref.Ref{}, cs}
 	lm00 := WriteValue(m00, cs)
-	m01 := compoundList{metaSequenceObject{metaSequenceData{{lm2, Uint64(2)}, {lm3, Uint64(4)}}, mtr}, &ref.Ref{}, cs}
+	m01 := compoundList{metaSequenceObject{metaSequenceData{{lm2, Uint64(2)}, {lm3, Uint64(4)}}, mtr}, 0, &ref.Ref{}, cs}
 	lm01 := WriteValue(m01, cs)
 
-	rootList := compoundList{metaSequenceObject{metaSequenceData{{lm00, Uint64(4)}, {lm01, Uint64(8)}}, mtr}, &ref.Ref{}, cs}
+	rootList := compoundList{metaSequenceObject{metaSequenceData{{lm00, Uint64(4)}, {lm01, Uint64(8)}}, mtr}, 0, &ref.Ref{}, cs}
 	rootRef := WriteValue(rootList, cs)
 
 	rootList = ReadValue(rootRef, cs).(compoundList)


### PR DESCRIPTION
This is simpler for chunking, since it no longer needs to "normalize"
the values when re-chunking. It's a bit less efficient because instead
of binary searching we need to linear search through chunk values.
