### PR TITLE
Make named DataStores first-class citizens

### DIFF
--- a/chunks/chunk_store.go
+++ b/chunks/chunk_store.go
@@ -15,9 +15,9 @@ type ChunkStore interface {
 
 // Factory allows the creation of namespaced ChunkStore instances. The details of how namespaces are separated is left up to the particular implementation of Factory and ChunkStore.
 type Factory interface {
-	CreateNamespacedStore(ns string) ChunkStore
+	CreateStore(ns string) ChunkStore
 
-	// Shutter shuts down the factory. Subsequent calls to CreateNamespacedStore() will fail.
+	// Shutter shuts down the factory. Subsequent calls to CreateStore() will fail.
 	Shutter()
 }
 

--- a/chunks/dynamo_store.go
+++ b/chunks/dynamo_store.go
@@ -408,18 +408,16 @@ func (s *DynamoStore) removeNamespace(namespaced []byte) []byte {
 }
 
 type DynamoStoreFlags struct {
-	dynamoTable     *string
-	dynamoNamespace *string
-	awsRegion       *string
-	authFromEnv     *bool
-	awsKey          *string
-	awsSecret       *string
+	dynamoTable *string
+	awsRegion   *string
+	authFromEnv *bool
+	awsKey      *string
+	awsSecret   *string
 }
 
 func DynamoFlags(prefix string) DynamoStoreFlags {
 	return DynamoStoreFlags{
 		flag.String(prefix+"dynamo-table", dynamoTableName, "dynamodb table to store the values of the chunkstore in. You probably don't want to change this."),
-		flag.String(prefix+"dynamo-ns", "", "namespace for keys used to store chunks in aws-based chunkstore"),
 		flag.String(prefix+"aws-region", "us-west-2", "aws region to put the aws-based chunkstore in"),
 		flag.Bool(prefix+"aws-auth-from-env", false, "creates the aws-based chunkstore from authorization found in the environment. This is typically used in production to get keys from IAM profile. If not specified, then -aws-key and aws-secret must be specified instead"),
 		flag.String(prefix+"aws-key", "", "aws key to use to create the aws-based chunkstore"),
@@ -427,15 +425,11 @@ func DynamoFlags(prefix string) DynamoStoreFlags {
 	}
 }
 
-func (f DynamoStoreFlags) CreateStore() ChunkStore {
-	return f.CreateNamespacedStore(*f.dynamoNamespace)
-}
-
-func (f DynamoStoreFlags) CreateNamespacedStore(ns string) (cs ChunkStore) {
+func (f DynamoStoreFlags) CreateStore(ns string) ChunkStore {
 	if f.check() {
-		cs = NewDynamoStore(*f.dynamoTable, ns, *f.awsRegion, *f.awsKey, *f.awsSecret)
+		return NewDynamoStore(*f.dynamoTable, ns, *f.awsRegion, *f.awsKey, *f.awsSecret)
 	}
-	return
+	return nil
 }
 
 func (f DynamoStoreFlags) Shutter() {}

--- a/chunks/http_store.go
+++ b/chunks/http_store.go
@@ -408,11 +408,7 @@ func HTTPFlags(prefix string) HTTPStoreFlags {
 	}
 }
 
-func (h HTTPStoreFlags) CreateStore() ChunkStore {
-	return h.CreateNamespacedStore("")
-}
-
-func (h HTTPStoreFlags) CreateNamespacedStore(ns string) ChunkStore {
+func (h HTTPStoreFlags) CreateStore(ns string) ChunkStore {
 	if h.check() {
 		return NewHTTPStore(*h.host + httprouter.CleanPath(ns))
 	}

--- a/chunks/leveldb_store_test.go
+++ b/chunks/leveldb_store_test.go
@@ -21,7 +21,7 @@ func (suite *LevelDBStoreTestSuite) SetupTest() {
 	var err error
 	suite.dir, err = ioutil.TempDir(os.TempDir(), "")
 	suite.NoError(err)
-	store := NewLevelDBStore(suite.dir, 24, false)
+	store := NewLevelDBStore(suite.dir, "name", 24, false)
 	suite.putCountFn = func() int {
 		return int(store.putCount)
 	}

--- a/chunks/memory_store.go
+++ b/chunks/memory_store.go
@@ -69,7 +69,7 @@ func MemoryFlags(prefix string) MemoryStoreFlags {
 	}
 }
 
-func (f MemoryStoreFlags) CreateStore() ChunkStore {
+func (f MemoryStoreFlags) CreateStore(ns string) ChunkStore {
 	if f.check() {
 		return NewMemoryStore()
 	}
@@ -92,7 +92,7 @@ type MemoryStoreFactory struct {
 	stores map[string]*MemoryStore
 }
 
-func (f *MemoryStoreFactory) CreateNamespacedStore(ns string) ChunkStore {
+func (f *MemoryStoreFactory) CreateStore(ns string) ChunkStore {
 	d.Chk.NotNil(f.stores, "Cannot use LevelDBStoreFactory after Shutter().")
 	if !f.flags.check() {
 		return nil

--- a/chunks/test_utils.go
+++ b/chunks/test_utils.go
@@ -54,7 +54,7 @@ func NewTestStoreFactory() *testStoreFactory {
 	return &testStoreFactory{map[string]*TestStore{}}
 }
 
-func (f *testStoreFactory) CreateNamespacedStore(ns string) ChunkStore {
+func (f *testStoreFactory) CreateStore(ns string) ChunkStore {
 	if cs, present := f.stores[ns]; present {
 		return cs
 	}

--- a/clients/csv/importer/importer_test.go
+++ b/clients/csv/importer/importer_test.go
@@ -35,12 +35,14 @@ func (s *testSuite) TestCSVImporter() {
 	_, err = input.Seek(0, 0)
 	d.Chk.NoError(err)
 
-	out := s.Run(main, []string{"-ds", "csv", input.Name()})
+	storeName := "store"
+	setName := "csv"
+	out := s.Run(main, []string{"-store", storeName, "-ds", setName, input.Name()})
 	s.Equal("", out)
 
-	cs := chunks.NewLevelDBStore(s.LdbDir, 1, false)
-	ds := dataset.NewDataset(datas.NewDataStore(cs), "csv")
-	defer ds.Close()
+	cs := chunks.NewLevelDBStore(s.LdbDir, storeName, 1, false)
+	ds := dataset.NewDataset(datas.NewDataStore(cs), setName)
+	defer ds.Store().Close()
 
 	l := ds.Head().Value().(types.List)
 	s.Equal(uint64(100), l.Len())
@@ -66,12 +68,15 @@ func (s *testSuite) TestCSVImporterWithPipe() {
 
 	_, err = input.WriteString("a|b\n1|2\n")
 	d.Chk.NoError(err)
-	out := s.Run(main, []string{"-ds", "csv", input.Name()})
+
+	storeName := "store"
+	setName := "csv"
+	out := s.Run(main, []string{"-store", storeName, "-ds", setName, input.Name()})
 	s.Equal("", out)
 
-	cs := chunks.NewLevelDBStore(s.LdbDir, 1, false)
-	ds := dataset.NewDataset(datas.NewDataStore(cs), "csv")
-	defer ds.Close()
+	cs := chunks.NewLevelDBStore(s.LdbDir, storeName, 1, false)
+	ds := dataset.NewDataset(datas.NewDataStore(cs), setName)
+	defer ds.Store().Close()
 
 	l := ds.Head().Value().(types.List)
 	s.Equal(uint64(1), l.Len())
@@ -92,12 +97,15 @@ func (s *testSuite) TestCSVImporterWithExternalHeader() {
 
 	_, err = input.WriteString("7,8\n")
 	d.Chk.NoError(err)
-	out := s.Run(main, []string{"-ds", "csv", input.Name()})
+
+	storeName := "store"
+	setName := "csv"
+	out := s.Run(main, []string{"-store", storeName, "-ds", setName, input.Name()})
 	s.Equal("", out)
 
-	cs := chunks.NewLevelDBStore(s.LdbDir, 1, false)
-	ds := dataset.NewDataset(datas.NewDataStore(cs), "csv")
-	defer ds.Close()
+	cs := chunks.NewLevelDBStore(s.LdbDir, storeName, 1, false)
+	ds := dataset.NewDataset(datas.NewDataStore(cs), setName)
+	defer ds.Store().Close()
 
 	l := ds.Head().Value().(types.List)
 	s.Equal(uint64(1), l.Len())

--- a/clients/shove/shove_test.go
+++ b/clients/shove/shove_test.go
@@ -22,27 +22,27 @@ type testSuite struct {
 
 func (s *testSuite) TestShove() {
 	s.LdbFlagName = "-source-ldb"
-	source1 := dataset.NewDataset(datas.NewDataStore(chunks.NewLevelDBStore(s.LdbDir, 1, false)), "foo")
+	sn := "storeName"
+	source1 := dataset.NewDataset(datas.NewDataStore(chunks.NewLevelDBStore(s.LdbDir, sn, 1, false)), "foo")
 	source1, err := source1.Commit(types.Int32(42))
 	s.NoError(err)
 	source2, err := source1.Commit(types.Int32(43))
 	s.NoError(err)
 	source1HeadRef := source1.Head().Ref()
-	source1.Close()
-	source2.Close()
+	source2.Store().Close() // Close DataStore backing both Datasets
 
 	ldb2dir := path.Join(s.TempDir, "ldb2")
-	out := s.Run(main, []string{"-source", source1HeadRef.String(), "-sink-ldb", ldb2dir, "-sink-ds", "bar"})
+	out := s.Run(main, []string{"-source-store", sn, "-source", source1HeadRef.String(), "-sink-ldb", ldb2dir, "-sink-store", sn, "-sink-ds", "bar"})
 	s.Equal("", out)
 
-	dest := dataset.NewDataset(datas.NewDataStore(chunks.NewLevelDBStore(ldb2dir, 1, false)), "bar")
+	dest := dataset.NewDataset(datas.NewDataStore(chunks.NewLevelDBStore(ldb2dir, sn, 1, false)), "bar")
 	s.True(types.Int32(42).Equals(dest.Head().Value()))
-	dest.Close()
+	dest.Store().Close()
 
-	out = s.Run(main, []string{"-source", "foo", "-sink-ldb", ldb2dir, "-sink-ds", "bar"})
+	out = s.Run(main, []string{"-source-store", sn, "-source", "foo", "-sink-ldb", ldb2dir, "-sink-ds", "bar"})
 	s.Equal("", out)
 
-	dest = dataset.NewDataset(datas.NewDataStore(chunks.NewLevelDBStore(ldb2dir, 1, false)), "bar")
+	dest = dataset.NewDataset(datas.NewDataStore(chunks.NewLevelDBStore(ldb2dir, sn, 1, false)), "bar")
 	s.True(types.Int32(43).Equals(dest.Head().Value()))
-	dest.Close()
+	dest.Store().Close()
 }

--- a/clients/tagdex/tagdex_test.go
+++ b/clients/tagdex/tagdex_test.go
@@ -32,7 +32,8 @@ func createRefOfRemotePhoto(id int, tag string, cs chunks.ChunkStore) RefOfRemot
 }
 
 func (s *testSuite) TestTagdex() {
-	cs := chunks.NewLevelDBStore(s.LdbDir, 1, false)
+	sn := "storeName"
+	cs := chunks.NewLevelDBStore(s.LdbDir, sn, 1, false)
 	inputDs := dataset.NewDataset(datas.NewDataStore(cs), "input-test")
 
 	fakePhotos := map[string]int{
@@ -58,10 +59,10 @@ func (s *testSuite) TestTagdex() {
 	s.NoError(err)
 	inputDs.Close()
 
-	out := s.Run(main, []string{"-in", "input-test", "-out", "tagdex-test"})
+	out := s.Run(main, []string{"-store", sn, "-in", "input-test", "-out", "tagdex-test"})
 	s.Contains(out, "Indexed 105 photos")
 
-	cs = chunks.NewLevelDBStore(s.LdbDir, 1, false)
+	cs = chunks.NewLevelDBStore(s.LdbDir, sn, 1, false)
 	ds := dataset.NewDataset(datas.NewDataStore(cs), "tagdex-test")
 
 	m := ds.Head().Value().(MapOfStringToSetOfRefOfRemotePhoto)

--- a/datas/factory.go
+++ b/datas/factory.go
@@ -6,7 +6,7 @@ import "github.com/attic-labs/noms/chunks"
 type Factory interface {
 	Create(string) (DataStore, bool)
 
-	// Shutter shuts down the factory. Subsequent calls to CreateNamespacedStore() will fail.
+	// Shutter shuts down the factory. Subsequent calls to Create() will fail.
 	Shutter()
 }
 
@@ -32,7 +32,7 @@ type localFactory struct {
 }
 
 func (lf *localFactory) Create(ns string) (DataStore, bool) {
-	if cs := lf.cf.CreateNamespacedStore(ns); cs != nil {
+	if cs := lf.cf.CreateStore(ns); cs != nil {
 		return newLocalDataStore(cs), true
 	}
 	return &LocalDataStore{}, false
@@ -47,7 +47,7 @@ type remoteFactory struct {
 }
 
 func (rf *remoteFactory) Create(ns string) (DataStore, bool) {
-	if cs := rf.cf.CreateNamespacedStore(ns); cs != nil {
+	if cs := rf.cf.CreateStore(ns); cs != nil {
 		return newRemoteDataStore(cs), true
 	}
 	return &LocalDataStore{}, false


### PR DESCRIPTION
In order to allow tools like shove to correctly address named
DataStores, we need to have the notion of a name be settable
at the DataStoreFlags level. Once we've done that, it doesn't
really make sense to have API surface for creating DataStores
without a name -- though for compatibility, the code will
continue to accept an empty string for a DataStore's name
