### PR TITLE
Fix bug in sequenceChunker when rechunking single item chunks.

### DIFF
--- a/types/compound_map_test.go
+++ b/types/compound_map_test.go
@@ -226,7 +226,7 @@ func TestCompoundMapIterAll(t *testing.T) {
 func TestCompoundMapSet(t *testing.T) {
 	assert := assert.New(t)
 
-	doTest := func(incr int, tm testMap) {
+	doTest := func(incr, offset int, tm testMap) {
 		cs := chunks.NewMemoryStore()
 		expected := tm.toCompoundMap(cs)
 		run := func(from, to int) {
@@ -234,24 +234,20 @@ func TestCompoundMapSet(t *testing.T) {
 			assert.Equal(expected.Len(), actual.Len())
 			assert.True(expected.Equals(actual))
 		}
-		for i := 0; i < len(tm.entries); i += incr {
-			run(i, i+1)
+		for i := 0; i < len(tm.entries)-offset; i += incr {
+			run(i, i+offset)
 		}
-		// TODO: make this pass, and make it fast:
-		// for i := 0; i < len(tm.entries)-incr; i += incr {
-		//   run(i, i+incr)
-		// }
-		// For example, run(256, 384) fails with the native order map.
-
+		run(len(tm.entries)-offset, len(tm.entries))
 		assert.Panics(func() {
 			expected.Set(Int8(1), Bool(true))
 		}, "Should panic due to wrong type")
 	}
 
-	doTest(128, getTestNativeOrderMap(32))
-	doTest(64, getTestRefValueOrderMap(4))
-	doTest(64, getTestRefToNativeOrderMap(4))
-	doTest(64, getTestRefToValueOrderMap(4))
+	doTest(18, 3, getTestNativeOrderMap(9))
+	doTest(128, 1, getTestNativeOrderMap(32))
+	doTest(64, 1, getTestRefValueOrderMap(4))
+	doTest(64, 1, getTestRefToNativeOrderMap(4))
+	doTest(64, 1, getTestRefToValueOrderMap(4))
 }
 
 func TestCompoundMapSetExistingKeyToExistingValue(t *testing.T) {

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -178,33 +178,28 @@ func TestCompoundSetIterAll(t *testing.T) {
 func TestCompoundSetInsert(t *testing.T) {
 	assert := assert.New(t)
 
-	doTest := func(incr int, ts testSet) {
+	doTest := func(incr, offset int, ts testSet) {
 		cs := chunks.NewMemoryStore()
 		expected := ts.toCompoundSet(cs)
 		run := func(from, to int) {
 			actual := ts.Remove(from, to).toCompoundSet(cs).Insert(ts.values[from:to]...)
-			assert.Equal(expected.Len(), actual.Len(), "%d-%d", from, to)
+			assert.Equal(expected.Len(), actual.Len())
 			assert.True(expected.Equals(actual))
 		}
-		for i := 0; i < len(ts.values); i += incr {
-			run(i, i+1)
+		for i := 0; i < len(ts.values)-offset; i += incr {
+			run(i, i+offset)
 		}
-		run(len(ts.values)-1, len(ts.values))
-		// TODO: make this pass, and make it fast:
-		// for i := 0; i < len(ts.values)-incr; i += incr {
-		//   run(i, i+incr)
-		// }
-		// For example, run(896, 960) fails for the native order set.
-
+		run(len(ts.values)-offset, len(ts.values))
 		assert.Panics(func() {
 			expected.Insert(Int8(1))
 		}, "Should panic due to wrong type")
 	}
 
-	doTest(64, getTestNativeOrderSet(32))
-	doTest(32, getTestRefValueOrderSet(4))
-	doTest(32, getTestRefToNativeOrderSet(4))
-	doTest(32, getTestRefToValueOrderSet(4))
+	doTest(18, 3, getTestNativeOrderSet(9))
+	doTest(64, 1, getTestNativeOrderSet(32))
+	doTest(32, 1, getTestRefValueOrderSet(4))
+	doTest(32, 1, getTestRefToNativeOrderSet(4))
+	doTest(32, 1, getTestRefToValueOrderSet(4))
 }
 
 func TestCompoundSetInsertExistingValue(t *testing.T) {
@@ -222,30 +217,26 @@ func TestCompoundSetInsertExistingValue(t *testing.T) {
 func TestCompoundSetRemove(t *testing.T) {
 	assert := assert.New(t)
 
-	doTest := func(incr int, ts testSet) {
+	doTest := func(incr, offset int, ts testSet) {
 		cs := chunks.NewMemoryStore()
 		whole := ts.toCompoundSet(cs)
 		run := func(from, to int) {
 			expected := ts.Remove(from, to).toCompoundSet(cs)
 			actual := whole.Remove(ts.values[from:to]...)
-			assert.Equal(expected.Len(), actual.Len(), "%d-%d", from, to)
+			assert.Equal(expected.Len(), actual.Len())
 			assert.True(expected.Equals(actual))
 		}
-		for i := 0; i < len(ts.values); i += incr {
-			run(i, i+1)
+		for i := 0; i < len(ts.values)-offset; i += incr {
+			run(i, i+offset)
 		}
-		run(len(ts.values)-1, len(ts.values))
-		// TODO: make this pass, and make it fast:
-		// for i := 0; i < len(ts.values)-incr; i += incr {
-		//   run(i, i+incr)
-		// }
-		// For example, run(448, 512) fails for the native order set.
+		run(len(ts.values)-offset, len(ts.values))
 	}
 
-	doTest(64, getTestNativeOrderSet(32))
-	doTest(32, getTestRefValueOrderSet(4))
-	doTest(32, getTestRefToNativeOrderSet(4))
-	doTest(32, getTestRefToValueOrderSet(4))
+	doTest(18, 3, getTestNativeOrderSet(9))
+	doTest(64, 1, getTestNativeOrderSet(32))
+	doTest(32, 1, getTestRefValueOrderSet(4))
+	doTest(32, 1, getTestRefToNativeOrderSet(4))
+	doTest(32, 1, getTestRefToValueOrderSet(4))
 }
 
 func TestCompoundSetRemoveNonexistentValue(t *testing.T) {

--- a/types/sequence_chunker.go
+++ b/types/sequence_chunker.go
@@ -132,15 +132,24 @@ func (seq *sequenceChunker) Done() Value {
 		return internalValueFromType(done, done.Type())
 	}
 
-	if seq.parent != nil && seq.parent.used {
-		if len(seq.current) > 0 {
-			seq.handleChunkBoundary()
-		}
-		return seq.parent.Done()
+	if seq.isRoot() {
+		_, done := seq.makeChunk(seq.current)
+		return internalValueFromType(done, done.Type())
 	}
 
-	_, done := seq.makeChunk(seq.current)
-	return internalValueFromType(done, done.Type())
+	if len(seq.current) > 0 {
+		seq.handleChunkBoundary()
+	}
+	return seq.parent.Done()
+}
+
+func (seq *sequenceChunker) isRoot() bool {
+	for ancstr := seq.parent; ancstr != nil; ancstr = ancstr.parent {
+		if ancstr.used {
+			return false
+		}
+	}
+	return true
 }
 
 func (seq *sequenceChunker) finalizeCursor() {


### PR DESCRIPTION
The problem was that if there are chunks in the middle of a prollytree
with only a single item, which can happen if the first item in a
sequence was a chunk boundary, in some circumstances sequenceChunker
would think that it's the root of the tree.
