### PR TITLE
Change csv importer API slightly

### DIFF
--- a/clients/csv/importer/importer.go
+++ b/clients/csv/importer/importer.go
@@ -58,11 +58,21 @@ func main() {
 		return
 	}
 
+	r := csv.NewCSVReader(res, comma)
+
+	var headers []string
+	if *header == "" {
+		headers, err = r.Read()
+		d.Exp.NoError(err)
+	} else {
+		headers = strings.Split(*header, string(comma))
+	}
+
 	if *reportTypes {
-		keys, kinds := csv.ReportValidFieldTypes(res, *header)
-		d.Chk.Equal(len(keys), len(kinds))
+		kinds := csv.ReportValidFieldTypes(r, headers)
+		d.Chk.Equal(len(headers), len(kinds))
 		fmt.Println("Possible types for each column:")
-		for i, key := range keys {
+		for i, key := range headers {
 			fmt.Printf("%s: %s\n", key, strings.Join(csv.KindsToStrings(kinds[i]), ","))
 		}
 		return
@@ -80,7 +90,7 @@ func main() {
 		kinds = csv.StringsToKinds(strings.Split(*columnTypes, ","))
 	}
 
-	value, _, _ := csv.Read(res, *name, *header, kinds, comma, ds.Store())
+	value, _, _ := csv.Read(r, *name, headers, kinds, ds.Store())
 	_, err = ds.Commit(value)
 	d.Exp.NoError(err)
 }

--- a/clients/csv/importer/importer_test.go
+++ b/clients/csv/importer/importer_test.go
@@ -59,7 +59,6 @@ func (s *testSuite) TestCSVImporter() {
 		s.Equal(types.Uint8(i), st.Get("b"))
 		i++
 	})
-
 }
 
 func (s *testSuite) TestCSVImporterReportTypes() {

--- a/clients/csv/schema_test.go
+++ b/clients/csv/schema_test.go
@@ -297,8 +297,12 @@ func TestReportValidFieldTypes(t *testing.T) {
 	for _, row := range data {
 		dataString = dataString + strings.Join(row, ",") + "\n"
 	}
-	keys, kinds := ReportValidFieldTypes(bytes.NewBufferString(dataString), "")
-	assert.Equal(data[0], keys)
+
+	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
+	headers, err := r.Read()
+	assert.NoError(err)
+	assert.Equal(data[0], headers)
+	kinds := ReportValidFieldTypes(r, headers)
 	for i, ks := range kinds {
 		assert.Equal(expectedKinds[i], ks)
 	}


### PR DESCRIPTION
This is in preparation of allowing editing the headers even when
using the first row as headers.

Now the consumer should create a CSVReader and read the first row
as the headers as needed.
