### PR TITLE
    Add run.py script to jsmodules/webpack-config

### DIFF
--- a/jsmodules/webpack-config/package.json
+++ b/jsmodules/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/webpack-config",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Shared webpack config for noms",
   "main": "index.js",
   "dependencies": {

--- a/jsmodules/webpack-config/run.py
+++ b/jsmodules/webpack-config/run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import argparse, os, subprocess, sys
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--out', type=str, help='destination js file')
+    parser.add_argument('--src', type=str, help='source of main js file')
+    parser.add_argument('mode', type=str, help='"production" or "development"')
+    args = parser.parse_args()
+
+    env = {
+        'NODE_ENV': args.mode,
+        'BABEL_ENV': args.mode,
+    }.update(os.environ)
+    subprocess.check_call(
+            ['node_modules/.bin/webpack',
+                '--config', 'node_modules/@attic/webpack-config/index.js', args.src, args.out],
+            env=env, shell=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```
This is intended to replace simpler uses of .npm_run_helper.py, then
I'll continually migrate views until they can use the simpler form.
Currently it will only be Splore that uses it.
```
