### PR TITLE
Support Dataset delete

### DIFF
--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -20,8 +20,11 @@ type DataStore interface {
 	// Datasets returns the root of the datastore which is a MapOfStringToRefOfCommit where string is a datasetID.
 	Datasets() MapOfStringToRefOfCommit
 
-	// Commit updates the commit that a datastore points at. The new Commit is constructed using v and the current Head. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the datastore is always returned.
+	// Commit updates the Commit that datasetID in this datastore points at. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the datastore is always returned.
 	Commit(datasetID string, commit Commit) (DataStore, error)
+
+	// Delete removes the Dataset named datasetID from the map at the root of the DataStore. The Dataset data is not necessarily cleaned up at this time, but may be garbage collected in the future. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the datastore is always returned.
+	Delete(datasetID string) (DataStore, error)
 
 	// Copies all chunks reachable from (and including)|r| but not reachable from (and including |exclude| in |source| to |sink|
 	CopyReachableChunksP(r, exclude ref.Ref, sink chunks.ChunkSink, concurrency int)

--- a/datas/datastore_test.go
+++ b/datas/datastore_test.go
@@ -92,6 +92,77 @@ func TestDataStoreCommit(t *testing.T) {
 	assert.Equal(uint64(2), datasets2.Len())
 }
 
+func TestDataStoreDelete(t *testing.T) {
+	assert := assert.New(t)
+	cs := chunks.NewMemoryStore()
+	ds := NewDataStore(cs)
+	datasetID1, datasetID2 := "ds1", "ds2"
+
+	datasets := ds.Datasets()
+	assert.Zero(datasets.Len())
+
+	// |a|
+	a := types.NewString("a")
+	ds, err := ds.Commit(datasetID1, NewCommit().SetValue(a))
+	assert.NoError(err)
+	assert.True(ds.Head(datasetID1).Value().Equals(a))
+
+	// ds1; |a|, ds2: |b|
+	b := types.NewString("b")
+	ds, err = ds.Commit(datasetID2, NewCommit().SetValue(b))
+	assert.NoError(err)
+	assert.True(ds.Head(datasetID2).Value().Equals(b))
+
+	ds, err = ds.Delete(datasetID1)
+	assert.NoError(err)
+	assert.True(ds.Head(datasetID2).Value().Equals(b))
+	h, present := ds.MaybeHead(datasetID1)
+	assert.False(present, "Dataset %s should not be present, but head is %v", datasetID1, h.Value())
+
+	// Get a fresh datastore, and verify that only ds1 is present
+	newDs := NewDataStore(cs)
+	datasets = newDs.Datasets()
+	assert.Equal(uint64(1), datasets.Len())
+	_, present = ds.MaybeHead(datasetID2)
+	assert.True(present, "Dataset %s should be present", datasetID2)
+}
+
+func TestDataStoreDeleteConcurrent(t *testing.T) {
+	assert := assert.New(t)
+	cs := chunks.NewMemoryStore()
+	ds := NewDataStore(cs)
+	datasetID := "ds1"
+
+	datasets := ds.Datasets()
+	assert.Zero(datasets.Len())
+
+	// |a|
+	a := types.NewString("a")
+	aCommit := NewCommit().SetValue(a)
+	ds, err := ds.Commit(datasetID, aCommit)
+	assert.NoError(err)
+
+	// |a| <- |b|
+	b := types.NewString("b")
+	bCommit := NewCommit().SetValue(b).SetParents(NewSetOfRefOfCommit().Insert(NewRefOfCommit(aCommit.Ref())))
+	ds2, err := ds.Commit(datasetID, bCommit)
+	assert.NoError(err)
+	assert.True(ds.Head(datasetID).Value().Equals(a))
+	assert.True(ds2.Head(datasetID).Value().Equals(b))
+
+	ds, err = ds.Delete(datasetID)
+	assert.NoError(err)
+	h, present := ds.MaybeHead(datasetID)
+	assert.False(present, "Dataset %s should not be present, but head is %v", datasetID, h.Value())
+	h, present = ds2.MaybeHead(datasetID)
+	assert.True(present, "Dataset %s should be present", datasetID)
+
+	// Get a fresh datastore, and verify that no datastores are present
+	newDs := NewDataStore(cs)
+	datasets = newDs.Datasets()
+	assert.Equal(uint64(0), datasets.Len())
+}
+
 func TestDataStoreConcurrency(t *testing.T) {
 	assert := assert.New(t)
 

--- a/datas/local_datastore.go
+++ b/datas/local_datastore.go
@@ -22,6 +22,11 @@ func (lds *LocalDataStore) Commit(datasetID string, commit Commit) (DataStore, e
 	return newLocalDataStore(lds.ChunkStore), err
 }
 
+func (lds *LocalDataStore) Delete(datasetID string) (DataStore, error) {
+	err := lds.doDelete(datasetID)
+	return newLocalDataStore(lds.ChunkStore), err
+}
+
 // Copies all chunks reachable from (and including)|sourceRef| but not reachable from (and including) |exclude| in |source| to |sink|
 func (lds *LocalDataStore) CopyReachableChunksP(sourceRef, exclude ref.Ref, sink chunks.ChunkSink, concurrency int) {
 	excludeRefs := map[ref.Ref]bool{}

--- a/datas/remote_datastore.go
+++ b/datas/remote_datastore.go
@@ -34,6 +34,11 @@ func (rds *RemoteDataStore) Commit(datasetID string, commit Commit) (DataStore, 
 	return newRemoteDataStore(rds.ChunkStore), err
 }
 
+func (rds *RemoteDataStore) Delete(datasetID string) (DataStore, error) {
+	err := rds.doDelete(datasetID)
+	return newRemoteDataStore(rds.ChunkStore), err
+}
+
 // Asks remote server to figure out which chunks need to be copied and return them.
 func (rds *RemoteDataStore) CopyReachableChunksP(r, exclude ref.Ref, cs chunks.ChunkSink, concurrency int) {
 	// POST http://<host>/ref/sha1----?all=true&exclude=sha1----. Response will be chunk data if present, 404 if absent.


### PR DESCRIPTION
This is the most naive implementation of Dataset deletion. It
does no cleanup of data, but simply drops the Dataset's head
from the map at the root of the DataStore.
