### PR TITLE
Don't pass ChunkStores to collection leaves

### DIFF
--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -26,10 +26,10 @@ type DataStore interface {
 	// Delete removes the Dataset named datasetID from the map at the root of the DataStore. The Dataset data is not necessarily cleaned up at this time, but may be garbage collected in the future. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the datastore is always returned.
 	Delete(datasetID string) (DataStore, error)
 
-	// Copies all chunks reachable from (and including)|r| but not reachable from (and including |exclude| in |source| to |sink|
+	// Copies all chunks reachable from (and including) |r| but not reachable from (and including) |exclude| from this DataStore to |sink|
 	CopyReachableChunksP(r, exclude ref.Ref, sink chunks.ChunkSink, concurrency int)
 
-	// Copies all chunks reachable from (and including) |r| in |source| that aren't present in |sink|
+	// Copies all chunks reachable from (and including) |r| in |source| that aren't present in this DataStore
 	CopyMissingChunksP(r ref.Ref, sink chunks.ChunkStore, concurrency int)
 }
 

--- a/types/compound_list.go
+++ b/types/compound_list.go
@@ -190,11 +190,11 @@ func (cl compoundList) sequenceCursorAtIndex(idx uint64) *sequenceCursor {
 
 func (cl compoundList) sequenceChunkerAtIndex(idx uint64) *sequenceChunker {
 	cur := cl.sequenceCursorAtIndex(idx)
-	return newSequenceChunker(cur, makeListLeafChunkFn(cl.t, cl.cs, nil), newIndexedMetaSequenceChunkFn(cl.t, cl.cs, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+	return newSequenceChunker(cur, makeListLeafChunkFn(cl.t, nil), newIndexedMetaSequenceChunkFn(cl.t, cl.cs, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 }
 
 func (cl compoundList) Filter(cb listFilterCallback) List {
-	seq := newEmptySequenceChunker(makeListLeafChunkFn(cl.t, cl.cs, nil), newIndexedMetaSequenceChunkFn(cl.t, cl.cs, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+	seq := newEmptySequenceChunker(makeListLeafChunkFn(cl.t, nil), newIndexedMetaSequenceChunkFn(cl.t, cl.cs, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 	cl.IterAll(func(v Value, idx uint64) {
 		if cb(v, idx) {
 			seq.Append(v)
@@ -256,7 +256,7 @@ func newListLeafBoundaryChecker() boundaryChecker {
 
 // If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are
 // written when the root is written.
-func makeListLeafChunkFn(t Type, cs chunks.ChunkSource, sink chunks.ChunkSink) makeChunkFn {
+func makeListLeafChunkFn(t Type, sink chunks.ChunkSink) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		values := make([]Value, len(items))
 
@@ -264,7 +264,7 @@ func makeListLeafChunkFn(t Type, cs chunks.ChunkSource, sink chunks.ChunkSink) m
 			values[i] = v.(Value)
 		}
 
-		list := valueFromType(newListLeaf(cs, t, values...), t)
+		list := valueFromType(newListLeaf(t, values...), t)
 		if sink != nil {
 			return newMetaTuple(Uint64(len(values)), nil, WriteValue(list, sink)), list
 		}

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -120,7 +120,7 @@ func (r *jsonArrayReader) readList(t Type, pkg *Package) Value {
 	}
 
 	t = fixupType(t, pkg)
-	return valueFromType(newListLeaf(r.cs, t, data...), t)
+	return valueFromType(newListLeaf(t, data...), t)
 }
 
 func (r *jsonArrayReader) readSet(t Type, pkg *Package) Value {
@@ -133,7 +133,7 @@ func (r *jsonArrayReader) readSet(t Type, pkg *Package) Value {
 	}
 
 	t = fixupType(t, pkg)
-	return valueFromType(newSetLeaf(r.cs, t, data...), t)
+	return valueFromType(newSetLeaf(t, data...), t)
 }
 
 func (r *jsonArrayReader) readMap(t Type, pkg *Package) Value {
@@ -149,7 +149,7 @@ func (r *jsonArrayReader) readMap(t Type, pkg *Package) Value {
 	}
 
 	t = fixupType(t, pkg)
-	return valueFromType(newMapLeaf(r.cs, t, data...), t)
+	return valueFromType(newMapLeaf(t, data...), t)
 }
 
 func indexTypeForMetaSequence(t Type) Type {

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -130,8 +130,8 @@ func TestReadCompoundList(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
-	leaf1 := newListLeaf(cs, tr, Int32(0))
-	leaf2 := newListLeaf(cs, tr, Int32(1), Int32(2), Int32(3))
+	leaf1 := newListLeaf(tr, Int32(0))
+	leaf2 := newListLeaf(tr, Int32(1), Int32(2), Int32(3))
 	l2 := buildCompoundList([]metaTuple{
 		newMetaTuple(Uint64(1), leaf1, ref.Ref{}),
 		newMetaTuple(Uint64(4), leaf2, ref.Ref{}),

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -108,7 +108,7 @@ func TestWriteMap(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	typ := MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(BoolKind))
-	v := newMapLeaf(cs, typ, mapEntry{NewString("a"), Bool(false)}, mapEntry{NewString("b"), Bool(true)})
+	v := newMapLeaf(typ, mapEntry{NewString("a"), Bool(false)}, mapEntry{NewString("b"), Bool(true)})
 
 	w := newJsonArrayWriter(cs)
 	w.writeTopLevelValue(v)
@@ -330,8 +330,8 @@ func TestWriteCompoundList(t *testing.T) {
 	cs := chunks.NewMemoryStore()
 
 	ltr := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
-	leaf1 := newListLeaf(cs, ltr, Int32(0))
-	leaf2 := newListLeaf(cs, ltr, Int32(1), Int32(2), Int32(3))
+	leaf1 := newListLeaf(ltr, Int32(0))
+	leaf2 := newListLeaf(ltr, Int32(1), Int32(2), Int32(3))
 	cl := buildCompoundList([]metaTuple{
 		newMetaTuple(Uint64(1), leaf1, ref.Ref{}),
 		newMetaTuple(Uint64(4), leaf2, ref.Ref{}),

--- a/types/get_ref_test.go
+++ b/types/get_ref_test.go
@@ -46,26 +46,26 @@ func TestEnsureRef(t *testing.T) {
 	bl := newBlobLeaf([]byte("hi"))
 	cb := newCompoundBlob([]metaTuple{{bl, ref.Ref{}, Uint64(2)}}, cs)
 
-	ll := newListLeaf(cs, listType, NewString("foo"))
+	ll := newListLeaf(listType, NewString("foo"))
 	cl := buildCompoundList([]metaTuple{{ll, ref.Ref{}, Uint64(1)}}, listType, cs)
 
-	ml := newMapLeaf(cs, mapType, mapEntry{NewString("foo"), NewString("bar")})
+	ml := newMapLeaf(mapType, mapEntry{NewString("foo"), NewString("bar")})
 	cm := buildCompoundMap([]metaTuple{{ml, ref.Ref{}, NewString("foo")}}, mapType, cs)
 
-	sl := newSetLeaf(cs, setType, NewString("foo"))
+	sl := newSetLeaf(setType, NewString("foo"))
 	cps := buildCompoundSet([]metaTuple{{sl, ref.Ref{}, NewString("foo")}}, setType, cs)
 
 	count = byte(1)
 	values := []Value{
 		newBlobLeaf([]byte{}),
 		cb,
-		newListLeaf(cs, listType, NewString("bar")),
+		newListLeaf(listType, NewString("bar")),
 		cl,
 		NewString(""),
 		cm,
-		newMapLeaf(cs, mapType),
+		newMapLeaf(mapType),
 		cps,
-		newSetLeaf(cs, setType),
+		newSetLeaf(setType),
 	}
 	for i := 0; i < 2; i++ {
 		for j, v := range values {

--- a/types/list.go
+++ b/types/list.go
@@ -35,7 +35,7 @@ func NewList(v ...Value) List {
 
 // NewTypedList creates a new List with type t, populated with values, chunking if and when needed.
 func NewTypedList(t Type, values ...Value) List {
-	seq := newEmptySequenceChunker(makeListLeafChunkFn(t, nil, nil), newIndexedMetaSequenceChunkFn(t, nil, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+	seq := newEmptySequenceChunker(makeListLeafChunkFn(t, nil), newIndexedMetaSequenceChunkFn(t, nil, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 	for _, v := range values {
 		seq.Append(v)
 	}
@@ -46,7 +46,7 @@ func NewTypedList(t Type, values ...Value) List {
 func NewStreamingTypedList(t Type, cs chunks.ChunkStore, values <-chan Value) <-chan List {
 	out := make(chan List)
 	go func() {
-		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, cs, cs), newIndexedMetaSequenceChunkFn(t, cs, cs), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, cs), newIndexedMetaSequenceChunkFn(t, cs, cs), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 		for v := range values {
 			seq.Append(v)
 		}

--- a/types/list_leaf.go
+++ b/types/list_leaf.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -13,12 +12,11 @@ type listLeaf struct {
 	values []Value
 	t      Type
 	ref    *ref.Ref
-	cs     chunks.ChunkSource
 }
 
-func newListLeaf(cs chunks.ChunkSource, t Type, v ...Value) List {
+func newListLeaf(t Type, v ...Value) List {
 	d.Chk.Equal(ListKind, t.Kind())
-	return listLeaf{v, t, &ref.Ref{}, cs}
+	return listLeaf{v, t, &ref.Ref{}}
 }
 
 func (l listLeaf) Len() uint64 {

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -171,7 +170,6 @@ func TestListRemoveAt(t *testing.T) {
 
 func TestListMap(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
 	testMap := func(concurrency, listLen int) {
 		values := make([]Value, listLen)
@@ -179,7 +177,7 @@ func TestListMap(t *testing.T) {
 			values[i] = Int64(i)
 		}
 
-		l := newListLeaf(cs, listType, values...)
+		l := newListLeaf(listType, values...)
 
 		cur := 0
 		mu := sync.Mutex{}
@@ -285,7 +283,6 @@ func TestListIterAll(t *testing.T) {
 
 func TestListIterAllP(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
 	testIter := func(concurrency, listLen int) {
 		values := make([]Value, listLen)
@@ -293,7 +290,7 @@ func TestListIterAllP(t *testing.T) {
 			values[i] = Int64(i)
 		}
 
-		l := newListLeaf(cs, listType, values...)
+		l := newListLeaf(listType, values...)
 
 		cur := 0
 		mu := sync.Mutex{}
@@ -342,13 +339,12 @@ func TestListIterAllP(t *testing.T) {
 
 func TestListType(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
 	l := NewList(Int32(0))
 	assert.True(l.Type().Equals(MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))))
 
 	tr := MakeCompoundType(ListKind, MakePrimitiveType(Uint8Kind))
-	l2 := newListLeaf(cs, tr, []Value{Uint8(0), Uint8(1)}...)
+	l2 := newListLeaf(tr, []Value{Uint8(0), Uint8(1)}...)
 	assert.Equal(tr, l2.Type())
 
 	l3 := l2.Slice(0, 1)

--- a/types/map_leaf.go
+++ b/types/map_leaf.go
@@ -16,7 +16,6 @@ type mapLeaf struct {
 	indexOf indexOfMapFn
 	t       Type
 	ref     *ref.Ref
-	cs      chunks.ChunkSource
 }
 
 type mapData []mapEntry
@@ -26,8 +25,8 @@ type mapEntry struct {
 	value Value
 }
 
-func newMapLeaf(cs chunks.ChunkSource, t Type, data ...mapEntry) Map {
-	return mapLeaf{data, getIndexFnForMapType(t), t, &ref.Ref{}, cs}
+func newMapLeaf(t Type, data ...mapEntry) Map {
+	return mapLeaf{data, getIndexFnForMapType(t), t, &ref.Ref{}}
 }
 
 func (m mapLeaf) First() (Value, Value) {
@@ -243,7 +242,7 @@ func makeMapLeafChunkFn(t Type, cs chunks.ChunkSource) makeChunkFn {
 			mapData[i] = v.(mapEntry)
 		}
 
-		mapLeaf := valueFromType(newMapLeaf(cs, t, mapData...), t)
+		mapLeaf := valueFromType(newMapLeaf(t, mapData...), t)
 
 		var indexValue Value
 		if len(mapData) > 0 {

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -6,15 +6,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewMap(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	m := newMapLeaf(cs, mapType)
-	assert.IsType(newMapLeaf(cs, mapType), m)
+	m := newMapLeaf(mapType)
+	assert.IsType(newMapLeaf(mapType), m)
 	assert.Equal(uint64(0), m.Len())
 	m = NewMap(NewString("foo"), NewString("foo"), NewString("bar"), NewString("bar"))
 	assert.Equal(uint64(2), m.Len())
@@ -24,8 +22,7 @@ func TestNewMap(t *testing.T) {
 
 func TestMapHasRemove(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	m1 := newMapLeaf(cs, mapType)
+	m1 := newMapLeaf(mapType)
 	assert.False(m1.Has(NewString("foo")))
 	m2 := m1.Set(NewString("foo"), NewString("foo"))
 	assert.False(m1.Has(NewString("foo")))
@@ -38,8 +35,7 @@ func TestMapHasRemove(t *testing.T) {
 
 func TestMapFirst(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	m1 := newMapLeaf(cs, mapType)
+	m1 := newMapLeaf(mapType)
 	k, v := m1.First()
 	assert.Nil(k)
 	assert.Nil(v)
@@ -60,8 +56,7 @@ func TestMapFirst(t *testing.T) {
 
 func TestMapSetGet(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	m1 := newMapLeaf(cs, mapType)
+	m1 := newMapLeaf(mapType)
 	assert.Nil(m1.Get(NewString("foo")))
 	m2 := m1.Set(NewString("foo"), Int32(42))
 	assert.Nil(m1.Get(NewString("foo")))
@@ -79,8 +74,7 @@ func TestMapSetGet(t *testing.T) {
 
 func TestMapSetM(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	m1 := newMapLeaf(cs, mapType)
+	m1 := newMapLeaf(mapType)
 	m2 := m1.SetM()
 	assert.True(m1.Equals(m2))
 	m3 := m2.SetM(NewString("foo"), NewString("bar"), NewString("hot"), NewString("dog"))
@@ -102,8 +96,7 @@ func TestMapDuplicateSet(t *testing.T) {
 
 func TestMapIter(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	m := newMapLeaf(cs, mapType)
+	m := newMapLeaf(mapType)
 
 	type entry struct {
 		key   Value
@@ -146,7 +139,6 @@ func TestMapIter(t *testing.T) {
 
 func TestMapIterAllP(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
 	testIter := func(concurrency, mapLen int) {
 		values := make([]Value, 2*mapLen)
@@ -155,7 +147,7 @@ func TestMapIterAllP(t *testing.T) {
 			values[2*i+1] = Uint64(i)
 		}
 
-		m := newMapLeaf(cs, mapType, buildMapData(mapData{}, values, mapType)...)
+		m := newMapLeaf(mapType, buildMapData(mapData{}, values, mapType)...)
 
 		cur := 0
 		mu := sync.Mutex{}
@@ -212,11 +204,10 @@ func TestMapFilter(t *testing.T) {
 
 func TestMapEquals(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
-	m1 := newMapLeaf(cs, mapType)
+	m1 := newMapLeaf(mapType)
 	m2 := m1
-	m3 := newMapLeaf(cs, mapType)
+	m3 := newMapLeaf(mapType)
 
 	assert.True(m1.Equals(m2))
 	assert.True(m2.Equals(m1))
@@ -233,7 +224,6 @@ func TestMapEquals(t *testing.T) {
 
 func TestMapNotStringKeys(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
 	b1 := NewBlob(bytes.NewBufferString("blob1"))
 	b2 := NewBlob(bytes.NewBufferString("blob2"))
@@ -248,8 +238,8 @@ func TestMapNotStringKeys(t *testing.T) {
 		b2, NewString("blob2"),
 		NewList(), NewString("empty list"),
 		NewList(NewList()), NewString("list of list"),
-		newMapLeaf(cs, mapType), NewString("empty map"),
-		NewMap(newMapLeaf(cs, mapType), newMapLeaf(cs, mapType)), NewString("map of map/map"),
+		newMapLeaf(mapType), NewString("empty map"),
+		NewMap(newMapLeaf(mapType), newMapLeaf(mapType)), NewString("map of map/map"),
 		NewSet(), NewString("empty set"),
 		NewSet(NewSet()), NewString("map of set/set"),
 	}
@@ -391,25 +381,23 @@ func TestMapOrdering(t *testing.T) {
 
 func TestMapEmpty(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
-	m := newMapLeaf(cs, mapType)
+	m := newMapLeaf(mapType)
 	assert.True(m.Empty())
 	m = m.Set(Bool(false), NewString("hi"))
 	assert.False(m.Empty())
-	m = m.Set(NewList(), newMapLeaf(cs, mapType))
+	m = m.Set(NewList(), newMapLeaf(mapType))
 	assert.False(m.Empty())
 }
 
 func TestMapType(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
-	m := newMapLeaf(cs, mapType)
+	m := newMapLeaf(mapType)
 	assert.True(m.Type().Equals(MakeCompoundType(MapKind, MakePrimitiveType(ValueKind), MakePrimitiveType(ValueKind))))
 
 	tr := MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(Uint64Kind))
-	m = newMapLeaf(cs, tr)
+	m = newMapLeaf(tr)
 	assert.Equal(tr, m.Type())
 
 	m2 := m.Remove(NewString("B"))

--- a/types/set_leaf.go
+++ b/types/set_leaf.go
@@ -16,13 +16,12 @@ type setLeaf struct {
 	indexOf indexOfSetFn
 	t       Type
 	ref     *ref.Ref
-	cs      chunks.ChunkSource
 }
 
 type setData []Value
 
-func newSetLeaf(cs chunks.ChunkSource, t Type, m ...Value) setLeaf {
-	return setLeaf{m, getIndexFnForSetType(t), t, &ref.Ref{}, cs}
+func newSetLeaf(t Type, m ...Value) setLeaf {
+	return setLeaf{m, getIndexFnForSetType(t), t, &ref.Ref{}}
 }
 
 func (s setLeaf) Empty() bool {
@@ -206,7 +205,7 @@ func makeSetLeafChunkFn(t Type, cs chunks.ChunkSource) makeChunkFn {
 			setData[i] = v.(Value)
 		}
 
-		setLeaf := valueFromType(newSetLeaf(cs, t, setData...), t)
+		setLeaf := valueFromType(newSetLeaf(t, setData...), t)
 
 		var indexValue Value
 		if len(setData) > 0 {
@@ -238,5 +237,5 @@ func (s setLeaf) sequenceCursorAtFirst() *sequenceCursor {
 }
 
 func (s setLeaf) chunkSource() chunks.ChunkSource {
-	return s.cs
+	return nil
 }

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -152,7 +151,6 @@ func TestSetIterAll(t *testing.T) {
 
 func TestSetIterAllP(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
 	testIter := func(concurrency, setLen int) {
 		values := make([]Value, setLen)
@@ -160,7 +158,7 @@ func TestSetIterAllP(t *testing.T) {
 			values[i] = Uint64(i)
 		}
 
-		s := newSetLeaf(cs, setType, values...)
+		s := newSetLeaf(setType, values...)
 
 		cur := 0
 		mu := sync.Mutex{}
@@ -348,14 +346,13 @@ func TestSetFilter(t *testing.T) {
 
 func TestSetType(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
 
-	s := newSetLeaf(cs, setType)
+	s := newSetLeaf(setType)
 	assert.True(s.Type().Equals(MakeCompoundType(SetKind, MakePrimitiveType(ValueKind))))
 
 	tr := MakeCompoundType(SetKind, MakePrimitiveType(Uint64Kind))
 
-	s = newSetLeaf(cs, tr)
+	s = newSetLeaf(tr)
 	assert.Equal(tr, s.Type())
 
 	s2 := s.Remove(Uint64(1))


### PR DESCRIPTION
It turns out that the collection leaves don't actually use the
ChunkStore we give them, so stop passing it to them.
