### PR TITLE
Make types.Ref implement the OrderedValue interface.

### DIFF
--- a/clients/common/incident.noms.go
+++ b/clients/common/incident.noms.go
@@ -496,8 +496,12 @@ func (r RefOfIncident) ChildValues() []types.Value {
 // A Noms Value that describes RefOfIncident.
 var __typeForRefOfIncident types.Type
 
-func (m RefOfIncident) Type() types.Type {
+func (r RefOfIncident) Type() types.Type {
 	return __typeForRefOfIncident
+}
+
+func (r RefOfIncident) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/common/quad_tree.noms.go
+++ b/clients/common/quad_tree.noms.go
@@ -570,8 +570,12 @@ func (r RefOfValue) ChildValues() []types.Value {
 // A Noms Value that describes RefOfValue.
 var __typeForRefOfValue types.Type
 
-func (m RefOfValue) Type() types.Type {
+func (r RefOfValue) Type() types.Type {
 	return __typeForRefOfValue
+}
+
+func (r RefOfValue) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -1181,8 +1185,12 @@ func (r RefOfSQuadTree) ChildValues() []types.Value {
 // A Noms Value that describes RefOfSQuadTree.
 var __typeForRefOfSQuadTree types.Type
 
-func (m RefOfSQuadTree) Type() types.Type {
+func (r RefOfSQuadTree) Type() types.Type {
 	return __typeForRefOfSQuadTree
+}
+
+func (r RefOfSQuadTree) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/crunchbase/importer/importer.noms.go
+++ b/clients/crunchbase/importer/importer.noms.go
@@ -289,8 +289,12 @@ func (r RefOfMapOfStringToRefOfCompany) ChildValues() []types.Value {
 // A Noms Value that describes RefOfMapOfStringToRefOfCompany.
 var __typeForRefOfMapOfStringToRefOfCompany types.Type
 
-func (m RefOfMapOfStringToRefOfCompany) Type() types.Type {
+func (r RefOfMapOfStringToRefOfCompany) Type() types.Type {
 	return __typeForRefOfMapOfStringToRefOfCompany
+}
+
+func (r RefOfMapOfStringToRefOfCompany) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -480,8 +484,12 @@ func (r RefOfCompany) ChildValues() []types.Value {
 // A Noms Value that describes RefOfCompany.
 var __typeForRefOfCompany types.Type
 
-func (m RefOfCompany) Type() types.Type {
+func (r RefOfCompany) Type() types.Type {
 	return __typeForRefOfCompany
+}
+
+func (r RefOfCompany) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/crunchbase/importer/sha1_9fb26a6.go
+++ b/clients/crunchbase/importer/sha1_9fb26a6.go
@@ -947,8 +947,12 @@ func (r RefOfRound) ChildValues() []types.Value {
 // A Noms Value that describes RefOfRound.
 var __typeForRefOfRound types.Type
 
-func (m RefOfRound) Type() types.Type {
+func (r RefOfRound) Type() types.Type {
 	return __typeForRefOfRound
+}
+
+func (r RefOfRound) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/crunchbase/index/index.noms.go
+++ b/clients/crunchbase/index/index.noms.go
@@ -898,8 +898,12 @@ func (r RefOfKey) ChildValues() []types.Value {
 // A Noms Value that describes RefOfKey.
 var __typeForRefOfKey types.Type
 
-func (m RefOfKey) Type() types.Type {
+func (r RefOfKey) Type() types.Type {
 	return __typeForRefOfKey
+}
+
+func (r RefOfKey) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -1105,8 +1109,12 @@ func (r RefOfSetOfRoundRaise) ChildValues() []types.Value {
 // A Noms Value that describes RefOfSetOfRoundRaise.
 var __typeForRefOfSetOfRoundRaise types.Type
 
-func (m RefOfSetOfRoundRaise) Type() types.Type {
+func (r RefOfSetOfRoundRaise) Type() types.Type {
 	return __typeForRefOfSetOfRoundRaise
+}
+
+func (r RefOfSetOfRoundRaise) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/crunchbase/index/sha1_2a87e00.go
+++ b/clients/crunchbase/index/sha1_2a87e00.go
@@ -289,8 +289,12 @@ func (r RefOfMapOfStringToRefOfCompany) ChildValues() []types.Value {
 // A Noms Value that describes RefOfMapOfStringToRefOfCompany.
 var __typeForRefOfMapOfStringToRefOfCompany types.Type
 
-func (m RefOfMapOfStringToRefOfCompany) Type() types.Type {
+func (r RefOfMapOfStringToRefOfCompany) Type() types.Type {
 	return __typeForRefOfMapOfStringToRefOfCompany
+}
+
+func (r RefOfMapOfStringToRefOfCompany) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -480,8 +484,12 @@ func (r RefOfCompany) ChildValues() []types.Value {
 // A Noms Value that describes RefOfCompany.
 var __typeForRefOfCompany types.Type
 
-func (m RefOfCompany) Type() types.Type {
+func (r RefOfCompany) Type() types.Type {
 	return __typeForRefOfCompany
+}
+
+func (r RefOfCompany) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/crunchbase/index/sha1_9fb26a6.go
+++ b/clients/crunchbase/index/sha1_9fb26a6.go
@@ -947,8 +947,12 @@ func (r RefOfRound) ChildValues() []types.Value {
 // A Noms Value that describes RefOfRound.
 var __typeForRefOfRound types.Type
 
-func (m RefOfRound) Type() types.Type {
+func (r RefOfRound) Type() types.Type {
 	return __typeForRefOfRound
+}
+
+func (r RefOfRound) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/flickr/types.noms.go
+++ b/clients/flickr/types.noms.go
@@ -503,8 +503,12 @@ func (r RefOfUser) ChildValues() []types.Value {
 // A Noms Value that describes RefOfUser.
 var __typeForRefOfUser types.Type
 
-func (m RefOfUser) Type() types.Type {
+func (r RefOfUser) Type() types.Type {
 	return __typeForRefOfUser
+}
+
+func (r RefOfUser) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -560,8 +564,12 @@ func (r RefOfSetOfRefOfRemotePhoto) ChildValues() []types.Value {
 // A Noms Value that describes RefOfSetOfRefOfRemotePhoto.
 var __typeForRefOfSetOfRefOfRemotePhoto types.Type
 
-func (m RefOfSetOfRefOfRemotePhoto) Type() types.Type {
+func (r RefOfSetOfRefOfRemotePhoto) Type() types.Type {
 	return __typeForRefOfSetOfRefOfRemotePhoto
+}
+
+func (r RefOfSetOfRefOfRemotePhoto) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -767,8 +775,12 @@ func (r RefOfRemotePhoto) ChildValues() []types.Value {
 // A Noms Value that describes RefOfRemotePhoto.
 var __typeForRefOfRemotePhoto types.Type
 
-func (m RefOfRemotePhoto) Type() types.Type {
+func (r RefOfRemotePhoto) Type() types.Type {
 	return __typeForRefOfRemotePhoto
+}
+
+func (r RefOfRemotePhoto) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/picasa/picasa.noms.go
+++ b/clients/picasa/picasa.noms.go
@@ -672,8 +672,12 @@ func (r RefOfUser) ChildValues() []types.Value {
 // A Noms Value that describes RefOfUser.
 var __typeForRefOfUser types.Type
 
-func (m RefOfUser) Type() types.Type {
+func (r RefOfUser) Type() types.Type {
 	return __typeForRefOfUser
+}
+
+func (r RefOfUser) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -729,8 +733,12 @@ func (r RefOfSetOfRefOfRemotePhoto) ChildValues() []types.Value {
 // A Noms Value that describes RefOfSetOfRefOfRemotePhoto.
 var __typeForRefOfSetOfRefOfRemotePhoto types.Type
 
-func (m RefOfSetOfRefOfRemotePhoto) Type() types.Type {
+func (r RefOfSetOfRefOfRemotePhoto) Type() types.Type {
 	return __typeForRefOfSetOfRefOfRemotePhoto
+}
+
+func (r RefOfSetOfRefOfRemotePhoto) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -936,8 +944,12 @@ func (r RefOfRemotePhoto) ChildValues() []types.Value {
 // A Noms Value that describes RefOfRemotePhoto.
 var __typeForRefOfRemotePhoto types.Type
 
-func (m RefOfRemotePhoto) Type() types.Type {
+func (r RefOfRemotePhoto) Type() types.Type {
 	return __typeForRefOfRemotePhoto
+}
+
+func (r RefOfRemotePhoto) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/pitchmap/index/types.noms.go
+++ b/clients/pitchmap/index/types.noms.go
@@ -447,8 +447,12 @@ func (r RefOfMapOfStringToValue) ChildValues() []types.Value {
 // A Noms Value that describes RefOfMapOfStringToValue.
 var __typeForRefOfMapOfStringToValue types.Type
 
-func (m RefOfMapOfStringToValue) Type() types.Type {
+func (r RefOfMapOfStringToValue) Type() types.Type {
 	return __typeForRefOfMapOfStringToValue
+}
+
+func (r RefOfMapOfStringToValue) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -781,8 +785,12 @@ func (r RefOfListOfPitch) ChildValues() []types.Value {
 // A Noms Value that describes RefOfListOfPitch.
 var __typeForRefOfListOfPitch types.Type
 
-func (m RefOfListOfPitch) Type() types.Type {
+func (r RefOfListOfPitch) Type() types.Type {
 	return __typeForRefOfListOfPitch
+}
+
+func (r RefOfListOfPitch) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/tagdex/types.noms.go
+++ b/clients/tagdex/types.noms.go
@@ -328,8 +328,12 @@ func (r RefOfRemotePhoto) ChildValues() []types.Value {
 // A Noms Value that describes RefOfRemotePhoto.
 var __typeForRefOfRemotePhoto types.Type
 
-func (m RefOfRemotePhoto) Type() types.Type {
+func (r RefOfRemotePhoto) Type() types.Type {
 	return __typeForRefOfRemotePhoto
+}
+
+func (r RefOfRemotePhoto) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/clients/util/types.noms.go
+++ b/clients/util/types.noms.go
@@ -187,8 +187,12 @@ func (r RefOfMapOfStringToValue) ChildValues() []types.Value {
 // A Noms Value that describes RefOfMapOfStringToValue.
 var __typeForRefOfMapOfStringToValue types.Type
 
-func (m RefOfMapOfStringToValue) Type() types.Type {
+func (r RefOfMapOfStringToValue) Type() types.Type {
 	return __typeForRefOfMapOfStringToValue
+}
+
+func (r RefOfMapOfStringToValue) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/datas/types.noms.go
+++ b/datas/types.noms.go
@@ -456,8 +456,12 @@ func (r RefOfCommit) ChildValues() []types.Value {
 // A Noms Value that describes RefOfCommit.
 var __typeForRefOfCommit types.Type
 
-func (m RefOfCommit) Type() types.Type {
+func (r RefOfCommit) Type() types.Type {
 	return __typeForRefOfCommit
+}
+
+func (r RefOfCommit) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/nomdl/codegen/ref.tmpl
+++ b/nomdl/codegen/ref.tmpl
@@ -36,8 +36,12 @@ func (r {{.Name}}) ChildValues() []{{$typesPackage}}Value {
 // A Noms Value that describes {{.Name}}.
 var __typeFor{{.Name}} {{$typesPackage}}Type
 
-func (m {{.Name}}) Type() {{$typesPackage}}Type {
+func (r {{.Name}}) Type() {{$typesPackage}}Type {
 	return __typeFor{{.Name}}
+}
+
+func (r {{.Name}}) Less(other {{$typesPackage}}OrderedValue) bool {
+  return r.TargetRef().Less(other.({{$typesPackage}}RefBase).TargetRef())
 }
 
 func init() {

--- a/nomdl/codegen/test/gen/ref.noms.go
+++ b/nomdl/codegen/test/gen/ref.noms.go
@@ -151,8 +151,12 @@ func (r RefOfListOfString) ChildValues() []types.Value {
 // A Noms Value that describes RefOfListOfString.
 var __typeForRefOfListOfString types.Type
 
-func (m RefOfListOfString) Type() types.Type {
+func (r RefOfListOfString) Type() types.Type {
 	return __typeForRefOfListOfString
+}
+
+func (r RefOfListOfString) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -351,8 +355,12 @@ func (r RefOfSetOfFloat32) ChildValues() []types.Value {
 // A Noms Value that describes RefOfSetOfFloat32.
 var __typeForRefOfSetOfFloat32 types.Type
 
-func (m RefOfSetOfFloat32) Type() types.Type {
+func (r RefOfSetOfFloat32) Type() types.Type {
 	return __typeForRefOfSetOfFloat32
+}
+
+func (r RefOfSetOfFloat32) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {
@@ -551,8 +559,12 @@ func (r RefOfFloat32) ChildValues() []types.Value {
 // A Noms Value that describes RefOfFloat32.
 var __typeForRefOfFloat32 types.Type
 
-func (m RefOfFloat32) Type() types.Type {
+func (r RefOfFloat32) Type() types.Type {
 	return __typeForRefOfFloat32
+}
+
+func (r RefOfFloat32) Less(other types.OrderedValue) bool {
+	return r.TargetRef().Less(other.(types.RefBase).TargetRef())
 }
 
 func init() {

--- a/nomdl/pkg/gen/generate_parser.sh
+++ b/nomdl/pkg/gen/generate_parser.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-pigeon "${1}" | goimports > "${1}".go
+"$GOPATH/bin/pigeon" "${1}" | "$GOPATH/bin/goimports" > "${1}".go

--- a/types/package_set_of_ref.go
+++ b/types/package_set_of_ref.go
@@ -197,6 +197,10 @@ func (m RefOfPackage) Type() Type {
 	return __typeForRefOfPackage
 }
 
+func (r RefOfPackage) Less(other OrderedValue) bool {
+	return r.TargetRef().Less(other.(RefBase).TargetRef())
+}
+
 func init() {
 	__typeForRefOfPackage = MakeCompoundType(RefKind, MakePrimitiveType(PackageKind))
 	RegisterRef(__typeForRefOfPackage, builderForRefOfPackage)

--- a/types/ref.go
+++ b/types/ref.go
@@ -49,6 +49,10 @@ func (r Ref) Type() Type {
 	return r.t
 }
 
+func (r Ref) Less(other OrderedValue) bool {
+	return r.target.Less(other.(Ref).target)
+}
+
 func (r Ref) TargetValue(cs chunks.ChunkStore) Value {
 	return ReadValue(r.target, cs)
 }

--- a/types/type.go
+++ b/types/type.go
@@ -69,10 +69,12 @@ func (t Type) Kind() NomsKind {
 }
 
 func (t Type) IsOrdered() bool {
-	if desc, ok := t.Desc.(PrimitiveDesc); ok {
-		return desc.IsOrdered()
+	switch t.Desc.Kind() {
+	case Float32Kind, Float64Kind, Int8Kind, Int16Kind, Int32Kind, Int64Kind, Uint8Kind, Uint16Kind, Uint32Kind, Uint64Kind, StringKind, RefKind:
+		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func (t Type) PackageRef() ref.Ref {

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -46,15 +46,6 @@ func (p PrimitiveDesc) Describe() string {
 	return KindToString[p.Kind()]
 }
 
-func (p PrimitiveDesc) IsOrdered() bool {
-	switch p.Kind() {
-	case Float32Kind, Float64Kind, Int8Kind, Int16Kind, Int32Kind, Int64Kind, Uint8Kind, Uint16Kind, Uint32Kind, Uint64Kind, StringKind:
-		return true
-	default:
-		return false
-	}
-}
-
 var KindToString = map[NomsKind]string{
 	BlobKind:    "Blob",
 	BoolKind:    "Bool",

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -110,5 +110,5 @@ func TestTypeOrdered(t *testing.T) {
 	assert.False(MakeCompoundType(ListKind, MakePrimitiveType(StringKind)).IsOrdered())
 	assert.False(MakeCompoundType(SetKind, MakePrimitiveType(StringKind)).IsOrdered())
 	assert.False(MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(ValueKind)).IsOrdered())
-	assert.False(MakeCompoundType(RefKind, MakePrimitiveType(StringKind)).IsOrdered())
+	assert.True(MakeCompoundType(RefKind, MakePrimitiveType(StringKind)).IsOrdered())
 }


### PR DESCRIPTION
This fixes the bug where compoundSets/Maps of refs are ordered by their
type.Ref's Ref, rather than their type.Ref's TargetRef.
