### PR TITLE
JS: Export the RemoteStore interface.

### DIFF
--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -7,6 +7,7 @@ export {default as Chunk} from './chunk.js';
 export {default as HttpStore} from './http_store.js';
 export {default as MemoryStore} from './memory_store.js';
 export {default as Ref} from './ref.js';
+export {RemoteStore} from './remote_store.js';
 export {default as Struct} from './struct.js';
 export {encodeNomsValue, writeValue} from './encode.js';
 export {invariant, notNull} from './assert.js';


### PR DESCRIPTION
To switch from HttpStore to CacheStore at the moment you need to do
find-replace CacheStore. It would be better to use the RemoteStore base
class then choose either HttpStore or CacheStore on construction.
