### PR TITLE
Change the git clone depth for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 notifications:
   email:
     recipients:
-      - aa@attic.io # has email rules to filter out PRs then forward to slack
+    - aa@attic.io # has email rules to filter out PRs then forward to slack
     on_failure: always
     on_success: change
     on_start: never
@@ -39,3 +39,5 @@ caches:
   - clients/pitchmap/ui/node_modules
   - clients/splore/node_modules
   - clients/tagshow/node_modules
+git:
+  depth: 5


### PR DESCRIPTION
By default Travis uses a depth of 50

https://docs.travis-ci.com/user/customizing-the-build#sts=Git Clone Depth

The reason to not make this 1 is that it prevents queuing up jobs.
