### PR TITLE
Move ReadValue and WriteValue to DataStore

### DIFF
--- a/chunks/test_utils.go
+++ b/chunks/test_utils.go
@@ -21,6 +21,7 @@ func assertInputNotInStore(input string, ref ref.Ref, s ChunkStore, assert *asse
 type TestStore struct {
 	MemoryStore
 	Reads  int
+	Hases  int
 	Writes int
 }
 
@@ -38,6 +39,7 @@ func (s *TestStore) Get(ref ref.Ref) Chunk {
 }
 
 func (s *TestStore) Has(ref ref.Ref) bool {
+	s.Hases++
 	return s.MemoryStore.Has(ref)
 }
 

--- a/clients/common/incident.noms.go
+++ b/clients/common/incident.noms.go
@@ -3,7 +3,6 @@
 package common
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -509,10 +508,10 @@ func builderForRefOfIncident(r ref.Ref) types.Value {
 	return NewRefOfIncident(r)
 }
 
-func (r RefOfIncident) TargetValue(cs chunks.ChunkSource) Incident {
-	return types.ReadValue(r.target, cs).(Incident)
+func (r RefOfIncident) TargetValue(vr types.ValueReader) Incident {
+	return vr.ReadValue(r.target).(Incident)
 }
 
-func (r RefOfIncident) SetTargetValue(val Incident, cs chunks.ChunkSink) RefOfIncident {
-	return NewRefOfIncident(types.WriteValue(val, cs))
+func (r RefOfIncident) SetTargetValue(val Incident, vw types.ValueWriter) RefOfIncident {
+	return NewRefOfIncident(vw.WriteValue(val))
 }

--- a/clients/common/quad_tree.noms.go
+++ b/clients/common/quad_tree.noms.go
@@ -3,7 +3,6 @@
 package common
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -578,12 +577,12 @@ func builderForRefOfValue(r ref.Ref) types.Value {
 	return NewRefOfValue(r)
 }
 
-func (r RefOfValue) TargetValue(cs chunks.ChunkSource) types.Value {
-	return types.ReadValue(r.target, cs)
+func (r RefOfValue) TargetValue(vr types.ValueReader) types.Value {
+	return vr.ReadValue(r.target)
 }
 
-func (r RefOfValue) SetTargetValue(val types.Value, cs chunks.ChunkSink) RefOfValue {
-	return NewRefOfValue(types.WriteValue(val, cs))
+func (r RefOfValue) SetTargetValue(val types.Value, vw types.ValueWriter) RefOfValue {
+	return NewRefOfValue(vw.WriteValue(val))
 }
 
 // ListOfNode
@@ -1189,10 +1188,10 @@ func builderForRefOfSQuadTree(r ref.Ref) types.Value {
 	return NewRefOfSQuadTree(r)
 }
 
-func (r RefOfSQuadTree) TargetValue(cs chunks.ChunkSource) SQuadTree {
-	return types.ReadValue(r.target, cs).(SQuadTree)
+func (r RefOfSQuadTree) TargetValue(vr types.ValueReader) SQuadTree {
+	return vr.ReadValue(r.target).(SQuadTree)
 }
 
-func (r RefOfSQuadTree) SetTargetValue(val SQuadTree, cs chunks.ChunkSink) RefOfSQuadTree {
-	return NewRefOfSQuadTree(types.WriteValue(val, cs))
+func (r RefOfSQuadTree) SetTargetValue(val SQuadTree, vw types.ValueWriter) RefOfSQuadTree {
+	return NewRefOfSQuadTree(vw.WriteValue(val))
 }

--- a/clients/common/quad_tree_query.go
+++ b/clients/common/quad_tree_query.go
@@ -1,26 +1,26 @@
 package common
 
-import "github.com/attic-labs/noms/datas"
+import "github.com/attic-labs/noms/types"
 
-func (qt *SQuadTree) Query(p GeopositionDef, kilometers float64, ds datas.DataStore) (GeorectangleDef, []Incident) {
+func (qt *SQuadTree) Query(p GeopositionDef, kilometers float64, vr types.ValueReader) (GeorectangleDef, []Incident) {
 	r := BoundingRectangle(p, kilometers)
-	nodes := qt.Search(r, p, float32(kilometers), ds)
+	nodes := qt.Search(r, p, float32(kilometers), vr)
 	return r, nodes
 }
 
-func (qt *SQuadTree) Search(r GeorectangleDef, p GeopositionDef, kilometers float32, ds datas.DataStore) []Incident {
+func (qt *SQuadTree) Search(r GeorectangleDef, p GeopositionDef, kilometers float32, vr types.ValueReader) []Incident {
 	nodes := []Incident{}
 	if qt.Tiles().Len() > 0 {
 		for _, q := range quadrants {
-			tile := qt.Tiles().Get(q).TargetValue(ds)
+			tile := qt.Tiles().Get(q).TargetValue(vr)
 			if IntersectsRect(tile.Georectangle().Def(), r) {
-				tnodes := tile.Search(r, p, kilometers, ds)
+				tnodes := tile.Search(r, p, kilometers, vr)
 				nodes = append(nodes, tnodes...)
 			}
 		}
 	} else if qt.Nodes().Len() > 0 {
 		qt.Nodes().Iter(func(r RefOfValue, i uint64) bool {
-			incident := r.TargetValue(ds).(Incident)
+			incident := r.TargetValue(vr).(Incident)
 			if DistanceTo(p, incident.Geoposition().Def()) < kilometers {
 				nodes = append(nodes, incident)
 			}

--- a/clients/crunchbase/importer/importer.go
+++ b/clients/crunchbase/importer/importer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/types"
 	"github.com/tealeg/xlsx"
 )
 
@@ -116,11 +115,11 @@ func importCompanies(ds dataset.Dataset, fileName string) ref.Ref {
 			rounds := roundsByPermalink[permalink]
 			roundRefs := SetOfRefOfRoundDef{}
 			for _, r := range rounds {
-				ref := types.WriteValue(r, ds.Store())
+				ref := ds.Store().WriteValue(r)
 				roundRefs[ref] = true
 			}
 			company = company.SetRounds(roundRefs.New())
-			ref := types.WriteValue(company, ds.Store())
+			ref := ds.Store().WriteValue(company)
 			companyRefsDef[company.Permalink()] = ref
 		}
 	}
@@ -131,7 +130,7 @@ func importCompanies(ds dataset.Dataset, fileName string) ref.Ref {
 	//	fmt.Printf("\rImported %d companies with %d rounds\n", companyRefs.Len(), numRounds)
 
 	// Write the list of companyRefs
-	return types.WriteValue(companyRefs, ds.Store())
+	return ds.Store().WriteValue(companyRefs)
 }
 
 func getExistingCompaniesRef(ds dataset.Dataset, h hash.Hash) ref.Ref {

--- a/clients/crunchbase/importer/importer.noms.go
+++ b/clients/crunchbase/importer/importer.noms.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -209,12 +208,12 @@ func builderForRefOfMapOfStringToRefOfCompany(r ref.Ref) types.Value {
 	return NewRefOfMapOfStringToRefOfCompany(r)
 }
 
-func (r RefOfMapOfStringToRefOfCompany) TargetValue(cs chunks.ChunkSource) MapOfStringToRefOfCompany {
-	return types.ReadValue(r.target, cs).(MapOfStringToRefOfCompany)
+func (r RefOfMapOfStringToRefOfCompany) TargetValue(vr types.ValueReader) MapOfStringToRefOfCompany {
+	return vr.ReadValue(r.target).(MapOfStringToRefOfCompany)
 }
 
-func (r RefOfMapOfStringToRefOfCompany) SetTargetValue(val MapOfStringToRefOfCompany, cs chunks.ChunkSink) RefOfMapOfStringToRefOfCompany {
-	return NewRefOfMapOfStringToRefOfCompany(types.WriteValue(val, cs))
+func (r RefOfMapOfStringToRefOfCompany) SetTargetValue(val MapOfStringToRefOfCompany, vw types.ValueWriter) RefOfMapOfStringToRefOfCompany {
+	return NewRefOfMapOfStringToRefOfCompany(vw.WriteValue(val))
 }
 
 // MapOfStringToRefOfCompany
@@ -403,10 +402,10 @@ func builderForRefOfCompany(r ref.Ref) types.Value {
 	return NewRefOfCompany(r)
 }
 
-func (r RefOfCompany) TargetValue(cs chunks.ChunkSource) Company {
-	return types.ReadValue(r.target, cs).(Company)
+func (r RefOfCompany) TargetValue(vr types.ValueReader) Company {
+	return vr.ReadValue(r.target).(Company)
 }
 
-func (r RefOfCompany) SetTargetValue(val Company, cs chunks.ChunkSink) RefOfCompany {
-	return NewRefOfCompany(types.WriteValue(val, cs))
+func (r RefOfCompany) SetTargetValue(val Company, vw types.ValueWriter) RefOfCompany {
+	return NewRefOfCompany(vw.WriteValue(val))
 }

--- a/clients/crunchbase/importer/sha1_91ae65b.go
+++ b/clients/crunchbase/importer/sha1_91ae65b.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -954,10 +953,10 @@ func builderForRefOfRound(r ref.Ref) types.Value {
 	return NewRefOfRound(r)
 }
 
-func (r RefOfRound) TargetValue(cs chunks.ChunkSource) Round {
-	return types.ReadValue(r.target, cs).(Round)
+func (r RefOfRound) TargetValue(vr types.ValueReader) Round {
+	return vr.ReadValue(r.target).(Round)
 }
 
-func (r RefOfRound) SetTargetValue(val Round, cs chunks.ChunkSink) RefOfRound {
-	return NewRefOfRound(types.WriteValue(val, cs))
+func (r RefOfRound) SetTargetValue(val Round, vw types.ValueWriter) RefOfRound {
+	return NewRefOfRound(vw.WriteValue(val))
 }

--- a/clients/crunchbase/index/index.go
+++ b/clients/crunchbase/index/index.go
@@ -13,7 +13,6 @@ import (
 	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/dataset"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/types"
 )
 
 var (
@@ -121,7 +120,7 @@ func main() {
 		for e := range c {
 			key := e.key
 			ref := e.ref
-			keyRef := types.WriteValue(key, ds)
+			keyRef := ds.WriteValue(key)
 			setDef := mapOfSets[keyRef]
 			if setDef == nil {
 				setDef = SetOfRefOfRoundDef{}

--- a/clients/crunchbase/index/index.noms.go
+++ b/clients/crunchbase/index/index.noms.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -658,10 +657,10 @@ func builderForRefOfKey(r ref.Ref) types.Value {
 	return NewRefOfKey(r)
 }
 
-func (r RefOfKey) TargetValue(cs chunks.ChunkSource) Key {
-	return types.ReadValue(r.target, cs).(Key)
+func (r RefOfKey) TargetValue(vr types.ValueReader) Key {
+	return vr.ReadValue(r.target).(Key)
 }
 
-func (r RefOfKey) SetTargetValue(val Key, cs chunks.ChunkSink) RefOfKey {
-	return NewRefOfKey(types.WriteValue(val, cs))
+func (r RefOfKey) SetTargetValue(val Key, vw types.ValueWriter) RefOfKey {
+	return NewRefOfKey(vw.WriteValue(val))
 }

--- a/clients/crunchbase/index/sha1_6c64b08.go
+++ b/clients/crunchbase/index/sha1_6c64b08.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -209,12 +208,12 @@ func builderForRefOfMapOfStringToRefOfCompany(r ref.Ref) types.Value {
 	return NewRefOfMapOfStringToRefOfCompany(r)
 }
 
-func (r RefOfMapOfStringToRefOfCompany) TargetValue(cs chunks.ChunkSource) MapOfStringToRefOfCompany {
-	return types.ReadValue(r.target, cs).(MapOfStringToRefOfCompany)
+func (r RefOfMapOfStringToRefOfCompany) TargetValue(vr types.ValueReader) MapOfStringToRefOfCompany {
+	return vr.ReadValue(r.target).(MapOfStringToRefOfCompany)
 }
 
-func (r RefOfMapOfStringToRefOfCompany) SetTargetValue(val MapOfStringToRefOfCompany, cs chunks.ChunkSink) RefOfMapOfStringToRefOfCompany {
-	return NewRefOfMapOfStringToRefOfCompany(types.WriteValue(val, cs))
+func (r RefOfMapOfStringToRefOfCompany) SetTargetValue(val MapOfStringToRefOfCompany, vw types.ValueWriter) RefOfMapOfStringToRefOfCompany {
+	return NewRefOfMapOfStringToRefOfCompany(vw.WriteValue(val))
 }
 
 // MapOfStringToRefOfCompany
@@ -403,10 +402,10 @@ func builderForRefOfCompany(r ref.Ref) types.Value {
 	return NewRefOfCompany(r)
 }
 
-func (r RefOfCompany) TargetValue(cs chunks.ChunkSource) Company {
-	return types.ReadValue(r.target, cs).(Company)
+func (r RefOfCompany) TargetValue(vr types.ValueReader) Company {
+	return vr.ReadValue(r.target).(Company)
 }
 
-func (r RefOfCompany) SetTargetValue(val Company, cs chunks.ChunkSink) RefOfCompany {
-	return NewRefOfCompany(types.WriteValue(val, cs))
+func (r RefOfCompany) SetTargetValue(val Company, vw types.ValueWriter) RefOfCompany {
+	return NewRefOfCompany(vw.WriteValue(val))
 }

--- a/clients/crunchbase/index/sha1_91ae65b.go
+++ b/clients/crunchbase/index/sha1_91ae65b.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -954,10 +953,10 @@ func builderForRefOfRound(r ref.Ref) types.Value {
 	return NewRefOfRound(r)
 }
 
-func (r RefOfRound) TargetValue(cs chunks.ChunkSource) Round {
-	return types.ReadValue(r.target, cs).(Round)
+func (r RefOfRound) TargetValue(vr types.ValueReader) Round {
+	return vr.ReadValue(r.target).(Round)
 }
 
-func (r RefOfRound) SetTargetValue(val Round, cs chunks.ChunkSink) RefOfRound {
-	return NewRefOfRound(types.WriteValue(val, cs))
+func (r RefOfRound) SetTargetValue(val Round, vw types.ValueWriter) RefOfRound {
+	return NewRefOfRound(vw.WriteValue(val))
 }

--- a/clients/csv/read.go
+++ b/clients/csv/read.go
@@ -4,7 +4,6 @@ import (
 	"encoding/csv"
 	"io"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
@@ -94,11 +93,11 @@ func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSl
 // Read takes a CSV reader and reads it into a typed List of structs. Each row gets read into a struct named structName, described by headers. If the original data contained headers it is expected that the input reader has already read those and are pointing at the first data row.
 // If kinds is non-empty, it will be used to type the fields in the generated structs; otherwise, they will be left as string-fields.
 // In addition to the list, Read returns the typeRef for the structs in the list, and last the typeDef of the structs.
-func Read(r *csv.Reader, structName string, headers []string, kinds KindSlice, cs chunks.ChunkStore) (l types.List, typeRef, typeDef types.Type) {
+func Read(r *csv.Reader, structName string, headers []string, kinds KindSlice, vrw types.ValueReadWriter) (l types.List, typeRef, typeDef types.Type) {
 	typeRef, typeDef = MakeStructTypeFromHeaders(headers, structName, kinds)
 	valueChan := make(chan types.Value, 128) // TODO: Make this a function param?
 	listType := types.MakeCompoundType(types.ListKind, typeRef)
-	listChan := types.NewStreamingTypedList(listType, cs, valueChan)
+	listChan := types.NewStreamingTypedList(listType, vrw, valueChan)
 
 	structFields := typeDef.Desc.(types.StructDesc).Fields
 

--- a/clients/csv/read_test.go
+++ b/clients/csv/read_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRead(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 
 	dataString := `a,1,true
 b,2,false
@@ -21,7 +22,7 @@ b,2,false
 
 	headers := []string{"A", "B", "C"}
 	kinds := KindSlice{types.StringKind, types.Int8Kind, types.BoolKind}
-	l, typeRef, typeDef := Read(r, "test", headers, kinds, cs)
+	l, typeRef, typeDef := Read(r, "test", headers, kinds, ds)
 
 	assert.Equal(uint64(2), l.Len())
 
@@ -46,13 +47,13 @@ b,2,false
 
 func testTrailingHelper(t *testing.T, dataString string) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 
 	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
 
 	headers := []string{"A", "B"}
 	kinds := KindSlice{types.StringKind, types.StringKind}
-	l, typeRef, typeDef := Read(r, "test", headers, kinds, cs)
+	l, typeRef, typeDef := Read(r, "test", headers, kinds, ds)
 
 	assert.Equal(uint64(3), l.Len())
 
@@ -91,7 +92,7 @@ g,h,i,j
 
 func TestReadParseError(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 
 	dataString := `a,"b`
 	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
@@ -105,6 +106,6 @@ func TestReadParseError(t *testing.T) {
 			_, ok := r.(*csv.ParseError)
 			assert.True(ok, "Should be a ParseError")
 		}()
-		Read(r, "test", headers, kinds, cs)
+		Read(r, "test", headers, kinds, ds)
 	}()
 }

--- a/clients/csv/write.go
+++ b/clients/csv/write.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/types"
 )
 
-// ValueToListAndElemDesc ensures that v is a types.List of structs, pulls the types.StructDesc that describes the elements of v out of cs, and returns the List and related StructDesc.
-func ValueToListAndElemDesc(v types.Value, cs chunks.ChunkSource) (types.List, types.StructDesc) {
+// ValueToListAndElemDesc ensures that v is a types.List of structs, pulls the types.StructDesc that describes the elements of v out of vr, and returns the List and related StructDesc.
+func ValueToListAndElemDesc(v types.Value, vr types.ValueReader) (types.List, types.StructDesc) {
 	d.Exp.Equal(types.ListKind, v.Type().Desc.Kind(),
 		"Dataset must be List<>, found: %s", v.Type().Desc.Describe())
 
@@ -19,7 +18,7 @@ func ValueToListAndElemDesc(v types.Value, cs chunks.ChunkSource) (types.List, t
 	d.Exp.Equal(types.UnresolvedKind, u.Desc.Kind(),
 		"List<> must be UnresolvedKind, found: %s", u.Desc.Describe())
 
-	pkg := types.ReadPackage(u.PackageRef(), cs)
+	pkg := types.ReadPackage(u.PackageRef(), vr)
 	d.Exp.Equal(types.PackageKind, pkg.Type().Desc.Kind(),
 		"Failed to read package: %s", pkg.Type().Desc.Describe())
 

--- a/clients/facebook/facebook.go
+++ b/clients/facebook/facebook.go
@@ -14,7 +14,6 @@ import (
 	"github.com/attic-labs/noms/clients/util"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
-	"github.com/attic-labs/noms/types"
 	"github.com/attic-labs/noms/util/http/retry"
 	"golang.org/x/oauth2"
 )
@@ -60,7 +59,7 @@ func main() {
 	var user = getUser()
 	printStats(user)
 
-	userRef := types.WriteValue(user, ds.Store())
+	userRef := ds.Store().WriteValue(user)
 	fmt.Printf("userRef: %s\n", userRef)
 	_, err := ds.Commit(NewRefOfUser(userRef))
 	d.Exp.NoError(err)
@@ -120,7 +119,7 @@ func getPhotos() SetOfRefOfRemotePhoto {
 				float32(entry.Images[0].Width),
 				float32(entry.Images[0].Height)))
 
-			photos = photos.Insert(NewRefOfRemotePhoto(types.WriteValue(photo, ds.Store())))
+			photos = photos.Insert(NewRefOfRemotePhoto(ds.Store().WriteValue(photo)))
 
 			numFetched++
 			// Be defensive and use Min(1.0) here - the user might have more than 1000 albums, or they

--- a/clients/facebook/facebook.noms.go
+++ b/clients/facebook/facebook.noms.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -207,12 +206,12 @@ func builderForRefOfUser(r ref.Ref) types.Value {
 	return NewRefOfUser(r)
 }
 
-func (r RefOfUser) TargetValue(cs chunks.ChunkSource) User {
-	return types.ReadValue(r.target, cs).(User)
+func (r RefOfUser) TargetValue(vr types.ValueReader) User {
+	return vr.ReadValue(r.target).(User)
 }
 
-func (r RefOfUser) SetTargetValue(val User, cs chunks.ChunkSink) RefOfUser {
-	return NewRefOfUser(types.WriteValue(val, cs))
+func (r RefOfUser) SetTargetValue(val User, vw types.ValueWriter) RefOfUser {
+	return NewRefOfUser(vw.WriteValue(val))
 }
 
 // SetOfRefOfRemotePhoto
@@ -413,10 +412,10 @@ func builderForRefOfRemotePhoto(r ref.Ref) types.Value {
 	return NewRefOfRemotePhoto(r)
 }
 
-func (r RefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) RemotePhoto {
-	return types.ReadValue(r.target, cs).(RemotePhoto)
+func (r RefOfRemotePhoto) TargetValue(vr types.ValueReader) RemotePhoto {
+	return vr.ReadValue(r.target).(RemotePhoto)
 }
 
-func (r RefOfRemotePhoto) SetTargetValue(val RemotePhoto, cs chunks.ChunkSink) RefOfRemotePhoto {
-	return NewRefOfRemotePhoto(types.WriteValue(val, cs))
+func (r RefOfRemotePhoto) SetTargetValue(val RemotePhoto, vw types.ValueWriter) RefOfRemotePhoto {
+	return NewRefOfRemotePhoto(vw.WriteValue(val))
 }

--- a/clients/flickr/flickr.go
+++ b/clients/flickr/flickr.go
@@ -18,7 +18,6 @@ import (
 	"github.com/attic-labs/noms/clients/util"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
-	"github.com/attic-labs/noms/types"
 	"github.com/attic-labs/noms/util/http/retry"
 	"github.com/bradfitz/latlong"
 	"github.com/garyburd/go-oauth/oauth"
@@ -213,7 +212,7 @@ func getAlbum(api flickrAPI, id string, gotPhoto chan struct{}) idAndRefOfAlbum 
 		SetTitle(response.Photoset.Title.Content).
 		SetPhotos(photos)
 	// TODO: Write albums in batches.
-	ref := NewRefOfAlbum(types.WriteValue(album, ds.Store()))
+	ref := NewRefOfAlbum(ds.Store().WriteValue(album))
 	return idAndRefOfAlbum{id, ref}
 }
 
@@ -309,7 +308,7 @@ func getAlbumPhotos(api flickrAPI, id string, gotPhoto chan struct{}) SetOfRefOf
 	})
 	d.Chk.NoError(err)
 
-	cs := ds.Store()
+	store := ds.Store()
 	photos := NewSetOfRefOfRemotePhoto()
 
 	for _, p := range response.Photoset.Photo {
@@ -351,7 +350,7 @@ func getAlbumPhotos(api flickrAPI, id string, gotPhoto chan struct{}) SetOfRefOf
 		}
 
 		// TODO: Write photos in batches.
-		photos = photos.Insert(NewRefOfRemotePhoto(types.WriteValue(photo, cs)))
+		photos = photos.Insert(NewRefOfRemotePhoto(store.WriteValue(photo)))
 		gotPhoto <- struct{}{}
 	}
 
@@ -423,7 +422,7 @@ func awaitOAuthResponse(l net.Listener, tempCred *oauth.Credentials) (tokenCred 
 
 func commitUser() {
 	var err error
-	r := NewRefOfUser(types.WriteValue(user, ds.Store()))
+	r := NewRefOfUser(ds.Store().WriteValue(user))
 	*ds, err = ds.Commit(r)
 	d.Exp.NoError(err)
 }

--- a/clients/flickr/flickr_test.go
+++ b/clients/flickr/flickr_test.go
@@ -25,8 +25,8 @@ func (api fakeFlickrAPI) Call(method string, response interface{}, args *map[str
 
 func TestGetAlbums(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	testDs := dataset.NewDataset(datas.NewDataStore(cs), "test")
+	store := datas.NewDataStore(chunks.NewMemoryStore())
+	testDs := dataset.NewDataset(store, "test")
 	ds = &testDs
 	progress := progressTracker{}
 	methods := map[string]string{
@@ -110,7 +110,7 @@ func TestGetAlbums(t *testing.T) {
 	albums := getAlbums(fakeFlickrAPI{methods}, &progress)
 	assert.Equal(uint64(1), albums.Len())
 
-	album := albums.Get("42").TargetValue(cs)
+	album := albums.Get("42").TargetValue(store)
 	assert.Equal("42", album.Id())
 	assert.Equal("My Photoset", album.Title())
 
@@ -119,7 +119,7 @@ func TestGetAlbums(t *testing.T) {
 
 	var photo0, photo1 RemotePhoto
 	photos.IterAll(func(photo RefOfRemotePhoto) {
-		p := photo.TargetValue(cs)
+		p := photo.TargetValue(store)
 		switch id := p.Id(); id {
 		case "0":
 			photo0 = p

--- a/clients/flickr/types.noms.go
+++ b/clients/flickr/types.noms.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -340,12 +339,12 @@ func builderForRefOfUser(r ref.Ref) types.Value {
 	return NewRefOfUser(r)
 }
 
-func (r RefOfUser) TargetValue(cs chunks.ChunkSource) User {
-	return types.ReadValue(r.target, cs).(User)
+func (r RefOfUser) TargetValue(vr types.ValueReader) User {
+	return vr.ReadValue(r.target).(User)
 }
 
-func (r RefOfUser) SetTargetValue(val User, cs chunks.ChunkSink) RefOfUser {
-	return NewRefOfUser(types.WriteValue(val, cs))
+func (r RefOfUser) SetTargetValue(val User, vw types.ValueWriter) RefOfUser {
+	return NewRefOfUser(vw.WriteValue(val))
 }
 
 // MapOfStringToRefOfAlbum
@@ -679,12 +678,12 @@ func builderForRefOfAlbum(r ref.Ref) types.Value {
 	return NewRefOfAlbum(r)
 }
 
-func (r RefOfAlbum) TargetValue(cs chunks.ChunkSource) Album {
-	return types.ReadValue(r.target, cs).(Album)
+func (r RefOfAlbum) TargetValue(vr types.ValueReader) Album {
+	return vr.ReadValue(r.target).(Album)
 }
 
-func (r RefOfAlbum) SetTargetValue(val Album, cs chunks.ChunkSink) RefOfAlbum {
-	return NewRefOfAlbum(types.WriteValue(val, cs))
+func (r RefOfAlbum) SetTargetValue(val Album, vw types.ValueWriter) RefOfAlbum {
+	return NewRefOfAlbum(vw.WriteValue(val))
 }
 
 // RefOfRemotePhoto
@@ -740,10 +739,10 @@ func builderForRefOfRemotePhoto(r ref.Ref) types.Value {
 	return NewRefOfRemotePhoto(r)
 }
 
-func (r RefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) RemotePhoto {
-	return types.ReadValue(r.target, cs).(RemotePhoto)
+func (r RefOfRemotePhoto) TargetValue(vr types.ValueReader) RemotePhoto {
+	return vr.ReadValue(r.target).(RemotePhoto)
 }
 
-func (r RefOfRemotePhoto) SetTargetValue(val RemotePhoto, cs chunks.ChunkSink) RefOfRemotePhoto {
-	return NewRefOfRemotePhoto(types.WriteValue(val, cs))
+func (r RefOfRemotePhoto) SetTargetValue(val RemotePhoto, vw types.ValueWriter) RefOfRemotePhoto {
+	return NewRefOfRemotePhoto(vw.WriteValue(val))
 }

--- a/clients/picasa/picasa.go
+++ b/clients/picasa/picasa.go
@@ -17,7 +17,6 @@ import (
 	"github.com/attic-labs/noms/clients/util"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
-	"github.com/attic-labs/noms/types"
 	"github.com/attic-labs/noms/util/http/retry"
 	"golang.org/x/oauth2"
 )
@@ -65,7 +64,7 @@ func main() {
 	start = time.Now()
 	user := getUser()
 
-	userRef := types.WriteValue(user, ds.Store())
+	userRef := ds.Store().WriteValue(user)
 	fmt.Printf("userRef: %s\n", userRef)
 	_, err := ds.Commit(NewRefOfUser(userRef))
 	d.Exp.NoError(err)
@@ -129,7 +128,7 @@ func getUser() User {
 		for {
 			album := <-ch
 			// TODO: batch write albums.
-			r := types.WriteValue(album, ds.Store())
+			r := ds.Store().WriteValue(album)
 			albums = append(albums, r)
 			wg.Done()
 		}
@@ -213,7 +212,7 @@ func getRemotePhotos(albumId string, numPhotos int, shapes shapeMap, progress ch
 
 				mu.Lock()
 				// TODO: batch write photos.
-				remotePhotos[types.WriteValue(p, ds.Store())] = true
+				remotePhotos[ds.Store().WriteValue(p)] = true
 				mu.Unlock()
 				progress <- struct{}{}
 			}

--- a/clients/picasa/picasa.noms.go
+++ b/clients/picasa/picasa.noms.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -340,12 +339,12 @@ func builderForRefOfUser(r ref.Ref) types.Value {
 	return NewRefOfUser(r)
 }
 
-func (r RefOfUser) TargetValue(cs chunks.ChunkSource) User {
-	return types.ReadValue(r.target, cs).(User)
+func (r RefOfUser) TargetValue(vr types.ValueReader) User {
+	return vr.ReadValue(r.target).(User)
 }
 
-func (r RefOfUser) SetTargetValue(val User, cs chunks.ChunkSink) RefOfUser {
-	return NewRefOfUser(types.WriteValue(val, cs))
+func (r RefOfUser) SetTargetValue(val User, vw types.ValueWriter) RefOfUser {
+	return NewRefOfUser(vw.WriteValue(val))
 }
 
 // ListOfRefOfAlbum
@@ -688,12 +687,12 @@ func builderForRefOfAlbum(r ref.Ref) types.Value {
 	return NewRefOfAlbum(r)
 }
 
-func (r RefOfAlbum) TargetValue(cs chunks.ChunkSource) Album {
-	return types.ReadValue(r.target, cs).(Album)
+func (r RefOfAlbum) TargetValue(vr types.ValueReader) Album {
+	return vr.ReadValue(r.target).(Album)
 }
 
-func (r RefOfAlbum) SetTargetValue(val Album, cs chunks.ChunkSink) RefOfAlbum {
-	return NewRefOfAlbum(types.WriteValue(val, cs))
+func (r RefOfAlbum) SetTargetValue(val Album, vw types.ValueWriter) RefOfAlbum {
+	return NewRefOfAlbum(vw.WriteValue(val))
 }
 
 // RefOfRemotePhoto
@@ -749,10 +748,10 @@ func builderForRefOfRemotePhoto(r ref.Ref) types.Value {
 	return NewRefOfRemotePhoto(r)
 }
 
-func (r RefOfRemotePhoto) TargetValue(cs chunks.ChunkSource) RemotePhoto {
-	return types.ReadValue(r.target, cs).(RemotePhoto)
+func (r RefOfRemotePhoto) TargetValue(vr types.ValueReader) RemotePhoto {
+	return vr.ReadValue(r.target).(RemotePhoto)
 }
 
-func (r RefOfRemotePhoto) SetTargetValue(val RemotePhoto, cs chunks.ChunkSink) RefOfRemotePhoto {
-	return NewRefOfRemotePhoto(types.WriteValue(val, cs))
+func (r RefOfRemotePhoto) SetTargetValue(val RemotePhoto, vw types.ValueWriter) RefOfRemotePhoto {
+	return NewRefOfRemotePhoto(vw.WriteValue(val))
 }

--- a/clients/pitchmap/index/types.noms.go
+++ b/clients/pitchmap/index/types.noms.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -459,12 +458,12 @@ func builderForRefOfMapOfStringToValue(r ref.Ref) types.Value {
 	return NewRefOfMapOfStringToValue(r)
 }
 
-func (r RefOfMapOfStringToValue) TargetValue(cs chunks.ChunkSource) MapOfStringToValue {
-	return types.ReadValue(r.target, cs).(MapOfStringToValue)
+func (r RefOfMapOfStringToValue) TargetValue(vr types.ValueReader) MapOfStringToValue {
+	return vr.ReadValue(r.target).(MapOfStringToValue)
 }
 
-func (r RefOfMapOfStringToValue) SetTargetValue(val MapOfStringToValue, cs chunks.ChunkSink) RefOfMapOfStringToValue {
-	return NewRefOfMapOfStringToValue(types.WriteValue(val, cs))
+func (r RefOfMapOfStringToValue) SetTargetValue(val MapOfStringToValue, vw types.ValueWriter) RefOfMapOfStringToValue {
+	return NewRefOfMapOfStringToValue(vw.WriteValue(val))
 }
 
 // MapOfStringToValue
@@ -795,10 +794,10 @@ func builderForRefOfListOfPitch(r ref.Ref) types.Value {
 	return NewRefOfListOfPitch(r)
 }
 
-func (r RefOfListOfPitch) TargetValue(cs chunks.ChunkSource) ListOfPitch {
-	return types.ReadValue(r.target, cs).(ListOfPitch)
+func (r RefOfListOfPitch) TargetValue(vr types.ValueReader) ListOfPitch {
+	return vr.ReadValue(r.target).(ListOfPitch)
 }
 
-func (r RefOfListOfPitch) SetTargetValue(val ListOfPitch, cs chunks.ChunkSink) RefOfListOfPitch {
-	return NewRefOfListOfPitch(types.WriteValue(val, cs))
+func (r RefOfListOfPitch) SetTargetValue(val ListOfPitch, vw types.ValueWriter) RefOfListOfPitch {
+	return NewRefOfListOfPitch(vw.WriteValue(val))
 }

--- a/clients/quad_tree/main.go
+++ b/clients/quad_tree/main.go
@@ -76,8 +76,8 @@ func main() {
 	}
 
 	go func() {
-		cs := dataset.Store()
-		walk.SomeP(types.ReadValue(inputRef, cs), cs, func(v types.Value) (stop bool) {
+		ds := dataset.Store()
+		walk.SomeP(ds.ReadValue(inputRef), ds, func(v types.Value) (stop bool) {
 			var g common.Geoposition
 
 			switch v := v.(type) {
@@ -95,7 +95,7 @@ func main() {
 			}
 
 			// TODO: This check is mega bummer. We really only want to consider RefOfStruct, but it's complicated to filter the case of an inline struct out.
-			if !cs.Has(v.Ref()) {
+			if !ds.Has(v.Ref()) {
 				return
 			}
 

--- a/clients/sfcrime/importer/sfcrime.go
+++ b/clients/sfcrime/importer/sfcrime.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/clients/common"
 	"github.com/attic-labs/noms/clients/util"
 	"github.com/attic-labs/noms/d"
@@ -154,7 +153,7 @@ func main() {
 		fmt.Printf("Converting refs list to noms list: %.2f secs\n", time.Now().Sub(start).Seconds())
 	}
 
-	ref := types.WriteValue(incidentRefs, ds.Store())
+	ref := ds.Store().WriteValue(incidentRefs)
 	_, err = ds.Commit(types.NewRef(ref))
 	d.Exp.NoError(err)
 
@@ -166,7 +165,7 @@ func main() {
 	fmt.Printf("Ref of list containing Incidents: %s, , elaspsed time: %.2f secs\n", incidentRefs.Ref(), time.Now().Sub(start).Seconds())
 }
 
-func getNomsWriter(cs chunks.ChunkStore) (iChan chan incidentWithIndex, rChan chan refIndex) {
+func getNomsWriter(vw types.ValueWriter) (iChan chan incidentWithIndex, rChan chan refIndex) {
 	iChan = make(chan incidentWithIndex, 3000)
 	rChan = make(chan refIndex, 3000)
 	var wg sync.WaitGroup
@@ -175,7 +174,7 @@ func getNomsWriter(cs chunks.ChunkStore) (iChan chan incidentWithIndex, rChan ch
 		go func() {
 			for incidentRecord := range iChan {
 				v := incidentRecord.incident.New()
-				r := types.WriteValue(v, cs)
+				r := vw.WriteValue(v)
 				rChan <- refIndex{types.NewRef(r), incidentRecord.index}
 			}
 			wg.Done()

--- a/clients/sfcrime/search/sfcrime_search.go
+++ b/clients/sfcrime/search/sfcrime_search.go
@@ -79,22 +79,22 @@ func main() {
 	fmt.Printf("Done, elapsed time: %.2f secs\n", time.Now().Sub(start).Seconds())
 }
 
-func searchWithQuadTree(gp common.GeopositionDef, ds datas.DataStore) []common.Incident {
+func searchWithQuadTree(gp common.GeopositionDef, vr types.ValueReader) []common.Incident {
 	argName := "quadtree-ref"
 	r := readRef(*quadTreeRefFlag, argName)
-	sqtRoot := types.ReadValue(r, ds).(common.SQuadTree)
+	sqtRoot := vr.ReadValue(r).(common.SQuadTree)
 	if !common.ContainsPoint(sqtRoot.Georectangle().Def(), gp) {
 		log.Fatalf("lat/lon: %+v is not within sf area: %+v\n", gp, sqtRoot.Georectangle().Def())
 	}
-	gr, results := sqtRoot.Query(gp, *distanceFlag, ds)
+	gr, results := sqtRoot.Query(gp, *distanceFlag, vr)
 	fmt.Printf("bounding Rectangle: %+v, numIncidents: %d\n", gr, len(results))
 	return results
 }
 
-func searchWithList(gp common.GeopositionDef, ds datas.DataStore) []common.Incident {
+func searchWithList(gp common.GeopositionDef, vr types.ValueReader) []common.Incident {
 	argName := "incident-list-ref"
 	r := readRef(*incidentListRefFlag, argName)
-	val := types.ReadValue(r, ds)
+	val := vr.ReadValue(r)
 	l, ok := val.(types.List)
 	if !ok {
 		log.Fatalf("Value for %s argument is not a list object\n", argName)
@@ -109,7 +109,7 @@ func searchWithList(gp common.GeopositionDef, ds datas.DataStore) []common.Incid
 		if i%uint64(10000) == 0 {
 			fmt.Printf("%.2f%%: %v\n", float64(i)/float64(incidentList.Len())*float64(100), time.Now().Sub(t0))
 		}
-		incident := incidentList.Get(i).TargetValue(ds).(common.Incident)
+		incident := incidentList.Get(i).TargetValue(vr).(common.Incident)
 		if common.DistanceTo(incident.Geoposition().Def(), gp) <= float32(*distanceFlag) {
 			results = append(results, incident)
 		}

--- a/clients/util/types.noms.go
+++ b/clients/util/types.noms.go
@@ -3,7 +3,6 @@
 package util
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -203,12 +202,12 @@ func builderForRefOfMapOfStringToValue(r ref.Ref) types.Value {
 	return NewRefOfMapOfStringToValue(r)
 }
 
-func (r RefOfMapOfStringToValue) TargetValue(cs chunks.ChunkSource) MapOfStringToValue {
-	return types.ReadValue(r.target, cs).(MapOfStringToValue)
+func (r RefOfMapOfStringToValue) TargetValue(vr types.ValueReader) MapOfStringToValue {
+	return vr.ReadValue(r.target).(MapOfStringToValue)
 }
 
-func (r RefOfMapOfStringToValue) SetTargetValue(val MapOfStringToValue, cs chunks.ChunkSink) RefOfMapOfStringToValue {
-	return NewRefOfMapOfStringToValue(types.WriteValue(val, cs))
+func (r RefOfMapOfStringToValue) SetTargetValue(val MapOfStringToValue, vw types.ValueWriter) RefOfMapOfStringToValue {
+	return NewRefOfMapOfStringToValue(vw.WriteValue(val))
 }
 
 // MapOfStringToValue

--- a/clients/xml_importer/xml_importer.go
+++ b/clients/xml_importer/xml_importer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/dataset"
 	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/types"
 	"github.com/clbanning/mxj"
 )
 
@@ -99,7 +98,7 @@ func main() {
 				r := ref.Ref{}
 
 				if !*noIO {
-					r = types.WriteValue(nomsObj, ds.Store())
+					r = ds.Store().WriteValue(nomsObj)
 				}
 
 				refsChan <- refIndex{r, f.index}

--- a/datas/caching_chunk_store_test.go
+++ b/datas/caching_chunk_store_test.go
@@ -1,0 +1,36 @@
+package datas
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasCachingChunkStore(t *testing.T) {
+	assert := assert.New(t)
+	ts := chunks.NewTestStore()
+	ccs := newHasCachingChunkStore(ts)
+	input := "abc"
+
+	c := chunks.NewChunk([]byte(input))
+	c1 := ccs.Get(c.Ref())
+	assert.True(c1.IsEmpty())
+
+	assert.False(ccs.Has(c.Ref()))
+	assert.Equal(ts.Hases, 0)
+
+	ccs.Put(c)
+	assert.True(ccs.Has(c.Ref()))
+	assert.Equal(ts.Hases, 0)
+
+	c1 = ccs.Get(c.Ref())
+	assert.False(c1.IsEmpty())
+
+	assert.True(ccs.Has(c.Ref()))
+	assert.Equal(ts.Hases, 0)
+
+	c = chunks.NewChunk([]byte("stuff"))
+	assert.False(ccs.Has(c.Ref()))
+	assert.Equal(ts.Hases, 1)
+}

--- a/datas/datastore_test.go
+++ b/datas/datastore_test.go
@@ -4,29 +4,16 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDataStoreAccess(t *testing.T) {
+func TestTolerateUngettableRefs(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
-	ds := NewDataStore(cs)
-	input := "abc"
-
-	c := chunks.NewChunk([]byte(input))
-	c1 := ds.Get(c.Ref())
-	assert.True(c1.IsEmpty())
-
-	has := ds.Has(c.Ref())
-	assert.False(has)
-
-	ds.Put(c)
-	c1 = ds.Get(c.Ref())
-	assert.False(c1.IsEmpty())
-
-	has = ds.Has(c.Ref())
-	assert.True(has)
+	ds := NewDataStore(chunks.NewTestStore())
+	v := ds.ReadValue(ref.Ref{})
+	assert.Nil(v)
 }
 
 func TestDataStoreCommit(t *testing.T) {

--- a/datas/has_caching_chunk_store.go
+++ b/datas/has_caching_chunk_store.go
@@ -1,0 +1,78 @@
+package datas
+
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/ref"
+)
+
+type hasCachingChunkStore struct {
+	backing  chunks.ChunkStore
+	hasCache map[ref.Ref]bool
+	mu       *sync.Mutex
+}
+
+func newHasCachingChunkStore(cs chunks.ChunkStore) *hasCachingChunkStore {
+	return &hasCachingChunkStore{cs, map[ref.Ref]bool{}, &sync.Mutex{}}
+}
+
+// Backing returns the non-caching ChunkStore that backs this instance. Helpful when creating and returing a new DataStore instance that shouldn't share a cache with DataStore that already exists.
+func (ccs *hasCachingChunkStore) Backing() chunks.ChunkStore {
+	return ccs.backing
+}
+
+func (ccs *hasCachingChunkStore) Root() ref.Ref {
+	return ccs.backing.Root()
+}
+
+func (ccs *hasCachingChunkStore) UpdateRoot(current, last ref.Ref) bool {
+	return ccs.backing.UpdateRoot(current, last)
+}
+
+func (ccs *hasCachingChunkStore) Has(r ref.Ref) bool {
+	has, ok := checkCache(ccs, r)
+	if ok {
+		return has
+	}
+	has = ccs.backing.Has(r)
+	setCache(ccs, r, has)
+	return has
+}
+
+func (ccs *hasCachingChunkStore) Get(r ref.Ref) chunks.Chunk {
+	has, ok := checkCache(ccs, r)
+	if ok && !has {
+		return chunks.EmptyChunk
+	}
+	c := ccs.backing.Get(r)
+	setCache(ccs, r, !c.IsEmpty())
+	return c
+}
+
+func (ccs *hasCachingChunkStore) Put(c chunks.Chunk) {
+	r := c.Ref()
+	has, _ := checkCache(ccs, r)
+	if has {
+		return
+	}
+	ccs.backing.Put(c)
+	setCache(ccs, r, true)
+}
+
+func (cs *hasCachingChunkStore) Close() error {
+	return cs.backing.Close()
+}
+
+func checkCache(ccs *hasCachingChunkStore, r ref.Ref) (has, ok bool) {
+	ccs.mu.Lock()
+	defer ccs.mu.Unlock()
+	has, ok = ccs.hasCache[r]
+	return
+}
+
+func setCache(ccs *hasCachingChunkStore, r ref.Ref, has bool) {
+	ccs.mu.Lock()
+	defer ccs.mu.Unlock()
+	ccs.hasCache[r] = has
+}

--- a/datas/types.noms.go
+++ b/datas/types.noms.go
@@ -3,7 +3,6 @@
 package datas
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -464,10 +463,10 @@ func builderForRefOfCommit(r ref.Ref) types.Value {
 	return NewRefOfCommit(r)
 }
 
-func (r RefOfCommit) TargetValue(cs chunks.ChunkSource) Commit {
-	return types.ReadValue(r.target, cs).(Commit)
+func (r RefOfCommit) TargetValue(vr types.ValueReader) Commit {
+	return vr.ReadValue(r.target).(Commit)
 }
 
-func (r RefOfCommit) SetTargetValue(val Commit, cs chunks.ChunkSink) RefOfCommit {
-	return NewRefOfCommit(types.WriteValue(val, cs))
+func (r RefOfCommit) SetTargetValue(val Commit, vw types.ValueWriter) RefOfCommit {
+	return NewRefOfCommit(vw.WriteValue(val))
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -87,7 +87,7 @@ func (ds *Dataset) pull(source datas.DataStore, sourceRef ref.Ref, concurrency i
 }
 
 func (ds *Dataset) validateRefAsCommit(r ref.Ref) datas.Commit {
-	v := types.ReadValue(r, ds.store)
+	v := ds.store.ReadValue(r)
 
 	d.Exp.NotNil(v, "%v cannot be found", r)
 	d.Exp.True(v.Type().Equals(datas.NewCommit().Type()), "Not a Commit: %+v", v)

--- a/dataset/pull_test.go
+++ b/dataset/pull_test.go
@@ -15,26 +15,26 @@ func createTestDataset(name string) Dataset {
 
 func TestValidateRef(t *testing.T) {
 	ds := createTestDataset("test")
-	r := types.WriteValue(types.Bool(true), ds.Store())
+	r := ds.Store().WriteValue(types.Bool(true))
 
 	assert.Panics(t, func() { ds.validateRefAsCommit(r) })
 }
 
 func NewList(ds Dataset, vs ...types.Value) types.Ref {
 	v := types.NewList(vs...)
-	r := types.WriteValue(v, ds.store)
+	r := ds.Store().WriteValue(v)
 	return types.NewRef(r)
 }
 
 func NewMap(ds Dataset, vs ...types.Value) types.Ref {
 	v := types.NewMap(vs...)
-	r := types.WriteValue(v, ds.store)
+	r := ds.Store().WriteValue(v)
 	return types.NewRef(r)
 }
 
 func NewSet(ds Dataset, vs ...types.Value) types.Ref {
 	v := types.NewSet(vs...)
-	r := types.WriteValue(v, ds.store)
+	r := ds.Store().WriteValue(v)
 	return types.NewRef(r)
 }
 

--- a/nomdl/codegen/codegen.go
+++ b/nomdl/codegen/codegen.go
@@ -120,11 +120,11 @@ func generate(packageName, in, out, outDir string, written map[string]bool, pars
 
 type depsMap map[ref.Ref]types.Package
 
-func generateDepCode(packageName, outDir string, written map[string]bool, p types.Package, localPkgs refSet, cs chunks.ChunkStore) depsMap {
+func generateDepCode(packageName, outDir string, written map[string]bool, p types.Package, localPkgs refSet, vr types.ValueReader) depsMap {
 	deps := depsMap{}
 	for _, r := range p.Dependencies() {
-		p := types.ReadValue(r, cs).(types.Package)
-		pDeps := generateDepCode(packageName, outDir, written, p, localPkgs, cs)
+		p := vr.ReadValue(r).(types.Package)
+		pDeps := generateDepCode(packageName, outDir, written, p, localPkgs, vr)
 		tag := code.ToTag(p.Ref())
 		parsed := pkg.Parsed{Package: p, Name: packageName}
 		if !localPkgs[parsed.Ref()] {
@@ -168,9 +168,9 @@ func buildSetOfRefOfPackage(pkg pkg.Parsed, deps depsMap, ds dataset.Dataset) ty
 	for _, dep := range deps {
 		// Writing the deps into ds should be redundant at this point, but do it to be sure.
 		// TODO: consider moving all dataset work over into nomdl/pkg BUG 409
-		s = s.Insert(types.NewRefOfPackage(types.WriteValue(dep, ds.Store())))
+		s = s.Insert(types.NewRefOfPackage(ds.Store().WriteValue(dep)))
 	}
-	r := types.WriteValue(pkg.Package, ds.Store())
+	r := ds.Store().WriteValue(pkg.Package)
 	return s.Insert(types.NewRefOfPackage(r))
 }
 

--- a/nomdl/codegen/ref.tmpl
+++ b/nomdl/codegen/ref.tmpl
@@ -53,10 +53,10 @@ func builderFor{{.Name}}(r ref.Ref) {{$typesPackage}}Value {
 	return New{{.Name}}(r)
 }
 
-func (r {{.Name}}) TargetValue(cs chunks.ChunkSource) {{userType .ElemType}} {
-	return {{valueToUser (printf "%sReadValue(r.target, cs)" $typesPackage) .ElemType}}
+func (r {{.Name}}) TargetValue(vr {{$typesPackage}}ValueReader) {{userType .ElemType}} {
+	return {{valueToUser "vr.ReadValue(r.target)" .ElemType}}
 }
 
-func (r {{.Name}}) SetTargetValue(val {{userType .ElemType}}, cs chunks.ChunkSink) {{.Name}} {
-	return New{{.Name}}({{$typesPackage}}WriteValue({{userToValue "val" .ElemType}}, cs))
+func (r {{.Name}}) SetTargetValue(val {{userType .ElemType}}, vw {{$typesPackage}}ValueWriter) {{.Name}} {
+	return New{{.Name}}(vw.WriteValue({{userToValue "val" .ElemType}}))
 }

--- a/nomdl/codegen/test/enum_struct_test.go
+++ b/nomdl/codegen/test/enum_struct_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/nomdl/codegen/test/gen"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
@@ -38,9 +39,9 @@ func TestEnumValue(t *testing.T) {
 }
 
 func TestEnumIsValue(t *testing.T) {
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 	var v types.Value = gen.NewEnumStruct()
-	ref := types.WriteValue(v, cs)
-	v2 := types.ReadValue(ref, cs)
+	ref := ds.WriteValue(v)
+	v2 := ds.ReadValue(ref)
 	assert.True(t, v.Equals(v2))
 }

--- a/nomdl/codegen/test/gen/ref.noms.go
+++ b/nomdl/codegen/test/gen/ref.noms.go
@@ -3,7 +3,6 @@
 package gen
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
 )
@@ -165,12 +164,12 @@ func builderForRefOfListOfString(r ref.Ref) types.Value {
 	return NewRefOfListOfString(r)
 }
 
-func (r RefOfListOfString) TargetValue(cs chunks.ChunkSource) ListOfString {
-	return types.ReadValue(r.target, cs).(ListOfString)
+func (r RefOfListOfString) TargetValue(vr types.ValueReader) ListOfString {
+	return vr.ReadValue(r.target).(ListOfString)
 }
 
-func (r RefOfListOfString) SetTargetValue(val ListOfString, cs chunks.ChunkSink) RefOfListOfString {
-	return NewRefOfListOfString(types.WriteValue(val, cs))
+func (r RefOfListOfString) SetTargetValue(val ListOfString, vw types.ValueWriter) RefOfListOfString {
+	return NewRefOfListOfString(vw.WriteValue(val))
 }
 
 // ListOfRefOfFloat32
@@ -368,12 +367,12 @@ func builderForRefOfSetOfFloat32(r ref.Ref) types.Value {
 	return NewRefOfSetOfFloat32(r)
 }
 
-func (r RefOfSetOfFloat32) TargetValue(cs chunks.ChunkSource) SetOfFloat32 {
-	return types.ReadValue(r.target, cs).(SetOfFloat32)
+func (r RefOfSetOfFloat32) TargetValue(vr types.ValueReader) SetOfFloat32 {
+	return vr.ReadValue(r.target).(SetOfFloat32)
 }
 
-func (r RefOfSetOfFloat32) SetTargetValue(val SetOfFloat32, cs chunks.ChunkSink) RefOfSetOfFloat32 {
-	return NewRefOfSetOfFloat32(types.WriteValue(val, cs))
+func (r RefOfSetOfFloat32) SetTargetValue(val SetOfFloat32, vw types.ValueWriter) RefOfSetOfFloat32 {
+	return NewRefOfSetOfFloat32(vw.WriteValue(val))
 }
 
 // ListOfString
@@ -571,12 +570,12 @@ func builderForRefOfFloat32(r ref.Ref) types.Value {
 	return NewRefOfFloat32(r)
 }
 
-func (r RefOfFloat32) TargetValue(cs chunks.ChunkSource) float32 {
-	return float32(types.ReadValue(r.target, cs).(types.Float32))
+func (r RefOfFloat32) TargetValue(vr types.ValueReader) float32 {
+	return float32(vr.ReadValue(r.target).(types.Float32))
 }
 
-func (r RefOfFloat32) SetTargetValue(val float32, cs chunks.ChunkSink) RefOfFloat32 {
-	return NewRefOfFloat32(types.WriteValue(types.Float32(val), cs))
+func (r RefOfFloat32) SetTargetValue(val float32, vw types.ValueWriter) RefOfFloat32 {
+	return NewRefOfFloat32(vw.WriteValue(types.Float32(val)))
 }
 
 // SetOfFloat32

--- a/nomdl/codegen/test/ref_test.go
+++ b/nomdl/codegen/test/ref_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/nomdl/codegen/test/gen"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
@@ -11,31 +12,31 @@ import (
 
 func SkipTestRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 
 	l := gen.ListOfStringDef{"a", "b", "c"}.New()
 	l2 := gen.ListOfStringDef{"d", "e", "f"}.New()
 	lRef := l.Ref()
 	r := gen.NewRefOfListOfString(lRef)
 
-	v := types.ReadValue(l.Ref(), cs)
+	v := ds.ReadValue(l.Ref())
 	assert.Nil(v)
 
-	assert.Panics(func() { r.TargetValue(cs) })
+	assert.Panics(func() { r.TargetValue(ds) })
 
-	r2 := r.SetTargetValue(l, cs)
+	r2 := r.SetTargetValue(l, ds)
 	assert.True(r.Equals(r2))
-	v2 := r2.TargetValue(cs)
-	v3 := r.TargetValue(cs)
+	v2 := r2.TargetValue(ds)
+	v3 := r.TargetValue(ds)
 	assert.True(v2.Equals(v3))
 
-	r3 := r2.SetTargetValue(l2, cs)
+	r3 := r2.SetTargetValue(l2, ds)
 	assert.False(r.Equals(r3))
 }
 
 func TestListOfRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 
 	a := types.Float32(0)
 	ra := a.Ref()
@@ -49,30 +50,30 @@ func TestListOfRef(t *testing.T) {
 	def := l.Def()
 	assert.EqualValues(ra, def[0])
 
-	l = l.Set(0, r.SetTargetValue(1, cs))
+	l = l.Set(0, r.SetTargetValue(1, ds))
 	r3 := l.Get(0)
 	assert.False(r.Equals(r3))
-	assert.Panics(func() { r.TargetValue(cs) })
+	assert.Panics(func() { r.TargetValue(ds) })
 }
 
 func TestStructWithRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 
 	set := gen.SetOfFloat32Def{0: true, 1: true, 2: true}.New()
-	types.WriteValue(set, cs)
+	ds.WriteValue(set)
 
 	str := gen.StructWithRefDef{
 		R: set.Ref(),
 	}.New()
-	types.WriteValue(str, cs)
+	ds.WriteValue(str)
 
 	r := str.R()
 	r2 := gen.NewRefOfSetOfFloat32(set.Ref())
 	assert.True(r.Equals(r2))
-	assert.True(r2.TargetValue(cs).Equals(set))
+	assert.True(r2.TargetValue(ds).Equals(set))
 
-	set2 := r2.TargetValue(cs)
+	set2 := r2.TargetValue(ds)
 	assert.True(set.Equals(set2))
 
 	def := str.Def()

--- a/nomdl/codegen/test/struct_with_list_test.go
+++ b/nomdl/codegen/test/struct_with_list_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/nomdl/codegen/test/gen"
 	"github.com/attic-labs/noms/types"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func TestStructWithList(t *testing.T) {
 
 func TestStructIsValue(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	ds := datas.NewDataStore(chunks.NewMemoryStore())
 	var v types.Value = gen.StructWithListDef{
 		L: gen.ListOfUint8Def{0, 1, 2},
 		B: true,
@@ -41,8 +42,8 @@ func TestStructIsValue(t *testing.T) {
 		I: 42,
 	}.New()
 
-	ref := types.WriteValue(v, cs)
-	v2 := types.ReadValue(ref, cs)
+	ref := ds.WriteValue(v)
+	v2 := ds.ReadValue(ref)
 	assert.True(v.Equals(v2))
 
 	s2 := v2.(gen.StructWithList)

--- a/nomdl/pkg/parse.go
+++ b/nomdl/pkg/parse.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"io"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
@@ -18,14 +17,14 @@ type Parsed struct {
 }
 
 // ParseNomDL reads a Noms package specification from r and returns a Package. Errors will be annotated with packageName and thrown.
-func ParseNomDL(packageName string, r io.Reader, includePath string, cs chunks.ChunkStore) Parsed {
+func ParseNomDL(packageName string, r io.Reader, includePath string, vrw types.ValueReadWriter) Parsed {
 	i := runParser(packageName, r)
 	i.Name = packageName
-	imports := resolveImports(i.Aliases, includePath, cs)
+	imports := resolveImports(i.Aliases, includePath, vrw)
 	deps := importsToDeps(imports)
 
 	resolveLocalOrdinals(&i)
-	resolveNamespaces(&i, imports, getDeps(deps, cs))
+	resolveNamespaces(&i, imports, getDeps(deps, vrw))
 	return Parsed{
 		types.NewPackage(i.Types, deps),
 		i.Name,

--- a/types/blob_ref.noms.go
+++ b/types/blob_ref.noms.go
@@ -2,10 +2,7 @@
 
 package types
 
-import (
-	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/ref"
-)
+import "github.com/attic-labs/noms/ref"
 
 // RefOfBlob
 
@@ -56,10 +53,10 @@ func builderForRefOfBlob(r ref.Ref) Value {
 	return NewRefOfBlob(r)
 }
 
-func (r RefOfBlob) TargetValue(cs chunks.ChunkStore) Blob {
-	return ReadValue(r.target, cs).(Blob)
+func (r RefOfBlob) TargetValue(vr ValueReader) Blob {
+	return vr.ReadValue(r.target).(Blob)
 }
 
-func (r RefOfBlob) SetTargetValue(val Blob, cs chunks.ChunkSink) RefOfBlob {
-	return NewRefOfBlob(WriteValue(val, cs))
+func (r RefOfBlob) SetTargetValue(val Blob, vw ValueWriter) RefOfBlob {
+	return NewRefOfBlob(vw.WriteValue(val))
 }

--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/stretchr/testify/assert"
 )
@@ -91,8 +90,8 @@ func TestCompoundBlobReader(t *testing.T) {
 	cb := getTestCompoundBlob("hello", "world")
 	test(cb)
 
-	ms := chunks.NewMemoryStore()
-	test(ReadValue(WriteValue(cb, ms), ms).(compoundBlob))
+	vs := NewTestValueStore()
+	test(vs.ReadValue(vs.WriteValue(cb)).(compoundBlob))
 }
 
 type testBlob struct {
@@ -180,7 +179,7 @@ func TestCompoundBlobLen(t *testing.T) {
 
 func TestCompoundBlobChunks(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 
 	cb := getTestCompoundBlob("hello", "world")
 	assert.Equal(2, len(cb.Chunks()))
@@ -190,7 +189,7 @@ func TestCompoundBlobChunks(t *testing.T) {
 	cb = newCompoundBlob([]metaTuple{
 		newMetaTuple(Uint64(uint64(5)), bl1, ref.Ref{}),
 		newMetaTuple(Uint64(uint64(10)), bl2, ref.Ref{}),
-	}, cs)
+	}, vs)
 	assert.Equal(2, len(cb.Chunks()))
 }
 
@@ -266,7 +265,7 @@ func printBlob(b Blob, indent int) {
 		fmt.Printf("%scompoundBlob, len: %d, chunks: %d\n", indentString, b.Len(), len(b.tuples))
 		indent++
 		for _, t := range b.tuples {
-			printBlob(ReadValue(t.ChildRef(), b.cs).(Blob), indent)
+			printBlob(b.vr.ReadValue(t.ChildRef()).(Blob), indent)
 		}
 	}
 }

--- a/types/compound_map_test.go
+++ b/types/compound_map_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,9 +120,9 @@ func TestCompoundMapHas(t *testing.T) {
 	assert := assert.New(t)
 
 	doTest := func(tm testMap) {
-		cs := chunks.NewMemoryStore()
+		vs := NewTestValueStore()
 		m := tm.toCompoundMap()
-		m2 := ReadValue(WriteValue(m, cs), cs).(compoundMap)
+		m2 := vs.ReadValue(vs.WriteValue(m)).(compoundMap)
 		for _, entry := range tm.entries {
 			k, v := entry.key, entry.value
 			assert.True(m.Has(k))
@@ -365,10 +364,10 @@ func TestCompoundMapFirstNNumbers(t *testing.T) {
 
 func TestCompoundMapModifyAfterRead(t *testing.T) {
 	assert := assert.New(t)
-	ms := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 	m := getTestNativeOrderMap(2).toCompoundMap()
 	// Drop chunk values.
-	m = ReadValue(WriteValue(m, ms), ms).(compoundMap)
+	m = vs.ReadValue(vs.WriteValue(m)).(compoundMap)
 	// Modify/query. Once upon a time this would crash.
 	fst, fstval := m.First()
 	m = m.Remove(fst).(compoundMap)

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,9 +97,9 @@ func TestCompoundSetHas(t *testing.T) {
 	assert := assert.New(t)
 
 	doTest := func(ts testSet) {
-		cs := chunks.NewMemoryStore()
+		vs := NewTestValueStore()
 		set := ts.toCompoundSet()
-		set2 := ReadValue(WriteValue(set, cs), cs).(compoundSet)
+		set2 := vs.ReadValue(vs.WriteValue(set)).(compoundSet)
 		for _, v := range ts.values {
 			assert.True(set.Has(v))
 			assert.True(set2.Has(v))
@@ -344,10 +343,10 @@ func TestCompoundSetFirstNNumbers(t *testing.T) {
 
 func TestCompoundSetModifyAfterRead(t *testing.T) {
 	assert := assert.New(t)
-	ms := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 	set := getTestNativeOrderSet(2).toCompoundSet()
 	// Drop chunk values.
-	set = ReadValue(WriteValue(set, ms), ms).(compoundSet)
+	set = vs.ReadValue(vs.WriteValue(set)).(compoundSet)
 	// Modify/query. Once upon a time this would crash.
 	fst := set.First()
 	set = set.Remove(fst).(compoundSet)

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRead(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := []interface{}{float64(1), "hi", true}
 	r := newJsonArrayReader(a, cs)
@@ -36,7 +35,7 @@ func parseJson(s string, vs ...interface{}) (v []interface{}) {
 }
 
 func TestReadTypeAsTag(t *testing.T) {
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	test := func(expected Type, s string, vs ...interface{}) {
 		a := parseJson(s, vs...)
@@ -58,7 +57,7 @@ func TestReadTypeAsTag(t *testing.T) {
 func TestReadPrimitives(t *testing.T) {
 	assert := assert.New(t)
 
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	test := func(expected Value, s string, vs ...interface{}) {
 		a := parseJson(s, vs...)
@@ -89,7 +88,7 @@ func TestReadPrimitives(t *testing.T) {
 
 func TestReadListOfInt32(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, false, ["0", "1", "2", "3"]]`, ListKind, Int32Kind)
 	r := newJsonArrayReader(a, cs)
@@ -103,7 +102,7 @@ func TestReadListOfInt32(t *testing.T) {
 
 func TestReadListOfValue(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, false, [%d, "1", %d, "hi", %d, true]]`, ListKind, ValueKind, Int32Kind, StringKind, BoolKind)
 	r := newJsonArrayReader(a, cs)
@@ -113,7 +112,7 @@ func TestReadListOfValue(t *testing.T) {
 
 func TestReadValueListOfInt8(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, %d, false, ["0", "1", "2"]]`, ValueKind, ListKind, Int8Kind)
 	r := newJsonArrayReader(a, cs)
@@ -127,7 +126,7 @@ func TestReadValueListOfInt8(t *testing.T) {
 
 func TestReadCompoundList(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
 	leaf1 := newListLeaf(tr, Int32(0))
@@ -146,7 +145,7 @@ func TestReadCompoundList(t *testing.T) {
 
 func TestReadMapOfInt64ToFloat64(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, %d, false, ["0", "1", "2", "3"]]`, MapKind, Int64Kind, Float64Kind)
 	r := newJsonArrayReader(a, cs)
@@ -160,7 +159,7 @@ func TestReadMapOfInt64ToFloat64(t *testing.T) {
 
 func TestReadValueMapOfUint64ToUint32(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, %d, %d, false, ["0", "1", "2", "3"]]`, ValueKind, MapKind, Uint64Kind, Uint32Kind)
 	r := newJsonArrayReader(a, cs)
@@ -174,7 +173,7 @@ func TestReadValueMapOfUint64ToUint32(t *testing.T) {
 
 func TestReadSetOfUint8(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, false, ["0", "1", "2", "3"]]`, SetKind, Uint8Kind)
 	r := newJsonArrayReader(a, cs)
@@ -188,7 +187,7 @@ func TestReadSetOfUint8(t *testing.T) {
 
 func TestReadValueSetOfUint16(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	a := parseJson(`[%d, %d, %d, false, ["0", "1", "2", "3"]]`, ValueKind, SetKind, Uint16Kind)
 	r := newJsonArrayReader(a, cs)
@@ -202,7 +201,7 @@ func TestReadValueSetOfUint16(t *testing.T) {
 
 func TestReadCompoundBlob(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	r1 := ref.Parse("sha1-0000000000000000000000000000000000000001")
 	r2 := ref.Parse("sha1-0000000000000000000000000000000000000002")
@@ -225,7 +224,7 @@ func TestReadCompoundBlob(t *testing.T) {
 
 func TestReadStruct(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	typ := MakeStructType("A1", []Field{
 		Field{"x", MakePrimitiveType(Int16Kind), false},
@@ -246,7 +245,7 @@ func TestReadStruct(t *testing.T) {
 
 func TestReadStructUnion(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	typ := MakeStructType("A2", []Field{
 		Field{"x", MakePrimitiveType(Float32Kind), false},
@@ -277,7 +276,7 @@ func TestReadStructUnion(t *testing.T) {
 
 func TestReadStructOptional(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	typ := MakeStructType("A3", []Field{
 		Field{"x", MakePrimitiveType(Float32Kind), false},
@@ -302,7 +301,7 @@ func TestReadStructOptional(t *testing.T) {
 
 func TestReadStructWithList(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	// struct A4 {
 	//   b: Bool
@@ -331,7 +330,7 @@ func TestReadStructWithList(t *testing.T) {
 
 func TestReadStructWithValue(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	// struct A5 {
 	//   b: Bool
@@ -358,7 +357,7 @@ func TestReadStructWithValue(t *testing.T) {
 
 func TestReadValueStruct(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	// struct A1 {
 	//   x: Float32
@@ -385,7 +384,7 @@ func TestReadValueStruct(t *testing.T) {
 
 func TestReadEnum(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	typeDef := MakeEnumType("E", "a", "b", "c")
 	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
@@ -400,7 +399,7 @@ func TestReadEnum(t *testing.T) {
 
 func TestReadValueEnum(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	typeDef := MakeEnumType("E", "a", "b", "c")
 	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
@@ -415,7 +414,7 @@ func TestReadValueEnum(t *testing.T) {
 
 func TestReadRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	r := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
 	a := parseJson(`[%d, %d, "%s"]`, RefKind, Uint32Kind, r.String())
@@ -427,7 +426,7 @@ func TestReadRef(t *testing.T) {
 
 func TestReadValueRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	r := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
 	a := parseJson(`[%d, %d, %d, "%s"]`, ValueKind, RefKind, Uint32Kind, r.String())
@@ -439,7 +438,7 @@ func TestReadValueRef(t *testing.T) {
 
 func TestReadStructWithEnum(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	// enum E {
 	//   a
@@ -472,7 +471,7 @@ func TestReadStructWithEnum(t *testing.T) {
 
 func TestReadStructWithBlob(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	// struct A5 {
 	//   b: Blob
@@ -494,7 +493,7 @@ func TestReadStructWithBlob(t *testing.T) {
 
 func TestReadTypeValue(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	test := func(expected Type, json string, vs ...interface{}) {
 		a := parseJson(json, vs...)
@@ -537,7 +536,7 @@ func TestReadTypeValue(t *testing.T) {
 }
 
 func TestReadPackage(t *testing.T) {
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 	pkg := NewPackage([]Type{
 		MakeStructType("EnumStruct",
 			[]Field{
@@ -569,7 +568,7 @@ func TestReadPackage(t *testing.T) {
 }
 
 func TestReadPackage2(t *testing.T) {
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	rr := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
 	setTref := MakeCompoundType(SetKind, MakePrimitiveType(Uint32Kind))
@@ -583,7 +582,7 @@ func TestReadPackage2(t *testing.T) {
 
 func TestReadPackageThroughChunkSource(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	cs := NewTestValueStore()
 
 	pkg := NewPackage([]Type{
 		MakeStructType("S", []Field{
@@ -591,7 +590,7 @@ func TestReadPackageThroughChunkSource(t *testing.T) {
 		}, Choices{}),
 	}, []ref.Ref{})
 	// Don't register
-	pkgRef := WriteValue(pkg, cs)
+	pkgRef := cs.WriteValue(pkg)
 
 	a := parseJson(`[%d, "%s", "0", "42"]`, UnresolvedKind, pkgRef.String())
 	r := newJsonArrayReader(a, cs)

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -143,7 +143,7 @@ func TestWriteCompoundBlob(t *testing.T) {
 		newMetaTuple(Uint64(20), nil, r1),
 		newMetaTuple(Uint64(40), nil, r2),
 		newMetaTuple(Uint64(60), nil, r3),
-	}, cs)
+	}, newValueStore(cs))
 	w := newJsonArrayWriter(cs)
 	w.writeTopLevelValue(v)
 
@@ -335,7 +335,7 @@ func TestWriteCompoundList(t *testing.T) {
 	cl := buildCompoundList([]metaTuple{
 		newMetaTuple(Uint64(1), leaf1, ref.Ref{}),
 		newMetaTuple(Uint64(4), leaf2, ref.Ref{}),
-	}, ltr, cs)
+	}, ltr, newValueStore(cs))
 
 	w := newJsonArrayWriter(cs)
 	w.writeTopLevelValue(cl)

--- a/types/enum_test.go
+++ b/types/enum_test.go
@@ -25,7 +25,7 @@ func TestGenericEnumWriteRead(t *testing.T) {
 	assert.False(vA.Equals(vB))
 
 	rA := WriteValue(vA, cs)
-	vA2 := ReadValue(rA, cs)
+	vA2 := newValueStore(cs).ReadValue(rA)
 
 	assert.True(vA.Equals(vA2))
 	assert.True(vA2.Equals(vA))

--- a/types/get_ref_test.go
+++ b/types/get_ref_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,7 +20,7 @@ func TestGetRef(t *testing.T) {
 
 func TestEnsureRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 	count := byte(1)
 	mockGetRef := func(v Value) ref.Ref {
 
@@ -44,16 +43,16 @@ func TestEnsureRef(t *testing.T) {
 	}()
 
 	bl := newBlobLeaf([]byte("hi"))
-	cb := newCompoundBlob([]metaTuple{{bl, ref.Ref{}, Uint64(2)}}, cs)
+	cb := newCompoundBlob([]metaTuple{{bl, ref.Ref{}, Uint64(2)}}, vs)
 
 	ll := newListLeaf(listType, NewString("foo"))
-	cl := buildCompoundList([]metaTuple{{ll, ref.Ref{}, Uint64(1)}}, listType, cs)
+	cl := buildCompoundList([]metaTuple{{ll, ref.Ref{}, Uint64(1)}}, listType, vs)
 
 	ml := newMapLeaf(mapType, mapEntry{NewString("foo"), NewString("bar")})
-	cm := buildCompoundMap([]metaTuple{{ml, ref.Ref{}, NewString("foo")}}, mapType, cs)
+	cm := buildCompoundMap([]metaTuple{{ml, ref.Ref{}, NewString("foo")}}, mapType, vs)
 
 	sl := newSetLeaf(setType, NewString("foo"))
-	cps := buildCompoundSet([]metaTuple{{sl, ref.Ref{}, NewString("foo")}}, setType, cs)
+	cps := buildCompoundSet([]metaTuple{{sl, ref.Ref{}, NewString("foo")}}, setType, vs)
 
 	count = byte(1)
 	values := []Value{

--- a/types/incremental_test.go
+++ b/types/incremental_test.go
@@ -40,11 +40,12 @@ func isEncodedOutOfLine(v Value) int {
 func TestIncrementalLoadList(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()
+	vs := newValueStore(cs)
 
 	expected := NewList(testVals...)
-	ref := WriteValue(expected, cs)
+	ref := vs.WriteValue(expected)
 
-	actualVar := ReadValue(ref, cs)
+	actualVar := vs.ReadValue(ref)
 	actual := actualVar.(List)
 
 	expectedCount := cs.Reads
@@ -67,11 +68,12 @@ func TestIncrementalLoadList(t *testing.T) {
 func SkipTestIncrementalLoadSet(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()
+	vs := newValueStore(cs)
 
 	expected := NewSet(testVals...)
-	ref := WriteValue(expected, cs)
+	ref := vs.WriteValue(expected)
 
-	actualVar := ReadValue(ref, cs)
+	actualVar := vs.ReadValue(ref)
 	actual := actualVar.(Set)
 
 	expectedCount := cs.Reads
@@ -86,11 +88,12 @@ func SkipTestIncrementalLoadSet(t *testing.T) {
 func SkipTestIncrementalLoadMap(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()
+	vs := newValueStore(cs)
 
 	expected := NewMap(testVals...)
-	ref := WriteValue(expected, cs)
+	ref := vs.WriteValue(expected)
 
-	actualVar := ReadValue(ref, cs)
+	actualVar := vs.ReadValue(ref)
 	actual := actualVar.(Map)
 
 	expectedCount := cs.Reads
@@ -106,13 +109,14 @@ func SkipTestIncrementalLoadMap(t *testing.T) {
 func SkipTestIncrementalAddRef(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()
+	vs := newValueStore(cs)
 
 	expectedItem := Uint32(42)
-	ref := WriteValue(expectedItem, cs)
+	ref := vs.WriteValue(expectedItem)
 
 	expected := NewList(NewRef(ref))
-	ref = WriteValue(expected, cs)
-	actualVar := ReadValue(ref, cs)
+	ref = vs.WriteValue(expected)
+	actualVar := vs.ReadValue(ref)
 
 	assert.Equal(1, cs.Reads)
 	assert.True(expected.Equals(actualVar))

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -3,7 +3,6 @@ package types
 import (
 	"crypto/sha1"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 )
 
@@ -16,7 +15,7 @@ func newIndexedMetaSequenceBoundaryChecker() boundaryChecker {
 
 // If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are
 // written when the root is written.
-func newIndexedMetaSequenceChunkFn(t Type, cs chunks.ChunkSource, sink chunks.ChunkSink) makeChunkFn {
+func newIndexedMetaSequenceChunkFn(t Type, source ValueReader, sink ValueWriter) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		tuples := make(metaSequenceData, len(items))
 
@@ -24,9 +23,9 @@ func newIndexedMetaSequenceChunkFn(t Type, cs chunks.ChunkSource, sink chunks.Ch
 			tuples[i] = v.(metaTuple)
 		}
 
-		meta := newMetaSequenceFromData(tuples, t, cs)
+		meta := newMetaSequenceFromData(tuples, t, source)
 		if sink != nil {
-			return metaTuple{nil, WriteValue(meta, sink), Uint64(tuples.uint64ValuesSum())}, meta
+			return metaTuple{nil, sink.WriteValue(meta), Uint64(tuples.uint64ValuesSum())}, meta
 		}
 		return metaTuple{meta, ref.Ref{}, Uint64(tuples.uint64ValuesSum())}, meta
 	}

--- a/types/list.go
+++ b/types/list.go
@@ -1,7 +1,5 @@
 package types
 
-import "github.com/attic-labs/noms/chunks"
-
 type List interface {
 	Value
 	Len() uint64
@@ -42,11 +40,11 @@ func NewTypedList(t Type, values ...Value) List {
 	return seq.Done().(List)
 }
 
-// NewStreamingTypedList creates a new List with type t, populated with values, chunking if and when needed. As chunks are created, they're written to cs -- including the root chunk of the list. Once the caller has closed values, she can read the completed List from the returned channel.
-func NewStreamingTypedList(t Type, cs chunks.ChunkStore, values <-chan Value) <-chan List {
+// NewStreamingTypedList creates a new List with type t, populated with values, chunking if and when needed. As chunks are created, they're written to vrw -- including the root chunk of the list. Once the caller has closed values, she can read the completed List from the returned channel.
+func NewStreamingTypedList(t Type, vrw ValueReadWriter, values <-chan Value) <-chan List {
 	out := make(chan List)
 	go func() {
-		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, cs), newIndexedMetaSequenceChunkFn(t, cs, cs), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
+		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, vrw), newIndexedMetaSequenceChunkFn(t, vrw, vrw), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 		for v := range values {
 			seq.Append(v)
 		}

--- a/types/map_leaf.go
+++ b/types/map_leaf.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -234,7 +233,7 @@ func newMapLeafBoundaryChecker() boundaryChecker {
 	})
 }
 
-func makeMapLeafChunkFn(t Type, cs chunks.ChunkSource) makeChunkFn {
+func makeMapLeafChunkFn(t Type, vr ValueReader) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		mapData := make([]mapEntry, len(items), len(items))
 

--- a/types/meta_sequence_cursor_test.go
+++ b/types/meta_sequence_cursor_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,46 +10,46 @@ import (
 func TestMeta(t *testing.T) {
 	assert := assert.New(t)
 
-	cs := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 
 	flatList := []Value{Uint32(0), Uint32(1), Uint32(2), Uint32(3), Uint32(4), Uint32(5), Uint32(6), Uint32(7)}
 	l0 := NewList(flatList[0])
-	lr0 := WriteValue(l0, cs)
+	lr0 := vs.WriteValue(l0)
 	l1 := NewList(flatList[1])
-	lr1 := WriteValue(l1, cs)
+	lr1 := vs.WriteValue(l1)
 	l2 := NewList(flatList[2])
-	lr2 := WriteValue(l2, cs)
+	lr2 := vs.WriteValue(l2)
 	l3 := NewList(flatList[3])
-	lr3 := WriteValue(l3, cs)
+	lr3 := vs.WriteValue(l3)
 	l4 := NewList(flatList[4])
-	lr4 := WriteValue(l4, cs)
+	lr4 := vs.WriteValue(l4)
 	l5 := NewList(flatList[5])
-	lr5 := WriteValue(l5, cs)
+	lr5 := vs.WriteValue(l5)
 	l6 := NewList(flatList[6])
-	lr6 := WriteValue(l6, cs)
+	lr6 := vs.WriteValue(l6)
 	l7 := NewList(flatList[7])
-	lr7 := WriteValue(l7, cs)
+	lr7 := vs.WriteValue(l7)
 
 	mtr := l0.Type()
 
-	m0 := compoundList{metaSequenceObject{metaSequenceData{{l0, lr0, Uint64(1)}, {l1, lr1, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
-	lm0 := WriteValue(m0, cs)
-	m1 := compoundList{metaSequenceObject{metaSequenceData{{l2, lr2, Uint64(1)}, {l3, lr3, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
-	lm1 := WriteValue(m1, cs)
-	m2 := compoundList{metaSequenceObject{metaSequenceData{{l4, lr4, Uint64(1)}, {l5, lr5, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
-	lm2 := WriteValue(m2, cs)
-	m3 := compoundList{metaSequenceObject{metaSequenceData{{l6, lr6, Uint64(1)}, {l7, lr7, Uint64(2)}}, mtr}, 0, &ref.Ref{}, cs}
-	lm3 := WriteValue(m3, cs)
+	m0 := compoundList{metaSequenceObject{metaSequenceData{{l0, lr0, Uint64(1)}, {l1, lr1, Uint64(2)}}, mtr}, 0, &ref.Ref{}, vs}
+	lm0 := vs.WriteValue(m0)
+	m1 := compoundList{metaSequenceObject{metaSequenceData{{l2, lr2, Uint64(1)}, {l3, lr3, Uint64(2)}}, mtr}, 0, &ref.Ref{}, vs}
+	lm1 := vs.WriteValue(m1)
+	m2 := compoundList{metaSequenceObject{metaSequenceData{{l4, lr4, Uint64(1)}, {l5, lr5, Uint64(2)}}, mtr}, 0, &ref.Ref{}, vs}
+	lm2 := vs.WriteValue(m2)
+	m3 := compoundList{metaSequenceObject{metaSequenceData{{l6, lr6, Uint64(1)}, {l7, lr7, Uint64(2)}}, mtr}, 0, &ref.Ref{}, vs}
+	lm3 := vs.WriteValue(m3)
 
-	m00 := compoundList{metaSequenceObject{metaSequenceData{{m0, lm0, Uint64(2)}, {m1, lm1, Uint64(4)}}, mtr}, 0, &ref.Ref{}, cs}
-	lm00 := WriteValue(m00, cs)
-	m01 := compoundList{metaSequenceObject{metaSequenceData{{m2, lm2, Uint64(2)}, {m3, lm3, Uint64(4)}}, mtr}, 0, &ref.Ref{}, cs}
-	lm01 := WriteValue(m01, cs)
+	m00 := compoundList{metaSequenceObject{metaSequenceData{{m0, lm0, Uint64(2)}, {m1, lm1, Uint64(4)}}, mtr}, 0, &ref.Ref{}, vs}
+	lm00 := vs.WriteValue(m00)
+	m01 := compoundList{metaSequenceObject{metaSequenceData{{m2, lm2, Uint64(2)}, {m3, lm3, Uint64(4)}}, mtr}, 0, &ref.Ref{}, vs}
+	lm01 := vs.WriteValue(m01)
 
-	rootList := compoundList{metaSequenceObject{metaSequenceData{{m00, lm00, Uint64(4)}, {m01, lm01, Uint64(8)}}, mtr}, 0, &ref.Ref{}, cs}
-	rootRef := WriteValue(rootList, cs)
+	rootList := compoundList{metaSequenceObject{metaSequenceData{{m00, lm00, Uint64(4)}, {m01, lm01, Uint64(8)}}, mtr}, 0, &ref.Ref{}, vs}
+	rootRef := vs.WriteValue(rootList)
 
-	rootList = ReadValue(rootRef, cs).(compoundList)
+	rootList = vs.ReadValue(rootRef).(compoundList)
 
 	rootList.IterAll(func(v Value, index uint64) {
 		assert.Equal(flatList[index], v)

--- a/types/ordered_sequences.go
+++ b/types/ordered_sequences.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha1"
 	"sort"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 )
 
@@ -16,8 +15,8 @@ func isSequenceOrderedByIndexedType(t Type) bool {
 type getLeafOrderedValuesFn func(Value) []Value
 
 // Returns a cursor to |key| in |ms|, plus the leaf + index that |key| is in. |t| is the type of the ordered values.
-func findLeafInOrderedSequence(ms metaSequence, t Type, key Value, getValues getLeafOrderedValuesFn, cs chunks.ChunkSource) (cursor *sequenceCursor, leaf Value, idx int) {
-	cursor, leaf = newMetaSequenceCursor(ms, cs)
+func findLeafInOrderedSequence(ms metaSequence, t Type, key Value, getValues getLeafOrderedValuesFn, vr ValueReader) (cursor *sequenceCursor, leaf Value, idx int) {
+	cursor, leaf = newMetaSequenceCursor(ms, vr)
 
 	if isSequenceOrderedByIndexedType(t) {
 		orderedKey := key.(OrderedValue)
@@ -32,7 +31,7 @@ func findLeafInOrderedSequence(ms metaSequence, t Type, key Value, getValues get
 	}
 
 	if current := cursor.current().(metaTuple); current.ChildRef() != valueFromType(leaf, leaf.Type()).Ref() {
-		leaf = readMetaTupleValue(current, cs)
+		leaf = readMetaTupleValue(current, vr)
 	}
 
 	if leafData := getValues(leaf); isSequenceOrderedByIndexedType(t) {
@@ -57,7 +56,7 @@ func newOrderedMetaSequenceBoundaryChecker() boundaryChecker {
 	})
 }
 
-func newOrderedMetaSequenceChunkFn(t Type, cs chunks.ChunkSource) makeChunkFn {
+func newOrderedMetaSequenceChunkFn(t Type, vr ValueReader) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		tuples := make(metaSequenceData, len(items))
 
@@ -65,7 +64,7 @@ func newOrderedMetaSequenceChunkFn(t Type, cs chunks.ChunkSource) makeChunkFn {
 			tuples[i] = v.(metaTuple) // chunk is written when the root sequence is written
 		}
 
-		meta := newMetaSequenceFromData(tuples, t, cs)
+		meta := newMetaSequenceFromData(tuples, t, vr)
 		return newMetaTuple(tuples.last().value, meta, ref.Ref{}), meta
 	}
 }

--- a/types/package_registry.go
+++ b/types/package_registry.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -51,8 +50,8 @@ func RegisterPackage(p *Package) (r ref.Ref) {
 	return
 }
 
-func ReadPackage(r ref.Ref, cs chunks.ChunkSource) *Package {
-	p := ReadValue(r, cs).(Package)
+func ReadPackage(r ref.Ref, vr ValueReader) *Package {
+	p := vr.ReadValue(r).(Package)
 	RegisterPackage(&p)
 	return &p
 }

--- a/types/package_set_of_ref.go
+++ b/types/package_set_of_ref.go
@@ -3,10 +3,7 @@
 
 package types
 
-import (
-	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/ref"
-)
+import "github.com/attic-labs/noms/ref"
 
 // SetOfRefOfPackage
 
@@ -205,10 +202,10 @@ func builderForRefOfPackage(r ref.Ref) Value {
 	return NewRefOfPackage(r)
 }
 
-func (r RefOfPackage) TargetValue(cs chunks.ChunkStore) Package {
-	return ReadValue(r.target, cs).(Package)
+func (r RefOfPackage) TargetValue(vr ValueReader) Package {
+	return vr.ReadValue(r.target).(Package)
 }
 
-func (r RefOfPackage) SetTargetValue(val Package, cs chunks.ChunkSink) RefOfPackage {
-	return NewRefOfPackage(WriteValue(val, cs))
+func (r RefOfPackage) SetTargetValue(val Package, vw ValueWriter) RefOfPackage {
+	return NewRefOfPackage(vw.WriteValue(val))
 }

--- a/types/primitives.go
+++ b/types/primitives.go
@@ -35,7 +35,6 @@ func (v Bool) Type() Type {
 	return typeForBool
 }
 
-
 type Float32 float32
 
 func (p Float32) Equals(other Value) bool {
@@ -63,7 +62,6 @@ var typeForFloat32 = MakePrimitiveType(Float32Kind)
 func (v Float32) Type() Type {
 	return typeForFloat32
 }
-
 
 func (v Float32) Less(other OrderedValue) bool {
 	return v < other.(Float32)
@@ -97,7 +95,6 @@ func (v Float64) Type() Type {
 	return typeForFloat64
 }
 
-
 func (v Float64) Less(other OrderedValue) bool {
 	return v < other.(Float64)
 }
@@ -129,7 +126,6 @@ var typeForInt16 = MakePrimitiveType(Int16Kind)
 func (v Int16) Type() Type {
 	return typeForInt16
 }
-
 
 func (v Int16) Less(other OrderedValue) bool {
 	return v < other.(Int16)
@@ -163,7 +159,6 @@ func (v Int32) Type() Type {
 	return typeForInt32
 }
 
-
 func (v Int32) Less(other OrderedValue) bool {
 	return v < other.(Int32)
 }
@@ -195,7 +190,6 @@ var typeForInt64 = MakePrimitiveType(Int64Kind)
 func (v Int64) Type() Type {
 	return typeForInt64
 }
-
 
 func (v Int64) Less(other OrderedValue) bool {
 	return v < other.(Int64)
@@ -229,7 +223,6 @@ func (v Int8) Type() Type {
 	return typeForInt8
 }
 
-
 func (v Int8) Less(other OrderedValue) bool {
 	return v < other.(Int8)
 }
@@ -261,7 +254,6 @@ var typeForUint16 = MakePrimitiveType(Uint16Kind)
 func (v Uint16) Type() Type {
 	return typeForUint16
 }
-
 
 func (v Uint16) Less(other OrderedValue) bool {
 	return v < other.(Uint16)
@@ -295,7 +287,6 @@ func (v Uint32) Type() Type {
 	return typeForUint32
 }
 
-
 func (v Uint32) Less(other OrderedValue) bool {
 	return v < other.(Uint32)
 }
@@ -327,7 +318,6 @@ var typeForUint64 = MakePrimitiveType(Uint64Kind)
 func (v Uint64) Type() Type {
 	return typeForUint64
 }
-
 
 func (v Uint64) Less(other OrderedValue) bool {
 	return v < other.(Uint64)
@@ -361,8 +351,6 @@ func (v Uint8) Type() Type {
 	return typeForUint8
 }
 
-
 func (v Uint8) Less(other OrderedValue) bool {
 	return v < other.(Uint8)
 }
-

--- a/types/read_value.go
+++ b/types/read_value.go
@@ -10,10 +10,19 @@ import (
 	"github.com/attic-labs/noms/ref"
 )
 
-// ReadValue reads and decodes a value from a chunk source. It is not considered an error for the requested chunk to be absent from cs; in this case, the function simply returns nil, nil.
-func ReadValue(r ref.Ref, cs chunks.ChunkSource) Value {
-	d.Chk.NotNil(cs)
-	c := cs.Get(r)
+// ValueReader is an interface that knows how to read Noms Values, e.g. datas/DataStore. Required to avoid import cycle between this package and the package that implements Value reading.
+type ValueReader interface {
+	ReadValue(r ref.Ref) Value
+}
+
+// ValueReadWriter is an interface that knows how to read and write Noms Values, e.g. datas/DataStore. Required to avoid import cycle between this package and the package that implements Value read/writing.
+type ValueReadWriter interface {
+	ValueReader
+	ValueWriter
+}
+
+// DecodeChunk decodes a value from a chunk source. It is not considered an error for the requested chunk to be empty; in this case, the function simply returns nil.
+func DecodeChunk(c chunks.Chunk, vr ValueReader) Value {
 	if c.IsEmpty() {
 		return nil
 	}
@@ -26,7 +35,7 @@ func ReadValue(r ref.Ref, cs chunks.ChunkSource) Value {
 		d.Chk.NoError(err)
 		return newBlobLeaf(data)
 	case []interface{}:
-		return fromTypedEncodeable(v, cs)
+		return fromTypedEncodeable(v, vr)
 	}
 	panic("Unreachable")
 }

--- a/types/read_value_test.go
+++ b/types/read_value_test.go
@@ -5,16 +5,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/ref"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestTolerateUngettableRefs(t *testing.T) {
-	assert := assert.New(t)
-	v := ReadValue(ref.Ref{}, chunks.NewTestStore())
-	assert.Nil(v)
-}
 
 func TestReadValueBlobLeafDecode(t *testing.T) {
 	assert := assert.New(t)

--- a/types/ref.go
+++ b/types/ref.go
@@ -1,9 +1,6 @@
 package types
 
-import (
-	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/ref"
-)
+import "github.com/attic-labs/noms/ref"
 
 type Ref struct {
 	target ref.Ref
@@ -53,11 +50,11 @@ func (r Ref) Less(other OrderedValue) bool {
 	return r.target.Less(other.(Ref).target)
 }
 
-func (r Ref) TargetValue(cs chunks.ChunkSource) Value {
-	return ReadValue(r.target, cs)
+func (r Ref) TargetValue(vr ValueReader) Value {
+	return vr.ReadValue(r.target)
 }
 
-func (r Ref) SetTargetValue(val Value, cs chunks.ChunkSink) Ref {
+func (r Ref) SetTargetValue(val Value, vw ValueWriter) Ref {
 	assertType(r.t.Desc.(CompoundDesc).ElemTypes[0], val)
-	return newRef(WriteValue(val, cs), r.t)
+	return newRef(vw.WriteValue(val), r.t)
 }

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +41,7 @@ func TestRefInMap(t *testing.T) {
 
 func TestRefType(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 
 	tr := MakeCompoundType(RefKind, MakePrimitiveType(ValueKind))
 
@@ -51,17 +50,17 @@ func TestRefType(t *testing.T) {
 	assert.True(r.Type().Equals(tr))
 
 	m := NewMap()
-	r2 := r.SetTargetValue(m, cs)
+	r2 := r.SetTargetValue(m, vs)
 	assert.True(r2.Type().Equals(tr))
 
 	b := Bool(true)
-	r2 = r.SetTargetValue(b, cs)
+	r2 = r.SetTargetValue(b, vs)
 	r2.t = MakeCompoundType(RefKind, b.Type())
 
-	r3 := r2.SetTargetValue(Bool(false), cs)
+	r3 := r2.SetTargetValue(Bool(false), vs)
 	assert.True(r2.Type().Equals(r3.Type()))
 
-	assert.Panics(func() { r2.SetTargetValue(Int16(1), cs) })
+	assert.Panics(func() { r2.SetTargetValue(Int16(1), vs) })
 }
 
 func TestRefChunks(t *testing.T) {

--- a/types/set_leaf.go
+++ b/types/set_leaf.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -197,7 +196,7 @@ func newSetLeafBoundaryChecker() boundaryChecker {
 	})
 }
 
-func makeSetLeafChunkFn(t Type, cs chunks.ChunkSource) makeChunkFn {
+func makeSetLeafChunkFn(t Type, vr ValueReader) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		setData := make([]Value, len(items), len(items))
 
@@ -236,6 +235,6 @@ func (s setLeaf) sequenceCursorAtFirst() *sequenceCursor {
 	}
 }
 
-func (s setLeaf) chunkSource() chunks.ChunkSource {
+func (s setLeaf) valueReader() ValueReader {
 	return nil
 }

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -3,14 +3,13 @@ package types
 import (
 	"testing"
 
-	"github.com/attic-labs/noms/chunks"
 	"github.com/attic-labs/noms/ref"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTypes(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 
 	boolType := MakePrimitiveType(BoolKind)
 	uint8Type := MakePrimitiveType(Uint8Kind)
@@ -28,32 +27,32 @@ func TestTypes(t *testing.T) {
 	pkgRef := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
 	trType := MakeType(pkgRef, 42)
 
-	mRef := WriteValue(mapType, cs)
-	setRef := WriteValue(setType, cs)
-	otherRef := WriteValue(otherType, cs)
-	mahRef := WriteValue(mahType, cs)
-	trRef := WriteValue(trType, cs)
+	mRef := vs.WriteValue(mapType)
+	setRef := vs.WriteValue(setType)
+	otherRef := vs.WriteValue(otherType)
+	mahRef := vs.WriteValue(mahType)
+	trRef := vs.WriteValue(trType)
 
-	assert.True(otherType.Equals(ReadValue(otherRef, cs)))
-	assert.True(mapType.Equals(ReadValue(mRef, cs)))
-	assert.True(setType.Equals(ReadValue(setRef, cs)))
-	assert.True(mahType.Equals(ReadValue(mahRef, cs)))
-	assert.True(trType.Equals(ReadValue(trRef, cs)))
+	assert.True(otherType.Equals(vs.ReadValue(otherRef)))
+	assert.True(mapType.Equals(vs.ReadValue(mRef)))
+	assert.True(setType.Equals(vs.ReadValue(setRef)))
+	assert.True(mahType.Equals(vs.ReadValue(mahRef)))
+	assert.True(trType.Equals(vs.ReadValue(trRef)))
 }
 
 func TestTypeWithPkgRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewMemoryStore()
+	vs := NewTestValueStore()
 
 	pkg := NewPackage([]Type{MakePrimitiveType(Float64Kind)}, []ref.Ref{})
 
 	pkgRef := RegisterPackage(&pkg)
 	unresolvedType := MakeType(pkgRef, 42)
-	unresolvedRef := WriteValue(unresolvedType, cs)
+	unresolvedRef := vs.WriteValue(unresolvedType)
 
-	v := ReadValue(unresolvedRef, cs)
+	v := vs.ReadValue(unresolvedRef)
 	assert.EqualValues(pkgRef, v.Chunks()[0])
-	assert.NotNil(ReadValue(pkgRef, cs))
+	assert.NotNil(vs.ReadValue(pkgRef))
 }
 
 func TestTypeType(t *testing.T) {

--- a/types/value_store.go
+++ b/types/value_store.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/ref"
+)
+
+// ValueStore is currently used only for tests in this pacakge.
+type ValueStore struct {
+	cs chunks.ChunkStore
+}
+
+func newValueStore(cs chunks.ChunkStore) *ValueStore {
+	return &ValueStore{cs}
+}
+
+func NewTestValueStore() *ValueStore {
+	return &ValueStore{chunks.NewTestStore()}
+}
+
+// ReadValue reads and decodes a value from vrw. It is not considered an error for the requested chunk to be empty; in this case, the function simply returns nil.
+func (vrw *ValueStore) ReadValue(r ref.Ref) Value {
+	c := vrw.cs.Get(r)
+	return DecodeChunk(c, vrw)
+}
+
+func (vrw *ValueStore) WriteValue(v Value) ref.Ref {
+	return WriteValue(v, vrw.cs)
+}

--- a/types/write_value.go
+++ b/types/write_value.go
@@ -6,10 +6,16 @@ import (
 	"github.com/attic-labs/noms/ref"
 )
 
+// ValueWriter is an interface that knows how to write Noms Values, e.g. datas/DataStore. Required to avoid import cycle between this package and the package that implements Value writing.
+type ValueWriter interface {
+	WriteValue(v Value) ref.Ref
+}
+
 type primitive interface {
 	ToPrimitive() interface{}
 }
 
+// WriteValue takes a Value, encodes it into Chunks, and puts them into cs. As a part of BUG 654, we're trying to get rid of the need to provide a ChunkSink here.
 func WriteValue(v Value, cs chunks.ChunkSink) ref.Ref {
 	d.Chk.NotNil(cs)
 	return writeValueInternal(v, cs)

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -16,23 +16,23 @@ func TestWalkTestSuite(t *testing.T) {
 
 type WalkAllTestSuite struct {
 	suite.Suite
-	cs *chunks.TestStore
+	vs *types.ValueStore
 }
 
 func (suite *WalkAllTestSuite) SetupTest() {
-	suite.cs = chunks.NewTestStore()
+	suite.vs = types.NewTestValueStore()
 }
 
 func (suite *WalkAllTestSuite) walkWorker(r ref.Ref, expected int) {
 	actual := 0
-	AllP(types.NewRef(r), suite.cs, func(c types.Value) {
+	AllP(types.NewRef(r), suite.vs, func(c types.Value) {
 		actual++
 	}, 1)
 	suite.Equal(expected, actual)
 }
 
 func (suite *WalkAllTestSuite) storeAndRef(v types.Value) ref.Ref {
-	return types.WriteValue(v, suite.cs)
+	return suite.vs.WriteValue(v)
 }
 
 func (suite *WalkAllTestSuite) TestWalkPrimitives() {
@@ -51,19 +51,19 @@ func (suite *WalkAllTestSuite) TestWalkComposites() {
 
 func (suite *WalkAllTestSuite) NewList(cs chunks.ChunkStore, vs ...types.Value) types.Ref {
 	v := types.NewList(vs...)
-	r := types.WriteValue(v, suite.cs)
+	r := suite.vs.WriteValue(v)
 	return types.NewRef(r)
 }
 
 func (suite *WalkAllTestSuite) NewMap(cs chunks.ChunkStore, vs ...types.Value) types.Ref {
 	v := types.NewMap(vs...)
-	r := types.WriteValue(v, suite.cs)
+	r := suite.vs.WriteValue(v)
 	return types.NewRef(r)
 }
 
 func (suite *WalkAllTestSuite) NewSet(cs chunks.ChunkStore, vs ...types.Value) types.Ref {
 	v := types.NewSet(vs...)
-	r := types.WriteValue(v, suite.cs)
+	r := suite.vs.WriteValue(v)
 	return types.NewRef(r)
 }
 
@@ -98,7 +98,7 @@ type WalkTestSuite struct {
 }
 
 func (suite *WalkTestSuite) SetupTest() {
-	suite.cs = chunks.NewTestStore()
+	suite.vs = types.NewTestValueStore()
 	suite.shouldSeeItem = types.NewString("zzz")
 	suite.shouldSee = types.NewList(suite.shouldSeeItem)
 	suite.deadValue = types.Uint64(0xDEADBEEF)
@@ -107,7 +107,7 @@ func (suite *WalkTestSuite) SetupTest() {
 
 func (suite *WalkTestSuite) TestStopWalkImmediately() {
 	actual := 0
-	SomeP(types.NewList(types.NewSet(), types.NewList()), suite.cs, func(v types.Value) bool {
+	SomeP(types.NewList(types.NewSet(), types.NewList()), suite.vs, func(v types.Value) bool {
 		actual++
 		return true
 	}, 1)
@@ -115,7 +115,7 @@ func (suite *WalkTestSuite) TestStopWalkImmediately() {
 }
 
 func (suite *WalkTestSuite) skipWorker(composite types.Value) (reached []types.Value) {
-	SomeP(composite, suite.cs, func(v types.Value) bool {
+	SomeP(composite, suite.vs, func(v types.Value) bool {
 		suite.False(v.Equals(suite.deadValue), "Should never have reached %+v", suite.deadValue)
 		reached = append(reached, v)
 		return v.Equals(suite.mustSkip)


### PR DESCRIPTION
This patch is the first step in moving all reading and writing to the
DataStore API, so that we can validate data commited to Noms.

The big change here is that types.ReadValue() no longer exists and is
replaced with a ReadValue() method on DataStore. A similar
WriteValue() method deprecates types.WriteValue(), but fully removing
that is left for a later patch. Since a lot of code in the types
package needs to read and write values, but cannot import the datas
package without creating an import cycle, the types package exports
ValueReader and ValueWriter interfaces, which DataStore implements.
Thus, a DataStore can be passed to anything in the types package which
needs to read or write values (e.g. a collection constructor or
typed-ref)

Relatedly, this patch also introduces the DataSink interface, so that
some public-facing apis no longer need to provide a ChunkSink.

Towards #654
