### PR TITLE
Change CSV import/export to inline structs

### DIFF
--- a/clients/csv/exporter/exporter_test.go
+++ b/clients/csv/exporter/exporter_test.go
@@ -56,20 +56,17 @@ func (s *testSuite) TestCSVExporter() {
 	structFields := typeDef.Desc.(types.StructDesc).Fields
 
 	// Build data rows
-	refs := make([]types.Value, 0, len(payload))
-	for i := 0; i < len(payload); i++ {
+	structs := make([]types.Value, len(payload))
+	for i, row := range payload {
 		fields := make(map[string]types.Value)
-		for j, v := range payload[i] {
+		for j, v := range row {
 			fields[structFields[j].Name] = types.NewString(v)
 		}
-		newStruct := types.NewStruct(typeRef, typeDef, fields)
-		r := types.NewRef(types.WriteValue(newStruct, cs))
-		refs = append(refs, r)
+		structs[i] = types.NewStruct(typeRef, typeDef, fields)
 	}
 
-	refType := types.MakeCompoundType(types.RefKind, typeRef)
-	listType := types.MakeCompoundType(types.ListKind, refType)
-	ds.Commit(types.NewTypedList(listType, refs...))
+	listType := types.MakeCompoundType(types.ListKind, typeRef)
+	ds.Commit(types.NewTypedList(listType, structs...))
 	ds.Store().Close()
 
 	// Run exporter

--- a/clients/csv/importer/importer.go
+++ b/clients/csv/importer/importer.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	p       = flag.Uint("p", 512, "parallelism")
 	dsFlags = dataset.NewFlags()
 	// Actually the delimiter uses runes, which can be multiple characters long.
 	// https://blog.golang.org/strings
@@ -61,7 +60,7 @@ func main() {
 		return
 	}
 
-	value, _, _ := csv.Read(res, *name, *header, comma, *p, ds.Store())
+	value, _, _ := csv.Read(res, *name, *header, comma, ds.Store())
 	_, err = ds.Commit(value)
 	d.Exp.NoError(err)
 }

--- a/clients/csv/importer/importer_test.go
+++ b/clients/csv/importer/importer_test.go
@@ -50,7 +50,7 @@ func (s *testSuite) TestCSVImporter() {
 	i := uint64(0)
 	l.IterAll(func(v types.Value, j uint64) {
 		s.Equal(i, j)
-		st := types.ReadValue(v.(types.Ref).TargetRef(), cs).(types.Struct)
+		st := v.(types.Struct)
 		s.Equal(types.NewString(fmt.Sprintf("a%d", i)), st.Get("a"))
 		s.Equal(types.NewString(fmt.Sprintf("%d", i)), st.Get("b"))
 		i++
@@ -81,7 +81,7 @@ func (s *testSuite) TestCSVImporterWithPipe() {
 	l := ds.Head().Value().(types.List)
 	s.Equal(uint64(1), l.Len())
 	v := l.Get(0)
-	st := types.ReadValue(v.(types.Ref).TargetRef(), cs).(types.Struct)
+	st := v.(types.Struct)
 	s.Equal(types.NewString("1"), st.Get("a"))
 	s.Equal(types.NewString("2"), st.Get("b"))
 }
@@ -110,7 +110,7 @@ func (s *testSuite) TestCSVImporterWithExternalHeader() {
 	l := ds.Head().Value().(types.List)
 	s.Equal(uint64(1), l.Len())
 	v := l.Get(0)
-	st := types.ReadValue(v.(types.Ref).TargetRef(), cs).(types.Struct)
+	st := v.(types.Struct)
 	s.Equal(types.NewString("7"), st.Get("x"))
 	s.Equal(types.NewString("8"), st.Get("y"))
 }

--- a/clients/csv/read.go
+++ b/clients/csv/read.go
@@ -4,32 +4,14 @@ import (
 	"encoding/csv"
 	"io"
 	"log"
-	"sort"
 	"strings"
-	"sync"
 
 	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
 
-type valuesWithIndex struct {
-	values []string
-	index  int
-}
-
-type refIndex struct {
-	ref   types.Ref
-	index int
-}
-
-type refIndexList []refIndex
-
-func (a refIndexList) Len() int           { return len(a) }
-func (a refIndexList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a refIndexList) Less(i, j int) bool { return a[i].index < a[j].index }
-
-// Creates a struct type by reading the first row of the csv.Reader.
+// MakeStructTypeFromHeader creates a struct type by reading the first row of the csv.Reader.
 func MakeStructTypeFromHeader(r *csv.Reader, structName string) (typeRef types.Type, typeDef types.Type) {
 	keys, err := r.Read()
 	if err != nil {
@@ -54,7 +36,9 @@ func MakeStructTypeFromHeader(r *csv.Reader, structName string) (typeRef types.T
 	return
 }
 
-func Read(res io.Reader, structName, header string, comma rune, p uint, cs chunks.ChunkStore) (types.List, types.Type, types.Type) {
+// Read takes comma-delineated data from res and parsed into a typed List of structs. Each row gets parsed into a struct named structName, optionally described by header. If header is empty, the first line of the file is used to guess the form of the struct into which rows are parsed.
+// In addition to the list, Read returns the typeRef for the structs in the list, and last the typeDef of the structs.
+func Read(res io.Reader, structName, header string, comma rune, cs chunks.ChunkStore) (l types.List, typeRef types.Type, typeDef types.Type) {
 	var input io.Reader
 	if len(header) == 0 {
 		input = res
@@ -68,69 +52,29 @@ func Read(res io.Reader, structName, header string, comma rune, p uint, cs chunk
 	r.Comma = comma
 	r.FieldsPerRecord = 0 // Let first row determine the number of fields.
 
-	typeRef, typeDef := MakeStructTypeFromHeader(r, structName)
+	typeRef, typeDef = MakeStructTypeFromHeader(r, structName)
 
-	recordChan := make(chan valuesWithIndex, 4096)
-	refChan := make(chan refIndex, 4096)
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	index := 0
-	go func() {
-		for {
-			row, err := r.Read()
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				log.Fatalln("Error decoding CSV: ", err)
-			}
-
-			wg.Add(1)
-			recordChan <- valuesWithIndex{row, index}
-			index++
-		}
-
-		wg.Done()
-		close(recordChan)
-	}()
+	valueChan := make(chan types.Value)
+	listType := types.MakeCompoundType(types.ListKind, typeRef)
+	listChan := types.NewStreamingTypedList(listType, cs, valueChan)
 
 	structFields := typeDef.Desc.(types.StructDesc).Fields
 
-	rowsToNoms := func() {
-		for row := range recordChan {
-			fields := make(map[string]types.Value)
-			for i, v := range row.values {
-				fields[structFields[i].Name] = types.NewString(v)
-			}
-			newStruct := types.NewStruct(typeRef, typeDef, fields)
-			r := types.NewRef(types.WriteValue(newStruct, cs))
-			refChan <- refIndex{r, row.index}
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			close(valueChan)
+			break
+		} else if err != nil {
+			log.Fatalln("Error decoding CSV: ", err)
 		}
-	}
 
-	for i := uint(0); i < p; i++ {
-		go rowsToNoms()
-	}
-
-	refList := refIndexList{}
-
-	go func() {
-		for r := range refChan {
-			refList = append(refList, r)
-			wg.Done()
+		fields := make(map[string]types.Value)
+		for i, v := range row {
+			fields[structFields[i].Name] = types.NewString(v)
 		}
-	}()
-
-	wg.Wait()
-	sort.Sort(refList)
-
-	refs := make([]types.Value, 0, len(refList))
-	for _, r := range refList {
-		refs = append(refs, r.ref)
+		valueChan <- types.NewStruct(typeRef, typeDef, fields)
 	}
 
-	refType := types.MakeCompoundType(types.RefKind, typeRef)
-	listType := types.MakeCompoundType(types.ListKind, refType)
-
-	return types.NewTypedList(listType, refs...), typeRef, typeDef
+	return <-listChan, typeRef, typeDef
 }

--- a/clients/csv/write.go
+++ b/clients/csv/write.go
@@ -22,23 +22,19 @@ func getFieldNamesFromStruct(structDesc types.StructDesc) (fieldNames []string) 
 func datasetToHeaderAndList(ds *dataset.Dataset) (fieldNames []string, nomsList types.List) {
 	v := ds.Head().Value()
 	d.Exp.Equal(types.ListKind, v.Type().Desc.Kind(),
-		"Dataset must be List<>, found:", v.Type().Desc.Describe())
+		"Dataset must be List<>, found: %s", v.Type().Desc.Describe())
 
-	t := v.Type().Desc.(types.CompoundDesc).ElemTypes[0]
-	d.Exp.Equal(types.RefKind, t.Desc.Kind(),
-		"List<> must be of Ref, found:", t.Desc.Describe())
-
-	u := t.Desc.(types.CompoundDesc).ElemTypes[0]
+	u := v.Type().Desc.(types.CompoundDesc).ElemTypes[0]
 	d.Exp.Equal(types.UnresolvedKind, u.Desc.Kind(),
-		"Ref must be UnresolvedKind, found:", u.Desc.Describe())
+		"List<> must be UnresolvedKind, found: %s", u.Desc.Describe())
 
 	pkg := types.ReadPackage(u.PackageRef(), ds.Store())
 	d.Exp.Equal(types.PackageKind, pkg.Type().Desc.Kind(),
-		"Failed to read package:", pkg.Type().Desc.Describe())
+		"Failed to read package: %s", pkg.Type().Desc.Describe())
 
 	structDesc := pkg.Types()[u.Ordinal()].Desc
 	d.Exp.Equal(types.StructKind, structDesc.Kind(),
-		"Did not find Struct:", structDesc.Describe())
+		"Did not find Struct: %s", structDesc.Describe())
 
 	fieldNames = getFieldNamesFromStruct(structDesc.(types.StructDesc))
 	nomsList = v.(types.List)
@@ -58,8 +54,8 @@ func Write(ds *dataset.Dataset, comma rune, concurrency int, output io.Writer) {
 		for _, f := range fieldNames {
 			records[index+1] = append(
 				records[index+1],
-				fmt.Sprintf("%s", v.(types.Ref).TargetValue(ds.Store()).(types.Struct).
-					Get(f)))
+				fmt.Sprintf("%s", v.(types.Struct).Get(f)),
+			)
 		}
 	})
 


### PR DESCRIPTION
Putting structs out of line while importing CSVs leads to
large numbers of tiny chunks in a noms DB. This seems like the
wrong way to hold noms, so this patch changes our importer to
keep the structs inline.
