### PR TITLE
Compress big chunks in DynamoStore

### DIFF
--- a/clients/csv/kind_slice.go
+++ b/clients/csv/kind_slice.go
@@ -8,6 +8,7 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
+// KindSlice is an alias for []types.NomsKind. It's needed because types.NomsKind are really just 8 bit unsigned ints, which are what Go uses to represent 'byte', and this confuses the Go JSON marshal/unmarshal code --  it treats them as byte arrays and base64 encodes them!
 type KindSlice []types.NomsKind
 
 func (ks KindSlice) MarshalJSON() ([]byte, error) {

--- a/clients/csv/read.go
+++ b/clients/csv/read.go
@@ -130,7 +130,7 @@ func Read(res io.Reader, structName, header string, kinds KindSlice, comma rune,
 	r.FieldsPerRecord = 0 // Let first row determine the number of fields.
 
 	typeRef, typeDef = MakeStructTypeFromHeader(r, structName, kinds)
-	valueChan := make(chan types.Value)
+	valueChan := make(chan types.Value, 128) // TODO: Make this a function param?
 	listType := types.MakeCompoundType(types.ListKind, typeRef)
 	listChan := types.NewStreamingTypedList(listType, cs, valueChan)
 


### PR DESCRIPTION
It turns out that many large chunks are quite compressible, and
writing smaller chunks to DynamoDB saves time, and allows more
headroom before hitting the provisioned capacity on the backing
table. Compressed chunks are tagged with the algorithm used to
compress them, though we treat untagged chunks as uncompressed for
backward compatibility.
