### PR TITLE
JS: Fix dependencies

### DIFF
--- a/clients/crunchbase/ui/package.json
+++ b/clients/crunchbase/ui/package.json
@@ -1,14 +1,7 @@
 {
   "name": "noms-crunchbase-ui",
-  "dependencies": {
-    "d3": "^3.4.4",
-    "@attic/noms": "^0.0.2",
-    "noms-webpack-config": "file:../../../js/webpack-config",
-    "nvd3": "1.8.2",
-    "react": "^0.14.1",
-    "react-dom": "^0.14.1"
-  },
   "devDependencies": {
+    "@attic/noms": "^0.0.2",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-eslint": "5.0.0",
@@ -20,13 +13,19 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-regenerator-runtime": "6.5.0",
+    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
-    "eslint": "^1.9.0",
+    "babel-regenerator-runtime": "6.5.0",
+    "d3": "^3.4.4",
     "eslint-plugin-react": "^3.8.0",
+    "eslint": "^1.9.0",
     "flow-bin": "^0.22.1",
-    "http-server": "^0.8.5"
+    "http-server": "^0.8.5",
+    "noms-webpack-config": "file:../../../js/webpack-config",
+    "nvd3": "1.8.2",
+    "react-dom": "^0.14.1",
+    "react": "^0.14.1"
   },
   "scripts": {
     "start": "python .npm_build_helper.py development",

--- a/clients/pitchmap/ui/package.json
+++ b/clients/pitchmap/ui/package.json
@@ -1,12 +1,7 @@
 {
   "name": "noms-pitchmap-ui",
-  "dependencies": {
-    "@attic/noms": "^0.0.2",
-    "noms-webpack-config": "file:../../../js/webpack-config",
-    "react": "^0.14.1",
-    "react-dom": "^0.14.1"
-  },
   "devDependencies": {
+    "@attic/noms": "^0.0.2",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-eslint": "5.0.0",
@@ -18,13 +13,17 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-regenerator-runtime": "6.5.0",
+    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
-    "eslint": "^1.9.0",
+    "babel-regenerator-runtime": "6.5.0",
     "eslint-plugin-react": "^3.8.0",
+    "eslint": "^1.9.0",
     "flow-bin": "^0.22.1",
-    "http-server": "^0.8.5"
+    "http-server": "^0.8.5",
+    "noms-webpack-config": "file:../../../js/webpack-config",
+    "react-dom": "^0.14.1",
+    "react": "^0.14.1"
   },
   "scripts": {
     "start": "python .npm_build_helper.py development",

--- a/clients/splore/package.json
+++ b/clients/splore/package.json
@@ -1,13 +1,7 @@
 {
   "name": "noms-splore",
-  "dependencies": {
-    "classnames": "^2.1.3",
-    "@attic/noms": "^1.0.0",
-    "noms-webpack-config": "file:../../js/webpack-config",
-    "react": "^0.14.1",
-    "react-dom": "^0.14.1"
-  },
   "devDependencies": {
+    "@attic/noms": "^1.0.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-eslint": "5.0.0",
@@ -19,13 +13,18 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
-    "babel-regenerator-runtime": "6.5.0",
+    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
-    "eslint": "^1.9.0",
+    "babel-regenerator-runtime": "6.5.0",
+    "classnames": "^2.1.3",
     "eslint-plugin-react": "^3.8.0",
+    "eslint": "^1.9.0",
     "flow-bin": "^0.22.1",
-    "http-server": "^0.8.5"
+    "http-server": "^0.8.5",
+    "noms-webpack-config": "file:../../js/webpack-config",
+    "react-dom": "^0.14.1",
+    "react": "^0.14.1"
   },
   "scripts": {
     "start": "python .npm_build_helper.py development",

--- a/js/package.json
+++ b/js/package.json
@@ -4,7 +4,6 @@
   "main": "dist/commonjs/noms.js",
   "jsnext:main": "dist/es6/noms.js",
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-regenerator-runtime": "6.5.0",
     "rusha": "0.8.3",
     "text-encoding-utf-8": "1.0.1"
@@ -21,6 +20,7 @@
     "babel-plugin-transform-es2015-destructuring": "6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "6.7.0",
     "babel-plugin-transform-es2015-parameters": "6.7.0",
+    "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "chai": "3.5.0",


### PR DESCRIPTION
The missing dep was babel-plugin-transform-runtime

The client apps only need devDependencies since no one is going to
depend on them.
