### PR TITLE
Update webapp README.md files to mention PYTHONPATH

### DIFF
--- a/clients/pitchmap/ui/README.md
+++ b/clients/pitchmap/ui/README.md
@@ -8,19 +8,20 @@ This is an (incomplete) sample app that visualizes pitching data as a heatmap.
 * Node.js: https://nodejs.org/download/
 * You probably want to configure npm to [use a global module path that your user owns](https://docs.npmjs.com/getting-started/fixing-npm-permissions)
 
-## Build
+## Example
 
-* `./link.sh`
-* `npm install`
-* `npm run build`
+```
+export PYTHONPATH="${GOPATH}/src/github.com/attic-labs/noms/tools"
+NOMS_SERVER=http://localhost:8000 NOMS_DATASET_ID=mlb/heatmap python build.py
+python -m SimpleHTTPServer 8080`
+```
 
-
-## Run
-
-* `python -m SimpleHTTPServer 8080` (expects ../server to run on same host, port 8000)
+Then, navigate to [http://localhost:8080](http://localhost:8080).
 
 ## Develop
 
-* `npm run start`
+* `./link.sh`  # only necessary first time, or if changes have happened in `js`
+* `npm install`  # only necessary first time, or if deps have changed
+* `NOMS_SERVER=http://localhost:8000 npm run start`
 
 This will start watchify which is continually building a shippable (but non minified) out.js

--- a/clients/pitchmap/ui/build.py
+++ b/clients/pitchmap/ui/build.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import os, os.path, subprocess
+
+import noms.symlink as symlink
+
+def main():
+	# ln -sf ../../js/.babelrc .babelrc hack, because zip files screw up symlinks.
+	babelrcPath = os.path.abspath('.babelrc')
+	symlink.Force('../../../js/.babelrc', babelrcPath)
+
+	subprocess.check_call('./link.sh', shell=False)
+	subprocess.check_call(['npm', 'install'], shell=False)
+	env = os.environ
+	if 'NOMS_SERVER' not in env:
+		env['NOMS_SERVER'] = 'http://localhost:8000'
+	if 'NOMS_DATASET_ID' not in env:
+		env['NOMS_DATASET_ID'] = 'mlb/heatmap'
+	subprocess.check_call(['npm', 'run', 'build'], env=env, shell=False)
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
If we didn't have to clean up symlinks before building, we wouldn't
need the little symlink library, and build.py files would have no
dependencies. But...they do :-/
