### PR TITLE
Fix csv.ReportValidFieldTypes

### DIFF
--- a/clients/csv/schema.go
+++ b/clients/csv/schema.go
@@ -8,24 +8,24 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-type SchemaOptions []*TypeCanFit
+type schemaOptions []*typeCanFit
 
-func NewSchemaOptions(fieldCount int) SchemaOptions {
-	options := make([]*TypeCanFit, fieldCount, fieldCount)
+func newSchemaOptions(fieldCount int) schemaOptions {
+	options := make([]*typeCanFit, fieldCount, fieldCount)
 	for i := 0; i < fieldCount; i++ {
-		options[i] = &TypeCanFit{true, true, true, true, true, true, true, true, true, true, true, true, true, true}
+		options[i] = &typeCanFit{true, true, true, true, true, true, true, true, true, true, true, true, true, true}
 	}
 	return options
 }
 
-func (so SchemaOptions) Test(values []string) {
+func (so schemaOptions) Test(values []string) {
 	d.Chk.True(len(so) == len(values))
 	for i, t := range so {
 		t.Test(values[i])
 	}
 }
 
-func (so SchemaOptions) ValidKinds() [][]types.NomsKind {
+func (so schemaOptions) ValidKinds() [][]types.NomsKind {
 	kinds := make([][]types.NomsKind, len(so))
 	for i, t := range so {
 		kinds[i] = t.ValidKinds()
@@ -33,7 +33,7 @@ func (so SchemaOptions) ValidKinds() [][]types.NomsKind {
 	return kinds
 }
 
-type TypeCanFit struct {
+type typeCanFit struct {
 	uintType    bool
 	intType     bool
 	boolType    bool
@@ -50,8 +50,7 @@ type TypeCanFit struct {
 	stringType  bool
 }
 
-func (tc *TypeCanFit) ValidKinds() []types.NomsKind {
-	kinds := make([]types.NomsKind, 0)
+func (tc *typeCanFit) ValidKinds() (kinds []types.NomsKind) {
 	if tc.uintType {
 		if tc.uint8Type {
 			kinds = append(kinds, types.Uint8Kind)
@@ -94,14 +93,14 @@ func (tc *TypeCanFit) ValidKinds() []types.NomsKind {
 	return kinds
 }
 
-func (tc *TypeCanFit) Test(value string) {
+func (tc *typeCanFit) Test(value string) {
 	tc.testUints(value)
 	tc.testInts(value)
 	tc.testFloats(value)
 	tc.testBool(value)
 }
 
-func (tc *TypeCanFit) testUints(value string) {
+func (tc *typeCanFit) testUints(value string) {
 	if !tc.uintType {
 		return
 	}
@@ -122,7 +121,7 @@ func (tc *TypeCanFit) testUints(value string) {
 	return
 }
 
-func (tc *TypeCanFit) testInts(value string) {
+func (tc *typeCanFit) testInts(value string) {
 	if !tc.intType {
 		return
 	}
@@ -146,7 +145,7 @@ func (tc *TypeCanFit) testInts(value string) {
 	return
 }
 
-func (tc *TypeCanFit) testFloats(value string) {
+func (tc *typeCanFit) testFloats(value string) {
 	if !tc.float32Type && !tc.float64Type {
 		return
 	}
@@ -163,7 +162,7 @@ func (tc *TypeCanFit) testFloats(value string) {
 	}
 }
 
-func (tc *TypeCanFit) testBool(value string) {
+func (tc *typeCanFit) testBool(value string) {
 	if !tc.boolType {
 		return
 	}
@@ -171,6 +170,7 @@ func (tc *TypeCanFit) testBool(value string) {
 	tc.boolType = err == nil
 }
 
+// StringToType takes a piece of data as a string and attempts to convert it to a types.Value of the appropriate types.NomsKind.
 func StringToType(s string, k types.NomsKind) types.Value {
 	switch k {
 	case types.Uint8Kind:

--- a/clients/csv/schema_test.go
+++ b/clients/csv/schema_test.go
@@ -1,7 +1,9 @@
 package csv
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/attic-labs/noms/types"
@@ -10,9 +12,8 @@ import (
 
 func TestSchemaDetection(t *testing.T) {
 	assert := assert.New(t)
-
 	test := func(input [][]string, expect [][]types.NomsKind) {
-		options := NewSchemaOptions(len(input[0]))
+		options := newSchemaOptions(len(input[0]))
 		for _, values := range input {
 			options.Test(values)
 		}
@@ -278,4 +279,27 @@ func TestSchemaDetection(t *testing.T) {
 				types.StringKind},
 		},
 	)
+}
+
+func TestReportValidFieldTypes(t *testing.T) {
+	assert := assert.New(t)
+	data := [][]string{
+		{"h1", "h2", "h3"},
+		{"1.1", "true", "d3"},
+		{"2", "false", "d6"},
+	}
+	expectedKinds := [][]types.NomsKind{
+		[]types.NomsKind{types.Float32Kind, types.Float64Kind, types.StringKind},
+		[]types.NomsKind{types.BoolKind, types.StringKind},
+		[]types.NomsKind{types.StringKind},
+	}
+	dataString := ""
+	for _, row := range data {
+		dataString = dataString + strings.Join(row, ",") + "\n"
+	}
+	keys, kinds := ReportValidFieldTypes(bytes.NewBufferString(dataString), "")
+	assert.Equal(data[0], keys)
+	for i, ks := range kinds {
+		assert.Equal(expectedKinds[i], ks)
+	}
 }


### PR DESCRIPTION
csv.ReportValidFieldTypes() was always reporting that all rows could
be represented by any kind, no matter what the data. This is because
the schemaOptions data structure created in that function was being
updated inside a goroutine for which the main line of execution was
never waiting. All the CSV data would be read, each row sent over a
channel, and then the function would return as soon as it was done
reading.

Additionally, some 'go verify' cleanup in read.go and schema.go.
There's currently no need to expose schemaOptions or typeCanFit
outside the csv package, so these are made private.
