### PR TITLE
Crunchbase: Hardcode the time to 2015/Q2-2015

### DIFF
--- a/clients/crunchbase/index/index.go
+++ b/clients/crunchbase/index/index.go
@@ -70,9 +70,9 @@ func main() {
 		}
 
 		// Compute a cutoff date which is later used to only include rounds after this date to reduce the amount of data.
-		now := time.Now()
-		currentYear := time.Date(now.Year(), time.January, 1, 0, 0, 0, 0, time.UTC)
-		lastQ := lastQuarter(now)
+		// Hardcode the time.
+		currentYear := time.Date(2015, time.January, 1, 0, 0, 0, 0, time.UTC)
+		lastQ := time.Date(2015, time.July, 1, 0, 0, 0, 0, time.UTC)
 		var timeCutoff time.Time
 		if currentYear.Before(lastQ) {
 			timeCutoff = currentYear

--- a/clients/crunchbase/ui/src/data.js
+++ b/clients/crunchbase/ui/src/data.js
@@ -192,7 +192,11 @@ export default class DataManager {
     const set = await map.get(r);
     if (set === undefined) {
       // TODO: Cleanup the NomsSet api (it shouldn't be this hard to create an emptySet)
-      return new NomsSet(this._store, setTr, new SetLeafSequence(setTr, []));
+      return new NomsSet(this._store, setType, new SetLeafSequence(setType, []));
+    } else {
+      // Update the type to something that is correct.
+      // An alternative would be to hardcode the ref/ordinal.
+      setType = set.type;
     }
 
     return set;
@@ -200,7 +204,7 @@ export default class DataManager {
 }
 
 // TODO: This is actually the wrong type. Fix when we have JS codegen.
-const setTr = makeCompoundType(Kind.Set, makeCompoundType(Kind.Ref, makePrimitiveType(Kind.Value)));
+let setType = makeCompoundType(Kind.Set, makeCompoundType(Kind.Ref, makePrimitiveType(Kind.Value)));
 
 /**
  * Loads the first key in the index and gets the package from the type.

--- a/clients/crunchbase/ui/src/main.js
+++ b/clients/crunchbase/ui/src/main.js
@@ -153,14 +153,13 @@ class Main extends React.Component<void, Props, State> {
 
 const series = ['Seed', 'A', 'B'];
 
-const d = new Date();
-const year = d.getFullYear();
-d.setMonth(d.getMonth() - 3);
-const qYear = d.getFullYear();
-const quarter = (d.getMonth() + 1) / 4 | 0;
+// Hardcode the time.
+const year = 2015;
+const qYear = 2105;
+const quarter = 2;
 const timeItems = [
-  {label: 'Current Year', key: {Year: year}},
-  {label: 'Last Quarter', key: {Year: qYear, Quarter: quarter}},
+  {label: '2015', key: {Year: year}},
+  {label: '2015 Q2', key: {Year: qYear, Quarter: quarter}},
 ];
 
 const categories = [


### PR DESCRIPTION
Also, work around issue with empty sets, which was using the wrong type.

Fixes #835
