### PR TITLE
JS: Add return method to AsyncIterator

### DIFF
--- a/js/src/async_iterator.js
+++ b/js/src/async_iterator.js
@@ -12,4 +12,7 @@ export class AsyncIterator<T> {
   next(): Promise<AsyncIteratorResult<T>> {
     throw new Error('override');
   }
+  return(): Promise<AsyncIteratorResult<T>> {
+    throw new Error('override');
+  }
 }

--- a/js/src/indexed_sequence.js
+++ b/js/src/indexed_sequence.js
@@ -45,10 +45,18 @@ export class IndexedSequenceIterator<T> extends AsyncIterator<T> {
     this._cursorP = cursorP;
   }
 
-  async next(): Promise<AsyncIteratorResult<T>> {
+  async _ensureIterator(): Promise<AsyncIterator<T>> {
     if (!this._iterator) {
       this._iterator = (await this._cursorP).iterator();
     }
-    return this._iterator.next();
+    return this._iterator;
+  }
+
+  next(): Promise<AsyncIteratorResult<T>> {
+    return this._ensureIterator().then(it => it.next());
+  }
+
+  return(): Promise<AsyncIteratorResult<T>> {
+    return this._ensureIterator().then(it => it.return());
   }
 }

--- a/js/src/list_test.js
+++ b/js/src/list_test.js
@@ -145,6 +145,19 @@ suite('CompoundList', () => {
     }
   });
 
+  test('iterator return', async () => {
+    const list = build();
+    const iter = list.iterator();
+    const values = [];
+    for (let res = await iter.next(); !res.done; res = await iter.next()) {
+      values.push(res.value);
+      if (values.length === 5) {
+        await iter.return();
+      }
+    }
+    assert.deepEqual(values, ['a', 'b', 'e', 'f', 'h']);
+  });
+
   test('chunks', () => {
     const l = build();
     assert.strictEqual(2, l.chunks.length);

--- a/js/src/map_test.js
+++ b/js/src/map_test.js
@@ -241,6 +241,22 @@ suite('CompoundMap', () => {
     }
   });
 
+  test('iterator return', async () => {
+    const ms = new MemoryStore();
+    const [c] = build(ms);
+    const iter = c.iterator();
+    const values = [];
+    for (let res = await iter.next(); !res.done; res = await iter.next()) {
+      values.push(res.value);
+      if (values.length === 5) {
+        await iter.return();
+      }
+    }
+    assert.deepEqual([{key: 'a', value: false}, {key: 'b', value: false}, {key: 'e', value: true},
+                      {key: 'f', value: true}, {key: 'h', value: false}],
+                     values);
+  });
+
   test('chunks', () => {
     const ms = new MemoryStore();
     const [c] = build(ms);

--- a/js/src/ordered_sequence.js
+++ b/js/src/ordered_sequence.js
@@ -91,10 +91,18 @@ export class OrderedSequenceIterator<T, K: valueOrPrimitive> extends AsyncIterat
     this._cursorP = cursorP;
   }
 
-  async next(): Promise<AsyncIteratorResult<T>> {
+  async _ensureIterator(): Promise<AsyncIterator<T>> {
     if (!this._iterator) {
       this._iterator = (await this._cursorP).iterator();
     }
-    return this._iterator.next();
+    return this._iterator;
+  }
+
+  next(): Promise<AsyncIteratorResult<T>> {
+    return this._ensureIterator().then(it => it.next());
+  }
+
+  return(): Promise<AsyncIteratorResult<T>> {
+    return this._ensureIterator().then(it => it.return());
   }
 }

--- a/js/src/set_test.js
+++ b/js/src/set_test.js
@@ -181,6 +181,21 @@ suite('CompoundSet', () => {
     }
   });
 
+  test('iterator return', async () => {
+    const ms = new MemoryStore();
+    const values = ['a', 'b', 'e', 'f', 'h', 'i', 'm', 'n'];
+    const c = build(ms, values);
+    const iter = c.iterator();
+    const values2 = [];
+    for (let res = await iter.next(); !res.done; res = await iter.next()) {
+      values2.push(res.value);
+      if (values2.length === 5) {
+        await iter.return();
+      }
+    }
+    assert.deepEqual(values.slice(0, 5), values2);
+  });
+
   test('chunks', () => {
     const ms = new MemoryStore();
     const c = build(ms, ['a', 'b', 'e', 'f', 'h', 'i', 'm', 'n']);


### PR DESCRIPTION
This follows ES6 and it allows exiting/closing an iterator cleanly.
