### PR TITLE
JS: Add no-fallthrough to eslint to prevent case fallthroughs

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -11,6 +11,7 @@
     "indent": [2, 2, {"SwitchCase": 1}],
     "linebreak-style": [2, "unix"],
     "max-len": [2, 100, 8],
+    "no-fallthrough": 2,
     "no-multi-spaces": 2,
     "no-new-wrappers": 2,
     "no-throw-literal": 2,


### PR DESCRIPTION
Fixes #988
