### PR TITLE
Tag root item in DynamoStore as uncompressed

### DIFF
--- a/chunks/dynamo_store.go
+++ b/chunks/dynamo_store.go
@@ -369,7 +369,7 @@ func (s *DynamoStore) Root() ref.Ref {
 	}
 
 	itemLen := len(result.Item)
-	d.Chk.True(itemLen == 2 || itemLen == 3)
+	d.Chk.True(itemLen == 2 || itemLen == 3, "Root should have 2 or three attributes on it: %+v", result.Item)
 	if itemLen == 3 {
 		d.Chk.NotNil(result.Item[compAttr])
 		d.Chk.NotNil(result.Item[compAttr].S)
@@ -386,7 +386,7 @@ func (s *DynamoStore) UpdateRoot(current, last ref.Ref) bool {
 		Item: map[string]*dynamodb.AttributeValue{
 			refAttr:   {B: s.rootKey},
 			chunkAttr: {B: current.DigestSlice()},
-			// compAttr:  {S: aws.String(noneValue)},  // We want to add this, but old versions of the code assert that items have only 2 elements.
+			compAttr:  {S: aws.String(noneValue)},
 		},
 	}
 


### PR DESCRIPTION
These items are never compressed, but all other items have a tag
on them, so it makes sense that these should as well. Remain
tolerant of old roots, though, that are not tagged.
