### PR TITLE
Fix ChildRef Type when reading meta sequences

### DIFF
--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -93,6 +93,24 @@ func getTestRefToValueOrderSet(scale int) testSet {
 	}, refType)
 }
 
+func TestCompoundSetChunks(t *testing.T) {
+	assert := assert.New(t)
+
+	doTest := func(ts testSet) {
+		vs := NewTestValueStore()
+		set := ts.toCompoundSet()
+		set2chunks := vs.ReadValue(vs.WriteValue(set)).(compoundSet).Chunks()
+		for i, r := range set.Chunks() {
+			assert.True(r.Type().Equals(set2chunks[i].Type()), "%s != %s", r.Type().Describe(), set2chunks[i].Type().Describe())
+		}
+	}
+
+	doTest(getTestNativeOrderSet(16))
+	doTest(getTestRefValueOrderSet(2))
+	doTest(getTestRefToNativeOrderSet(2))
+	doTest(getTestRefToValueOrderSet(2))
+}
+
 func TestCompoundSetHas(t *testing.T) {
 	assert := assert.New(t)
 

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -174,13 +174,13 @@ func (r *jsonArrayReader) maybeReadMetaSequence(t Type, pkg *Package) (Value, bo
 	r2 := newJsonArrayReader(r.readArray(), r.vr)
 	data := metaSequenceData{}
 	indexType := indexTypeForMetaSequence(t)
+	t = fixupType(t, pkg)
 	for !r2.atEnd() {
-		ref := r2.readRef()
+		ref := refFromType(r2.readRef(), MakeRefType(t))
 		v := r2.readValueWithoutTag(indexType, pkg)
-		data = append(data, newMetaTuple(v, nil, refFromType(ref, MakeRefType(v.Type()))))
+		data = append(data, newMetaTuple(v, nil, ref))
 	}
 
-	t = fixupType(t, pkg)
 	return newMetaSequenceFromData(data, t, r.vr), true
 }
 


### PR DESCRIPTION
When reading a meta sequence, the ChildRef of each metaTuple
is populated directly during decoding. This should be a
Ref<S> for a sequence of Type S. The old code was putting
in a Ref<T> for a sequence of Type S<T>.
