### PR TITLE
JS: Allow defs to contain correct noms value

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "main": "dist/commonjs/noms.js",
   "jsnext:main": "dist/es6/noms.js",
   "dependencies": {

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -29,6 +29,7 @@ import {lookupPackage, Package, readPackage} from './package.js';
 import {NomsMap, MapLeafSequence} from './map.js';
 import {NomsSet, SetLeafSequence} from './set.js';
 import {IndexedMetaSequence} from './meta-sequence.js';
+import fixupType from './fixup-type.js';
 
 const typedTag = 't ';
 const blobTag = 'b ';

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -29,7 +29,6 @@ import {lookupPackage, Package, readPackage} from './package.js';
 import {NomsMap, MapLeafSequence} from './map.js';
 import {NomsSet, SetLeafSequence} from './set.js';
 import {IndexedMetaSequence} from './meta-sequence.js';
-import fixupType from './fixup-type.js';
 
 const typedTag = 't ';
 const blobTag = 'b ';

--- a/js/src/defs-test.js
+++ b/js/src/defs-test.js
@@ -46,6 +46,18 @@ suite('defs', () => {
     const l2 = await defToNoms([0, 1, 2, 3], listOfUint8Type);
     invariant(l2 instanceof ValueBase);
     assert.isTrue(l1.equals(l2));
+
+    const l3 = await defToNoms(l1, listOfUint8Type);
+    invariant(l3 instanceof ValueBase);
+    assert.isTrue(l1.equals(l3));
+
+    let ex;
+    try {
+      await defToNoms(l1, makeListType(stringType));
+    } catch (e) {
+      ex = e;
+    }
+    assert.ok(ex);
   });
 
   test('set', async () => {
@@ -54,6 +66,14 @@ suite('defs', () => {
     const s2 = await defToNoms([0, 1, 2, 3], setOfFloat64Type);
     invariant(s2 instanceof ValueBase);
     assert.isTrue(s1.equals(s2));
+
+    let ex;
+    try {
+      await defToNoms(s1, makeSetType(stringType));
+    } catch (e) {
+      ex = e;
+    }
+    assert.ok(ex);
   });
 
   test('map', async () => {
@@ -62,6 +82,14 @@ suite('defs', () => {
     const m2 = await defToNoms([0, 'zero', 1, 'one'], mapOfFloat64ToStringType);
     invariant(m2 instanceof ValueBase);
     assert.isTrue(m1.equals(m2));
+
+    let ex;
+    try {
+      await defToNoms(m1, makeMapType(stringType, float64Type));
+    } catch (e) {
+      ex = e;
+    }
+    assert.ok(ex);
   });
 
   test('struct', async () => {
@@ -84,8 +112,6 @@ suite('defs', () => {
       b: true,
       s: 'hi',
     }, type);
-
-
     assert.isTrue(s1.equals(s2));
   });
 
@@ -129,9 +155,12 @@ suite('defs', () => {
     ], listType);
 
     const l2 = await defToNoms([{i: 1}, {i: 2}], listType);
-
     invariant(l2 instanceof ValueBase);
     assert.isTrue(l1.equals(l2));
+
+    const l3 = await defToNoms([newStruct(structType, typeDef, {i: 1}), {i: 2}], listType);
+    invariant(l3 instanceof ValueBase);
+    assert.isTrue(l1.equals(l3));
   });
 
   test('recursive struct', async () => {
@@ -171,5 +200,15 @@ suite('defs', () => {
 
     invariant(t2 instanceof ValueBase);
     assert.isTrue(t1.equals(t2));
+
+    const t3 = await defToNoms({
+      children: [
+        {children: []},
+        {children: await newList([], listType)},
+      ],
+    }, type);
+
+    invariant(t3 instanceof ValueBase);
+    assert.isTrue(t1.equals(t3));
   });
 });

--- a/js/src/defs.js
+++ b/js/src/defs.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type {valueOrPrimitive} from './value.js';
+import {ValueBase} from './value.js';
 import {Type, CompoundDesc, StructDesc, makeType} from './type.js';
 import type {Field} from './type.js';
 import {invariant, notNull} from './assert.js';
@@ -13,6 +14,7 @@ import {lookupPackage} from './package.js';
 import type {Package} from './package.js';
 import type Struct from './struct.js';
 import {newStruct} from './struct.js';
+import fixupType from './fixup-type.js';
 
 type StructDefType = {[name: string]: DefType};
 type DefType = number | string | boolean | Array<DefType> | StructDefType | Uint8Array;
@@ -27,6 +29,13 @@ export async function defToNoms(v: DefType, t: Type, pkg: ?Package): Promise<val
       break;
     default:
       invariant(false);
+  }
+
+  if (v instanceof ValueBase) {
+    t = fixupType(t, pkg);
+    if (t.equals(v.type)) {
+      return v;
+    }
   }
 
   switch (t.kind) {

--- a/js/src/defs.js
+++ b/js/src/defs.js
@@ -14,10 +14,9 @@ import {lookupPackage} from './package.js';
 import type {Package} from './package.js';
 import type Struct from './struct.js';
 import {newStruct} from './struct.js';
-import fixupType from './fixup-type.js';
 
 type StructDefType = {[name: string]: DefType};
-type DefType = number | string | boolean | Array<DefType> | StructDefType | Uint8Array;
+type DefType = number | string | boolean | Array<DefType> | StructDefType | Uint8Array | ValueBase;
 
 export async function defToNoms(v: DefType, t: Type, pkg: ?Package): Promise<valueOrPrimitive> {
   switch (typeof v) {
@@ -32,7 +31,6 @@ export async function defToNoms(v: DefType, t: Type, pkg: ?Package): Promise<val
   }
 
   if (v instanceof ValueBase) {
-    t = fixupType(t, pkg);
     if (t.equals(v.type)) {
       return v;
     }


### PR DESCRIPTION
If a Def for type T is already a noms value of type T we can just
return that
