### PR TITLE
Add datas.NewTestFactory()

### DIFF
--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -73,3 +73,20 @@ func (f Flags) CreateDataStore() (DataStore, bool) {
 
 	return &LocalDataStore{}, false
 }
+
+func (f Flags) CreateFactory() (Factory, bool) {
+	var cf chunks.Factory
+	if cf = f.ldb.CreateFactory(); cf != nil {
+	} else if cf = f.dynamo.CreateFactory(); cf != nil {
+	} else if cf = f.memory.CreateFactory(); cf != nil {
+	}
+
+	if cf != nil {
+		return &localFactory{cf}, true
+	}
+
+	if cf = f.hflags.CreateFactory(); cf != nil {
+		return &remoteFactory{cf}, true
+	}
+	return &localFactory{}, false
+}

--- a/datas/factory.go
+++ b/datas/factory.go
@@ -10,23 +10,6 @@ type Factory interface {
 	Shutter()
 }
 
-func (f Flags) CreateFactory() (Factory, bool) {
-	var cf chunks.Factory
-	if cf = f.ldb.CreateFactory(); cf != nil {
-	} else if cf = f.dynamo.CreateFactory(); cf != nil {
-	} else if cf = f.memory.CreateFactory(); cf != nil {
-	}
-
-	if cf != nil {
-		return &localFactory{cf}, true
-	}
-
-	if cf = f.hflags.CreateFactory(); cf != nil {
-		return &remoteFactory{cf}, true
-	}
-	return &localFactory{}, false
-}
-
 type localFactory struct {
 	cf chunks.Factory
 }
@@ -55,4 +38,8 @@ func (rf *remoteFactory) Create(ns string) (DataStore, bool) {
 
 func (rf *remoteFactory) Shutter() {
 	rf.cf.Shutter()
+}
+
+func NewTestFactory(cf chunks.Factory) Factory {
+	return &localFactory{cf}
 }


### PR DESCRIPTION
There was no way to create a datas.Factory from outside
the datas package except via datas.Flags. Also, this patch
moves the CreateFactory() method on Flags into the file
where all the rest of the Flags stuff is defined.
