### PR TITLE
Update and unify HTTPStore and DynamoStore batching strategies

### DIFF
--- a/chunks/chunk_serializer.go
+++ b/chunks/chunk_serializer.go
@@ -67,6 +67,13 @@ func (sz *serializer) Put(c Chunk) {
 	sz.chs <- c
 }
 
+func (sz *serializer) PutMany(chunks ...Chunk) (e BackpressureError) {
+	for _, c := range chunks {
+		sz.chs <- c
+	}
+	return
+}
+
 func (sz *serializer) Close() error {
 	close(sz.chs)
 	<-sz.done

--- a/chunks/chunk_store.go
+++ b/chunks/chunk_store.go
@@ -1,6 +1,7 @@
 package chunks
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/attic-labs/noms/ref"
@@ -38,6 +39,18 @@ type ChunkSource interface {
 
 // ChunkSink is a place to put chunks.
 type ChunkSink interface {
+	// Put writes c into the ChunkSink. c may or may not be persisted when Put() returns.
 	Put(c Chunk)
+
+	// PutMany tries to write chunks into the sink. It will handle as many as possible, then return a BackpressureError containing the rest (if any). Handled chunks may or may not be persisted when PutMany() returns.
+	PutMany(chunks ...Chunk) BackpressureError
+
 	io.Closer
+}
+
+// BackpressureError is a slice of Chunk that indicates some chunks could not be Put(). Caller is free to try to Put them again later.
+type BackpressureError []Chunk
+
+func (b BackpressureError) Error() string {
+	return fmt.Sprintf("Tried to Put %d too many Chunks", len(b))
 }

--- a/chunks/leveldb_store.go
+++ b/chunks/leveldb_store.go
@@ -64,6 +64,18 @@ func (l *LevelDBStore) Put(c Chunk) {
 	l.putByKey(l.toChunkKey(c.Ref()), c)
 }
 
+func (l *LevelDBStore) PutMany(chunks ...Chunk) (e BackpressureError) {
+	numBytes := 0
+	b := new(leveldb.Batch)
+	for _, c := range chunks {
+		d := c.Data()
+		numBytes += len(d)
+		b.Put(l.toChunkKey(c.Ref()), d)
+	}
+	l.putBatch(b, numBytes)
+	return
+}
+
 func (l *LevelDBStore) Close() error {
 	if l.closeBackingStore {
 		l.internalLevelDBStore.Close()
@@ -152,6 +164,15 @@ func (l *internalLevelDBStore) putByKey(key []byte, c Chunk) {
 	d.Chk.NoError(err)
 	l.putCount++
 	l.putBytes += int64(len(c.Data()))
+	<-l.concurrentWriteLimit
+}
+
+func (l *internalLevelDBStore) putBatch(b *leveldb.Batch, numBytes int) {
+	l.concurrentWriteLimit <- struct{}{}
+	err := l.db.Write(b, nil)
+	d.Chk.NoError(err)
+	l.putCount += int64(b.Len())
+	l.putBytes += int64(numBytes)
 	<-l.concurrentWriteLimit
 }
 

--- a/chunks/memory_store.go
+++ b/chunks/memory_store.go
@@ -49,13 +49,20 @@ func (ms *MemoryStore) Put(c Chunk) {
 	ms.data[c.Ref()] = c
 }
 
+func (ms *MemoryStore) PutMany(chunks ...Chunk) (e BackpressureError) {
+	for _, c := range chunks {
+		ms.Put(c)
+	}
+	return
+}
+
 func (ms *MemoryStore) Len() int {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 	return len(ms.data)
 }
 
-func (l *MemoryStore) Close() error {
+func (ms *MemoryStore) Close() error {
 	return nil
 }
 

--- a/chunks/put_cache.go
+++ b/chunks/put_cache.go
@@ -26,6 +26,13 @@ func (p *unwrittenPutCache) Add(c Chunk) bool {
 	return false
 }
 
+func (p *unwrittenPutCache) Has(c Chunk) (has bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, has = p.unwrittenPuts[c.Ref()]
+	return
+}
+
 func (p *unwrittenPutCache) Get(r ref.Ref) Chunk {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/chunks/read_through_store.go
+++ b/chunks/read_through_store.go
@@ -46,6 +46,27 @@ func (rts ReadThroughStore) Put(c Chunk) {
 	rts.cachingStore.Put(c)
 }
 
+func (rts ReadThroughStore) PutMany(chunks ...Chunk) BackpressureError {
+	bpe1 := rts.backingStore.PutMany(chunks...)
+	bpe2 := rts.cachingStore.PutMany(chunks...)
+	if bpe1 == nil {
+		return bpe2
+	} else if bpe2 == nil {
+		return bpe1
+	}
+	// Neither is nil
+	lookup := make(map[ref.Ref]bool, len(bpe1))
+	for _, c := range bpe1 {
+		lookup[c.Ref()] = true
+	}
+	for _, c := range bpe2 {
+		if !lookup[c.Ref()] {
+			bpe1 = append(bpe1, c)
+		}
+	}
+	return bpe1
+}
+
 func (rts ReadThroughStore) Root() ref.Ref {
 	return rts.backingStore.Root()
 }

--- a/chunks/remote_requests.go
+++ b/chunks/remote_requests.go
@@ -96,3 +96,12 @@ func (gb *getBatch) Put(c Chunk) {
 
 	delete(*gb, c.Ref())
 }
+
+// PutMany is implemented so that getBatch implements the ChunkSink interface.
+// FIXME? Should this have backpressure? I think no
+func (gb *getBatch) PutMany(chunks ...Chunk) (e BackpressureError) {
+	for _, c := range chunks {
+		gb.Put(c)
+	}
+	return
+}

--- a/chunks/stat_keeper.go
+++ b/chunks/stat_keeper.go
@@ -1,0 +1,69 @@
+package chunks
+
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/d"
+)
+
+type statKeeper struct {
+	stats   map[string]int64
+	chans   map[string]chan int64
+	width   int
+	wg      *sync.WaitGroup
+	stopped bool
+}
+
+func newStatKeeper(w int) *statKeeper {
+	return &statKeeper{
+		stats: map[string]int64{},
+		chans: map[string]chan int64{},
+		width: w,
+		wg:    &sync.WaitGroup{},
+	}
+}
+
+// AddStat prepares the keeper to record samples for a stat named n
+func (sk *statKeeper) AddStat(n string) {
+	if _, present := sk.chans[n]; !present {
+		sk.wg.Add(1)
+		sk.chans[n] = make(chan int64, sk.width)
+		go func() {
+			for sample := range sk.chans[n] {
+				sk.stats[n] += sample
+			}
+			sk.wg.Done()
+		}()
+	}
+	return
+}
+
+// Chan returns a channel over which the caller can pass samples to be added to the accumulator for n
+func (sk *statKeeper) Chan(n string) chan<- int64 {
+	c, ok := sk.chans[n]
+	d.Chk.True(ok, "Stat %s is unknown", n)
+	return c
+}
+
+// Get returns the accumulated value for n. It's an error to call Get() before Stop()
+func (sk *statKeeper) Get(n string) int64 {
+	d.Chk.True(sk.stopped, "Calling Get() before Stop() is an error")
+	return sk.stats[n]
+}
+
+// Has returns whether there's an accumulator for n. It's an error to call Has() before Stop()
+func (sk *statKeeper) Has(n string) (has bool) {
+	d.Chk.True(sk.stopped, "Calling Has() before Stop() is an error")
+	_, has = sk.stats[n]
+	return
+}
+
+// Stop stops accumulating samples. It's an error to try to use channels returned by Chan() after Stop() until you've re-added new stats using AddStat
+func (sk *statKeeper) Stop() {
+	for _, c := range sk.chans {
+		close(c)
+	}
+	sk.stopped = true
+	sk.wg.Wait()
+	sk.chans = nil
+}

--- a/chunks/stat_keeper_test.go
+++ b/chunks/stat_keeper_test.go
@@ -1,0 +1,38 @@
+package chunks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeepStats(t *testing.T) {
+	sk := newStatKeeper(1)
+	stat := "statName"
+	sk.AddStat(stat)
+	count := int64(0)
+
+	update := func(c int64) {
+		count += c
+		sk.Chan(stat) <- c
+	}
+
+	update(2)
+	update(4)
+	update(-3)
+	sk.Stop()
+	assert.Equal(t, count, sk.Get(stat))
+}
+
+func TestKeepStatsHas(t *testing.T) {
+	assert := assert.New(t)
+	sk := newStatKeeper(1)
+	stat := "statName"
+	sk.AddStat(stat)
+	assert.Panics(func() { sk.Has(stat) })
+
+	sk.Chan(stat) <- 1
+	sk.Stop()
+	assert.True(sk.Has(stat))
+	assert.False(sk.Has("other"))
+}

--- a/chunks/test_utils.go
+++ b/chunks/test_utils.go
@@ -46,6 +46,13 @@ func (s *TestStore) Put(c Chunk) {
 	s.MemoryStore.Put(c)
 }
 
+func (s *TestStore) PutMany(chunks ...Chunk) (e BackpressureError) {
+	for _, c := range chunks {
+		s.Put(c)
+	}
+	return
+}
+
 type testStoreFactory struct {
 	stores map[string]*TestStore
 }


### PR DESCRIPTION
In DynamoStore, write full batches (until UpdateRoot), do so
concurrently.  Make HTTPStore use the same batching strategy for
writes as DynamoStore does.

Instead of having a dedicated set of goroutines in HTTPStore reading
from whichever queue (get, has, put) becomes readable, create a single
dedicated worker for each that batches up requests and then fires off
goroutines to do HTTP work in the background.  In order to keep the
same number of allowed concurrent HTTP requests as before, these
get/has/put workers all use a single channel to ratelimit how many
HTTP requests can be in flight at a time.
