### PR TITLE
JS: Change Chunk.p.ref to allow inlining

### DIFF
--- a/js/src/chunk.js
+++ b/js/src/chunk.js
@@ -16,11 +16,7 @@ export default class Chunk {
   }
 
   get ref(): Ref {
-    if (this._ref) {
-      return this._ref;
-    } else {
-      return this._ref = Ref.fromData(this.data);
-    }
+    return this._ref || (this._ref = Ref.fromData(this.data));
   }
 
   isEmpty(): boolean {


### PR DESCRIPTION
Not sure why the old code did not get inlined correctly. With this
change `ref` no longer shows up in my profile. (It was the hottest
function before.)
