### PR TITLE
JS: Remove makePrimitiveType

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "7.6.2",
+  "version": "8.0.0",
   "main": "dist/commonjs/noms.js",
   "jsnext:main": "dist/es6/noms.js",
   "dependencies": {

--- a/js/src/data-store.js
+++ b/js/src/data-store.js
@@ -11,12 +11,12 @@ import type {valueOrPrimitive} from './value.js';
 import {
   Field,
   makeCompoundType,
-  makePrimitiveType,
   makeStructType,
   makeType,
   Type,
   stringType,
   boolType,
+  valueType,
 } from './type.js';
 import {Kind} from './noms-kind.js';
 import {newMap} from './map.js';
@@ -48,7 +48,7 @@ let datasTypes: DatasTypes;
 export function getDatasTypes(): DatasTypes {
   if (!datasTypes) {
     const commitTypeDef = makeStructType('Commit', [
-      new Field('value', makePrimitiveType(Kind.Value), false),
+      new Field('value', valueType, false),
       new Field('parents', makeCompoundType(Kind.Set,
         makeCompoundType(Kind.Ref, makeType(new Ref(), 0))), false),
     ], []);
@@ -59,8 +59,7 @@ export function getDatasTypes(): DatasTypes {
     const commitType = makeType(datasPackage.ref, 0);
     const refOfCommitType = makeCompoundType(Kind.Ref, commitType);
     const commitSetType = makeCompoundType(Kind.Set, refOfCommitType);
-    const commitMapType = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                                     refOfCommitType);
+    const commitMapType = makeCompoundType(Kind.Map, stringType, refOfCommitType);
     datasTypes = {
       commitTypeDef,
       datasPackage,

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -13,15 +13,16 @@ import {
   CompoundDesc,
   EnumDesc,
   Field,
+  getPrimitiveType,
   makeCompoundType,
   makeEnumType,
-  makePrimitiveType,
   makeStructType,
   makeType,
   makeUnresolvedType,
   PrimitiveDesc,
   StructDesc,
   Type,
+  typeType,
   UnresolvedDesc,
 } from './type.js';
 import {indexTypeForMetaSequence, MetaTuple, newMetaSequenceFromData} from './meta-sequence.js';
@@ -129,7 +130,7 @@ export class JsonArrayReader {
         return makeCompoundType(kind, keyType, valueType);
       }
       case Kind.Type:
-        return makePrimitiveType(Kind.Type);
+        return typeType;
       case Kind.Unresolved: {
         const pkgRef = this.readRef();
         const ordinal = this.readOrdinal();
@@ -138,7 +139,7 @@ export class JsonArrayReader {
     }
 
     if (isPrimitiveKind(kind)) {
-      return makePrimitiveType(kind);
+      return getPrimitiveType(kind);
     }
 
     throw new Error('Unreachable');
@@ -404,8 +405,7 @@ export class JsonArrayReader {
     }
 
     invariant(isPrimitiveKind(k));
-    return makePrimitiveType(k);
-
+    return getPrimitiveType(k);
   }
 
   readStruct<T: Struct>(typeDef: Type, type: Type, pkg: Package): T {

--- a/js/src/encode.js
+++ b/js/src/encode.js
@@ -7,7 +7,7 @@ import {default as Struct, StructMirror} from './struct.js';
 import type DataStore from './data-store.js';
 import type {NomsKind} from './noms-kind.js';
 import {encode as encodeBase64} from './base64.js';
-import {boolType, EnumDesc, makePrimitiveType, stringType, StructDesc, Type} from './type.js';
+import {boolType, EnumDesc, stringType, StructDesc, Type, typeType} from './type.js';
 import {indexTypeForMetaSequence, MetaTuple} from './meta-sequence.js';
 import {invariant, notNull} from './assert.js';
 import {isPrimitiveKind, Kind} from './noms-kind.js';
@@ -196,9 +196,8 @@ export class JsonArrayWriter {
       case Kind.Package: {
         invariant(v instanceof Package,
                   `Failed to write Package. Invalid type: ${describeType(v)}`);
-        const ptr = makePrimitiveType(Kind.Type);
         const w2 = new JsonArrayWriter(this._ds);
-        v.types.forEach(type => w2.writeValue(type, ptr, pkg));
+        v.types.forEach(type => w2.writeValue(type, typeType, pkg));
         this.write(w2.array);
         const w3 = new JsonArrayWriter(this._ds);
         v.dependencies.forEach(ref => w3.writeRef(ref));

--- a/js/src/get-ref-test.js
+++ b/js/src/get-ref-test.js
@@ -5,14 +5,14 @@ import Ref from './ref.js';
 import {assert} from 'chai';
 import {ensureRef, getRef} from './get-ref.js';
 import {Kind} from './noms-kind.js';
-import {makePrimitiveType} from './type.js';
+import {boolType} from './type.js';
 import {suite, test} from 'mocha';
 
 suite('get ref', () => {
   test('getRef', () => {
     const input = `t [${Kind.Bool},false]`;
     const ref = Chunk.fromString(input).ref;
-    const tr = makePrimitiveType(Kind.Bool);
+    const tr = boolType;
     const actual = getRef(false, tr);
 
     assert.strictEqual(ref.toString(), actual.toString());
@@ -20,7 +20,7 @@ suite('get ref', () => {
 
   test('ensureRef', () => {
     let r: ?Ref = null;
-    const tr = makePrimitiveType(Kind.Bool);
+    const tr = boolType;
     r = ensureRef(r, false, tr);
     assert.isNotNull(r);
     assert.strictEqual(r, ensureRef(r, false, tr));

--- a/js/src/list-test.js
+++ b/js/src/list-test.js
@@ -8,7 +8,16 @@ import MemoryStore from './memory-store.js';
 import RefValue from './ref-value.js';
 import {newStruct} from './struct.js';
 import {calcSplices} from './edit-distance.js';
-import {Field, makeCompoundType, makePrimitiveType, makeStructType, makeType} from './type.js';
+import {
+  Field,
+  int32Type,
+  int64Type,
+  makeCompoundType,
+  makeStructType,
+  makeType,
+  stringType,
+  valueType,
+} from './type.js';
 import {flatten, flattenParallel} from './test-util.js';
 import {IndexedMetaSequence, MetaTuple} from './meta-sequence.js';
 import {invariant} from './assert.js';
@@ -44,7 +53,7 @@ suite('BuildList', () => {
 
   test('set of n numbers, length', async () => {
     const nums = firstNNumbers(testListSize);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const s = await newList(nums, tr);
     assert.strictEqual(s.ref.toString(), listOfNRef);
     assert.strictEqual(testListSize, s.length);
@@ -54,7 +63,7 @@ suite('BuildList', () => {
     const nums = firstNNumbers(testListSize);
 
     const structTypeDef = makeStructType('num', [
-      new Field('n', makePrimitiveType(Kind.Int64), false),
+      new Field('n', int64Type, false),
     ], []);
     const pkg = new Package([structTypeDef], []);
     registerPackage(pkg);
@@ -76,7 +85,7 @@ suite('BuildList', () => {
 
   test('toJS', async () => {
     const nums = firstNNumbers(5000);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const s = await newList(nums, tr);
     assert.strictEqual(s.ref.toString(), listOfNRef);
     assert.strictEqual(testListSize, s.length);
@@ -96,7 +105,7 @@ suite('BuildList', () => {
 
   test('insert', async () => {
     const nums = firstNNumbers(testListSize - 10);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     let s = await newList(nums, tr);
 
     for (let i = testListSize - 10; i < testListSize; i++) {
@@ -108,7 +117,7 @@ suite('BuildList', () => {
 
   test('append', async () => {
     const nums = firstNNumbers(testListSize - 10);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     let s = await newList(nums, tr);
 
     for (let i = testListSize - 10; i < testListSize; i++) {
@@ -120,7 +129,7 @@ suite('BuildList', () => {
 
   test('remove', async () => {
     const nums = firstNNumbers(testListSize + 10);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     let s = await newList(nums, tr);
 
     let count = 10;
@@ -133,7 +142,7 @@ suite('BuildList', () => {
 
   test('splice', async () => {
     const nums = firstNNumbers(testListSize);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     let s = await newList(nums, tr);
 
     const splice500At = async (idx: number) => {
@@ -154,7 +163,7 @@ suite('BuildList', () => {
     const ds = new DataStore(ms);
 
     const nums = firstNNumbers(testListSize);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const s = await newList(nums, tr);
     const r = ds.writeValue(s);
     const s2 = await ds.readValue(r);
@@ -173,7 +182,7 @@ suite('ListLeafSequence', () => {
   test('isEmpty', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.String));
+    const tr = makeCompoundType(Kind.List, stringType);
     const newList = items => new NomsList(tr, new ListLeafSequence(ds, tr, items));
     assert.isTrue(newList([]).isEmpty());
     assert.isFalse(newList(['z', 'x', 'a', 'b']).isEmpty());
@@ -182,7 +191,7 @@ suite('ListLeafSequence', () => {
   test('get', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.String));
+    const tr = makeCompoundType(Kind.List, stringType);
     const l = new NomsList(tr, new ListLeafSequence(ds, tr, ['z', 'x', 'a', 'b']));
     assert.strictEqual('z', await l.get(0));
     assert.strictEqual('x', await l.get(1));
@@ -193,7 +202,7 @@ suite('ListLeafSequence', () => {
   test('forEach', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.List, int32Type);
     const l = new NomsList(tr, new ListLeafSequence(ds, tr, [4, 2, 10, 16]));
 
     const values = [];
@@ -204,7 +213,7 @@ suite('ListLeafSequence', () => {
   test('iterator', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.List, int32Type);
 
     const test = async items => {
       const l = new NomsList(tr, new ListLeafSequence(ds, tr, items));
@@ -220,7 +229,7 @@ suite('ListLeafSequence', () => {
   test('iteratorAt', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.List, int32Type);
 
     const test = async items => {
       const l = new NomsList(tr, new ListLeafSequence(ds, tr, items));
@@ -240,7 +249,7 @@ suite('ListLeafSequence', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
     const tr = makeCompoundType(Kind.List, elemType);
-    const st = makePrimitiveType(Kind.String);
+    const st = stringType;
     const refOfSt = makeCompoundType(Kind.Ref, st);
     const r1 = new RefValue(ds.writeValue('x'), refOfSt);
     const r2 = new RefValue(ds.writeValue('a'), refOfSt);
@@ -253,11 +262,11 @@ suite('ListLeafSequence', () => {
   }
 
   test('chunks, list of value', () => {
-    testChunks(makePrimitiveType(Kind.Value));
+    testChunks(valueType);
   });
 
   test('chunks', () => {
-    testChunks(makePrimitiveType(Kind.String));
+    testChunks(stringType);
   });
 });
 
@@ -265,7 +274,7 @@ suite('CompoundList', () => {
   function build(): NomsList {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.String));
+    const tr = makeCompoundType(Kind.List, stringType);
     const l1 = new NomsList(tr, new ListLeafSequence(ds, tr, ['a', 'b']));
     const r1 = ds.writeValue(l1);
     const l2 = new NomsList(tr, new ListLeafSequence(ds, tr, ['e', 'f']));
@@ -391,7 +400,7 @@ suite('Diff List', () => {
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => nums1[i] === nums2[j]);
 
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const l1 = await newList(nums1, tr);
     const l2 = await newList(nums2, tr);
 
@@ -410,7 +419,7 @@ suite('Diff List', () => {
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => nums1[i] === nums2[j]);
 
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const l1 = await newList(nums1, tr);
     const l2 = await newList(nums2, tr);
 
@@ -429,7 +438,7 @@ suite('Diff List', () => {
     }
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => nums1[i] === nums2[j]);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const l1 = await newList(nums1, tr);
     const l2 = await newList(nums2, tr);
 
@@ -442,7 +451,7 @@ suite('Diff List', () => {
     const nums2 = firstNNumbers(5000);
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => nums1[i] === nums2[j]);
-    const tr = makeCompoundType(Kind.List, makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.List, int64Type);
     const l1 = await newList(nums1, tr);
     const l2 = await newList(nums2, tr);
 

--- a/js/src/map-test.js
+++ b/js/src/map-test.js
@@ -7,7 +7,17 @@ import DataStore from './data-store';
 import MemoryStore from './memory-store.js';
 import RefValue from './ref-value.js';
 import {newStruct} from './struct.js';
-import {Field, makeCompoundType, makePrimitiveType, makeStructType, makeType} from './type.js';
+import {
+  boolType,
+  Field,
+  int32Type,
+  int64Type,
+  makeCompoundType,
+  makeStructType,
+  makeType,
+  stringType,
+  valueType,
+} from './type.js';
 import {flatten, flattenParallel} from './test-util.js';
 import {invariant} from './assert.js';
 import {Kind} from './noms-kind.js';
@@ -26,8 +36,8 @@ suite('BuildMap', () => {
       kvs.push(i, i + 1);
     }
 
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.Int64),
-                                makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.Map, int64Type,
+                                int64Type);
     const m = await newMap(kvs, tr);
     assert.strictEqual(m.ref.toString(), mapOfNRef);
 
@@ -50,7 +60,7 @@ suite('BuildMap', () => {
     }
 
     const structTypeDef = makeStructType('num', [
-      new Field('n', makePrimitiveType(Kind.Int64), false),
+      new Field('n', int64Type, false),
     ], []);
     const pkg = new Package([structTypeDef], []);
     registerPackage(pkg);
@@ -75,8 +85,8 @@ suite('BuildMap', () => {
       kvs.push(i, i + 1);
     }
 
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.Int64),
-                                makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.Map, int64Type,
+                                int64Type);
     let m = await newMap(kvs, tr);
     for (let i = testMapSize - 10; i < testMapSize; i++) {
       m = await m.set(i, i + 1);
@@ -91,8 +101,8 @@ suite('BuildMap', () => {
       kvs.push(i, i + 1);
     }
 
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.Int64),
-                                makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.Map, int64Type,
+                                int64Type);
     let m = await newMap(kvs, tr);
     for (let i = 0; i < testMapSize; i++) {
       m = await m.set(i, i + 1);
@@ -107,8 +117,8 @@ suite('BuildMap', () => {
       kvs.push(i, i + 1);
     }
 
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.Int64),
-                                makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.Map, int64Type,
+                                int64Type);
     let m = await newMap(kvs, tr);
     for (let i = testMapSize; i < testMapSize + 10; i++) {
       m = await m.remove(i);
@@ -126,8 +136,8 @@ suite('BuildMap', () => {
       kvs.push(i, i + 1);
     }
 
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.Int64),
-                                makePrimitiveType(Kind.Int64));
+    const tr = makeCompoundType(Kind.Map, int64Type,
+                                int64Type);
     const m = await newMap(kvs, tr);
 
     const r = ds.writeValue(m);
@@ -149,8 +159,8 @@ suite('MapLeaf', () => {
   test('isEmpty', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                makePrimitiveType(Kind.Bool));
+    const tr = makeCompoundType(Kind.Map, stringType,
+                                boolType);
     const newMap = entries => new NomsMap(tr, new MapLeafSequence(ds, tr, entries));
     assert.isTrue(newMap([]).isEmpty());
     assert.isFalse(newMap([{key: 'a', value: false}, {key:'k', value:true}]).isEmpty());
@@ -159,8 +169,8 @@ suite('MapLeaf', () => {
   test('has', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                makePrimitiveType(Kind.Bool));
+    const tr = makeCompoundType(Kind.Map, stringType,
+                                boolType);
     const m = new NomsMap(tr,
         new MapLeafSequence(ds, tr, [{key: 'a', value: false}, {key:'k', value:true}]));
     assert.isTrue(await m.has('a'));
@@ -172,8 +182,8 @@ suite('MapLeaf', () => {
   test('first/last/get', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.Map, stringType,
+                                int32Type);
     const m = new NomsMap(tr,
         new MapLeafSequence(ds, tr, [{key: 'a', value: 4}, {key:'k', value:8}]));
 
@@ -189,8 +199,8 @@ suite('MapLeaf', () => {
   test('forEach', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.Map, stringType,
+                                int32Type);
     const m = new NomsMap(tr,
         new MapLeafSequence(ds, tr, [{key: 'a', value: 4}, {key:'k', value:8}]));
 
@@ -202,8 +212,8 @@ suite('MapLeaf', () => {
   test('iterator', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.Map, stringType,
+                                int32Type);
 
     const test = async entries => {
       const m = new NomsMap(tr, new MapLeafSequence(ds, tr, entries));
@@ -219,8 +229,8 @@ suite('MapLeaf', () => {
   test('iteratorAt', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-                                makePrimitiveType(Kind.Int32));
+    const tr = makeCompoundType(Kind.Map, stringType,
+                                int32Type);
     const build = entries => new NomsMap(tr, new MapLeafSequence(ds, tr, entries));
 
     assert.deepEqual([], await flatten(build([]).iteratorAt('a')));
@@ -246,7 +256,7 @@ suite('MapLeaf', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
     const tr = makeCompoundType(Kind.Map, keyType, valueType);
-    const st = makePrimitiveType(Kind.String);
+    const st = stringType;
     const refOfSt = makeCompoundType(Kind.Ref, st);
     const r1 = new RefValue(ds.writeValue('x'), refOfSt);
     const r2 = new RefValue(ds.writeValue(true), refOfSt);
@@ -262,18 +272,18 @@ suite('MapLeaf', () => {
   }
 
   test('chunks', () => {
-    testChunks(makePrimitiveType(Kind.String), makePrimitiveType(Kind.Bool));
+    testChunks(stringType, boolType);
   });
 
   test('chunks, map from value to value', () => {
-    testChunks(makePrimitiveType(Kind.Value), makePrimitiveType(Kind.Value));
+    testChunks(valueType, valueType);
   });
 });
 
 suite('CompoundMap', () => {
   function build(ds: DataStore): Array<NomsMap> {
-    const tr = makeCompoundType(Kind.Map, makePrimitiveType(Kind.String),
-        makePrimitiveType(Kind.Bool));
+    const tr = makeCompoundType(Kind.Map, stringType,
+        boolType);
     const l1 = new NomsMap(tr, new MapLeafSequence(ds, tr, [{key: 'a', value: false},
         {key:'b', value:false}]));
     const r1 = ds.writeValue(l1);

--- a/js/src/meta-sequence.js
+++ b/js/src/meta-sequence.js
@@ -6,7 +6,7 @@ import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type DataStore from './data-store.js';
 import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
 import type {Collection} from './collection.js';
-import {CompoundDesc, makeCompoundType, makePrimitiveType} from './type.js';
+import {CompoundDesc, makeCompoundType, uint64Type, valueType} from './type.js';
 import type {Type} from './type.js';
 import {IndexedSequence} from './indexed-sequence.js';
 import {invariant} from './assert.js';
@@ -152,7 +152,7 @@ export function newMetaSequenceFromData(ds: DataStore, type: Type, tuples: Array
   }
 }
 
-const indexedSequenceIndexType = makePrimitiveType(Kind.Uint64);
+const indexedSequenceIndexType = uint64Type;
 
 export function indexTypeForMetaSequence(t: Type): Type {
   switch (t.kind) {
@@ -164,7 +164,7 @@ export function indexTypeForMetaSequence(t: Type): Type {
       if (elemType.ordered) {
         return elemType;
       } else {
-        return makeCompoundType(Kind.Ref, makePrimitiveType(Kind.Value));
+        return makeCompoundType(Kind.Ref, valueType);
       }
     }
     case Kind.Blob:

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -37,7 +37,6 @@ export {
   makeEnumType,
   makeListType,
   makeMapType,
-  makePrimitiveType,
   makeRefType,
   makeSetType,
   makeStructType,

--- a/js/src/sequence-test.js
+++ b/js/src/sequence-test.js
@@ -5,14 +5,14 @@ import {assert} from 'chai';
 import {Sequence, SequenceCursor} from './sequence.js';
 import type {int64} from './primitives.js';
 import {notNull} from './assert.js';
-import {makeCompoundType, makePrimitiveType} from './type.js';
+import {makeCompoundType, valueType} from './type.js';
 import {Kind} from './noms-kind.js';
 import MemoryStore from './memory-store.js';
 import DataStore from './data-store.js';
 
 class TestSequence extends Sequence<any> {
   constructor(ds: ?DataStore, items: Array<any>) {
-    super(ds, makeCompoundType(Kind.List, makePrimitiveType(Kind.Value)), items);
+    super(ds, makeCompoundType(Kind.List, valueType), items);
   }
 
   getChildSequence(idx: number): // eslint-disable-line no-unused-vars

--- a/js/src/struct-test.js
+++ b/js/src/struct-test.js
@@ -5,12 +5,12 @@ import RefValue from './ref-value.js';
 import {newStruct, StructMirror, createStructClass} from './struct.js';
 import {assert} from 'chai';
 import {
+  boolType,
   Field,
+  float64Type,
   makeCompoundType,
-  makePrimitiveType,
   makeStructType,
   makeType,
-  float64Type,
   stringType,
 } from './type.js';
 import {Kind} from './noms-kind.js';
@@ -22,8 +22,8 @@ import Ref from './ref.js';
 suite('Struct', () => {
   test('equals', () => {
     const typeDef = makeStructType('S1', [
-      new Field('x', makePrimitiveType(Kind.Bool), false),
-      new Field('o', makePrimitiveType(Kind.String), true),
+      new Field('x', boolType, false),
+      new Field('o', stringType, true),
     ], []);
 
     const pkg = new Package([typeDef], []);
@@ -42,7 +42,7 @@ suite('Struct', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
 
-    const bt = makePrimitiveType(Kind.Bool);
+    const bt = boolType;
     const refOfBoolType = makeCompoundType(Kind.Ref, bt);
     const typeDef = makeStructType('S1', [
       new Field('r', refOfBoolType, false),
@@ -65,7 +65,7 @@ suite('Struct', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
 
-    const bt = makePrimitiveType(Kind.Bool);
+    const bt = boolType;
     const refOfBoolType = makeCompoundType(Kind.Ref, bt);
     const typeDef = makeStructType('S1', [
       new Field('r', refOfBoolType, true),
@@ -93,11 +93,11 @@ suite('Struct', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
 
-    const bt = makePrimitiveType(Kind.Bool);
+    const bt = boolType;
     const refOfBoolType = makeCompoundType(Kind.Ref, bt);
     const typeDef = makeStructType('S1', [], [
       new Field('r', refOfBoolType, false),
-      new Field('s', makePrimitiveType(Kind.String), false),
+      new Field('s', stringType, false),
     ]);
 
     const pkg = new Package([typeDef], []);
@@ -119,8 +119,8 @@ suite('Struct', () => {
 
   test('new', () => {
     const typeDef = makeStructType('S2', [
-      new Field('b', makePrimitiveType(Kind.Bool), false),
-      new Field('o', makePrimitiveType(Kind.String), true),
+      new Field('b', boolType, false),
+      new Field('o', stringType, true),
     ], []);
 
     const pkg = new Package([typeDef], []);
@@ -150,8 +150,8 @@ suite('Struct', () => {
 
   test('new union', () => {
     const typeDef = makeStructType('S3', [], [
-      new Field('b', makePrimitiveType(Kind.Bool), false),
-      new Field('o', makePrimitiveType(Kind.String), false),
+      new Field('b', boolType, false),
+      new Field('o', stringType, false),
     ]);
 
     const pkg = new Package([typeDef], []);
@@ -166,8 +166,8 @@ suite('Struct', () => {
 
   test('struct set', () => {
     const typeDef = makeStructType('S3', [
-      new Field('b', makePrimitiveType(Kind.Bool), false),
-      new Field('o', makePrimitiveType(Kind.String), true),
+      new Field('b', boolType, false),
+      new Field('o', stringType, true),
     ], []);
 
     const pkg = new Package([typeDef], []);
@@ -197,8 +197,8 @@ suite('Struct', () => {
 
   test('struct set union', () => {
     const typeDef = makeStructType('S3', [], [
-      new Field('b', makePrimitiveType(Kind.Bool), false),
-      new Field('s', makePrimitiveType(Kind.String), false),
+      new Field('b', boolType, false),
+      new Field('s', stringType, false),
     ]);
 
     const pkg = new Package([typeDef], []);
@@ -225,7 +225,7 @@ suite('Struct', () => {
 
   test('type assertion on construct', () => {
     const typeDef = makeStructType('S3', [
-      new Field('b', makePrimitiveType(Kind.Bool), false),
+      new Field('b', boolType, false),
     ], []);
 
     const pkg = new Package([typeDef], []);

--- a/js/src/type-test.js
+++ b/js/src/type-test.js
@@ -3,7 +3,17 @@
 import MemoryStore from './memory-store.js';
 import Ref from './ref.js';
 import {assert} from 'chai';
-import {Field, makeCompoundType, makePrimitiveType, makeStructType, makeType} from './type.js';
+import {
+  boolType,
+  Field,
+  float64Type,
+  makeCompoundType,
+  makeStructType,
+  makeType,
+  stringType,
+  typeType,
+  uint8Type,
+} from './type.js';
 import {Kind} from './noms-kind.js';
 import {Package, registerPackage} from './package.js';
 import {suite, test} from 'mocha';
@@ -14,9 +24,6 @@ suite('Type', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
 
-    const boolType = makePrimitiveType(Kind.Bool);
-    const uint8Type = makePrimitiveType(Kind.Uint8);
-    const stringType = makePrimitiveType(Kind.String);
     const mapType = makeCompoundType(Kind.Map, stringType, uint8Type);
     const setType = makeCompoundType(Kind.Set, stringType);
     const mahType = makeStructType('MahStruct', [
@@ -45,9 +52,6 @@ suite('Type', () => {
   });
 
   test('typeRef describe', async () => {
-    const boolType = makePrimitiveType(Kind.Bool);
-    const uint8Type = makePrimitiveType(Kind.Uint8);
-    const stringType = makePrimitiveType(Kind.String);
     const mapType = makeCompoundType(Kind.Map, stringType, uint8Type);
     const setType = makeCompoundType(Kind.Set, stringType);
 
@@ -81,7 +85,7 @@ suite('Type', () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
 
-    const pkg = new Package([makePrimitiveType(Kind.Float64)], []);
+    const pkg = new Package([float64Type], []);
     registerPackage(pkg);
     const pkgRef = pkg.ref;
 
@@ -96,7 +100,7 @@ suite('Type', () => {
   });
 
   test('type Type', () => {
-    assert.isTrue(makePrimitiveType(Kind.Bool).type.equals(makePrimitiveType(Kind.Type)));
+    assert.isTrue(boolType.type.equals(typeType));
   });
 
   test('empty package ref', async () => {

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -358,7 +358,7 @@ function buildType(n: string, desc: TypeDesc): Type {
   }
 }
 
-export function makePrimitiveType(k: NomsKind): Type {
+function makePrimitiveType(k: NomsKind): Type {
   return buildType('', new PrimitiveDesc(k));
 }
 
@@ -428,3 +428,46 @@ export const setOfValueType = makeCompoundType(Kind.Set, valueType);
 export const mapOfValueType = makeCompoundType(Kind.Map, valueType, valueType);
 
 export const packageRefType = makeCompoundType(Kind.Ref, packageType);
+
+/**
+ * Gives the existing primitive Type value for a NomsKind.
+ */
+export function getPrimitiveType(k: NomsKind): Type {
+  invariant(isPrimitiveKind(k));
+  switch (k) {
+    case Kind.Bool:
+      return boolType;
+    case Kind.Uint8:
+      return uint8Type;
+    case Kind.Uint16:
+      return uint16Type;
+    case Kind.Uint32:
+      return uint32Type;
+    case Kind.Uint64:
+      return uint64Type;
+    case Kind.Int8:
+      return int8Type;
+    case Kind.Int16:
+      return int16Type;
+    case Kind.Int32:
+      return int32Type;
+    case Kind.Int64:
+      return int64Type;
+    case Kind.Float32:
+      return float32Type;
+    case Kind.Float64:
+      return float64Type;
+    case Kind.String:
+      return stringType;
+    case Kind.Blob:
+      return blobType;
+    case Kind.Type:
+      return typeType;
+    case Kind.Package:
+      return packageType;
+    case Kind.Value:
+      return valueType;
+    default:
+      invariant(false, 'not reachable');
+  }
+}


### PR DESCRIPTION
type.js no longer exports makePrimitiveType. It is recommended to use
the type constants directly. There are a few cases where we had a
NomsKind and needed a Type. For those cases there is now a
getPrimitiveType but it is not exported by noms.

Fixes #1168
