### PR TITLE
JS: Remove usage of for-of loops

### DIFF
--- a/clients/splore/buchheim.js
+++ b/clients/splore/buchheim.js
@@ -77,7 +77,8 @@ export class TreeNode {
   leftBrother(): ?TreeNode {
     let n = null;
     if (this.parent) {
-      for (let node of this.parent.children) {
+      for (let i = 0; i < this.parent.children.length; i++) {
+        let node = this.parent.children[i];
         if (node === this) {
           return n;
         } else {
@@ -111,7 +112,8 @@ function firstWalk(v: TreeNode, distance: number): void {
     }
   } else {
     let defaultAncestor = v.children[0];
-    for (let w of v.children) {
+    for (let i = 0; i < v.children.length; i++) {
+      let w = v.children[i];
       firstWalk(w, distance);
       defaultAncestor = apportion(w, defaultAncestor, distance);
     }
@@ -205,7 +207,7 @@ function secondWalk(v: TreeNode, m: number, depth: number): void {
   v.x += m;
   v.y = depth;
 
-  for (let w of v.children) {
-    secondWalk(w, m + v.mod, depth + 1);
+  for (let i = 0; i < v.children.length; i++) {
+    secondWalk(v.children[i], m + v.mod, depth + 1);
   }
 }

--- a/js/src/chunk_serializer.js
+++ b/js/src/chunk_serializer.js
@@ -10,14 +10,15 @@ const chunkHeaderSize = sha1Size + chunkLengthSize;
 
 export function serialize(chunks: Array<Chunk>): ArrayBuffer {
   let totalSize = 0;
-  for (let chunk of chunks) {
-    totalSize += chunkHeaderSize + chunk.data.length;
+  for (let i = 0; i < chunks.length; i++) {
+    totalSize += chunkHeaderSize + chunks[i].data.length;
   }
 
   let buffer = new ArrayBuffer(totalSize);
   let offset = 0;
 
-  for (let chunk of chunks) {
+  for (let i = 0; i < chunks.length; i++) {
+    let chunk = chunks[i];
     let refArray = new Uint8Array(buffer, offset, sha1Size);
     refArray.set(chunk.ref.digest);
     offset += sha1Size;

--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -78,13 +78,15 @@ export default class Struct extends ValueBase {
 }
 
 function findField(desc: StructDesc, name: string): [?Field, boolean] {
-  for (let f of desc.fields) {
+  for (let i = 0; i < desc.fields.length; i++) {
+    let f = desc.fields[i];
     if (f.name === name) {
       return [f, false];
     }
   }
 
-  for (let f of desc.union) {
+  for (let i = 0; i < desc.union.length; i++) {
+    let f = desc.union[i];
     if (f.name === name) {
       return [f, true];
     }


### PR DESCRIPTION
Babel generates slow code for these. Use ordinary for loops when the
performance might matter.

Fixes #754
