### PR TITLE
Travis: No need to do go get in install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: go
 go:
 - 1.5
-before_script:
+before_install:
 - npm version
 - nvm install stable
 - nvm use stable
 - npm version
+install: true # no need to do the default install
+before_script:
 - pushd js
 - npm install
 - npm test


### PR DESCRIPTION
The defaul install is to do `go get`. By overriding this value we
make it a no op.

https://docs.travis-ci.com/user/languages/go#Dependency-Management
