### PR TITLE
Report backpressure over the wire

### DIFF
--- a/chunks/chunk_store.go
+++ b/chunks/chunk_store.go
@@ -48,9 +48,13 @@ type ChunkSink interface {
 	io.Closer
 }
 
-// BackpressureError is a slice of Chunk that indicates some chunks could not be Put(). Caller is free to try to Put them again later.
-type BackpressureError []Chunk
+// BackpressureError is a slice of ref.Ref that indicates some chunks could not be Put(). Caller is free to try to Put them again later.
+type BackpressureError ref.RefSlice
 
 func (b BackpressureError) Error() string {
 	return fmt.Sprintf("Tried to Put %d too many Chunks", len(b))
+}
+
+func (b BackpressureError) AsHashes() ref.RefSlice {
+	return ref.RefSlice(b)
 }

--- a/chunks/dynamo_store.go
+++ b/chunks/dynamo_store.go
@@ -136,7 +136,12 @@ func (s *DynamoStore) PutMany(chunks []Chunk) (e BackpressureError) {
 			s.requestWg.Add(1)
 			s.unwrittenPuts.Add(c)
 		default:
-			return BackpressureError(chunks[i:])
+			notPut := chunks[i:]
+			e = make(BackpressureError, len(notPut))
+			for j, np := range notPut {
+				e[j] = np.Ref()
+			}
+			return
 		}
 	}
 	return

--- a/chunks/read_through_store.go
+++ b/chunks/read_through_store.go
@@ -50,8 +50,8 @@ func (rts ReadThroughStore) Put(c Chunk) {
 func (rts ReadThroughStore) PutMany(chunks []Chunk) BackpressureError {
 	bpe := rts.backingStore.PutMany(chunks)
 	lookup := make(map[ref.Ref]bool, len(bpe))
-	for _, c := range bpe {
-		lookup[c.Ref()] = true
+	for _, r := range bpe {
+		lookup[r] = true
 	}
 	toPut := make([]Chunk, 0, len(chunks)-len(bpe))
 	for _, c := range chunks {

--- a/datas/put_cache.go
+++ b/datas/put_cache.go
@@ -43,10 +43,10 @@ func (p *unwrittenPutCache) Get(r ref.Ref) chunks.Chunk {
 	return chunks.EmptyChunk
 }
 
-func (p *unwrittenPutCache) Clear(chunks []chunks.Chunk) {
+func (p *unwrittenPutCache) Clear(hashes ref.RefSlice) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for _, c := range chunks {
-		delete(p.unwrittenPuts, c.Ref())
+	for _, hash := range hashes {
+		delete(p.unwrittenPuts, hash)
 	}
 }

--- a/datas/remote_datastore_handlers_test.go
+++ b/datas/remote_datastore_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -42,15 +43,49 @@ func TestHandleWriteValue(t *testing.T) {
 	sz.Put(listChunk)
 	sz.Close()
 
-	w := newFakeHTTPResponseWriter()
+	w := httptest.NewRecorder()
 	HandleWriteValue(w, &http.Request{Body: ioutil.NopCloser(body), Method: "POST"}, params{}, cs)
 
-	if assert.Equal(http.StatusCreated, w.resp.StatusCode, "Handler error:\n%s", string(w.buf.Bytes())) {
+	if assert.Equal(http.StatusCreated, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
 		ds2 := NewDataStore(cs)
 		v := ds2.ReadValue(l2.Ref())
 		if assert.NotNil(v) {
 			assert.True(v.Equals(l2), "%+v != %+v", v, l2)
 		}
+	}
+}
+
+func TestHandleWriteValueBackpressure(t *testing.T) {
+	assert := assert.New(t)
+	cs := &backpressureCS{ChunkStore: chunks.NewMemoryStore()}
+	ds := NewDataStore(cs)
+
+	l := types.NewList(
+		ds.WriteValue(types.Bool(true)),
+		ds.WriteValue(types.Bool(false)),
+	)
+	ds.WriteValue(l)
+
+	hint := l.Ref()
+	newItem := types.NewEmptyBlob()
+	itemChunk := types.EncodeValue(newItem, nil)
+	l2 := l.Insert(1, types.NewRefOfBlob(itemChunk.Ref()))
+	listChunk := types.EncodeValue(l2, nil)
+
+	body := &bytes.Buffer{}
+	serializeHints(body, map[ref.Ref]struct{}{hint: struct{}{}})
+	sz := chunks.NewSerializer(body)
+	sz.Put(itemChunk)
+	sz.Put(listChunk)
+	sz.Close()
+
+	w := httptest.NewRecorder()
+	HandleWriteValue(w, &http.Request{Body: ioutil.NopCloser(body), Method: "POST"}, params{}, cs)
+
+	if assert.Equal(httpStatusTooManyRequests, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
+		hashes := deserializeHashes(w.Body)
+		assert.Len(hashes, 1)
+		assert.Equal(l2.Ref(), hashes[0])
 	}
 }
 
@@ -133,7 +168,7 @@ func TestHandleGetRefs(t *testing.T) {
 
 	body := strings.NewReader(fmt.Sprintf("ref=%s&ref=%s", chnx[0].Ref(), chnx[1].Ref()))
 
-	w := newFakeHTTPResponseWriter()
+	w := httptest.NewRecorder()
 	HandleGetRefs(w,
 		&http.Request{Body: ioutil.NopCloser(body), Method: "POST", Header: http.Header{
 			"Content-Type": {"application/x-www-form-urlencoded"},
@@ -142,9 +177,9 @@ func TestHandleGetRefs(t *testing.T) {
 		cs,
 	)
 
-	if assert.Equal(http.StatusOK, w.resp.StatusCode, "Handler error:\n%s", string(w.buf.Bytes())) {
+	if assert.Equal(http.StatusOK, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
 		chunkChan := make(chan chunks.Chunk)
-		go chunks.DeserializeToChan(w.buf, chunkChan)
+		go chunks.DeserializeToChan(w.Body, chunkChan)
 		for c := range chunkChan {
 			assert.Equal(chnx[0].Ref(), c.Ref())
 			chnx = chnx[1:]
@@ -160,11 +195,11 @@ func TestHandleGetRoot(t *testing.T) {
 	cs.Put(c)
 	assert.True(cs.UpdateRoot(c.Ref(), ref.Ref{}))
 
-	w := newFakeHTTPResponseWriter()
+	w := httptest.NewRecorder()
 	HandleRootGet(w, &http.Request{Method: "GET"}, params{}, cs)
 
-	if assert.Equal(http.StatusOK, w.resp.StatusCode, "Handler error:\n%s", string(w.buf.Bytes())) {
-		root := ref.Parse(string(w.buf.Bytes()))
+	if assert.Equal(http.StatusOK, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
+		root := ref.Parse(string(w.Body.Bytes()))
 		assert.Equal(c.Ref(), root)
 	}
 }
@@ -187,50 +222,19 @@ func TestHandlePostRoot(t *testing.T) {
 	queryParams.Add("current", chnx[1].Ref().String())
 	u.RawQuery = queryParams.Encode()
 
-	w := newFakeHTTPResponseWriter()
+	w := httptest.NewRecorder()
 	HandleRootPost(w, &http.Request{URL: u, Method: "POST"}, params{}, cs)
-	assert.Equal(http.StatusConflict, w.resp.StatusCode, "Handler error:\n%s", string(w.buf.Bytes()))
+	assert.Equal(http.StatusConflict, w.Code, "Handler error:\n%s", string(w.Body.Bytes()))
 
 	// Now, update the root manually to 'last' and try again.
 	assert.True(cs.UpdateRoot(chnx[0].Ref(), ref.Ref{}))
-	w = newFakeHTTPResponseWriter()
+	w = httptest.NewRecorder()
 	HandleRootPost(w, &http.Request{URL: u, Method: "POST"}, params{}, cs)
-	assert.Equal(http.StatusOK, w.resp.StatusCode, "Handler error:\n%s", string(w.buf.Bytes()))
+	assert.Equal(http.StatusOK, w.Code, "Handler error:\n%s", string(w.Body.Bytes()))
 }
 
 type params map[string]string
 
 func (p params) ByName(k string) string {
 	return p[k]
-}
-
-type fakeHTTPResponseWriter struct {
-	buf  *bytes.Buffer
-	resp *http.Response
-}
-
-func newFakeHTTPResponseWriter() *fakeHTTPResponseWriter {
-	buf := &bytes.Buffer{}
-	return &fakeHTTPResponseWriter{
-		buf: buf,
-		resp: &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     http.StatusText(http.StatusOK),
-			Header:     http.Header{},
-			Body:       ioutil.NopCloser(buf),
-		},
-	}
-}
-
-func (rw *fakeHTTPResponseWriter) Header() http.Header {
-	return rw.resp.Header
-}
-
-func (rw *fakeHTTPResponseWriter) Write(b []byte) (int, error) {
-	return rw.buf.Write(b)
-}
-
-func (rw *fakeHTTPResponseWriter) WriteHeader(ret int) {
-	rw.resp.StatusCode = ret
-	rw.resp.Status = http.StatusText(ret)
 }

--- a/datas/serialize_hints.go
+++ b/datas/serialize_hints.go
@@ -11,15 +11,27 @@ import (
 	"github.com/attic-labs/noms/types"
 )
 
-func serializeHints(w io.Writer, hints map[ref.Ref]struct{}) {
+func serializeHints(w io.Writer, hints types.Hints) {
 	err := binary.Write(w, binary.LittleEndian, uint32(len(hints))) // 4 billion hints is probably absurd. Maybe this should be smaller?
 	d.Chk.NoError(err)
 	for r := range hints {
-		digest := r.Digest()
-		n, err := io.Copy(w, bytes.NewReader(digest[:]))
-		d.Chk.NoError(err)
-		d.Chk.Equal(int64(sha1.Size), n)
+		serializeHash(w, r)
 	}
+}
+
+func serializeHashes(w io.Writer, hashes ref.RefSlice) {
+	err := binary.Write(w, binary.LittleEndian, uint32(len(hashes))) // 4 billion hashes is probably absurd. Maybe this should be smaller?
+	d.Chk.NoError(err)
+	for _, r := range hashes {
+		serializeHash(w, r)
+	}
+}
+
+func serializeHash(w io.Writer, hash ref.Ref) {
+	digest := hash.Digest()
+	n, err := io.Copy(w, bytes.NewReader(digest[:]))
+	d.Chk.NoError(err)
+	d.Chk.Equal(int64(sha1.Size), n)
 }
 
 func deserializeHints(reader io.Reader) types.Hints {
@@ -29,12 +41,27 @@ func deserializeHints(reader io.Reader) types.Hints {
 
 	hints := make(types.Hints, numRefs)
 	for i := uint32(0); i < numRefs; i++ {
-		digest := ref.Sha1Digest{}
-		n, err := io.ReadFull(reader, digest[:])
-		d.Chk.NoError(err)
-		d.Chk.Equal(int(sha1.Size), n)
-
-		hints[ref.New(digest)] = struct{}{}
+		hints[deserializeHash(reader)] = struct{}{}
 	}
 	return hints
+}
+
+func deserializeHashes(reader io.Reader) ref.RefSlice {
+	numRefs := uint32(0)
+	err := binary.Read(reader, binary.LittleEndian, &numRefs)
+	d.Chk.NoError(err)
+
+	hashes := make(ref.RefSlice, numRefs)
+	for i := range hashes {
+		hashes[i] = deserializeHash(reader)
+	}
+	return hashes
+}
+
+func deserializeHash(reader io.Reader) ref.Ref {
+	digest := ref.Sha1Digest{}
+	n, err := io.ReadFull(reader, digest[:])
+	d.Chk.NoError(err)
+	d.Chk.Equal(int(sha1.Size), n)
+	return ref.New(digest)
 }


### PR DESCRIPTION
Using ChunkStore.PutMany() means that the DataStore server code
can detect when the ChunkStore it's writing to can't handle
the amount of data being pushed. This patch reports that
status back across the wire to the client that's attempting
to write a Value graph. Due to Issue #1259, the only thing the
client can currently do is retry the entire batch, but we hope
to do better in the future.
