### PR TITLE
Make sure noms have babel-loader in its deps

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -11,6 +11,7 @@
     "babel-core": "^6.3.15",
     "babel-eslint": "^4.1.5",
     "babel-generator": "^6.4.2",
+    "babel-loader": "^6.2.1",
     "babel-plugin-syntax-async-functions": "^6.3.13",
     "babel-plugin-syntax-flow": "^6.3.13",
     "babel-plugin-transform-async-to-generator": "^6.3.13",
@@ -27,7 +28,8 @@
     "eslint-plugin-react": "^3.8.0",
     "flow-bin": "^0.19.1",
     "fs-extra": "^0.26.2",
-    "mocha": "^2.3.0"
+    "mocha": "^2.3.0",
+    "webpack": "^1.12.11"
   },
   "scripts": {
     "start": "node build/copy-flow-files.js -w & babel -w src/ -d dist/",


### PR DESCRIPTION
For some reason webpack wants to resolve the babel-loader inside
noms/js/
