### PR TITLE
Re-land "Implement compoundSet.Filter()"

### DIFF
--- a/types/compound_set.go
+++ b/types/compound_set.go
@@ -113,7 +113,16 @@ func (cs compoundSet) Subtract(others ...Set) Set {
 }
 
 func (cs compoundSet) Filter(cb setFilterCallback) Set {
-	panic("not implemented")
+	seq := newEmptySequenceChunker(makeSetLeafChunkFn(cs.t, cs.cs), newSetMetaSequenceChunkFn(cs.t, cs.cs), newSetLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
+
+	cs.IterAll(func(v Value) {
+		if cb(v) {
+			seq.Append(v)
+		}
+	})
+
+	s := seq.Done()
+	return internalValueFromType(s, s.Type()).(Set)
 }
 
 func (cs compoundSet) findLeaf(key Value) (*sequenceCursor, setLeaf, int) {

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -255,3 +255,30 @@ func TestCompoundSetRemoveNonexistentValue(t *testing.T) {
 	assert.Equal(original.Len(), actual.Len())
 	assert.True(original.Equals(actual))
 }
+
+func TestCompoundSetFilter(t *testing.T) {
+	assert := assert.New(t)
+
+	doTest := func(ts testSet) {
+		cs := chunks.NewMemoryStore()
+		set := ts.toCompoundSet(cs)
+		sort.Sort(ts)
+		pivotPoint := 10
+		pivot := ts.values[pivotPoint]
+		actual := set.Filter(func(v Value) bool {
+			return ts.less(v, pivot)
+		})
+		assert.True(newTypedSet(cs, ts.tr, ts.values[:pivotPoint+1]...).Equals(actual))
+
+		idx := 0
+		actual.IterAll(func(v Value) {
+			assert.True(ts.values[idx].Equals(v), "%v != %v", v, ts.values[idx])
+			idx++
+		})
+	}
+
+	doTest(getTestNativeOrderSet(16))
+	doTest(getTestRefValueOrderSet(2))
+	doTest(getTestRefToNativeOrderSet(2))
+	doTest(getTestRefToValueOrderSet(2))
+}


### PR DESCRIPTION
This reverts commit 60ab9c7f0c7d884ccc1152341e27d8815e102a53.

Fixes initial patch to correctly use test harness.  Implementation is
based on newTypedSet(), so hopefully has similar performance
characteristics.
