### PR TITLE
Support parallel iteration with AsyncIterator.

### DIFF
--- a/js/src/indexed_sequence.js
+++ b/js/src/indexed_sequence.js
@@ -49,27 +49,19 @@ export class IndexedSequenceCursor<T> extends SequenceCursor<T, IndexedSequence>
 }
 
 export class IndexedSequenceIterator<T> extends AsyncIterator<T> {
-  _cursorP: Promise<IndexedSequenceCursor<T>>;
-  _iterator: ?AsyncIterator<T>;
+  _iterator: Promise<AsyncIterator<T>>;
 
   constructor(cursorP: Promise<IndexedSequenceCursor<T>>) {
     super();
-    this._cursorP = cursorP;
-  }
-
-  async _ensureIterator(): Promise<AsyncIterator<T>> {
-    if (!this._iterator) {
-      this._iterator = (await this._cursorP).iterator();
-    }
-    return this._iterator;
+    this._iterator = cursorP.then(cur => cur.iterator());
   }
 
   next(): Promise<AsyncIteratorResult<T>> {
-    return this._ensureIterator().then(it => it.next());
+    return this._iterator.then(it => it.next());
   }
 
   return(): Promise<AsyncIteratorResult<T>> {
-    return this._ensureIterator().then(it => it.return());
+    return this._iterator.then(it => it.return());
   }
 }
 

--- a/js/src/ordered_sequence.js
+++ b/js/src/ordered_sequence.js
@@ -93,26 +93,18 @@ export class OrderedSequenceCursor<T, K: valueOrPrimitive> extends
 }
 
 export class OrderedSequenceIterator<T, K: valueOrPrimitive> extends AsyncIterator<T> {
-  _cursorP: Promise<OrderedSequenceCursor<T, K>>;
-  _iterator: ?AsyncIterator<T>;
+  _iterator: Promise<AsyncIterator<T>>;
 
   constructor(cursorP: Promise<OrderedSequenceCursor<T, K>>) {
     super();
-    this._cursorP = cursorP;
-  }
-
-  async _ensureIterator(): Promise<AsyncIterator<T>> {
-    if (!this._iterator) {
-      this._iterator = (await this._cursorP).iterator();
-    }
-    return this._iterator;
+    this._iterator = cursorP.then(cur => cur.iterator());
   }
 
   next(): Promise<AsyncIteratorResult<T>> {
-    return this._ensureIterator().then(it => it.next());
+    return this._iterator.then(it => it.next());
   }
 
   return(): Promise<AsyncIteratorResult<T>> {
-    return this._ensureIterator().then(it => it.return());
+    return this._iterator.then(it => it.return());
   }
 }

--- a/js/src/test_util.js
+++ b/js/src/test_util.js
@@ -10,3 +10,12 @@ export async function flatten<T>(iter: AsyncIterator<T>): Promise<Array<T>> {
   }
   return values;
 }
+
+export async function flattenParallel<T>(iter: AsyncIterator<T>, count: number): Promise<Array<T>> {
+  const promises = [];
+  for (let i = 0; i < count; i++) {
+    promises.push(iter.next());
+  }
+  const results = await Promise.all(promises);
+  return results.map(res => notNull(res.value));
+}


### PR DESCRIPTION
There is a bug at the moment when you try to resolve more than 1 Promise
returned from next() at the same time, e.g.,

const list = new NomsList([1, 2, 3]);
const iter = list.iterator();
const n1 = iter.next();
const n2 = iter.next();
console.log(Promise.all(n1, n2));

It will not print "[1, 2]" as you'd expect, but instead "[1, 1]". This
was caused by an artificial race condition in the async/await pattern
used in the AsyncIterator next() implementations.
