### PR TITLE
Work around Babel bug // Work around Babel bug T6926

### DIFF
--- a/clients/splore/main.js
+++ b/clients/splore/main.js
@@ -69,7 +69,13 @@ function handleChunkLoad(ref: Ref, val: any, fromRef: ?string) {
 
     // Populate links.
     if (fromId) {
-      (data.links[fromId] || (data.links[fromId] = [])).push(id);
+      // Work around Babel bug: https://phabricator.babeljs.io/T6926
+      let links = data.links[fromId];
+      if (!links) {
+        links = [];
+        data.links[fromId] = links;
+      }
+      links.push(id);
     }
 
     switch (typeof val) {

--- a/js/src/chunk.js
+++ b/js/src/chunk.js
@@ -16,7 +16,11 @@ export default class Chunk {
   }
 
   get ref(): Ref {
-    return this._ref || (this._ref = Ref.fromData(this.data));
+    // Work around Babel bug: https://phabricator.babeljs.io/T6926
+    if (!this._ref) {
+      this._ref = Ref.fromData(this.data);
+    }
+    return this._ref;
   }
 
   isEmpty(): boolean {


### PR DESCRIPTION
Babel removes required parens: https://phabricator.babeljs.io/T6926
