### PR TITLE
Fix deprecated eslint rule name

### DIFF
--- a/jsmodules/eslintrc/index.js
+++ b/jsmodules/eslintrc/index.js
@@ -25,7 +25,7 @@ module.exports = {
     'quotes': [2, 'single'],
     'radix': 2,
     'semi': 2,
-    'space-after-keywords': 2,
+    'keyword-spacing': 2,
     'space-before-function-paren': 0,
     'space-in-parens': [2, 'never'],
     'space-infix-ops': 2,


### PR DESCRIPTION
eslint keeps telling me that "Rule 'space-after-keywords' was removed
and replaced by: keyword-spacing" so I figured we should make the
change.
