### PR TITLE
JS codegen: Add test for recursive type

### DIFF
--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -219,6 +219,7 @@ export function createStructClass<T: Struct>(type: Type, typeDef: Type): Class<T
   invariant(desc instanceof StructDesc);
 
   for (const fields of [desc.fields, desc.union]) {
+    const isUnion = fields === desc.union;
     for (const field of fields) {
       const {name} = field;
       Object.defineProperty(c.prototype, name, {
@@ -231,7 +232,7 @@ export function createStructClass<T: Struct>(type: Type, typeDef: Type): Class<T
       Object.defineProperty(c.prototype, setterName(name), {
         configurable: true,
         enumerable: false,
-        value: getSetter(name, field.optional, fields === desc.union),
+        value: getSetter(name, field.optional, isUnion),
         writable: true,
       });
     }

--- a/nomdl/codegen/js/package.tmpl
+++ b/nomdl/codegen/js/package.tmpl
@@ -5,6 +5,6 @@ const _pkg = new {{importJs "Package"}}([{{range $i, $t := .Types}}
   {{importJs "Ref"}}.parse('{{$deps}}'),{{end}}
 ]);
 {{importJs "registerPackage"}}(_pkg);{{range $i, $t := .Types}}
-const {{userType $t}}$type = {{importJs "makeType"}}(_pkg.ref, {{$i}});
+export const typeFor{{userType $t}} = {{importJs "makeType"}}(_pkg.ref, {{$i}});
 const {{userType $t}}$typeDef = _pkg.types[{{$i}}];{{end}}
 {{end}}

--- a/nomdl/codegen/js/struct.tmpl
+++ b/nomdl/codegen/js/struct.tmpl
@@ -11,4 +11,4 @@ interface {{.Name}}$Interface extends {{importJsType "Struct"}} {
   set{{title .Name}}(value: {{userTypeJS .T}}): {{$name}}$Interface;{{end}}
 }
 
-export const {{.Name}}: Class<{{.Name}}$Interface> = {{importJs "createStructClass"}}({{.Name}}$type, {{.Name}}$typeDef);
+export const {{.Name}}: Class<{{.Name}}$Interface> = {{importJs "createStructClass"}}(typeFor{{userType .Type}}, {{userType .Type}}$typeDef);

--- a/nomdl/codegen/test/gen/enum_struct.noms.js
+++ b/nomdl/codegen/test/gen/enum_struct.noms.js
@@ -29,9 +29,9 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const Handedness$type = _makeType(_pkg.ref, 0);
+export const typeForHandedness = _makeType(_pkg.ref, 0);
 const Handedness$typeDef = _pkg.types[0];
-const EnumStruct$type = _makeType(_pkg.ref, 1);
+export const typeForEnumStruct = _makeType(_pkg.ref, 1);
 const EnumStruct$typeDef = _pkg.types[1];
 
 
@@ -50,4 +50,4 @@ interface EnumStruct$Interface extends _Struct {
   setHand(value: Handedness): EnumStruct$Interface;
 }
 
-export const EnumStruct: Class<EnumStruct$Interface> = _createStructClass(EnumStruct$type, EnumStruct$typeDef);
+export const EnumStruct: Class<EnumStruct$Interface> = _createStructClass(typeForEnumStruct, EnumStruct$typeDef);

--- a/nomdl/codegen/test/gen/ref.noms.js
+++ b/nomdl/codegen/test/gen/ref.noms.js
@@ -32,7 +32,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const StructWithRef$type = _makeType(_pkg.ref, 0);
+export const typeForStructWithRef = _makeType(_pkg.ref, 0);
 const StructWithRef$typeDef = _pkg.types[0];
 
 
@@ -46,4 +46,4 @@ interface StructWithRef$Interface extends _Struct {
   setR(value: _RefValue<_NomsSet<_float32>>): StructWithRef$Interface;
 }
 
-export const StructWithRef: Class<StructWithRef$Interface> = _createStructClass(StructWithRef$type, StructWithRef$typeDef);
+export const StructWithRef: Class<StructWithRef$Interface> = _createStructClass(typeForStructWithRef, StructWithRef$typeDef);

--- a/nomdl/codegen/test/gen/sha1_1c216c6.js
+++ b/nomdl/codegen/test/gen/sha1_1c216c6.js
@@ -31,9 +31,9 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const S$type = _makeType(_pkg.ref, 0);
+export const typeForS = _makeType(_pkg.ref, 0);
 const S$typeDef = _pkg.types[0];
-const E$type = _makeType(_pkg.ref, 1);
+export const typeForE = _makeType(_pkg.ref, 1);
 const E$typeDef = _pkg.types[1];
 
 
@@ -50,7 +50,7 @@ interface S$Interface extends _Struct {
   setB(value: boolean): S$Interface;
 }
 
-export const S: Class<S$Interface> = _createStructClass(S$type, S$typeDef);
+export const S: Class<S$Interface> = _createStructClass(typeForS, S$typeDef);
 
 export type E =
   0 |  // e1

--- a/nomdl/codegen/test/gen/sha1_b3ecb0f.js
+++ b/nomdl/codegen/test/gen/sha1_b3ecb0f.js
@@ -31,7 +31,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const A$type = _makeType(_pkg.ref, 0);
+export const typeForA = _makeType(_pkg.ref, 0);
 const A$typeDef = _pkg.types[0];
 
 
@@ -45,4 +45,4 @@ interface A$Interface extends _Struct {
   setA(value: _NomsList<_NomsList<_Blob>>): A$Interface;
 }
 
-export const A: Class<A$Interface> = _createStructClass(A$type, A$typeDef);
+export const A: Class<A$Interface> = _createStructClass(typeForA, A$typeDef);

--- a/nomdl/codegen/test/gen/sha1_eda4273.js
+++ b/nomdl/codegen/test/gen/sha1_eda4273.js
@@ -39,9 +39,9 @@ const _pkg = new _Package([
   _Ref.parse('sha1-1c216c6f1d6989e4ede5f78b7689214948dabeef'),
 ]);
 _registerPackage(_pkg);
-const D$type = _makeType(_pkg.ref, 0);
+export const typeForD = _makeType(_pkg.ref, 0);
 const D$typeDef = _pkg.types[0];
-const DUser$type = _makeType(_pkg.ref, 1);
+export const typeForDUser = _makeType(_pkg.ref, 1);
 const DUser$typeDef = _pkg.types[1];
 
 
@@ -58,7 +58,7 @@ interface D$Interface extends _Struct {
   setEnumField(value: _sha1_1c216c6.E): D$Interface;
 }
 
-export const D: Class<D$Interface> = _createStructClass(D$type, D$typeDef);
+export const D: Class<D$Interface> = _createStructClass(typeForD, D$typeDef);
 
 type DUser$Data = {
   Dfield: D;
@@ -70,4 +70,4 @@ interface DUser$Interface extends _Struct {
   setDfield(value: D): DUser$Interface;
 }
 
-export const DUser: Class<DUser$Interface> = _createStructClass(DUser$type, DUser$typeDef);
+export const DUser: Class<DUser$Interface> = _createStructClass(typeForDUser, DUser$typeDef);

--- a/nomdl/codegen/test/gen/struct.noms.js
+++ b/nomdl/codegen/test/gen/struct.noms.js
@@ -29,7 +29,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const Struct$type = _makeType(_pkg.ref, 0);
+export const typeForStruct = _makeType(_pkg.ref, 0);
 const Struct$typeDef = _pkg.types[0];
 
 
@@ -46,4 +46,4 @@ interface Struct$Interface extends _Struct {
   setB(value: boolean): Struct$Interface;
 }
 
-export const Struct: Class<Struct$Interface> = _createStructClass(Struct$type, Struct$typeDef);
+export const Struct: Class<Struct$Interface> = _createStructClass(typeForStruct, Struct$typeDef);

--- a/nomdl/codegen/test/gen/struct_optional.noms.js
+++ b/nomdl/codegen/test/gen/struct_optional.noms.js
@@ -29,7 +29,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const OptionalStruct$type = _makeType(_pkg.ref, 0);
+export const typeForOptionalStruct = _makeType(_pkg.ref, 0);
 const OptionalStruct$typeDef = _pkg.types[0];
 
 
@@ -46,4 +46,4 @@ interface OptionalStruct$Interface extends _Struct {
   setB(value: ?boolean): OptionalStruct$Interface;
 }
 
-export const OptionalStruct: Class<OptionalStruct$Interface> = _createStructClass(OptionalStruct$type, OptionalStruct$typeDef);
+export const OptionalStruct: Class<OptionalStruct$Interface> = _createStructClass(typeForOptionalStruct, OptionalStruct$typeDef);

--- a/nomdl/codegen/test/gen/struct_primitives.noms.js
+++ b/nomdl/codegen/test/gen/struct_primitives.noms.js
@@ -65,7 +65,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const StructPrimitives$type = _makeType(_pkg.ref, 0);
+export const typeForStructPrimitives = _makeType(_pkg.ref, 0);
 const StructPrimitives$typeDef = _pkg.types[0];
 
 
@@ -118,4 +118,4 @@ interface StructPrimitives$Interface extends _Struct {
   setValue(value: _Value): StructPrimitives$Interface;
 }
 
-export const StructPrimitives: Class<StructPrimitives$Interface> = _createStructClass(StructPrimitives$type, StructPrimitives$typeDef);
+export const StructPrimitives: Class<StructPrimitives$Interface> = _createStructClass(typeForStructPrimitives, StructPrimitives$typeDef);

--- a/nomdl/codegen/test/gen/struct_recursive.noms.js
+++ b/nomdl/codegen/test/gen/struct_recursive.noms.js
@@ -30,7 +30,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const Tree$type = _makeType(_pkg.ref, 0);
+export const typeForTree = _makeType(_pkg.ref, 0);
 const Tree$typeDef = _pkg.types[0];
 
 
@@ -44,4 +44,4 @@ interface Tree$Interface extends _Struct {
   setChildren(value: _NomsList<Tree>): Tree$Interface;
 }
 
-export const Tree: Class<Tree$Interface> = _createStructClass(Tree$type, Tree$typeDef);
+export const Tree: Class<Tree$Interface> = _createStructClass(typeForTree, Tree$typeDef);

--- a/nomdl/codegen/test/gen/struct_with_dup_list.noms.js
+++ b/nomdl/codegen/test/gen/struct_with_dup_list.noms.js
@@ -31,7 +31,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const StructWithDupList$type = _makeType(_pkg.ref, 0);
+export const typeForStructWithDupList = _makeType(_pkg.ref, 0);
 const StructWithDupList$typeDef = _pkg.types[0];
 
 
@@ -45,4 +45,4 @@ interface StructWithDupList$Interface extends _Struct {
   setL(value: _NomsList<_uint8>): StructWithDupList$Interface;
 }
 
-export const StructWithDupList: Class<StructWithDupList$Interface> = _createStructClass(StructWithDupList$type, StructWithDupList$typeDef);
+export const StructWithDupList: Class<StructWithDupList$Interface> = _createStructClass(typeForStructWithDupList, StructWithDupList$typeDef);

--- a/nomdl/codegen/test/gen/struct_with_imports.noms.js
+++ b/nomdl/codegen/test/gen/struct_with_imports.noms.js
@@ -33,9 +33,9 @@ const _pkg = new _Package([
   _Ref.parse('sha1-eda4273cba9d5d4a1bccf41bcaec64743863cde0'),
 ]);
 _registerPackage(_pkg);
-const LocalE$type = _makeType(_pkg.ref, 0);
+export const typeForLocalE = _makeType(_pkg.ref, 0);
 const LocalE$typeDef = _pkg.types[0];
-const ImportUser$type = _makeType(_pkg.ref, 1);
+export const typeForImportUser = _makeType(_pkg.ref, 1);
 const ImportUser$typeDef = _pkg.types[1];
 
 
@@ -56,4 +56,4 @@ interface ImportUser$Interface extends _Struct {
   setEnum(value: LocalE): ImportUser$Interface;
 }
 
-export const ImportUser: Class<ImportUser$Interface> = _createStructClass(ImportUser$type, ImportUser$typeDef);
+export const ImportUser: Class<ImportUser$Interface> = _createStructClass(typeForImportUser, ImportUser$typeDef);

--- a/nomdl/codegen/test/gen/struct_with_list.noms.js
+++ b/nomdl/codegen/test/gen/struct_with_list.noms.js
@@ -38,7 +38,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const StructWithList$type = _makeType(_pkg.ref, 0);
+export const typeForStructWithList = _makeType(_pkg.ref, 0);
 const StructWithList$typeDef = _pkg.types[0];
 
 
@@ -61,4 +61,4 @@ interface StructWithList$Interface extends _Struct {
   setI(value: _int64): StructWithList$Interface;
 }
 
-export const StructWithList: Class<StructWithList$Interface> = _createStructClass(StructWithList$type, StructWithList$typeDef);
+export const StructWithList: Class<StructWithList$Interface> = _createStructClass(typeForStructWithList, StructWithList$typeDef);

--- a/nomdl/codegen/test/gen/struct_with_union_field.noms.js
+++ b/nomdl/codegen/test/gen/struct_with_union_field.noms.js
@@ -44,7 +44,7 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const StructWithUnionField$type = _makeType(_pkg.ref, 0);
+export const typeForStructWithUnionField = _makeType(_pkg.ref, 0);
 const StructWithUnionField$typeDef = _pkg.types[0];
 
 
@@ -68,4 +68,4 @@ interface StructWithUnionField$Interface extends _Struct {
   setF(value: _NomsSet<_uint8>): StructWithUnionField$Interface;
 }
 
-export const StructWithUnionField: Class<StructWithUnionField$Interface> = _createStructClass(StructWithUnionField$type, StructWithUnionField$typeDef);
+export const StructWithUnionField: Class<StructWithUnionField$Interface> = _createStructClass(typeForStructWithUnionField, StructWithUnionField$typeDef);

--- a/nomdl/codegen/test/gen/struct_with_unions.noms.js
+++ b/nomdl/codegen/test/gen/struct_with_unions.noms.js
@@ -49,11 +49,11 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const StructWithUnions$type = _makeType(_pkg.ref, 0);
+export const typeForStructWithUnions = _makeType(_pkg.ref, 0);
 const StructWithUnions$typeDef = _pkg.types[0];
-const __unionOfBOfFloat64AndCOfString$type = _makeType(_pkg.ref, 1);
+export const typeFor__unionOfBOfFloat64AndCOfString = _makeType(_pkg.ref, 1);
 const __unionOfBOfFloat64AndCOfString$typeDef = _pkg.types[1];
-const __unionOfEOfFloat64AndFOfString$type = _makeType(_pkg.ref, 2);
+export const typeFor__unionOfEOfFloat64AndFOfString = _makeType(_pkg.ref, 2);
 const __unionOfEOfFloat64AndFOfString$typeDef = _pkg.types[2];
 
 
@@ -70,7 +70,7 @@ interface StructWithUnions$Interface extends _Struct {
   setD(value: __unionOfEOfFloat64AndFOfString): StructWithUnions$Interface;
 }
 
-export const StructWithUnions: Class<StructWithUnions$Interface> = _createStructClass(StructWithUnions$type, StructWithUnions$typeDef);
+export const StructWithUnions: Class<StructWithUnions$Interface> = _createStructClass(typeForStructWithUnions, StructWithUnions$typeDef);
 
 type __unionOfBOfFloat64AndCOfString$Data = {
 };
@@ -83,7 +83,7 @@ interface __unionOfBOfFloat64AndCOfString$Interface extends _Struct {
   setC(value: string): __unionOfBOfFloat64AndCOfString$Interface;
 }
 
-export const __unionOfBOfFloat64AndCOfString: Class<__unionOfBOfFloat64AndCOfString$Interface> = _createStructClass(__unionOfBOfFloat64AndCOfString$type, __unionOfBOfFloat64AndCOfString$typeDef);
+export const __unionOfBOfFloat64AndCOfString: Class<__unionOfBOfFloat64AndCOfString$Interface> = _createStructClass(typeFor__unionOfBOfFloat64AndCOfString, __unionOfBOfFloat64AndCOfString$typeDef);
 
 type __unionOfEOfFloat64AndFOfString$Data = {
 };
@@ -96,4 +96,4 @@ interface __unionOfEOfFloat64AndFOfString$Interface extends _Struct {
   setF(value: string): __unionOfEOfFloat64AndFOfString$Interface;
 }
 
-export const __unionOfEOfFloat64AndFOfString: Class<__unionOfEOfFloat64AndFOfString$Interface> = _createStructClass(__unionOfEOfFloat64AndFOfString$type, __unionOfEOfFloat64AndFOfString$typeDef);
+export const __unionOfEOfFloat64AndFOfString: Class<__unionOfEOfFloat64AndFOfString$Interface> = _createStructClass(typeFor__unionOfEOfFloat64AndFOfString, __unionOfEOfFloat64AndFOfString$typeDef);

--- a/nomdl/codegen/test/struct-recursive-test.js
+++ b/nomdl/codegen/test/struct-recursive-test.js
@@ -1,0 +1,17 @@
+// @flow
+
+import {assert} from 'chai';
+import {suite, test} from 'mocha';
+import {Tree, typeForTree} from './gen/struct_recursive.noms.js';
+import {newList, makeListType} from '@attic/noms';
+
+suite('struct_recursive.noms', () => {
+  test('constructor', async () => {
+    const listOfTreeType = makeListType(typeForTree);
+    const t: Tree = new Tree({children: await newList([
+      new Tree({children: await newList([], listOfTreeType)}),
+      new Tree({children: await newList([], listOfTreeType)}),
+    ], listOfTreeType)});
+    assert.equal(t.children.length, 2);
+  });
+});

--- a/nomdl/codegen/testDeps/leafDep/leafDep.noms.js
+++ b/nomdl/codegen/testDeps/leafDep/leafDep.noms.js
@@ -31,9 +31,9 @@ const _pkg = new _Package([
 ], [
 ]);
 _registerPackage(_pkg);
-const S$type = _makeType(_pkg.ref, 0);
+export const typeForS = _makeType(_pkg.ref, 0);
 const S$typeDef = _pkg.types[0];
-const E$type = _makeType(_pkg.ref, 1);
+export const typeForE = _makeType(_pkg.ref, 1);
 const E$typeDef = _pkg.types[1];
 
 
@@ -50,7 +50,7 @@ interface S$Interface extends _Struct {
   setB(value: boolean): S$Interface;
 }
 
-export const S: Class<S$Interface> = _createStructClass(S$type, S$typeDef);
+export const S: Class<S$Interface> = _createStructClass(typeForS, S$typeDef);
 
 export type E =
   0 |  // e1


### PR DESCRIPTION
To make this work we also have to export the noms `Type` for types
defined in the package.

Issue #1081
