### PR TITLE
Precompute the compare function before calling sort

### DIFF
--- a/js/src/compare.js
+++ b/js/src/compare.js
@@ -2,6 +2,8 @@
 
 import type {valueOrPrimitive, Value} from './value.js';
 import {invariant} from './assert.js';
+import {Kind} from './noms-kind.js';
+import type {Type} from './type.js';
 
 export function less(v1: any, v2: any): boolean {
   invariant(v1 !== null && v1 !== undefined && v2 !== null && v2 !== undefined);
@@ -39,4 +41,56 @@ export function compare(v1: valueOrPrimitive, v2: valueOrPrimitive): number {
   }
 
   return equals(v1, v2) ? 0 : 1;
+}
+
+function compareNumbers(v1: number, v2: number) {
+  return v1 - v2;
+}
+
+function compareObjects(v1: Value, v2: Value) {
+  return v1.less(v2) ? -1 : 1;
+}
+
+function compareStrings(v1: string, v2: string): number {
+  return v1 < v2 ? -1 : 1;
+}
+
+/**
+ * Returns a compare function that can be used with `Array.prototype.sort` based on the type.
+ */
+export function getCompareFunction(t: Type): (v1: any, v2: any) => number {
+  switch (t.kind) {
+    case Kind.Uint8:
+    case Kind.Uint16:
+    case Kind.Uint32:
+    case Kind.Uint64:
+    case Kind.Int8:
+    case Kind.Int16:
+    case Kind.Int32:
+    case Kind.Int64:
+    case Kind.Float32:
+    case Kind.Float64:
+      return compareNumbers;
+
+    case Kind.String:
+      return compareStrings;
+
+    case Kind.Blob:
+    case Kind.List:
+    case Kind.Map:
+    case Kind.Ref:
+    case Kind.Set:
+    case Kind.Struct:
+    case Kind.Type:
+    case Kind.Unresolved:
+    case Kind.Package:
+      return compareObjects;
+
+    case Kind.Value:
+    case Kind.Bool:
+      throw new Error('not implemented');
+
+    default:
+      invariant(false, 'unreachable');
+  }
 }

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -8,7 +8,7 @@ import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unus
 import {AsyncIterator} from './async-iterator.js';
 import {chunkSequence} from './sequence-chunker.js';
 import {Collection} from './collection.js';
-import {compare, equals} from './compare.js';
+import {getCompareFunction, equals} from './compare.js';
 import {default as Ref, sha1Size} from './ref.js';
 import {getRefOfValueOrPrimitive} from './get-ref.js';
 import {invariant} from './assert.js';
@@ -60,6 +60,7 @@ function buildMapData(t: Type, kvs: Array<any>): Array<MapEntry> {
       value: kvs[i + 1],
     });
   }
+  const compare = getCompareFunction(t.elemTypes[0]);
   entries.sort((v1, v2) => compare(v1.key, v2.key));
   return entries;
 }

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -8,7 +8,7 @@ import type {valueOrPrimitive, Value} from './value.js'; // eslint-disable-line 
 import {AsyncIterator} from './async-iterator.js';
 import {chunkSequence} from './sequence-chunker.js';
 import {Collection} from './collection.js';
-import {compare, equals, less} from './compare.js';
+import {getCompareFunction, equals, less} from './compare.js';
 import {getRefOfValueOrPrimitive} from './get-ref.js';
 import {invariant} from './assert.js';
 import {MetaTuple, newOrderedMetaSequenceBoundaryChecker,
@@ -49,7 +49,8 @@ function newSetLeafBoundaryChecker<T:valueOrPrimitive>(t: Type): BoundaryChecker
 
 function buildSetData<T>(t: Type, values: Array<any>): Array<T> {
   // TODO: Assert values are of correct type
-  values.sort((v1, v2) => compare(v1, v2));
+  const compare = getCompareFunction(t.elemTypes[0]);
+  values.sort(compare);
   return values;
 }
 


### PR DESCRIPTION
Currently we do the type detection inside every compare callback.
Since we know the type ahead of time we can use a more optimized
compare function based on the type.

Fixes #1122
Towards #1142
