### PR TITLE
Fix Splore and clients/fs

### DIFF
--- a/clients/fs/package.json
+++ b/clients/fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "directory-import",
   "dependencies": {
-    "@attic/noms": "^9.0.1"
+    "@attic/noms": "^10.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.6.5",

--- a/clients/fs/src/fs.noms.js
+++ b/clients/fs/src/fs.noms.js
@@ -6,9 +6,9 @@ import {
   Field as _Field,
   Kind as _Kind,
   Package as _Package,
-  Ref as _Ref,
   blobType as _blobType,
   createStructClass as _createStructClass,
+  emptyRef as _emptyRef,
   makeCompoundType as _makeCompoundType,
   makeMapType as _makeMapType,
   makeStructType as _makeStructType,
@@ -26,38 +26,38 @@ import type {
 
 const _pkg = new _Package([
   _makeStructType('Directory',
-      [
-        new _Field('entries', _makeCompoundType(_Kind.Map, _stringType, _makeCompoundType(_Kind.Ref, _makeType(new _Ref(), 2))), false),
-      ],
-      [
+    [
+      new _Field('entries', _makeCompoundType(_Kind.Map, _stringType, _makeCompoundType(_Kind.Ref, _makeType(_emptyRef, 2))), false),
+    ],
+    [
 
-      ]
-    ),
+    ]
+  ),
   _makeStructType('File',
-      [
-        new _Field('content', _makeCompoundType(_Kind.Ref, _blobType), false),
-      ],
-      [
+    [
+      new _Field('content', _makeCompoundType(_Kind.Ref, _blobType), false),
+    ],
+    [
 
-      ]
-    ),
+    ]
+  ),
   _makeStructType('DirectoryEntry',
-      [
+    [
 
-      ],
-      [
-        new _Field('file', _makeType(new _Ref(), 1), false),
-        new _Field('directory', _makeType(new _Ref(), 0), false),
-      ]
-    ),
+    ],
+    [
+      new _Field('file', _makeType(_emptyRef, 1), false),
+      new _Field('directory', _makeType(_emptyRef, 0), false),
+    ]
+  ),
 ], [
 ]);
 _registerPackage(_pkg);
-export const typeForDirectory = _makeType(_pkg.ref, 0);
+const Directory$type = _makeType(_pkg.ref, 0);
 const Directory$typeDef = _pkg.types[0];
-export const typeForFile = _makeType(_pkg.ref, 1);
+const File$type = _makeType(_pkg.ref, 1);
 const File$typeDef = _pkg.types[1];
-export const typeForDirectoryEntry = _makeType(_pkg.ref, 2);
+const DirectoryEntry$type = _makeType(_pkg.ref, 2);
 const DirectoryEntry$typeDef = _pkg.types[2];
 
 
@@ -71,7 +71,7 @@ interface Directory$Interface extends _Struct {
   setEntries(value: _NomsMap<string, _RefValue<DirectoryEntry>>): Directory$Interface;
 }
 
-export const Directory: Class<Directory$Interface> = _createStructClass(typeForDirectory, Directory$typeDef);
+export const Directory: Class<Directory$Interface> = _createStructClass(Directory$type, Directory$typeDef);
 
 type File$Data = {
   content: _RefValue<_Blob>;
@@ -83,7 +83,7 @@ interface File$Interface extends _Struct {
   setContent(value: _RefValue<_Blob>): File$Interface;
 }
 
-export const File: Class<File$Interface> = _createStructClass(typeForFile, File$typeDef);
+export const File: Class<File$Interface> = _createStructClass(File$type, File$typeDef);
 
 type DirectoryEntry$Data = {
 };
@@ -96,7 +96,7 @@ interface DirectoryEntry$Interface extends _Struct {
   setDirectory(value: Directory): DirectoryEntry$Interface;
 }
 
-export const DirectoryEntry: Class<DirectoryEntry$Interface> = _createStructClass(typeForDirectoryEntry, DirectoryEntry$typeDef);
+export const DirectoryEntry: Class<DirectoryEntry$Interface> = _createStructClass(DirectoryEntry$type, DirectoryEntry$typeDef);
 
 export function newMapOfStringToRefOfDirectoryEntry(values: Array<any>): Promise<_NomsMap<string, _RefValue<DirectoryEntry>>> {
   return _newMap(values, _makeMapType(_stringType, _makeCompoundType(_Kind.Ref, _makeType(_pkg.ref, 2))));

--- a/clients/fs/src/main.js
+++ b/clients/fs/src/main.js
@@ -75,7 +75,7 @@ async function processDirectory(p: string, store: DataStore): Promise<Directory>
   const names = await fs.readdir(p);
   const children = names.map(name => {
     const chPath = path.join(p, name);
-    return processPath(chPath, store).then(dirEntryRef => [chPath, dirEntryRef]);
+    return processPath(chPath, store).then(dirEntryRef => [name, dirEntryRef]);
   });
 
   numFilesComplete++;

--- a/clients/splore/src/main.js
+++ b/clients/splore/src/main.js
@@ -198,7 +198,7 @@ function handleChunkLoad(ref: Ref, val: any, fromRef: ?string) {
       };
 
       mirror.forEachField(processField);
-      if (val.hasUnion) {
+      if (mirror.hasUnion) {
         processField(mirror.unionField);
       }
     } else {


### PR DESCRIPTION
- Splore had a type after the last update
- Update clients/fs to latest sdk and change the key name to be
  the base file name instead of the full path.
