### PR TITLE
JS: Add flow-vars to eslint

### DIFF
--- a/clients/crunchbase/ui/package.json
+++ b/clients/crunchbase/ui/package.json
@@ -18,6 +18,7 @@
     "babel-preset-react": "6.5.0",
     "babel-regenerator-runtime": "6.5.0",
     "d3": "^3.4.4",
+    "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "^3.8.0",
     "eslint": "^1.9.0",
     "flow-bin": "^0.22.1",

--- a/clients/pitchmap/ui/package.json
+++ b/clients/pitchmap/ui/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-regenerator-runtime": "6.5.0",
+    "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "^3.8.0",
     "eslint": "^1.9.0",
     "flow-bin": "^0.22.1",

--- a/clients/splore/package.json
+++ b/clients/splore/package.json
@@ -18,6 +18,7 @@
     "babel-preset-react": "6.5.0",
     "babel-regenerator-runtime": "6.5.0",
     "classnames": "^2.1.3",
+    "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "^3.8.0",
     "eslint": "^1.9.0",
     "flow-bin": "^0.22.1",

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -8,6 +8,8 @@
     "camelcase": 2,
     "comma-dangle": [2, "always-multiline"],
     "eqeqeq": 2,
+    "flow-vars/define-flow-type": 1,
+    "flow-vars/use-flow-type": 1,
     "indent": [2, 2, {"SwitchCase": 1}],
     "linebreak-style": [2, "unix"],
     "max-len": [2, 100, 8],
@@ -38,6 +40,7 @@
     "experimentalObjectRestSpread": true
   },
   "plugins": [
+    "flow-vars",
     "react"
   ]
 }

--- a/js/package.json
+++ b/js/package.json
@@ -26,6 +26,7 @@
     "chai": "3.5.0",
     "chokidar": "1.4.3",
     "commander": "2.9.0",
+    "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "4.2.3",
     "eslint": "^1.10.3",
     "flow-bin": "0.22.1",

--- a/js/src/remote-store.js
+++ b/js/src/remote-store.js
@@ -9,8 +9,7 @@ export type UnsentReadMap = { [key: string]: (c: Chunk) => void };
 
 export type WriteMap = { [key: string]: Chunk };
 
-// https://github.com/babel/babel-eslint/issues/279
-interface Delegate {  // eslint-disable-line no-undef
+interface Delegate {
   readBatch(reqs: UnsentReadMap): Promise<void>;
   writeBatch(reqs: WriteMap): Promise<void>;
   updateRoot(current: Ref, last: Ref): Promise<boolean>;
@@ -30,9 +29,9 @@ export class RemoteStore {
   _maxWrites: number;
   _allWritesFinishedFn: ?() => void;
   _canUpdateRoot: Promise<void>;
-  _delegate: Delegate;  // eslint-disable-line no-undef
+  _delegate: Delegate;
 
-  constructor(maxReads: number, maxWrites: number, delegate: Delegate) {  // eslint-disable-line
+  constructor(maxReads: number, maxWrites: number, delegate: Delegate) {
     this._pendingReads = Object.create(null);
     this._unsentReads = null;
     this._readScheduled = false;


### PR DESCRIPTION
This fixes an issue where flow types where considered ununsed and
undefined.
