### PR TITLE
JS: Remove empty Refs in package when the package is created

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "main": "dist/commonjs/noms.js",
   "jsnext:main": "dist/es6/noms.js",
   "dependencies": {

--- a/js/src/data-store-test.js
+++ b/js/src/data-store-test.js
@@ -2,7 +2,7 @@
 
 import {suite, test} from 'mocha';
 import MemoryStore from './memory-store.js';
-import Ref from './ref.js';
+import {emptyRef} from './ref.js';
 import {assert} from 'chai';
 import {default as DataStore, getDatasTypes, newCommit} from './data-store.js';
 import {invariant, notNull} from './assert.js';
@@ -146,7 +146,7 @@ suite('DataStore', () => {
     const commitRef = ds.writeValue(commit);
     const datasets = await newMap(['foo', commitRef], types.commitMapType);
     const rootRef = ds.writeValue(datasets).targetRef;
-    assert.isTrue(await ms.updateRoot(rootRef, new Ref()));
+    assert.isTrue(await ms.updateRoot(rootRef, emptyRef));
     ds = new DataStore(ms); // refresh the datasets
 
     assert.strictEqual(1, datasets.size);

--- a/js/src/data-store.js
+++ b/js/src/data-store.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Chunk from './chunk.js';
-import Ref from './ref.js';
+import {default as Ref, emptyRef} from './ref.js';
 import RefValue from './ref-value.js';
 import {newStruct} from './struct.js';
 import type {ChunkStore} from './chunk-store.js';
@@ -51,7 +51,7 @@ export function getDatasTypes(): DatasTypes {
     const commitTypeDef = makeStructType('Commit', [
       new Field('value', valueType, false),
       new Field('parents', makeCompoundType(Kind.Set,
-        makeCompoundType(Kind.Ref, makeType(new Ref(), 0))), false),
+        makeCompoundType(Kind.Ref, makeType(emptyRef, 0))), false),
     ], []);
 
     const datasPackage = new Package([commitTypeDef], []);

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -3,7 +3,7 @@
 import Chunk from './chunk.js';
 import DataStore from './data-store.js';
 import MemoryStore from './memory-store.js';
-import Ref from './ref.js';
+import {default as Ref, emptyRef} from './ref.js';
 import RefValue from './ref-value.js';
 import {default as Struct, StructMirror} from './struct.js';
 import type {float64, int32, int64, uint8, uint16, uint32, uint64} from './primitives.js';
@@ -440,14 +440,15 @@ suite('Decode', () => {
   test('test read struct with', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const tr = makeStructType('A1', [
+    let tr = makeStructType('A1', [
       new Field('x', int16Type, false),
-      new Field('e', makeType(new Ref(), 1), false),
+      new Field('e', makeType(emptyRef, 1), false),
       new Field('b', boolType, false),
     ], []);
     const enumTref = makeEnumType('E', ['a', 'b', 'c']);
     const pkg = new Package([tr, enumTref], []);
     registerPackage(pkg);
+    tr = pkg.types[0];
 
     const a = [Kind.Unresolved, pkg.ref.toString(), '0', '42', '1', true];
     const r = new JsonArrayReader(a, ds);

--- a/js/src/defs-test.js
+++ b/js/src/defs-test.js
@@ -20,7 +20,7 @@ import {newList} from './list.js';
 import {newStruct} from './struct.js';
 import {newSet} from './set.js';
 import {newMap} from './map.js';
-import Ref from './ref.js';
+import {emptyRef} from './ref.js';
 import {ValueBase} from './value.js';
 import {invariant} from './assert.js';
 
@@ -137,7 +137,7 @@ suite('defs', () => {
   test('recursive struct', async () => {
     const pkg = new Package([
       makeStructType('Struct', [
-        new Field('children', makeListType(makeType(new Ref(), 0)), false),
+        new Field('children', makeListType(makeType(emptyRef, 0)), false),
       ], []),
     ], []);
     registerPackage(pkg);

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -4,7 +4,7 @@ import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
 import MemoryStore from './memory-store.js';
-import Ref from './ref.js';
+import {default as Ref, emptyRef} from './ref.js';
 import RefValue from './ref-value.js';
 import {newStruct} from './struct.js';
 import type {NomsKind} from './noms-kind.js';
@@ -304,12 +304,13 @@ suite('Encode', () => {
     const s2TypeDef = makeStructType('S2', [
       new Field('x', int32Type, false),
     ], []);
-    const sTypeDef = makeStructType('S', [
-      new Field('s', makeType(new Ref(), 0), false),
+    let sTypeDef = makeStructType('S', [
+      new Field('s', makeType(emptyRef, 0), false),
     ], []);
 
     const pkg = new Package([s2TypeDef, sTypeDef], []);
     registerPackage(pkg);
+    sTypeDef = pkg.types[1];
     const pkgRef = pkg.ref;
     const s2Type = makeType(pkgRef, 0);
     const sType = makeType(pkgRef, 1);

--- a/js/src/fixup-type.js
+++ b/js/src/fixup-type.js
@@ -1,0 +1,65 @@
+// @flow
+
+import {
+  CompoundDesc,
+  EnumDesc,
+  Field,
+  makeCompoundType,
+  makeStructType,
+  makeType,
+  PrimitiveDesc,
+  StructDesc,
+  Type,
+  UnresolvedDesc,
+} from './type.js';
+import {Package} from './package.js';
+import {invariant, notNull} from './assert.js';
+
+/**
+ * Goes through the type and returns a new type where all the empty refs have been replaced by
+ * the package ref.
+ */
+export default function fixupType(t: Type, pkg: ?Package): Type {
+  const desc = t.desc;
+
+  if (desc instanceof CompoundDesc) {
+    let changed = false;
+    const newTypes = desc.elemTypes.map(t => {
+      const newT = fixupType(t, pkg);
+      if (newT === t) {
+        return t;
+      }
+      changed = true;
+      return newT;
+    });
+
+    return changed ? makeCompoundType(t.kind, ...newTypes) : t;
+  }
+
+  if (desc instanceof UnresolvedDesc) {
+    if (t.hasPackageRef) {
+      return t;
+    }
+
+    return makeType(notNull(pkg).ref, t.ordinal);
+  }
+
+  if (desc instanceof StructDesc) {
+    let changed = false;
+    const fixField = f => {
+      const newT = fixupType(f.t, pkg);
+      if (newT === t) {
+        return f;
+      }
+      changed = true;
+      return new Field(f.name, newT, f.optional);
+    };
+
+    const newFields = desc.fields.map(fixField);
+    const newUnion = desc.union.map(fixField);
+    return changed ? makeStructType(t.name, newFields, newUnion) : t;
+  }
+
+  invariant(desc instanceof EnumDesc || desc instanceof PrimitiveDesc);
+  return t;
+}

--- a/js/src/memory-store.js
+++ b/js/src/memory-store.js
@@ -1,7 +1,9 @@
 // @flow
 
-import Ref from './ref.js';
-import {emptyChunk, default as Chunk} from './chunk.js';
+import type Ref from './ref.js';
+import {emptyRef} from './ref.js';
+import type Chunk from './chunk.js';
+import {emptyChunk} from './chunk.js';
 
 export default class MemoryStore {
   _data: { [key: string]: Chunk };
@@ -9,7 +11,7 @@ export default class MemoryStore {
 
   constructor() {
     this._data = Object.create(null);
-    this._root = new Ref();
+    this._root = emptyRef;
   }
 
   getRoot(): Promise<Ref> {

--- a/js/src/package.js
+++ b/js/src/package.js
@@ -7,15 +7,24 @@ import type {Type} from './type.js';
 import {packageType, packageRefType} from './type.js';
 import {ValueBase} from './value.js';
 import type DataStore from './data-store.js';
+import {getRef} from './get-ref.js';
+import fixupType from './fixup-type.js';
 
 export class Package extends ValueBase {
   types: Array<Type>;
   dependencies: Array<Ref>;
+  _ref: Ref;
 
   constructor(types: Array<Type>, dependencies: Array<Ref>) {
     super();
     this.types = types;
     this.dependencies = dependencies;
+    this._ref = getRef(this, this.type);
+    this.types = types.map(t => fixupType(t, this));
+  }
+
+  get ref(): Ref {
+    return this._ref;
   }
 
   get type(): Type {

--- a/js/src/ref-test.js
+++ b/js/src/ref-test.js
@@ -2,7 +2,7 @@
 
 import {assert} from 'chai';
 import {suite, test} from 'mocha';
-import Ref from './ref.js';
+import {default as Ref, emptyRef} from './ref.js';
 import {encode} from './utf8.js';
 
 suite('Ref', () => {
@@ -64,7 +64,7 @@ suite('Ref', () => {
     r = Ref.fromDigest(digest);
     assert.isFalse(r.isEmpty());
 
-    r = new Ref();
+    r = emptyRef;
     assert.isTrue(r.isEmpty());
   });
 });

--- a/js/src/ref.js
+++ b/js/src/ref.js
@@ -36,7 +36,7 @@ function hexToUint8(s: string): Uint8Array {
 export default class Ref {
   _refStr: string;
 
-  constructor(refStr: string = emtpyRefStr) {
+  constructor(refStr: string) {
     this._refStr = refStr;
   }
 
@@ -86,3 +86,5 @@ export default class Ref {
     return new Ref(sha1Prefix + r.digest(data));
   }
 }
+
+export const emptyRef = new Ref(emtpyRefStr);

--- a/js/src/struct-test.js
+++ b/js/src/struct-test.js
@@ -16,7 +16,7 @@ import {Kind} from './noms-kind.js';
 import {Package, registerPackage} from './package.js';
 import {suite, test} from 'mocha';
 import DataStore from './data-store.js';
-import Ref from './ref.js';
+import {emptyRef} from './ref.js';
 
 suite('Struct', () => {
   test('equals', () => {
@@ -245,8 +245,8 @@ suite('Struct', () => {
     let typeDef, typeDefA, typeDefD;
     const pkg = new Package([
       typeDef = makeStructType('StructWithUnions', [
-        new Field('a', makeType(new Ref(), 1), false),
-        new Field('d', makeType(new Ref(), 2), false),
+        new Field('a', makeType(emptyRef, 1), false),
+        new Field('d', makeType(emptyRef, 2), false),
       ], []),
       typeDefA = makeStructType('', [], [
         new Field('b', float64Type, false),

--- a/js/src/type-test.js
+++ b/js/src/type-test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import MemoryStore from './memory-store.js';
-import Ref from './ref.js';
+import {default as Ref, emptyRef} from './ref.js';
 import {assert} from 'chai';
 import {
   boolType,
@@ -106,7 +106,7 @@ suite('Type', () => {
   test('empty package ref', async () => {
     const ms = new MemoryStore();
     const ds = new DataStore(ms);
-    const v = makeType(new Ref(), -1);
+    const v = makeType(emptyRef, -1);
     const r = ds.writeValue(v).targetRef;
     const v2 = await ds.readValue(r);
     assert.isTrue(v.equals(v2));

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -1,6 +1,7 @@
 // @flow
 
-import Ref from './ref.js';
+import type Ref from './ref.js';
+import {emptyRef} from './ref.js';
 import RefValue from './ref-value.js';
 import type {NomsKind} from './noms-kind.js';
 import {invariant} from './assert.js';
@@ -403,7 +404,7 @@ export function makeType(pkgRef: Ref, ordinal: number): Type {
 }
 
 export function makeUnresolvedType(namespace: string, name: string): Type {
-  return new Type(name, namespace, new UnresolvedDesc(new Ref(), -1));
+  return new Type(name, namespace, new UnresolvedDesc(emptyRef, -1));
 }
 
 export const boolType = makePrimitiveType(Kind.Bool);


### PR DESCRIPTION
This means that we do not need to use fixup type in any other
place in the code.
