### PR TITLE
JS: Use babel-regenerator-runtime instead of babel-polyfill

### DIFF
--- a/clients/crunchbase/ui/package.json
+++ b/clients/crunchbase/ui/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-polyfill": "6.7.2",
+    "babel-regenerator-runtime": "6.5.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "eslint": "^1.9.0",

--- a/clients/pitchmap/ui/package.json
+++ b/clients/pitchmap/ui/package.json
@@ -18,7 +18,7 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-polyfill": "6.7.2",
+    "babel-regenerator-runtime": "6.5.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "eslint": "^1.9.0",

--- a/clients/splore/package.json
+++ b/clients/splore/package.json
@@ -19,7 +19,7 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-polyfill": "6.7.2",
+    "babel-regenerator-runtime": "6.5.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "eslint": "^1.9.0",

--- a/js/package.json
+++ b/js/package.json
@@ -21,7 +21,7 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-polyfill": "6.7.2",
+    "babel-regenerator-runtime": "6.5.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "chokidar": "1.4.3",
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "pretest": "eslint src/ && flow src/",
-    "test": "mocha --ui tdd --reporter dot --require babel-polyfill --compilers js:babel-core/register src/*-test.js",
+    "test": "mocha --ui tdd --reporter dot --require babel-regenerator-runtime --compilers js:babel-core/register src/*-test.js",
     "prepublish": "npm run compile && npm run copy-flow-files",
     "compile": "npm run compile-to-commonjs && npm run compile-to-es6",
     "compile-to-commonjs": "BABEL_ENV=production babel -d dist/commonjs src/",


### PR DESCRIPTION
This only affects the unit tests but it makes debugging easier and
it makes the tests faster.
