### PR TITLE
Fix LevelDB support for named datastores

### DIFF
--- a/chunks/chunk_store.go
+++ b/chunks/chunk_store.go
@@ -16,6 +16,9 @@ type ChunkStore interface {
 // Factory allows the creation of namespaced ChunkStore instances. The details of how namespaces are separated is left up to the particular implementation of Factory and ChunkStore.
 type Factory interface {
 	CreateNamespacedStore(ns string) ChunkStore
+
+	// Shutter shuts down the factory. Subsequent calls to CreateNamespacedStore() will fail.
+	Shutter()
 }
 
 // RootTracker allows querying and management of the root of an entire tree of references. The "root" is the single mutable variable in a ChunkStore. It can store any ref, but it is typically used by higher layers (such as DataStore) to store a ref to a value that represents the current state and entire history of a datastore.

--- a/chunks/dynamo_store.go
+++ b/chunks/dynamo_store.go
@@ -438,6 +438,8 @@ func (f DynamoStoreFlags) CreateNamespacedStore(ns string) (cs ChunkStore) {
 	return
 }
 
+func (f DynamoStoreFlags) Shutter() {}
+
 func (f DynamoStoreFlags) CreateFactory() (factree Factory) {
 	if f.check() {
 		factree = f

--- a/chunks/http_store.go
+++ b/chunks/http_store.go
@@ -419,6 +419,8 @@ func (h HTTPStoreFlags) CreateNamespacedStore(ns string) ChunkStore {
 	return nil
 }
 
+func (h HTTPStoreFlags) Shutter() {}
+
 func (h HTTPStoreFlags) CreateFactory() Factory {
 	if h.check() {
 		return h

--- a/chunks/test_utils.go
+++ b/chunks/test_utils.go
@@ -61,3 +61,7 @@ func (f *testStoreFactory) CreateNamespacedStore(ns string) ChunkStore {
 	f.stores[ns] = NewTestStore()
 	return f.stores[ns]
 }
+
+func (f *testStoreFactory) Shutter() {
+	f.stores = map[string]*TestStore{}
+}

--- a/clients/server/server.go
+++ b/clients/server/server.go
@@ -41,4 +41,5 @@ func main() {
 		}
 		server.Run()
 	})
+	dsf.Shutter()
 }


### PR DESCRIPTION
We use a conceptually similar approach to the one we use with DynamoDB
to allow a single database to provide multiple named datastores: keys
are all namespaced using the name of the datastore. The implementation
is a bit different, as we need to run the backing database ourselves.

Fixes #917
