### PR TITLE
Preserve environment when running subprocesses.

### DIFF
--- a/clients/crunchbase/ui/build.go
+++ b/clients/crunchbase/ui/build.go
@@ -15,6 +15,7 @@ func main() {
 	d.Chk.NoError(err)
 	fileutil.ForceSymlink("../../js/.babelrc", path)
 
+	runner.ForceRun("./link.sh")
 	runner.ForceRun("npm", "install")
 	if _, present := os.LookupEnv("NOMS_SERVER"); !present {
 		os.Setenv("NOMS_SERVER", "http://localhost:8000")

--- a/tools/runner/serial.go
+++ b/tools/runner/serial.go
@@ -15,14 +15,15 @@ import (
 type Env map[string]string
 
 func (e Env) toStrings() (out []string) {
+	out = os.Environ()
+	// Sadly, it seems like we need to force-set GOROOT in the environment to handle some funky runtime environments (e.g. on our Travis setup)
+	if _, overridden := e["GOROOT"]; !overridden {
+		e["GOROOT"] = runtime.GOROOT()
+	}
 	for n, v := range e {
 		out = append(out, fmt.Sprintf("%s=%s", n, v))
 	}
-	if out == nil {
-		// Sadly, it seems like we need to force-set GOROOT in the environment, which means that we need to manually copy out the current environment and add to it instead of just returning nil and allowing the exec library to take its course.
-		out = os.Environ()
-	}
-	return append(out, "GOROOT="+runtime.GOROOT())
+	return
 }
 
 // ForceRun runs 'exe [args...]' in current working directory, and d.Chk()s on failure. Inherits the environment of the current process.

--- a/tools/runner/serial_test.go
+++ b/tools/runner/serial_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -66,6 +67,10 @@ func (suite *SerialRunnerTestSuite) TestEnvVars() {
 		makeEnvVarPrintBuildFile(tc.path, tc.varname)
 		tests = append(tests, tc)
 	}
+	gorootTestCase := testCase{suite.uniqueBuildFile(), "GOROOT", runtime.GOROOT()}
+	makeEnvVarPrintBuildFile(gorootTestCase.path, gorootTestCase.varname)
+	tests = append(tests, gorootTestCase)
+
 	log := &bytes.Buffer{}
 	if suite.True(Serial(log, log, env, suite.dir, buildFileBasename), "Serial() should have succeeded! logs:\n%s", string(log.Bytes())) {
 		logText := string(log.Bytes())


### PR DESCRIPTION
Trying to whitelist needed env vars is just going to be a maintenance
headache, so don't do it.
