### PR TITLE
Fix a Read() semantic issue in seekableReader

### DIFF
--- a/base/seekable_reader.go
+++ b/base/seekable_reader.go
@@ -33,7 +33,11 @@ type seekableReader struct {
 func (s *seekableReader) Read(b []byte) (n int, err error) {
 	if s.pos < s.cached {
 		// Caller sought backwards, so current position is somewhere in the cached data. Satisfy the Read() from the cache as much as possible. If that doesn't fill b, the caller will see that n < len(b) and try again.
-		n, err = io.ReadAtLeast(s.cache, b, int(s.cached-s.pos))
+		min := int(s.cached - s.pos)
+		if min > len(b) {
+			min = len(b)
+		}
+		n, err = io.ReadAtLeast(s.cache, b, min)
 		if err == io.EOF {
 			err = nil
 		}

--- a/base/seekable_reader_test.go
+++ b/base/seekable_reader_test.go
@@ -94,6 +94,12 @@ func (suite *SeekableReaderTestSuite) TestReadSeekBackRead() {
 	suite.readAndExpect(suite.content)
 }
 
+func (suite *SeekableReaderTestSuite) TestSeekFwdSeekBackReadSome() {
+	suite.contentRSC.Seek(0, 2)
+	suite.contentRSC.Seek(0, 0)
+	suite.readAndExpect(suite.content[:4])
+}
+
 func (suite *SeekableReaderTestSuite) readAndExpect(expected []byte) {
 	expectedLen := len(expected)
 	p := make([]byte, expectedLen)


### PR DESCRIPTION
I wasn't correctly handling the case where the seekableReader had
cached a bunch of data, and then the caller sought backward and
subsequently read _less_ data than what was in the cache. I now
handle that, and have a new test to cover this case.
