### PR TITLE
Implement Set Union

### DIFF
--- a/types/assert.go
+++ b/types/assert.go
@@ -10,7 +10,7 @@ func assertType(t Type, v ...Value) {
 	}
 }
 
-func assertSetsSameType(s setLeaf, v ...Set) {
+func assertSetsSameType(s Set, v ...Set) {
 	if s.elemType().Kind() != ValueKind {
 		t := s.Type()
 		for _, v := range v {

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -282,3 +282,53 @@ func TestCompoundSetFilter(t *testing.T) {
 	doTest(getTestRefToNativeOrderSet(2))
 	doTest(getTestRefToValueOrderSet(2))
 }
+
+func TestCompoundSetUnion(t *testing.T) {
+	assert := assert.New(t)
+	ms := chunks.NewMemoryStore()
+
+	doTest := func(ts testSet) {
+		cs := ts.toCompoundSet(ms)
+		cs2 := cs.Union()
+		assert.True(cs.Equals(cs2))
+		cs3 := cs.Union(cs2)
+		assert.True(cs.Equals(cs3))
+		cs4 := cs.Union(cs2, cs3)
+		assert.True(cs.Equals(cs4))
+		emptySet := NewTypedSet(ms, ts.tr)
+		cs5 := cs.Union(emptySet)
+		assert.True(cs.Equals(cs5))
+		cs6 := emptySet.Union(cs)
+		assert.True(cs.Equals(cs6))
+
+		r := rand.New(rand.NewSource(123))
+		subsetValues1 := make([]Value, 0, len(ts.values))
+		subsetValues2 := make([]Value, 0, len(ts.values))
+		subsetValues3 := make([]Value, 0, len(ts.values))
+		subsetValuesAll := make([]Value, 0, len(ts.values))
+		for _, v := range ts.values {
+			if r.Intn(3) == 0 {
+				subsetValues1 = append(subsetValues1, v)
+				subsetValuesAll = append(subsetValuesAll, v)
+			} else if r.Intn(3) == 0 {
+				subsetValues2 = append(subsetValues2, v)
+				subsetValuesAll = append(subsetValuesAll, v)
+			} else if r.Intn(3) == 0 {
+				subsetValues3 = append(subsetValues3, v)
+				subsetValuesAll = append(subsetValuesAll, v)
+			}
+		}
+
+		s1 := NewTypedSet(ms, ts.tr, subsetValues1...)
+		s2 := NewTypedSet(ms, ts.tr, subsetValues2...)
+		s3 := NewTypedSet(ms, ts.tr, subsetValues3...)
+		sAll := NewTypedSet(ms, ts.tr, subsetValuesAll...)
+
+		assert.True(s1.Union(s2, s3).Equals(sAll))
+	}
+
+	doTest(getTestNativeOrderSet(16))
+	doTest(getTestRefValueOrderSet(2))
+	doTest(getTestRefToNativeOrderSet(2))
+	doTest(getTestRefToValueOrderSet(2))
+}

--- a/types/set_leaf.go
+++ b/types/set_leaf.go
@@ -57,15 +57,7 @@ func (s setLeaf) Remove(values ...Value) Set {
 }
 
 func (s setLeaf) Union(others ...Set) Set {
-	assertSetsSameType(s, others...)
-	var result Set = s
-	for _, other := range others {
-		other.Iter(func(v Value) (stop bool) {
-			result = result.Insert(v)
-			return
-		})
-	}
-	return result
+	return setUnion(s, s.cs, others)
 }
 
 func (s setLeaf) Subtract(others ...Set) Set {
@@ -239,5 +231,20 @@ func makeSetLeafChunkFn(t Type, cs chunks.ChunkStore) makeChunkFn {
 		}
 
 		return metaTuple{ref, indexValue}, setLeaf
+	}
+}
+
+func (s setLeaf) sequenceCursorAtFirst() *sequenceCursor {
+	return &sequenceCursor{
+		nil,
+		s.data,
+		0,
+		len(s.data),
+		func(parent sequenceItem, idx int) sequenceItem {
+			return s.data[idx]
+		},
+		func(reference sequenceItem) (sequence sequenceItem, length int) {
+			panic("unreachable")
+		},
 	}
 }


### PR DESCRIPTION
This is done by creating a cursor for each set. This is a cursor for
the actual values in the sets. We then pick the "smallest" value from
the cursors and advance that cursor. This continues until we have
exhausted all the cursors.

  setA.Union(set0, ... setN)

The time complexity is O(len(setA) + len(set0)) + ... len(setN))
