### PR TITLE
Refactor DataStore Copy methods into functions

### DIFF
--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -40,12 +40,6 @@ type DataStore interface {
 	// Delete removes the Dataset named datasetID from the map at the root of the DataStore. The Dataset data is not necessarily cleaned up at this time, but may be garbage collected in the future. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the datastore is always returned.
 	Delete(datasetID string) (DataStore, error)
 
-	// CopyReachableChunksP copies to |sink| all chunks reachable from (and including) |r|, but that are not in the subtree rooted at |exclude|
-	CopyReachableChunksP(r, exclude ref.Ref, sink DataSink, concurrency int)
-
-	// CopyMissingChunksP copies to sink all chunks reachable from (and including) |r| that it does not already have
-	CopyMissingChunksP(r ref.Ref, sink DataStore, concurrency int)
-
 	// transitionalChunkStore is awkwardly named on purpose. Hopefully we can do away with it.
 	transitionalChunkStore() chunks.ChunkStore
 }

--- a/datas/datastore_common.go
+++ b/datas/datastore_common.go
@@ -8,7 +8,6 @@ import (
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 	"github.com/attic-labs/noms/types"
-	"github.com/attic-labs/noms/walk"
 )
 
 type dataStoreCommon struct {
@@ -141,18 +140,6 @@ func (ds *dataStoreCommon) Has(r ref.Ref) bool {
 
 func (ds *dataStoreCommon) Close() error {
 	return ds.cs.Close()
-}
-
-// CopyMissingChunksP copies to |sink| all chunks in ds that are reachable from (and including) |r|, skipping chunks that |sink| already has
-func (ds *dataStoreCommon) CopyMissingChunksP(sourceRef ref.Ref, sink DataStore, concurrency int) {
-	sinkCS := sink.transitionalChunkStore()
-	tcs := &teeDataSource{ds.cs, sinkCS}
-
-	copyCallback := func(r ref.Ref) bool {
-		return sinkCS.Has(r)
-	}
-
-	walk.SomeChunksP(sourceRef, tcs, copyCallback, concurrency)
 }
 
 func (ds *dataStoreCommon) transitionalChunkSink() chunks.ChunkSink {

--- a/datas/local_datastore.go
+++ b/datas/local_datastore.go
@@ -1,13 +1,6 @@
 package datas
 
-import (
-	"sync"
-
-	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/ref"
-	"github.com/attic-labs/noms/types"
-	"github.com/attic-labs/noms/walk"
-)
+import "github.com/attic-labs/noms/chunks"
 
 // DataStore provides versioned storage for noms values. Each DataStore instance represents one moment in history. Heads() returns the Commit from each active fork at that moment. The Commit() method returns a new DataStore, representing a new moment in history.
 type LocalDataStore struct {
@@ -26,44 +19,4 @@ func (lds *LocalDataStore) Commit(datasetID string, commit Commit) (DataStore, e
 func (lds *LocalDataStore) Delete(datasetID string) (DataStore, error) {
 	err := lds.doDelete(datasetID)
 	return newLocalDataStore(lds.cs), err
-}
-
-// CopyReachableChunksP copies to |sink| all chunks reachable from (and including) |r|, but that are not in the subtree rooted at |exclude|
-func (lds *LocalDataStore) CopyReachableChunksP(sourceRef, exclude ref.Ref, sink DataSink, concurrency int) {
-	excludeRefs := map[ref.Ref]bool{}
-
-	if !exclude.IsEmpty() {
-		mu := sync.Mutex{}
-		excludeCallback := func(r ref.Ref) bool {
-			mu.Lock()
-			excludeRefs[r] = true
-			mu.Unlock()
-			return false
-		}
-
-		walk.SomeChunksP(exclude, lds, excludeCallback, concurrency)
-	}
-
-	tcs := &teeDataSource{lds.cs, sink.transitionalChunkSink()}
-	copyCallback := func(r ref.Ref) bool {
-		return excludeRefs[r]
-	}
-
-	walk.SomeChunksP(sourceRef, tcs, copyCallback, concurrency)
-}
-
-// teeDataSource just serves the purpose of writing to |sink| every chunk that is read from |source|.
-type teeDataSource struct {
-	source chunks.ChunkSource
-	sink   chunks.ChunkSink
-}
-
-func (trs *teeDataSource) ReadValue(ref ref.Ref) types.Value {
-	c := trs.source.Get(ref)
-	if c.IsEmpty() {
-		return nil
-	}
-
-	trs.sink.Put(c)
-	return types.DecodeChunk(c, trs)
 }

--- a/datas/pull.go
+++ b/datas/pull.go
@@ -1,0 +1,62 @@
+package datas
+
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/ref"
+	"github.com/attic-labs/noms/types"
+	"github.com/attic-labs/noms/walk"
+)
+
+// CopyMissingChunksP copies to |sink| all chunks in source that are reachable from (and including) |r|, skipping chunks that |sink| already has
+func CopyMissingChunksP(source DataStore, sink *LocalDataStore, sourceRef ref.Ref, concurrency int) {
+	sinkCS := sink.transitionalChunkStore()
+	copyCallback := func(r ref.Ref) bool {
+		return sinkCS.Has(r)
+	}
+	copyWorker(source, sinkCS, sourceRef, copyCallback, concurrency)
+}
+
+// CopyReachableChunksP copies to |sink| all chunks reachable from (and including) |r|, but that are not in the subtree rooted at |exclude|
+func CopyReachableChunksP(source, sink DataStore, sourceRef, exclude ref.Ref, concurrency int) {
+	excludeRefs := map[ref.Ref]bool{}
+
+	if !exclude.IsEmpty() {
+		mu := sync.Mutex{}
+		excludeCallback := func(r ref.Ref) bool {
+			mu.Lock()
+			excludeRefs[r] = true
+			mu.Unlock()
+			return false
+		}
+
+		walk.SomeChunksP(exclude, source, excludeCallback, concurrency)
+	}
+
+	copyCallback := func(r ref.Ref) bool {
+		return excludeRefs[r]
+	}
+	copyWorker(source, sink.transitionalChunkSink(), sourceRef, copyCallback, concurrency)
+}
+
+func copyWorker(source DataStore, sink chunks.ChunkSink, sourceRef ref.Ref, stopFn walk.SomeChunksCallback, concurrency int) {
+	tcs := &teeDataSource{source.transitionalChunkStore(), sink}
+	walk.SomeChunksP(sourceRef, tcs, stopFn, concurrency)
+}
+
+// teeDataSource just serves the purpose of writing to |sink| every chunk that is read from |source|.
+type teeDataSource struct {
+	source chunks.ChunkSource
+	sink   chunks.ChunkSink
+}
+
+func (trs *teeDataSource) ReadValue(ref ref.Ref) types.Value {
+	c := trs.source.Get(ref)
+	if c.IsEmpty() {
+		return nil
+	}
+
+	trs.sink.Put(c)
+	return types.DecodeChunk(c, trs)
+}

--- a/datas/remote_datastore.go
+++ b/datas/remote_datastore.go
@@ -1,17 +1,9 @@
 package datas
 
 import (
-	"compress/gzip"
-	"io/ioutil"
-	"net/http"
 	"net/url"
-	"path"
-	"strings"
 
 	"github.com/attic-labs/noms/chunks"
-	"github.com/attic-labs/noms/constants"
-	"github.com/attic-labs/noms/d"
-	"github.com/attic-labs/noms/ref"
 )
 
 // DataStore provides versioned storage for noms values. Each DataStore instance represents one moment in history. Heads() returns the Commit from each active fork at that moment. The Commit() method returns a new DataStore, representing a new moment in history.
@@ -35,45 +27,4 @@ func (rds *RemoteDataStore) Commit(datasetID string, commit Commit) (DataStore, 
 func (rds *RemoteDataStore) Delete(datasetID string) (DataStore, error) {
 	err := rds.doDelete(datasetID)
 	return newRemoteDataStore(rds.cs), err
-}
-
-// CopyReachableChunksP copies to |sink| all chunks in rds that are reachable from (and including) |r|, but that are not in the subtree rooted at |exclude|. This implementation asks the remote server to return the desired chunks and writes them to |sink|.
-func (rds *RemoteDataStore) CopyReachableChunksP(r, exclude ref.Ref, sink DataSink, concurrency int) {
-	// POST http://<host>/ref/sha1----?all=true&exclude=sha1----. Response will be chunk data if present, 404 if absent.
-	u := rds.host()
-	u.Path = path.Join(constants.RefPath, r.String())
-
-	values := &url.Values{}
-	values.Add("all", "true")
-	if !exclude.IsEmpty() {
-		values.Add("exclude", exclude.String())
-	}
-	u.RawQuery = values.Encode()
-
-	req, err := http.NewRequest("GET", u.String(), nil)
-	req.Header.Add("Accept-Encoding", "gzip")
-	d.Chk.NoError(err)
-
-	res, err := http.DefaultClient.Do(req)
-	d.Chk.NoError(err)
-	defer closeResponse(res)
-	d.Chk.Equal(http.StatusOK, res.StatusCode, "Unexpected response: %s", http.StatusText(res.StatusCode))
-
-	reader := res.Body
-	if strings.Contains(res.Header.Get("Content-Encoding"), "gzip") {
-		gr, err := gzip.NewReader(reader)
-		d.Chk.NoError(err)
-		defer gr.Close()
-		reader = gr
-	}
-
-	chunks.Deserialize(reader, sink.transitionalChunkSink(), nil)
-}
-
-// In order for keep alive to work we must read to EOF on every response. We may want to add a timeout so that a server that left its connection open can't cause all of ports to be eaten up.
-func closeResponse(res *http.Response) error {
-	data, err := ioutil.ReadAll(res.Body)
-	d.Chk.NoError(err)
-	d.Chk.Equal(0, len(data))
-	return res.Body.Close()
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -75,9 +75,9 @@ func (ds *Dataset) pull(source datas.DataStore, sourceRef ref.Ref, concurrency i
 	}
 
 	if topDown {
-		source.CopyMissingChunksP(sourceRef, sink.Store(), concurrency)
+		datas.CopyMissingChunksP(source, sink.Store().(*datas.LocalDataStore), sourceRef, concurrency)
 	} else {
-		source.CopyReachableChunksP(sourceRef, sinkHeadRef, sink.Store(), concurrency)
+		datas.CopyReachableChunksP(source, sink.Store(), sourceRef, sinkHeadRef, concurrency)
 	}
 	err := datas.ErrOptimisticLockFailed
 	for ; err == datas.ErrOptimisticLockFailed; sink, err = sink.SetNewHead(sourceRef) {

--- a/ref/ref.go
+++ b/ref/ref.go
@@ -34,6 +34,7 @@ func (r Ref) IsEmpty() bool {
 	return r.digest == emptyRef.digest
 }
 
+// DigestSlice returns a slice of the digest that backs A NEW COPY of Ref, because the receiver of this method is not a pointer.
 func (r Ref) DigestSlice() []byte {
 	return r.digest[:]
 }


### PR DESCRIPTION
This patch removes the special RemoteDataStore implementation of
CopyReachableChunksP, as this is seldom-used and adds complexity
that stands in the way of Issue 654
