### PR TITLE
Webpack, screw ie8

### DIFF
--- a/js/webpack-config/index.js
+++ b/js/webpack-config/index.js
@@ -25,6 +25,7 @@ function getPlugins(envVars) {
     plugins.push(new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,
+        screw_ie8: true,  //eslint-disable-line
       },
     }));
   }


### PR DESCRIPTION
We do not need to do ugly things like rewriting foo.default to
foo["default"]
