### PR TITLE
Remove isNullOrUndefined

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "10.3.0",
+  "version": "11.0.0",
   "main": "dist/commonjs/noms.js",
   "jsnext:main": "dist/es6/noms.js",
   "dependencies": {

--- a/js/src/assert.js
+++ b/js/src/assert.js
@@ -5,10 +5,6 @@ export function invariant(exp: any, message: string = 'Invariant violated') {
   if (!exp) throw new Error(message);
 }
 
-export function isNullOrUndefined<T>(v: ?T): boolean {
-  return v === null || v === undefined;
-}
-
 export function notNull<T>(v: ?T): T {
   invariant(v !== null && v !== undefined, 'Unexpected null value');
   return v;

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -18,7 +18,7 @@ export {
   createStructClass,
 } from './struct.js';
 export {encodeNomsValue} from './encode.js';
-export {invariant, isNullOrUndefined, notNull} from './assert.js';
+export {invariant, notNull} from './assert.js';
 export {isPrimitiveKind, Kind, kindToString} from './noms-kind.js';
 export {lookupPackage, Package, readPackage, registerPackage} from './package.js';
 export {newList, ListLeafSequence, NomsList} from './list.js';

--- a/js/src/ordered-sequence.js
+++ b/js/src/ordered-sequence.js
@@ -3,7 +3,7 @@
 import {AsyncIterator} from './async-iterator.js';
 import type {AsyncIteratorResult} from './async-iterator.js';
 import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
-import {invariant, isNullOrUndefined, notNull} from './assert.js';
+import {invariant, notNull} from './assert.js';
 import {less} from './compare.js';
 import {search, Sequence, SequenceCursor} from './sequence.js';
 
@@ -21,7 +21,7 @@ export class OrderedSequence<K: valueOrPrimitive, T> extends Sequence<T> {
 
     while (sequence) {
       cursor = new OrderedSequenceCursor(cursor, sequence, last ? -1 : 0);
-      if (!isNullOrUndefined(key)) {
+      if (key !== null && key !== undefined) {
         const lastPositionIfNotfound = forInsertion && sequence.isMeta;
         if (!cursor._seekTo(key, lastPositionIfNotfound)) {
           return cursor; // invalid


### PR DESCRIPTION
The usage of isNullOrUndefined prevented flow 0.23 from detecting
that the value cannot be null or undefined.

This function was only used in one place.
