### PR TITLE
DynamoStore: write full batches (until UpdateRoot), do so concurrently

### DIFF
--- a/chunks/put_cache.go
+++ b/chunks/put_cache.go
@@ -1,0 +1,44 @@
+package chunks
+
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/ref"
+)
+
+func newUnwrittenPutCache() *unwrittenPutCache {
+	return &unwrittenPutCache{map[ref.Ref]Chunk{}, &sync.Mutex{}}
+}
+
+type unwrittenPutCache struct {
+	unwrittenPuts map[ref.Ref]Chunk
+	mu            *sync.Mutex
+}
+
+func (p *unwrittenPutCache) Add(c Chunk) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.unwrittenPuts[c.Ref()]; !ok {
+		p.unwrittenPuts[c.Ref()] = c
+		return true
+	}
+
+	return false
+}
+
+func (p *unwrittenPutCache) Get(r ref.Ref) Chunk {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c, ok := p.unwrittenPuts[r]; ok {
+		return c
+	}
+	return EmptyChunk
+}
+
+func (p *unwrittenPutCache) Clear(chunks []Chunk) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range chunks {
+		delete(p.unwrittenPuts, c.Ref())
+	}
+}

--- a/chunks/stat_keeper.go
+++ b/chunks/stat_keeper.go
@@ -1,0 +1,69 @@
+package chunks
+
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/d"
+)
+
+type statKeeper struct {
+	stats   map[string]int64
+	chans   map[string]chan int64
+	width   int
+	wg      *sync.WaitGroup
+	stopped bool
+}
+
+func newStatKeeper(w int) *statKeeper {
+	return &statKeeper{
+		stats: map[string]int64{},
+		chans: map[string]chan int64{},
+		width: w,
+		wg:    &sync.WaitGroup{},
+	}
+}
+
+// AddStat prepares the keeper to record samples for a stat named n
+func (sk *statKeeper) AddStat(n string) {
+	if _, present := sk.chans[n]; !present {
+		sk.wg.Add(1)
+		sk.chans[n] = make(chan int64, sk.width)
+		go func() {
+			for sample := range sk.chans[n] {
+				sk.stats[n] += sample
+			}
+			sk.wg.Done()
+		}()
+	}
+	return
+}
+
+// Chan returns a channel over which the caller can pass samples to be added to the accumulator for n
+func (sk *statKeeper) Chan(n string) chan<- int64 {
+	c, ok := sk.chans[n]
+	d.Chk.True(ok, "Stat %s is unknown", n)
+	return c
+}
+
+// Get returns the accumulated value for n. It's an error to call Get() before Stop()
+func (sk *statKeeper) Get(n string) int64 {
+	d.Chk.True(sk.stopped, "Calling Get() before Stop() is an error")
+	return sk.stats[n]
+}
+
+// Has returns whether there's an accumulator for n. It's an error to call Has() before Stop()
+func (sk *statKeeper) Has(n string) (has bool) {
+	d.Chk.True(sk.stopped, "Calling Has() before Stop() is an error")
+	_, has = sk.stats[n]
+	return
+}
+
+// Stop stops accumulating samples. It's an error to try to use channels returned by Chan() after Stop() until you've re-added new stats using AddStat
+func (sk *statKeeper) Stop() {
+	for _, c := range sk.chans {
+		close(c)
+	}
+	sk.stopped = true
+	sk.wg.Wait()
+	sk.chans = nil
+}

--- a/chunks/stat_keeper_test.go
+++ b/chunks/stat_keeper_test.go
@@ -1,0 +1,38 @@
+package chunks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeepStats(t *testing.T) {
+	sk := newStatKeeper(1)
+	stat := "statName"
+	sk.AddStat(stat)
+	count := int64(0)
+
+	update := func(c int64) {
+		count += c
+		sk.Chan(stat) <- c
+	}
+
+	update(2)
+	update(4)
+	update(-3)
+	sk.Stop()
+	assert.Equal(t, count, sk.Get(stat))
+}
+
+func TestKeepStatsHas(t *testing.T) {
+	assert := assert.New(t)
+	sk := newStatKeeper(1)
+	stat := "statName"
+	sk.AddStat(stat)
+	assert.Panics(func() { sk.Has(stat) })
+
+	sk.Chan(stat) <- 1
+	sk.Stop()
+	assert.True(sk.Has(stat))
+	assert.False(sk.Has("other"))
+}

--- a/clients/csv/importer/importer.go
+++ b/clients/csv/importer/importer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/attic-labs/noms/clients/csv"
+	"github.com/attic-labs/noms/clients/util"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
 	"github.com/attic-labs/noms/types"
@@ -51,6 +52,10 @@ func main() {
 	d.Exp.NoError(err)
 	defer res.Close()
 
+	if util.MaybeStartCPUProfile() {
+		defer util.StopCPUProfile()
+	}
+
 	comma, err := csv.StringToRune(*delimiter)
 	if err != nil {
 		fmt.Println(err.Error())
@@ -83,4 +88,6 @@ func main() {
 	value, _, _ := csv.Read(res, *name, *header, kinds, comma, ds.Store())
 	_, err = ds.Commit(value)
 	d.Exp.NoError(err)
+
+	util.MaybeWriteMemProfile()
 }


### PR DESCRIPTION
With this patch, DynamoStore will now hold off writing anything to
the backend until it's got a full batch or someone calls UpdateRoot().
When it's time to write, DynamoStore will now fire off a new goroutine
to build the request (including compressing chunks), send it, and wait
for a response. It will keep up to dynamoWriteConcurrency concurrent
batch writes in flight.

Includes statKeeper, which provides a way for concurrent goroutines to
keep stats like write count, bytes written, etc. Also includes a refactor
to make unwrittenPutCache a separate type that both HTTPStore and
DynamoStore use instead of using copypasted code.
