### PR TITLE
Allow streaming chunks during container creation

### DIFF
--- a/types/blob.go
+++ b/types/blob.go
@@ -50,7 +50,7 @@ func newBlobLeafChunkFn() makeChunkFn {
 }
 
 func NewBlob(r io.Reader) Blob {
-	seq := newEmptySequenceChunker(newBlobLeafChunkFn(), newIndexedMetaSequenceChunkFn(typeForBlob), newBlobLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+	seq := newEmptySequenceChunker(newBlobLeafChunkFn(), newIndexedMetaSequenceChunkFn(typeForBlob, nil), newBlobLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 	buf := []byte{0}
 	for {
 		n, err := r.Read(buf)

--- a/types/blob.go
+++ b/types/blob.go
@@ -45,7 +45,7 @@ func newBlobLeafChunkFn() makeChunkFn {
 		}
 
 		leaf := newBlobLeaf(buff)
-		return metaTuple{leaf, ref.Ref{}, Uint64(uint64(len(buff)))}, leaf
+		return newMetaTuple(Uint64(uint64(len(buff))), leaf, ref.Ref{}), leaf
 	}
 }
 

--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -18,7 +18,7 @@ func getTestCompoundBlob(datas ...string) compoundBlob {
 	tuples := make([]metaTuple, len(datas))
 	for i, s := range datas {
 		b := NewBlob(bytes.NewBufferString(s))
-		tuples[i] = metaTuple{b, ref.Ref{}, Uint64(len(s))}
+		tuples[i] = newMetaTuple(Uint64(len(s)), b, ref.Ref{})
 	}
 	return newCompoundBlob(tuples, nil)
 }
@@ -187,7 +187,10 @@ func TestCompoundBlobChunks(t *testing.T) {
 
 	bl1 := newBlobLeaf([]byte("hello"))
 	bl2 := newBlobLeaf([]byte("world"))
-	cb = newCompoundBlob([]metaTuple{{bl1, ref.Ref{}, Uint64(uint64(5))}, {bl2, ref.Ref{}, Uint64(uint64(10))}}, cs)
+	cb = newCompoundBlob([]metaTuple{
+		newMetaTuple(Uint64(uint64(5)), bl1, ref.Ref{}),
+		newMetaTuple(Uint64(uint64(10)), bl2, ref.Ref{}),
+	}, cs)
 	assert.Equal(2, len(cb.Chunks()))
 }
 

--- a/types/compound_list.go
+++ b/types/compound_list.go
@@ -254,7 +254,7 @@ func newListLeafBoundaryChecker() boundaryChecker {
 	})
 }
 
-func makeListLeafChunkFn(t Type, cs chunks.ChunkSink) makeChunkFn {
+func makeListLeafChunkFn(t Type, cs chunks.ChunkStore) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		values := make([]Value, len(items))
 
@@ -262,10 +262,10 @@ func makeListLeafChunkFn(t Type, cs chunks.ChunkSink) makeChunkFn {
 			values[i] = v.(Value)
 		}
 
-		list := valueFromType(newListLeaf(nil, t, values...), t)
+		list := valueFromType(newListLeaf(cs, t, values...), t)
 		if cs != nil {
-			return metaTuple{nil, WriteValue(list, cs), Uint64(len(values))}, list
+			return newMetaTuple(Uint64(len(values)), nil, WriteValue(list, cs)), list
 		}
-		return metaTuple{list, ref.Ref{}, Uint64(len(values))}, list
+		return newMetaTuple(Uint64(len(values)), list, ref.Ref{}), list
 	}
 }

--- a/types/compound_map.go
+++ b/types/compound_map.go
@@ -95,9 +95,8 @@ func (cm compoundMap) Remove(k Value) Map {
 	if seq, found := cm.sequenceChunkerAtKey(k); found {
 		seq.Skip()
 		return seq.Done().(Map)
-	} else {
-		return cm
 	}
+	return cm
 }
 
 func (cm compoundMap) sequenceChunkerAtKey(k Value) (*sequenceChunker, bool) {

--- a/types/compound_map_test.go
+++ b/types/compound_map_test.go
@@ -186,16 +186,14 @@ func TestCompoundMapIter(t *testing.T) {
 		idx := uint64(0)
 		endAt := uint64(mapPattern)
 
-		m.Iter(func(k, v Value) bool {
+		m.Iter(func(k, v Value) (done bool) {
 			assert.True(tm.entries[idx].key.Equals(k))
 			assert.True(tm.entries[idx].value.Equals(v))
 			if idx == endAt {
-				idx += 1
-				return true
+				done = true
 			}
-
-			idx += 1
-			return false
+			idx++
+			return
 		})
 
 		assert.Equal(endAt, idx-1)

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -138,15 +138,13 @@ func TestCompoundSetIter(t *testing.T) {
 		idx := uint64(0)
 		endAt := uint64(setPattern)
 
-		set.Iter(func(v Value) bool {
+		set.Iter(func(v Value) (done bool) {
 			assert.True(ts.values[idx].Equals(v))
 			if idx == endAt {
-				idx += 1
-				return true
+				done = true
 			}
-
-			idx += 1
-			return false
+			idx++
+			return
 		})
 
 		assert.Equal(endAt, idx-1)

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -178,7 +178,7 @@ func (r *jsonArrayReader) maybeReadMetaSequence(t Type, pkg *Package) (Value, bo
 	for !r2.atEnd() {
 		ref := r2.readRef()
 		v := r2.readValueWithoutTag(indexType, pkg)
-		data = append(data, metaTuple{nil, ref, v})
+		data = append(data, newMetaTuple(v, nil, ref))
 	}
 
 	t = fixupType(t, pkg)

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -153,18 +154,17 @@ func (r *jsonArrayReader) readMap(t Type, pkg *Package) Value {
 
 func indexTypeForMetaSequence(t Type) Type {
 	switch t.Kind() {
+	default:
+		panic(fmt.Sprintf("Unknown type used for metaSequence: %s", t.Describe()))
+	case BlobKind, ListKind:
+		return MakePrimitiveType(Uint64Kind)
 	case MapKind, SetKind:
 		elemType := t.Desc.(CompoundDesc).ElemTypes[0]
 		if elemType.IsOrdered() {
 			return elemType
-		} else {
-			return MakeCompoundType(RefKind, MakePrimitiveType(ValueKind))
 		}
-	case BlobKind, ListKind:
-		return MakePrimitiveType(Uint64Kind)
+		return MakeCompoundType(RefKind, MakePrimitiveType(ValueKind))
 	}
-
-	panic("unreached")
 }
 
 func (r *jsonArrayReader) maybeReadMetaSequence(t Type, pkg *Package) (Value, bool) {

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -132,7 +132,10 @@ func TestReadCompoundList(t *testing.T) {
 	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
 	leaf1 := newListLeaf(cs, tr, Int32(0))
 	leaf2 := newListLeaf(cs, tr, Int32(1), Int32(2), Int32(3))
-	l2 := buildCompoundList([]metaTuple{{leaf1, ref.Ref{}, Uint64(1)}, {leaf2, ref.Ref{}, Uint64(4)}}, tr, cs)
+	l2 := buildCompoundList([]metaTuple{
+		newMetaTuple(Uint64(1), leaf1, ref.Ref{}),
+		newMetaTuple(Uint64(4), leaf2, ref.Ref{}),
+	}, tr, cs)
 
 	a := parseJson(`[%d, %d, true, ["%s", "1", "%s", "4"]]`, ListKind, Int32Kind, leaf1.Ref(), leaf2.Ref())
 	r := newJsonArrayReader(a, cs)
@@ -210,7 +213,11 @@ func TestReadCompoundBlob(t *testing.T) {
 	m := r.readTopLevelValue()
 	_, ok := m.(compoundBlob)
 	assert.True(ok)
-	m2 := newCompoundBlob([]metaTuple{{nil, r1, Uint64(20)}, {nil, r2, Uint64(40)}, {nil, r3, Uint64(60)}}, cs)
+	m2 := newCompoundBlob([]metaTuple{
+		newMetaTuple(Uint64(20), nil, r1),
+		newMetaTuple(Uint64(40), nil, r2),
+		newMetaTuple(Uint64(60), nil, r3),
+	}, cs)
 
 	assert.True(m.Type().Equals(m2.Type()))
 	assert.Equal(m.Ref().String(), m2.Ref().String())

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -139,7 +139,11 @@ func TestWriteCompoundBlob(t *testing.T) {
 	r2 := ref.Parse("sha1-0000000000000000000000000000000000000002")
 	r3 := ref.Parse("sha1-0000000000000000000000000000000000000003")
 
-	v := newCompoundBlob([]metaTuple{{nil, r1, Uint64(20)}, {nil, r2, Uint64(40)}, {nil, r3, Uint64(60)}}, cs)
+	v := newCompoundBlob([]metaTuple{
+		newMetaTuple(Uint64(20), nil, r1),
+		newMetaTuple(Uint64(40), nil, r2),
+		newMetaTuple(Uint64(60), nil, r3),
+	}, cs)
 	w := newJsonArrayWriter(cs)
 	w.writeTopLevelValue(v)
 
@@ -328,7 +332,10 @@ func TestWriteCompoundList(t *testing.T) {
 	ltr := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
 	leaf1 := newListLeaf(cs, ltr, Int32(0))
 	leaf2 := newListLeaf(cs, ltr, Int32(1), Int32(2), Int32(3))
-	cl := buildCompoundList([]metaTuple{{leaf1, ref.Ref{}, Uint64(1)}, {leaf2, ref.Ref{}, Uint64(4)}}, ltr, cs)
+	cl := buildCompoundList([]metaTuple{
+		newMetaTuple(Uint64(1), leaf1, ref.Ref{}),
+		newMetaTuple(Uint64(4), leaf2, ref.Ref{}),
+	}, ltr, cs)
 
 	w := newJsonArrayWriter(cs)
 	w.writeTopLevelValue(cl)

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -59,7 +59,10 @@ func TestValueEquals(t *testing.T) {
 		func() Value {
 			b1 := NewBlob(bytes.NewBufferString("hi"))
 			b2 := NewBlob(bytes.NewBufferString("bye"))
-			return newCompoundBlob([]metaTuple{{b1, ref.Ref{}, Uint64(uint64(2))}, {b2, ref.Ref{}, Uint64(uint64(5))}}, nil)
+			return newCompoundBlob([]metaTuple{
+				newMetaTuple(Uint64(uint64(2)), b1, ref.Ref{}),
+				newMetaTuple(Uint64(uint64(5)), b2, ref.Ref{}),
+			}, nil)
 		},
 		func() Value { return NewList() },
 		func() Value { return NewList(NewString("foo")) },

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -3,6 +3,7 @@ package types
 import (
 	"crypto/sha1"
 
+	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 )
 
@@ -13,7 +14,7 @@ func newIndexedMetaSequenceBoundaryChecker() boundaryChecker {
 	})
 }
 
-func newIndexedMetaSequenceChunkFn(t Type) makeChunkFn {
+func newIndexedMetaSequenceChunkFn(t Type, cs chunks.ChunkSink) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		tuples := make(metaSequenceData, len(items))
 
@@ -22,6 +23,9 @@ func newIndexedMetaSequenceChunkFn(t Type) makeChunkFn {
 		}
 
 		meta := newMetaSequenceFromData(tuples, t, nil)
+		if cs != nil {
+			return metaTuple{nil, WriteValue(meta, cs), Uint64(tuples.uint64ValuesSum())}, meta
+		}
 		return metaTuple{meta, ref.Ref{}, Uint64(tuples.uint64ValuesSum())}, meta
 	}
 }

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -14,7 +14,7 @@ func newIndexedMetaSequenceBoundaryChecker() boundaryChecker {
 	})
 }
 
-func newIndexedMetaSequenceChunkFn(t Type, cs chunks.ChunkSink) makeChunkFn {
+func newIndexedMetaSequenceChunkFn(t Type, cs chunks.ChunkStore) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		tuples := make(metaSequenceData, len(items))
 
@@ -22,7 +22,7 @@ func newIndexedMetaSequenceChunkFn(t Type, cs chunks.ChunkSink) makeChunkFn {
 			tuples[i] = v.(metaTuple) // chunk is written when the root sequence is written
 		}
 
-		meta := newMetaSequenceFromData(tuples, t, nil)
+		meta := newMetaSequenceFromData(tuples, t, cs)
 		if cs != nil {
 			return metaTuple{nil, WriteValue(meta, cs), Uint64(tuples.uint64ValuesSum())}, meta
 		}

--- a/types/list.go
+++ b/types/list.go
@@ -43,7 +43,7 @@ func NewTypedList(t Type, values ...Value) List {
 }
 
 // NewStreamingTypedList creates a new List with type t, populated with values, chunking if and when needed. As chunks are created, they're written to cs -- including the root chunk of the list. Once the caller has closed values, she can read the completed List from the returned channel.
-func NewStreamingTypedList(t Type, cs chunks.ChunkSink, values <-chan Value) <-chan List {
+func NewStreamingTypedList(t Type, cs chunks.ChunkStore, values <-chan Value) <-chan List {
 	out := make(chan List)
 	go func() {
 		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, cs), newIndexedMetaSequenceChunkFn(t, cs), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)

--- a/types/list.go
+++ b/types/list.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/attic-labs/noms/chunks"
+
 type List interface {
 	Value
 	Len() uint64
@@ -26,15 +28,30 @@ type MapFunc func(v Value, index uint64) interface{}
 
 var listType = MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))
 
+// NewList creates a new untyped List, populated with values, chunking if and when needed.
 func NewList(v ...Value) List {
 	return NewTypedList(listType, v...)
 }
 
+// NewTypedList creates a new List with type t, populated with values, chunking if and when needed.
 func NewTypedList(t Type, values ...Value) List {
-	seq := newEmptySequenceChunker(makeListLeafChunkFn(t), newIndexedMetaSequenceChunkFn(t), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+	seq := newEmptySequenceChunker(makeListLeafChunkFn(t, nil), newIndexedMetaSequenceChunkFn(t, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 	for _, v := range values {
 		seq.Append(v)
 	}
-
 	return seq.Done().(List)
+}
+
+// NewStreamingTypedList creates a new List with type t, populated with values, chunking if and when needed. As chunks are created, they're written to cs -- including the root chunk of the list. Once the caller has closed values, she can read the completed List from the returned channel.
+func NewStreamingTypedList(t Type, cs chunks.ChunkSink, values <-chan Value) <-chan List {
+	out := make(chan List)
+	go func() {
+		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, cs), newIndexedMetaSequenceChunkFn(t, cs), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+		for v := range values {
+			seq.Append(v)
+		}
+		out <- seq.Done().(List)
+		close(out)
+	}()
+	return out
 }

--- a/types/map_leaf.go
+++ b/types/map_leaf.go
@@ -255,6 +255,6 @@ func makeMapLeafChunkFn(t Type) makeChunkFn {
 			}
 		}
 
-		return metaTuple{mapLeaf, ref.Ref{}, indexValue}, mapLeaf
+		return newMetaTuple(indexValue, mapLeaf, ref.Ref{}), mapLeaf
 	}
 }

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -21,10 +21,15 @@ type metaSequence interface {
 	tupleCount() int
 }
 
+func newMetaTuple(value, child Value, childRef ref.Ref) metaTuple {
+	d.Chk.True((child != nil) != (childRef != ref.Ref{}), "Either child or childRef can be set, but not both")
+	return metaTuple{child, childRef, value}
+}
+
 // metaTuple is a node in a "probably" tree, consisting of data in the node (either tree leaves or other metaSequences), and a Value annotation for exploring the tree (e.g. the largest item if this an ordered sequence).
 type metaTuple struct {
 	child    Value   // nil if the child data hasn't been read, or has already been written
-	childRef ref.Ref // maybe empty if |child| is non-nil, call ChildRef() instead of accessing |childRef| directly
+	childRef ref.Ref // may be empty if |child| is non-nil; call ChildRef() instead of accessing |childRef| directly
 	value    Value
 }
 

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -137,8 +137,6 @@ func newMetaSequenceCursor(root metaSequence, cs chunks.ChunkSource) (*sequenceC
 			return cursor, val
 		}
 	}
-
-	panic("not reachable")
 }
 
 func readMetaTupleValue(item sequenceItem, cs chunks.ChunkSource) Value {
@@ -160,6 +158,4 @@ func iterateMetaSequenceLeaf(ms metaSequence, cs chunks.ChunkSource, cb func(Val
 
 		v = readMetaTupleValue(cursor.current(), cs)
 	}
-
-	panic("not reachable")
 }

--- a/types/ordered_sequences.go
+++ b/types/ordered_sequences.go
@@ -66,6 +66,6 @@ func newOrderedMetaSequenceChunkFn(t Type) makeChunkFn {
 		}
 
 		meta := newMetaSequenceFromData(tuples, t, nil)
-		return metaTuple{meta, ref.Ref{}, tuples.last().value}, meta
+		return newMetaTuple(tuples.last().value, meta, ref.Ref{}), meta
 	}
 }

--- a/types/set_leaf.go
+++ b/types/set_leaf.go
@@ -218,7 +218,7 @@ func makeSetLeafChunkFn(t Type) makeChunkFn {
 			}
 		}
 
-		return metaTuple{setLeaf, ref.Ref{}, indexValue}, setLeaf
+		return newMetaTuple(indexValue, setLeaf, ref.Ref{}), setLeaf
 	}
 }
 

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -10,19 +10,19 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-// SomeCallback takes a ref.Ref and returns a bool indicating whether
+// SomeCallback takes a types.Value and returns a bool indicating whether
 // the current walk should skip the tree descending from value.
 type SomeCallback func(v types.Value) bool
 
-// AllCallback takes a ref and processes it.
+// AllCallback takes a types.Value and processes it.
 type AllCallback func(v types.Value)
 
-// Some recursively walks over all ref.Refs reachable from r and calls cb on them. If cb ever returns true, the walk will stop recursing on the current ref. If |concurrency| > 1, it is the callers responsibility to make ensure that |cb| is threadsafe.
+// SomeP recursively walks over all types.Values reachable from r and calls cb on them. If cb ever returns true, the walk will stop recursing on the current ref. If |concurrency| > 1, it is the callers responsibility to make ensure that |cb| is threadsafe.
 func SomeP(v types.Value, cs chunks.ChunkSource, cb SomeCallback, concurrency int) {
 	doTreeWalkP(v, cs, cb, concurrency)
 }
 
-// All recursively walks over all ref.Refs reachable from r and calls cb on them. If |concurrency| > 1, it is the callers responsibility to make ensure that |cb| is threadsafe.
+// AllP recursively walks over all types.Values reachable from r and calls cb on them. If |concurrency| > 1, it is the callers responsibility to make ensure that |cb| is threadsafe.
 func AllP(v types.Value, cs chunks.ChunkSource, cb AllCallback, concurrency int) {
 	doTreeWalkP(v, cs, func(v types.Value) (skip bool) {
 		cb(v)
@@ -92,15 +92,16 @@ func doTreeWalkP(v types.Value, cs chunks.ChunkSource, cb SomeCallback, concurre
 	f.checkNotFailed()
 }
 
+// SomeChunksCallback takes a ref.Ref and returns a bool indicating whether
+// the current walk should skip the tree descending from value.
 type SomeChunksCallback func(r ref.Ref) bool
 
-// Invokes callback on all chunks reachable from |r| in top-down order. |callback| is invoked only
-// once for each chunk regardless of how many times the chunk appears
-func SomeChunksP(r ref.Ref, cs chunks.ChunkStore, callback SomeChunksCallback, concurrency int) {
+// SomeChunksP Invokes callback on all chunks reachable from |r| in top-down order. |callback| is invoked only once for each chunk regardless of how many times the chunk appears
+func SomeChunksP(r ref.Ref, cs chunks.ChunkSource, callback SomeChunksCallback, concurrency int) {
 	doChunkWalkP(r, cs, callback, concurrency)
 }
 
-func doChunkWalkP(r ref.Ref, cs chunks.ChunkStore, callback SomeChunksCallback, concurrency int) {
+func doChunkWalkP(r ref.Ref, cs chunks.ChunkSource, callback SomeChunksCallback, concurrency int) {
 	rq := newRefQueue()
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}


### PR DESCRIPTION
NewStreamingTypedList() reads Values from a channel and appends them
to a List, chunking as it goes and writing these chunks to a given
ChunkSink. It returns a `chan List` that the caller can get the
finished List from once he's done writing values to the `chan Value`
he provided at call-time.
