### PR TITLE
Add csv.KindSlice

### DIFF
--- a/clients/csv/kind_slice.go
+++ b/clients/csv/kind_slice.go
@@ -1,0 +1,32 @@
+package csv
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/attic-labs/noms/types"
+)
+
+type KindSlice []types.NomsKind
+
+func (ks KindSlice) MarshalJSON() ([]byte, error) {
+	elems := make([]string, len(ks))
+	for i, k := range ks {
+		elems[i] = fmt.Sprintf("%d", k)
+	}
+	return []byte("[" + strings.Join(elems, ",") + "]"), nil
+}
+
+func (ks *KindSlice) UnmarshalJSON(value []byte) error {
+	elems := strings.Split(string(value[1:len(value)-1]), ",")
+	*ks = make(KindSlice, len(elems))
+	for i, e := range elems {
+		ival, err := strconv.ParseUint(e, 10, 8)
+		if err != nil {
+			return err
+		}
+		(*ks)[i] = types.NomsKind(ival)
+	}
+	return nil
+}

--- a/clients/csv/kind_slice_test.go
+++ b/clients/csv/kind_slice_test.go
@@ -1,0 +1,24 @@
+package csv
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/attic-labs/noms/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKindSliceJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	ks := KindSlice{types.Uint8Kind, types.StringKind, types.BoolKind}
+	b, err := json.Marshal(&ks)
+	assert.NoError(err)
+
+	assert.Equal(fmt.Sprintf("[%d,%d,%d]", ks[0], ks[1], ks[2]), string(b))
+
+	var uks KindSlice
+	err = json.Unmarshal(b, &uks)
+	assert.Equal(ks, uks)
+}

--- a/clients/csv/read.go
+++ b/clients/csv/read.go
@@ -22,8 +22,8 @@ var StringToKind = func(kindMap map[types.NomsKind]string) map[string]types.Noms
 }(types.KindToString)
 
 // StringsToKinds looks up each element of strs in the StringToKind map and returns a slice of answers
-func StringsToKinds(strs []string) []types.NomsKind {
-	kinds := make([]types.NomsKind, len(strs))
+func StringsToKinds(strs []string) KindSlice {
+	kinds := make(KindSlice, len(strs))
 	for i, str := range strs {
 		k, ok := StringToKind[str]
 		d.Exp.True(ok)
@@ -33,7 +33,7 @@ func StringsToKinds(strs []string) []types.NomsKind {
 }
 
 // KindsToStrings looks up each element of kinds in the types.KindToString map and returns a slice of answers
-func KindsToStrings(kinds []types.NomsKind) []string {
+func KindsToStrings(kinds KindSlice) []string {
 	strs := make([]string, len(kinds))
 	for i, k := range kinds {
 		strs[i] = types.KindToString[k]
@@ -51,7 +51,7 @@ func NewCSVReader(res io.Reader, comma rune) *csv.Reader {
 
 // ReportValidFieldTypes takes res, a reader expected to contain CSV data, and an optional header. Excluding the header (assumed to be the first row if no header is given), it returns a slice of types.NomsKind for each column in the data indicating what Noms types could be used to represent that row.
 // For example, if all values in a row are negative integers between -127 and 0, the slice for that row would be [types.Int8Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Float32Kind, types.Float64Kind, types.StringKind]. If even one value in the row is a floating point number, however, all the integer kinds would be dropped. All values can be represented as a string, so that option is always provided.
-func ReportValidFieldTypes(res io.Reader, header string) ([]string, [][]types.NomsKind) {
+func ReportValidFieldTypes(res io.Reader, header string) ([]string, []KindSlice) {
 	var input io.Reader
 	if len(header) == 0 {
 		input = res
@@ -88,7 +88,7 @@ func ReportValidFieldTypes(res io.Reader, header string) ([]string, [][]types.No
 }
 
 // MakeStructTypeFromHeader creates a struct type by reading the first row of the csv.Reader using |kinds| as the type of each field. If |kinds| is empty, default to strings.
-func MakeStructTypeFromHeader(r *csv.Reader, structName string, kinds []types.NomsKind) (typeRef, typeDef types.Type) {
+func MakeStructTypeFromHeader(r *csv.Reader, structName string, kinds KindSlice) (typeRef, typeDef types.Type) {
 	keys, err := r.Read()
 	d.Exp.NoError(err, "Error decoding CSV")
 
@@ -117,7 +117,7 @@ func MakeStructTypeFromHeader(r *csv.Reader, structName string, kinds []types.No
 
 // Read takes comma-delineated data from res and parses it into a typed List of structs. Each row gets parsed into a struct named structName, optionally described by header. If header is empty, the first line of the file is used to guess the form of the struct into which rows are parsed. If kinds is non-empty, it will be used to type the fields in the generated structs; otherwise, they will be left as string-fields.
 // In addition to the list, Read returns the typeRef for the structs in the list, and last the typeDef of the structs.
-func Read(res io.Reader, structName, header string, kinds []types.NomsKind, comma rune, cs chunks.ChunkStore) (l types.List, typeRef, typeDef types.Type) {
+func Read(res io.Reader, structName, header string, kinds KindSlice, comma rune, cs chunks.ChunkStore) (l types.List, typeRef, typeDef types.Type) {
 	var input io.Reader
 	if len(header) == 0 {
 		input = res

--- a/clients/csv/schema.go
+++ b/clients/csv/schema.go
@@ -25,8 +25,8 @@ func (so schemaOptions) Test(values []string) {
 	}
 }
 
-func (so schemaOptions) ValidKinds() [][]types.NomsKind {
-	kinds := make([][]types.NomsKind, len(so))
+func (so schemaOptions) ValidKinds() []KindSlice {
+	kinds := make([]KindSlice, len(so))
 	for i, t := range so {
 		kinds[i] = t.ValidKinds()
 	}
@@ -50,7 +50,7 @@ type typeCanFit struct {
 	stringType  bool
 }
 
-func (tc *typeCanFit) ValidKinds() (kinds []types.NomsKind) {
+func (tc *typeCanFit) ValidKinds() (kinds KindSlice) {
 	if tc.uintType {
 		if tc.uint8Type {
 			kinds = append(kinds, types.Uint8Kind)

--- a/clients/csv/schema_test.go
+++ b/clients/csv/schema_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSchemaDetection(t *testing.T) {
 	assert := assert.New(t)
-	test := func(input [][]string, expect [][]types.NomsKind) {
+	test := func(input [][]string, expect []KindSlice) {
 		options := newSchemaOptions(len(input[0]))
 		for _, values := range input {
 			options.Test(values)
@@ -28,10 +28,10 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1", "1", "60"},
 			[]string{"1.1", "false", "75"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{types.StringKind},
-			[]types.NomsKind{types.BoolKind, types.StringKind},
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{types.StringKind},
+			KindSlice{types.BoolKind, types.StringKind},
+			KindSlice{
 				types.Uint8Kind, types.Uint16Kind, types.Uint32Kind, types.Uint64Kind,
 				types.Int8Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
@@ -47,8 +47,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1"},
 			[]string{"1.1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{types.StringKind},
+		[]KindSlice{
+			KindSlice{types.StringKind},
 		},
 	)
 	test(
@@ -57,8 +57,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1"},
 			[]string{"1.1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{types.StringKind},
+		[]KindSlice{
+			KindSlice{types.StringKind},
 		},
 	)
 	test(
@@ -72,8 +72,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1"},
 			[]string{"0"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{types.BoolKind, types.StringKind},
+		[]KindSlice{
+			KindSlice{types.BoolKind, types.StringKind},
 		},
 	)
 	test(
@@ -81,8 +81,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1"},
 			[]string{"1.1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
 		},
@@ -94,8 +94,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"4.940656458412465441765687928682213723651e-50"},
 			[]string{"-4.940656458412465441765687928682213723651e-50"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Float32Kind,
 				types.Float64Kind,
 				types.StringKind},
@@ -109,8 +109,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1.797693134862315708145274237317043567981e+102"},
 			[]string{"-1.797693134862315708145274237317043567981e+102"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Float64Kind,
 				types.StringKind},
 		},
@@ -122,8 +122,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1.797693134862315708145274237317043567981e+309"},
 			[]string{"-1.797693134862315708145274237317043567981e+309"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.StringKind},
 		},
 	)
@@ -132,8 +132,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"1"},
 			[]string{"0"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Uint8Kind, types.Uint16Kind, types.Uint32Kind, types.Uint64Kind,
 				types.Int8Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind,
 				types.Float32Kind,
@@ -148,8 +148,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int8Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -160,8 +160,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-0"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int8Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -174,8 +174,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int16Kind, types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -188,8 +188,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int16Kind, types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -202,8 +202,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -216,8 +216,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int32Kind, types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -230,8 +230,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -244,8 +244,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{"0"},
 			[]string{"-1"},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Int64Kind,
 				types.Float32Kind, types.Float64Kind,
 				types.StringKind},
@@ -257,8 +257,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{fmt.Sprintf("%d", uint64(1<<63))},
 			[]string{fmt.Sprintf("%d", uint64(1<<63)+1)},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Uint64Kind,
 				types.Float32Kind,
 				types.Float64Kind,
@@ -271,8 +271,8 @@ func TestSchemaDetection(t *testing.T) {
 			[]string{fmt.Sprintf("%d", uint64(1<<32))},
 			[]string{fmt.Sprintf("%d", uint64(1<<32)+1)},
 		},
-		[][]types.NomsKind{
-			[]types.NomsKind{
+		[]KindSlice{
+			KindSlice{
 				types.Uint64Kind, types.Int64Kind,
 				types.Float32Kind,
 				types.Float64Kind,
@@ -288,10 +288,10 @@ func TestReportValidFieldTypes(t *testing.T) {
 		{"1.1", "true", "d3"},
 		{"2", "false", "d6"},
 	}
-	expectedKinds := [][]types.NomsKind{
-		[]types.NomsKind{types.Float32Kind, types.Float64Kind, types.StringKind},
-		[]types.NomsKind{types.BoolKind, types.StringKind},
-		[]types.NomsKind{types.StringKind},
+	expectedKinds := []KindSlice{
+		KindSlice{types.Float32Kind, types.Float64Kind, types.StringKind},
+		KindSlice{types.BoolKind, types.StringKind},
+		KindSlice{types.StringKind},
 	}
 	dataString := ""
 	for _, row := range data {


### PR DESCRIPTION
Since types.NomsKind are really just 8 bit unsigned ints, which are
what Go uses to represent 'byte', the Go JSON marshal/unmarshal code
was treating slices of types.NomsKind as byte arrays and marshaling
them accordingly. Since that's not what we want, we need to do some
custom marshaling and unmarshaling, which means we need a Go type
to attach those functions to.
