### PR TITLE
Correct seekableReader.Read() semantics

### DIFF
--- a/base/seekable_reader.go
+++ b/base/seekable_reader.go
@@ -41,10 +41,10 @@ func (s *seekableReader) Read(b []byte) (n int, err error) {
 		return
 	}
 	d.Chk.Equal(s.cached, s.pos, "Position is somehow _after_ the cached data!")
-	if n, err = io.ReadFull(s.r, b); err != nil {
+	if n, err = s.r.Read(b); err != nil {
 		return
 	}
-	if _, werr := s.cache.Write(b); werr != nil {
+	if _, werr := s.cache.Write(b[:n]); werr != nil {
 		return 0, werr
 	}
 	s.pos += int64(n)

--- a/base/seekable_reader_test.go
+++ b/base/seekable_reader_test.go
@@ -48,6 +48,12 @@ func (suite *SeekableReaderTestSuite) TestRead() {
 	suite.readAndExpect(suite.content)
 }
 
+func (suite *SeekableReaderTestSuite) TestReadAll() {
+	b, err := ioutil.ReadAll(suite.contentRSC)
+	suite.NoError(err)
+	suite.Equal(string(suite.content), string(b))
+}
+
 func (suite *SeekableReaderTestSuite) TestSeekFromStart() {
 	offset := suite.contentLen - 2
 	ret, err := suite.contentRSC.Seek(offset, 0)


### PR DESCRIPTION
I hadn't tested the case where the caller tries to Read() into
buffer that has more space than needed. ioutil.ReadAll() does this,
so it's important that this work right.
