### PR TITLE
Make all usages of Type in Go use pointers

### DIFF
--- a/clients/common/date.noms.go
+++ b/clients/common/date.noms.go
@@ -11,7 +11,7 @@ import (
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func init() {
-	p := types.NewPackage([]types.Type{
+	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("Date",
 			[]types.Field{
 				types.Field{"MsSinceEpoch", types.MakePrimitiveType(types.Int64Kind), false},
@@ -54,9 +54,9 @@ func (s Date) Def() (d DateDef) {
 	return
 }
 
-var __typeForDate types.Type
+var __typeForDate *types.Type
 
-func (m Date) Type() types.Type {
+func (m Date) Type() *types.Type {
 	return __typeForDate
 }
 

--- a/clients/common/geo.noms.go
+++ b/clients/common/geo.noms.go
@@ -11,7 +11,7 @@ import (
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func init() {
-	p := types.NewPackage([]types.Type{
+	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("Geoposition",
 			[]types.Field{
 				types.Field{"Latitude", types.MakePrimitiveType(types.Float32Kind), false},
@@ -67,9 +67,9 @@ func (s Geoposition) Def() (d GeopositionDef) {
 	return
 }
 
-var __typeForGeoposition types.Type
+var __typeForGeoposition *types.Type
 
-func (m Geoposition) Type() types.Type {
+func (m Geoposition) Type() *types.Type {
 	return __typeForGeoposition
 }
 
@@ -172,9 +172,9 @@ func (s Georectangle) Def() (d GeorectangleDef) {
 	return
 }
 
-var __typeForGeorectangle types.Type
+var __typeForGeorectangle *types.Type
 
-func (m Georectangle) Type() types.Type {
+func (m Georectangle) Type() *types.Type {
 	return __typeForGeorectangle
 }
 

--- a/clients/common/photo.noms.go
+++ b/clients/common/photo.noms.go
@@ -11,7 +11,7 @@ import (
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func init() {
-	p := types.NewPackage([]types.Type{
+	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("RemotePhoto",
 			[]types.Field{
 				types.Field{"Id", types.MakePrimitiveType(types.StringKind), false},
@@ -110,9 +110,9 @@ func (s RemotePhoto) Def() (d RemotePhotoDef) {
 	return
 }
 
-var __typeForRemotePhoto types.Type
+var __typeForRemotePhoto *types.Type
 
-func (m RemotePhoto) Type() types.Type {
+func (m RemotePhoto) Type() *types.Type {
 	return __typeForRemotePhoto
 }
 
@@ -305,9 +305,9 @@ func (s Face) Def() (d FaceDef) {
 	return
 }
 
-var __typeForFace types.Type
+var __typeForFace *types.Type
 
-func (m Face) Type() types.Type {
+func (m Face) Type() *types.Type {
 	return __typeForFace
 }
 
@@ -452,9 +452,9 @@ func (s Size) Def() (d SizeDef) {
 	return
 }
 
-var __typeForSize types.Type
+var __typeForSize *types.Type
 
-func (m Size) Type() types.Type {
+func (m Size) Type() *types.Type {
 	return __typeForSize
 }
 
@@ -569,9 +569,9 @@ func (m MapOfSizeToString) ChildValues() []types.Value {
 }
 
 // A Noms Value that describes MapOfSizeToString.
-var __typeForMapOfSizeToString types.Type
+var __typeForMapOfSizeToString *types.Type
 
-func (m MapOfSizeToString) Type() types.Type {
+func (m MapOfSizeToString) Type() *types.Type {
 	return __typeForMapOfSizeToString
 }
 
@@ -704,9 +704,9 @@ func (s SetOfString) ChildValues() []types.Value {
 }
 
 // A Noms Value that describes SetOfString.
-var __typeForSetOfString types.Type
+var __typeForSetOfString *types.Type
 
-func (m SetOfString) Type() types.Type {
+func (m SetOfString) Type() *types.Type {
 	return __typeForSetOfString
 }
 
@@ -849,9 +849,9 @@ func (s SetOfFace) ChildValues() []types.Value {
 }
 
 // A Noms Value that describes SetOfFace.
-var __typeForSetOfFace types.Type
+var __typeForSetOfFace *types.Type
 
-func (m SetOfFace) Type() types.Type {
+func (m SetOfFace) Type() *types.Type {
 	return __typeForSetOfFace
 }
 

--- a/clients/csv/exporter/exporter_test.go
+++ b/clients/csv/exporter/exporter_test.go
@@ -50,7 +50,7 @@ func (s *testSuite) TestCSVExporter() {
 	}
 
 	typeDef := types.MakeStructType(structName, f, []types.Field{})
-	pkg := types.NewPackage([]types.Type{typeDef}, []ref.Ref{})
+	pkg := types.NewPackage([]*types.Type{typeDef}, []ref.Ref{})
 	pkgRef := types.RegisterPackage(&pkg)
 	typeRef := types.MakeType(pkgRef, 0)
 	structFields := typeDef.Desc.(types.StructDesc).Fields

--- a/clients/csv/read.go
+++ b/clients/csv/read.go
@@ -66,7 +66,7 @@ func ReportValidFieldTypes(r *csv.Reader, headers []string) []KindSlice {
 }
 
 // MakeStructTypeFromHeaders creates a struct type from the headers using |kinds| as the type of each field. If |kinds| is empty, default to strings.
-func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSlice) (typeRef, typeDef types.Type) {
+func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSlice) (typeRef, typeDef *types.Type) {
 	useStringType := len(kinds) == 0
 	d.Chk.True(useStringType || len(headers) == len(kinds))
 	fields := make([]types.Field, len(headers))
@@ -83,7 +83,7 @@ func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSl
 		}
 	}
 	typeDef = types.MakeStructType(structName, fields, []types.Field{})
-	pkg := types.NewPackage([]types.Type{typeDef}, []ref.Ref{})
+	pkg := types.NewPackage([]*types.Type{typeDef}, []ref.Ref{})
 	pkgRef := types.RegisterPackage(&pkg)
 	typeRef = types.MakeType(pkgRef, 0)
 
@@ -93,7 +93,7 @@ func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSl
 // Read takes a CSV reader and reads it into a typed List of structs. Each row gets read into a struct named structName, described by headers. If the original data contained headers it is expected that the input reader has already read those and are pointing at the first data row.
 // If kinds is non-empty, it will be used to type the fields in the generated structs; otherwise, they will be left as string-fields.
 // In addition to the list, Read returns the typeRef for the structs in the list, and last the typeDef of the structs.
-func Read(r *csv.Reader, structName string, headers []string, kinds KindSlice, vrw types.ValueReadWriter) (l types.List, typeRef, typeDef types.Type) {
+func Read(r *csv.Reader, structName string, headers []string, kinds KindSlice, vrw types.ValueReadWriter) (l types.List, typeRef, typeDef *types.Type) {
 	typeRef, typeDef = MakeStructTypeFromHeaders(headers, structName, kinds)
 	valueChan := make(chan types.Value, 128) // TODO: Make this a function param?
 	listType := types.MakeCompoundType(types.ListKind, typeRef)

--- a/datas/commit.go
+++ b/datas/commit.go
@@ -11,7 +11,7 @@ import (
 // package implemented by this file and registers it with the global
 // type package definition cache.
 func init() {
-	p := types.NewPackage([]types.Type{
+	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("Commit",
 			[]types.Field{
 				types.Field{"value", types.MakePrimitiveType(types.ValueKind), false},
@@ -41,9 +41,9 @@ func NewCommit() Commit {
 	}
 }
 
-var __typeForCommit types.Type
+var __typeForCommit *types.Type
 
-func (m Commit) Type() types.Type {
+func (m Commit) Type() *types.Type {
 	return __typeForCommit
 }
 
@@ -111,7 +111,7 @@ func (s Commit) SetParents(val types.Set) Commit {
 	return s
 }
 
-func typeForMapOfStringToRefOfCommit() types.Type {
+func typeForMapOfStringToRefOfCommit() *types.Type {
 	return types.MakeMapType(types.StringType, types.MakeRefType(__typeForCommit))
 }
 
@@ -119,7 +119,7 @@ func NewMapOfStringToRefOfCommit() types.Map {
 	return types.NewTypedMap(typeForMapOfStringToRefOfCommit())
 }
 
-func typeForSetOfRefOfCommit() types.Type {
+func typeForSetOfRefOfCommit() *types.Type {
 	return types.MakeSetType(types.MakeRefType(__typeForCommit))
 }
 

--- a/nomdl/codegen/code/generate.go
+++ b/nomdl/codegen/code/generate.go
@@ -1,4 +1,4 @@
-// Package code provides Generator, which has methods for generating code snippets from a types.Type.
+// Package code provides Generator, which has methods for generating code snippets from a *types.Type.
 // Conceptually there are few type spaces here:
 //
 // - Def - MyStructDef, ListOfBoolDef; convenient Go types for working with data from a given Noms Value.
@@ -21,7 +21,7 @@ import (
 
 // Resolver provides a single method for resolving an unresolved types.Type.
 type Resolver interface {
-	Resolve(t types.Type, pkg *types.Package) types.Type
+	Resolve(t *types.Type, pkg *types.Package) *types.Type
 }
 
 // Generator provides methods for generating code snippets from both resolved and unresolved types.Types. In the latter case, it uses R to resolve the types.Type before generating code.
@@ -35,7 +35,7 @@ type Generator struct {
 }
 
 // DefType returns a string containing the Go type that should be used as the 'Def' for the Noms type described by t.
-func (gen *Generator) DefType(t types.Type) string {
+func (gen *Generator) DefType(t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -58,7 +58,7 @@ func (gen *Generator) DefType(t types.Type) string {
 }
 
 // UserType returns a string containing the Go type that should be used when the Noms type described by t needs to be returned by a generated getter or taken as a parameter to a generated setter.
-func (gen *Generator) UserType(t types.Type) string {
+func (gen *Generator) UserType(t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -79,7 +79,7 @@ func (gen *Generator) UserType(t types.Type) string {
 }
 
 // UserTypeJS returns a string containing the JS type that should be used when the Noms type described by t needs to be returned by a generated getter or taken as a parameter to a generated setter.
-func (gen *Generator) UserTypeJS(t types.Type) string {
+func (gen *Generator) UserTypeJS(t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -116,7 +116,7 @@ func (gen *Generator) UserTypeJS(t types.Type) string {
 }
 
 // DefToValue returns a string containing Go code to convert an instance of a Def type (named val) to a Noms types.Value of the type described by t.
-func (gen *Generator) DefToValue(val string, t types.Type) string {
+func (gen *Generator) DefToValue(val string, t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	switch rt.Kind() {
 	case types.BlobKind, types.PackageKind, types.ValueKind, types.TypeKind:
@@ -132,7 +132,7 @@ func (gen *Generator) DefToValue(val string, t types.Type) string {
 }
 
 // DefToUser returns a string containing Go code to convert an instance of a Def type (named val) to a User type described by t.
-func (gen *Generator) DefToUser(val string, t types.Type) string {
+func (gen *Generator) DefToUser(val string, t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	switch rt.Kind() {
 	case types.BlobKind, types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.PackageKind, types.StringKind, types.TypeKind, types.Uint16Kind, types.Uint32Kind, types.Uint64Kind, types.Uint8Kind, types.ValueKind:
@@ -144,7 +144,7 @@ func (gen *Generator) DefToUser(val string, t types.Type) string {
 }
 
 // MayHaveChunks returns whether the type (t) may contain more chunks.
-func (gen *Generator) MayHaveChunks(t types.Type) bool {
+func (gen *Generator) MayHaveChunks(t *types.Type) bool {
 	rt := gen.R.Resolve(t, gen.Package)
 	switch rt.Kind() {
 	case types.BlobKind, types.ListKind, types.MapKind, types.PackageKind, types.RefKind, types.SetKind, types.StructKind, types.TypeKind, types.ValueKind:
@@ -156,7 +156,7 @@ func (gen *Generator) MayHaveChunks(t types.Type) bool {
 }
 
 // ValueToDef returns a string containing Go code to convert an instance of a types.Value (val) into the Def type appropriate for t.
-func (gen *Generator) ValueToDef(val string, t types.Type) string {
+func (gen *Generator) ValueToDef(val string, t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	switch rt.Kind() {
 	case types.BlobKind, types.PackageKind, types.TypeKind:
@@ -174,7 +174,7 @@ func (gen *Generator) ValueToDef(val string, t types.Type) string {
 }
 
 // UserToDef returns a string containing Go code to convert an User value (val) into the Def type appropriate for t.
-func (gen *Generator) UserToDef(val string, t types.Type) string {
+func (gen *Generator) UserToDef(val string, t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	switch rt.Kind() {
 	case types.BlobKind, types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.PackageKind, types.StringKind, types.TypeKind, types.Uint16Kind, types.Uint32Kind, types.Uint64Kind, types.Uint8Kind, types.ValueKind:
@@ -188,7 +188,7 @@ func (gen *Generator) UserToDef(val string, t types.Type) string {
 }
 
 // NativeToValue returns a string containing Go code to convert an instance of a native type (named val) to a Noms types.Value of the type described by t.
-func (gen *Generator) NativeToValue(val string, t types.Type) string {
+func (gen *Generator) NativeToValue(val string, t *types.Type) string {
 	t = gen.R.Resolve(t, gen.Package)
 	k := t.Kind()
 	switch k {
@@ -201,7 +201,7 @@ func (gen *Generator) NativeToValue(val string, t types.Type) string {
 }
 
 // ValueToNative returns a string containing Go code to convert an instance of a types.Value (val) into the native type appropriate for t.
-func (gen *Generator) ValueToNative(val string, t types.Type) string {
+func (gen *Generator) ValueToNative(val string, t *types.Type) string {
 	k := t.Kind()
 	switch k {
 	case types.BoolKind, types.Float32Kind, types.Float64Kind, types.Int16Kind, types.Int32Kind, types.Int64Kind, types.Int8Kind, types.Uint16Kind, types.Uint32Kind, types.Uint64Kind, types.Uint8Kind:
@@ -214,7 +214,7 @@ func (gen *Generator) ValueToNative(val string, t types.Type) string {
 }
 
 // UserToValue returns a string containing Go code to convert an instance of a User type (named val) to a Noms types.Value of the type described by t. For Go primitive types, this will use NativeToValue(). For other types, their UserType is a Noms types.Value (or a wrapper around one), so this is more-or-less a pass-through.
-func (gen *Generator) UserToValue(val string, t types.Type) string {
+func (gen *Generator) UserToValue(val string, t *types.Type) string {
 	t = gen.R.Resolve(t, gen.Package)
 	k := t.Kind()
 	switch k {
@@ -227,7 +227,7 @@ func (gen *Generator) UserToValue(val string, t types.Type) string {
 }
 
 // ValueToUser returns a string containing Go code to convert an instance of a types.Value (val) into the User type appropriate for t. For Go primitives, this will use ValueToNative().
-func (gen *Generator) ValueToUser(val string, t types.Type) string {
+func (gen *Generator) ValueToUser(val string, t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -248,7 +248,7 @@ func (gen *Generator) ValueToUser(val string, t types.Type) string {
 }
 
 // UserZero returns a string containing Go code to create an uninitialized instance of the User type appropriate for t.
-func (gen *Generator) UserZero(t types.Type) string {
+func (gen *Generator) UserZero(t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -276,7 +276,7 @@ func (gen *Generator) UserZero(t types.Type) string {
 }
 
 // ValueZero returns a string containing Go code to create an uninitialized instance of the Noms types.Value appropriate for t.
-func (gen *Generator) ValueZero(t types.Type) string {
+func (gen *Generator) ValueZero(t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -304,7 +304,7 @@ func (gen *Generator) ValueZero(t types.Type) string {
 }
 
 // UserName returns the name of the User type appropriate for t, taking into account Noms types imported from other packages.
-func (gen *Generator) UserName(t types.Type) string {
+func (gen *Generator) UserName(t *types.Type) string {
 	rt := gen.R.Resolve(t, gen.Package)
 	k := rt.Kind()
 	switch k {
@@ -337,12 +337,12 @@ func (gen *Generator) UserName(t types.Type) string {
 	panic("unreachable")
 }
 
-func (gen Generator) importedUserNameJS(t types.Type) string {
+func (gen Generator) importedUserNameJS(t *types.Type) string {
 	d.Chk.True(t.HasPackageRef())
 	return fmt.Sprintf("%s.%s", gen.RefToAliasName(t.PackageRef()), gen.UserName(t))
 }
 
-func (gen *Generator) refToID(t types.Type) string {
+func (gen *Generator) refToID(t *types.Type) string {
 	if !t.IsUnresolved() || !t.HasPackageRef() {
 		return gen.UserName(t)
 	}
@@ -363,8 +363,8 @@ func (gen *Generator) RefToAliasName(r ref.Ref) string {
 	return fmt.Sprintf("_%s", gen.RefToJSIdentfierName(r))
 }
 
-// ToTypesType returns a string containing Go code that instantiates a types.Type instance equivalent to t.
-func (gen *Generator) ToTypesType(t types.Type, inPackageDef bool) string {
+// ToTypesType returns a string containing Go code that instantiates a *types.Type instance equivalent to t.
+func (gen *Generator) ToTypesType(t *types.Type, inPackageDef bool) string {
 	if t.IsUnresolved() {
 		d.Chk.True(t.HasPackageRef())
 		d.Chk.True(t.HasOrdinal(), "%s does not have an ordinal set", t.Name())
@@ -413,7 +413,7 @@ func firstToLower(s string) string {
 }
 
 // ToTypeValueJS returns a string containing JS code that instantiates a Type instance equivalent to t for JavaScript.
-func (gen *Generator) ToTypeValueJS(t types.Type, inPackageDef bool, indent int) string {
+func (gen *Generator) ToTypeValueJS(t *types.Type, inPackageDef bool, indent int) string {
 	if t.IsUnresolved() {
 		d.Chk.True(t.HasPackageRef())
 		d.Chk.True(t.HasOrdinal(), "%s does not have an ordinal set", t.Name())

--- a/nomdl/codegen/code/generate_test.go
+++ b/nomdl/codegen/code/generate_test.go
@@ -13,7 +13,7 @@ type testResolver struct {
 	deps   map[ref.Ref]types.Package
 }
 
-func (res *testResolver) Resolve(t types.Type, pkg *types.Package) types.Type {
+func (res *testResolver) Resolve(t *types.Type, pkg *types.Package) *types.Type {
 	if !t.IsUnresolved() {
 		return t
 	}
@@ -34,7 +34,7 @@ func (res *testResolver) Resolve(t types.Type, pkg *types.Package) types.Type {
 func TestUserName(t *testing.T) {
 	assert := assert.New(t)
 
-	imported := types.NewPackage([]types.Type{
+	imported := types.NewPackage([]*types.Type{
 		types.MakeStructType("S1", []types.Field{
 			types.Field{"f", types.MakePrimitiveType(types.BoolKind), false},
 		}, []types.Field{}),

--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -70,13 +70,13 @@ func TestSkipDuplicateTypes(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
-	leaf1 := types.NewPackage([]types.Type{
+	leaf1 := types.NewPackage([]*types.Type{
 		types.MakeStructType("S1", []types.Field{
 			types.Field{"f", types.MakeCompoundType(types.ListKind, types.MakePrimitiveType(types.Uint16Kind)), false},
 			types.Field{"e", types.MakeType(ref.Ref{}, 0), false},
 		}, []types.Field{}),
 	}, []ref.Ref{})
-	leaf2 := types.NewPackage([]types.Type{
+	leaf2 := types.NewPackage([]*types.Type{
 		types.MakeStructType("S2", []types.Field{
 			types.Field{"f", types.MakeCompoundType(types.ListKind, types.MakePrimitiveType(types.Uint16Kind)), false},
 		}, []types.Field{}),

--- a/nomdl/pkg/grammar.peg
+++ b/nomdl/pkg/grammar.peg
@@ -14,9 +14,9 @@ type namespaceIdent struct {
 
 Package <- _ dd:Definition+ _ EOF {
 	aliases := map[string]string{}
-	usings := []types.Type{}
+	usings := []*types.Type{}
 	seenTypes := map[string]bool{}
-	orderedTypes := []types.Type{}
+	orderedTypes := []*types.Type{}
 	for _, d := range dd.([]interface{}) {
 		switch d := d.(type) {
 		default:
@@ -26,7 +26,7 @@ Package <- _ dd:Definition+ _ EOF {
 				return nil, fmt.Errorf("Redefinition of " + d.Name)
 			}
 			aliases[d.Name] = d.Target
-		case types.Type:
+		case *types.Type:
 			switch d.Kind() {
 			default:
 				return nil, fmt.Errorf("%v can't be defined at the top-level", d)
@@ -109,16 +109,16 @@ Union <- `union` _ `{` _ u:UnionField+ _ `}` _ {
 }
 
 Field <- i:Ident _ `:` _ o:(`optional` _)? t:Type _ {
-	return types.Field{i.(string), t.(types.Type), o != nil}, nil
+	return types.Field{i.(string), t.(*types.Type), o != nil}, nil
 }
 
 UnionField <- i:Ident _ `:` _ t:Type _ {
-	return types.Field{i.(string), t.(types.Type), false}, nil
+	return types.Field{i.(string), t.(*types.Type), false}, nil
 }
 
 Type <- t:(PrimitiveType / CompoundType / Union / NamespaceIdent) {
 	switch t := t.(type) {
-	case types.Type:
+	case *types.Type:
 		return t, nil
 	case []types.Field:
 		return types.MakeStructType("", nil, t), nil
@@ -130,13 +130,13 @@ Type <- t:(PrimitiveType / CompoundType / Union / NamespaceIdent) {
 }
 
 CompoundType <- `List` _ `<` _ t:Type _ `>` _ {
-	return types.MakeCompoundType(types.ListKind, t.(types.Type)), nil
+	return types.MakeCompoundType(types.ListKind, t.(*types.Type)), nil
 } / `Map` _ `<` _ k:Type _ `,` _ v:Type _ `>` _ {
-	return types.MakeCompoundType(types.MapKind, k.(types.Type), v.(types.Type)), nil
+	return types.MakeCompoundType(types.MapKind, k.(*types.Type), v.(*types.Type)), nil
 } / `Set` _ `<` _ t:Type _ `>` _ {
-	return types.MakeCompoundType(types.SetKind, t.(types.Type)), nil
+	return types.MakeCompoundType(types.SetKind, t.(*types.Type)), nil
 } / `Ref` _ `<` _ t:Type _ `>` _ {
-	return types.MakeCompoundType(types.RefKind, t.(types.Type)), nil
+	return types.MakeCompoundType(types.RefKind, t.(*types.Type)), nil
 }
 
 PrimitiveType <- p:(`Uint64` / `Uint32` / `Uint16` / `Uint8` / `Int64` / `Int32` / `Int16` / `Int8` / `Float64` / `Float32` / `Bool` / `String` / `Blob` / `Value` / `Type`) {

--- a/nomdl/pkg/grammar.peg.go
+++ b/nomdl/pkg/grammar.peg.go
@@ -64,20 +64,20 @@ var g = &grammar{
 		},
 		{
 			name: "Definition",
-			pos:  position{line: 57, col: 1, offset: 1320},
+			pos:  position{line: 57, col: 1, offset: 1323},
 			expr: &choiceExpr{
-				pos: position{line: 57, col: 15, offset: 1334},
+				pos: position{line: 57, col: 15, offset: 1337},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 57, col: 15, offset: 1334},
+						pos:  position{line: 57, col: 15, offset: 1337},
 						name: "Struct",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 57, col: 24, offset: 1343},
+						pos:  position{line: 57, col: 24, offset: 1346},
 						name: "Using",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 57, col: 32, offset: 1351},
+						pos:  position{line: 57, col: 32, offset: 1354},
 						name: "Alias",
 					},
 				},
@@ -85,62 +85,62 @@ var g = &grammar{
 		},
 		{
 			name: "Alias",
-			pos:  position{line: 59, col: 1, offset: 1358},
+			pos:  position{line: 59, col: 1, offset: 1361},
 			expr: &actionExpr{
-				pos: position{line: 59, col: 10, offset: 1367},
+				pos: position{line: 59, col: 10, offset: 1370},
 				run: (*parser).callonAlias1,
 				expr: &seqExpr{
-					pos: position{line: 59, col: 10, offset: 1367},
+					pos: position{line: 59, col: 10, offset: 1370},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 59, col: 10, offset: 1367},
+							pos:        position{line: 59, col: 10, offset: 1370},
 							val:        "alias",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 59, col: 18, offset: 1375},
+							pos:  position{line: 59, col: 18, offset: 1378},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 59, col: 20, offset: 1377},
+							pos:   position{line: 59, col: 20, offset: 1380},
 							label: "i",
 							expr: &ruleRefExpr{
-								pos:  position{line: 59, col: 22, offset: 1379},
+								pos:  position{line: 59, col: 22, offset: 1382},
 								name: "Ident",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 59, col: 28, offset: 1385},
+							pos:  position{line: 59, col: 28, offset: 1388},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 59, col: 30, offset: 1387},
+							pos:        position{line: 59, col: 30, offset: 1390},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 59, col: 34, offset: 1391},
+							pos:  position{line: 59, col: 34, offset: 1394},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 59, col: 36, offset: 1393},
+							pos:        position{line: 59, col: 36, offset: 1396},
 							val:        "import",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 59, col: 45, offset: 1402},
+							pos:  position{line: 59, col: 45, offset: 1405},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 59, col: 47, offset: 1404},
+							pos:   position{line: 59, col: 47, offset: 1407},
 							label: "q",
 							expr: &ruleRefExpr{
-								pos:  position{line: 59, col: 49, offset: 1406},
+								pos:  position{line: 59, col: 49, offset: 1409},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 59, col: 62, offset: 1419},
+							pos:  position{line: 59, col: 62, offset: 1422},
 							name: "_",
 						},
 					},
@@ -149,32 +149,32 @@ var g = &grammar{
 		},
 		{
 			name: "Using",
-			pos:  position{line: 63, col: 1, offset: 1469},
+			pos:  position{line: 63, col: 1, offset: 1472},
 			expr: &actionExpr{
-				pos: position{line: 63, col: 10, offset: 1478},
+				pos: position{line: 63, col: 10, offset: 1481},
 				run: (*parser).callonUsing1,
 				expr: &seqExpr{
-					pos: position{line: 63, col: 10, offset: 1478},
+					pos: position{line: 63, col: 10, offset: 1481},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 63, col: 10, offset: 1478},
+							pos:        position{line: 63, col: 10, offset: 1481},
 							val:        "using",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 63, col: 18, offset: 1486},
+							pos:  position{line: 63, col: 18, offset: 1489},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 63, col: 20, offset: 1488},
+							pos:   position{line: 63, col: 20, offset: 1491},
 							label: "ct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 63, col: 23, offset: 1491},
+								pos:  position{line: 63, col: 23, offset: 1494},
 								name: "CompoundType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 63, col: 36, offset: 1504},
+							pos:  position{line: 63, col: 36, offset: 1507},
 							name: "_",
 						},
 					},
@@ -183,65 +183,65 @@ var g = &grammar{
 		},
 		{
 			name: "Struct",
-			pos:  position{line: 68, col: 1, offset: 1528},
+			pos:  position{line: 68, col: 1, offset: 1531},
 			expr: &actionExpr{
-				pos: position{line: 68, col: 11, offset: 1538},
+				pos: position{line: 68, col: 11, offset: 1541},
 				run: (*parser).callonStruct1,
 				expr: &seqExpr{
-					pos: position{line: 68, col: 11, offset: 1538},
+					pos: position{line: 68, col: 11, offset: 1541},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 68, col: 11, offset: 1538},
+							pos:        position{line: 68, col: 11, offset: 1541},
 							val:        "struct",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 68, col: 20, offset: 1547},
+							pos:  position{line: 68, col: 20, offset: 1550},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 68, col: 22, offset: 1549},
+							pos:   position{line: 68, col: 22, offset: 1552},
 							label: "i",
 							expr: &ruleRefExpr{
-								pos:  position{line: 68, col: 24, offset: 1551},
+								pos:  position{line: 68, col: 24, offset: 1554},
 								name: "Ident",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 68, col: 30, offset: 1557},
+							pos:  position{line: 68, col: 30, offset: 1560},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 68, col: 32, offset: 1559},
+							pos:        position{line: 68, col: 32, offset: 1562},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 68, col: 36, offset: 1563},
+							pos:  position{line: 68, col: 36, offset: 1566},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 68, col: 38, offset: 1565},
+							pos:   position{line: 68, col: 38, offset: 1568},
 							label: "l",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 68, col: 40, offset: 1567},
+								pos: position{line: 68, col: 40, offset: 1570},
 								expr: &ruleRefExpr{
-									pos:  position{line: 68, col: 40, offset: 1567},
+									pos:  position{line: 68, col: 40, offset: 1570},
 									name: "StructEntry",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 68, col: 53, offset: 1580},
+							pos:  position{line: 68, col: 53, offset: 1583},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 68, col: 55, offset: 1582},
+							pos:        position{line: 68, col: 55, offset: 1585},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 68, col: 59, offset: 1586},
+							pos:  position{line: 68, col: 59, offset: 1589},
 							name: "_",
 						},
 					},
@@ -250,16 +250,16 @@ var g = &grammar{
 		},
 		{
 			name: "StructEntry",
-			pos:  position{line: 93, col: 1, offset: 2266},
+			pos:  position{line: 93, col: 1, offset: 2269},
 			expr: &choiceExpr{
-				pos: position{line: 93, col: 16, offset: 2281},
+				pos: position{line: 93, col: 16, offset: 2284},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 93, col: 16, offset: 2281},
+						pos:  position{line: 93, col: 16, offset: 2284},
 						name: "Union",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 93, col: 24, offset: 2289},
+						pos:  position{line: 93, col: 24, offset: 2292},
 						name: "Field",
 					},
 				},
@@ -267,53 +267,53 @@ var g = &grammar{
 		},
 		{
 			name: "Union",
-			pos:  position{line: 96, col: 1, offset: 2297},
+			pos:  position{line: 96, col: 1, offset: 2300},
 			expr: &actionExpr{
-				pos: position{line: 96, col: 10, offset: 2306},
+				pos: position{line: 96, col: 10, offset: 2309},
 				run: (*parser).callonUnion1,
 				expr: &seqExpr{
-					pos: position{line: 96, col: 10, offset: 2306},
+					pos: position{line: 96, col: 10, offset: 2309},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 96, col: 10, offset: 2306},
+							pos:        position{line: 96, col: 10, offset: 2309},
 							val:        "union",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 96, col: 18, offset: 2314},
+							pos:  position{line: 96, col: 18, offset: 2317},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 96, col: 20, offset: 2316},
+							pos:        position{line: 96, col: 20, offset: 2319},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 96, col: 24, offset: 2320},
+							pos:  position{line: 96, col: 24, offset: 2323},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 96, col: 26, offset: 2322},
+							pos:   position{line: 96, col: 26, offset: 2325},
 							label: "u",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 96, col: 28, offset: 2324},
+								pos: position{line: 96, col: 28, offset: 2327},
 								expr: &ruleRefExpr{
-									pos:  position{line: 96, col: 28, offset: 2324},
+									pos:  position{line: 96, col: 28, offset: 2327},
 									name: "UnionField",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 96, col: 40, offset: 2336},
+							pos:  position{line: 96, col: 40, offset: 2339},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 96, col: 42, offset: 2338},
+							pos:        position{line: 96, col: 42, offset: 2341},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 96, col: 46, offset: 2342},
+							pos:  position{line: 96, col: 46, offset: 2345},
 							name: "_",
 						},
 					},
@@ -322,49 +322,49 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 111, col: 1, offset: 2676},
+			pos:  position{line: 111, col: 1, offset: 2679},
 			expr: &actionExpr{
-				pos: position{line: 111, col: 10, offset: 2685},
+				pos: position{line: 111, col: 10, offset: 2688},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 111, col: 10, offset: 2685},
+					pos: position{line: 111, col: 10, offset: 2688},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 111, col: 10, offset: 2685},
+							pos:   position{line: 111, col: 10, offset: 2688},
 							label: "i",
 							expr: &ruleRefExpr{
-								pos:  position{line: 111, col: 12, offset: 2687},
+								pos:  position{line: 111, col: 12, offset: 2690},
 								name: "Ident",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 111, col: 18, offset: 2693},
+							pos:  position{line: 111, col: 18, offset: 2696},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 111, col: 20, offset: 2695},
+							pos:        position{line: 111, col: 20, offset: 2698},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 111, col: 24, offset: 2699},
+							pos:  position{line: 111, col: 24, offset: 2702},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 111, col: 26, offset: 2701},
+							pos:   position{line: 111, col: 26, offset: 2704},
 							label: "o",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 111, col: 28, offset: 2703},
+								pos: position{line: 111, col: 28, offset: 2706},
 								expr: &seqExpr{
-									pos: position{line: 111, col: 29, offset: 2704},
+									pos: position{line: 111, col: 29, offset: 2707},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 111, col: 29, offset: 2704},
+											pos:        position{line: 111, col: 29, offset: 2707},
 											val:        "optional",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 111, col: 40, offset: 2715},
+											pos:  position{line: 111, col: 40, offset: 2718},
 											name: "_",
 										},
 									},
@@ -372,15 +372,15 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 111, col: 44, offset: 2719},
+							pos:   position{line: 111, col: 44, offset: 2722},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 111, col: 46, offset: 2721},
+								pos:  position{line: 111, col: 46, offset: 2724},
 								name: "Type",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 111, col: 51, offset: 2726},
+							pos:  position{line: 111, col: 51, offset: 2729},
 							name: "_",
 						},
 					},
@@ -389,44 +389,44 @@ var g = &grammar{
 		},
 		{
 			name: "UnionField",
-			pos:  position{line: 115, col: 1, offset: 2796},
+			pos:  position{line: 115, col: 1, offset: 2800},
 			expr: &actionExpr{
-				pos: position{line: 115, col: 15, offset: 2810},
+				pos: position{line: 115, col: 15, offset: 2814},
 				run: (*parser).callonUnionField1,
 				expr: &seqExpr{
-					pos: position{line: 115, col: 15, offset: 2810},
+					pos: position{line: 115, col: 15, offset: 2814},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 115, col: 15, offset: 2810},
+							pos:   position{line: 115, col: 15, offset: 2814},
 							label: "i",
 							expr: &ruleRefExpr{
-								pos:  position{line: 115, col: 17, offset: 2812},
+								pos:  position{line: 115, col: 17, offset: 2816},
 								name: "Ident",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 23, offset: 2818},
+							pos:  position{line: 115, col: 23, offset: 2822},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 25, offset: 2820},
+							pos:        position{line: 115, col: 25, offset: 2824},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 29, offset: 2824},
+							pos:  position{line: 115, col: 29, offset: 2828},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 115, col: 31, offset: 2826},
+							pos:   position{line: 115, col: 31, offset: 2830},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 115, col: 33, offset: 2828},
+								pos:  position{line: 115, col: 33, offset: 2832},
 								name: "Type",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 38, offset: 2833},
+							pos:  position{line: 115, col: 38, offset: 2837},
 							name: "_",
 						},
 					},
@@ -435,30 +435,30 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 119, col: 1, offset: 2900},
+			pos:  position{line: 119, col: 1, offset: 2905},
 			expr: &actionExpr{
-				pos: position{line: 119, col: 9, offset: 2908},
+				pos: position{line: 119, col: 9, offset: 2913},
 				run: (*parser).callonType1,
 				expr: &labeledExpr{
-					pos:   position{line: 119, col: 9, offset: 2908},
+					pos:   position{line: 119, col: 9, offset: 2913},
 					label: "t",
 					expr: &choiceExpr{
-						pos: position{line: 119, col: 12, offset: 2911},
+						pos: position{line: 119, col: 12, offset: 2916},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 119, col: 12, offset: 2911},
+								pos:  position{line: 119, col: 12, offset: 2916},
 								name: "PrimitiveType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 119, col: 28, offset: 2927},
+								pos:  position{line: 119, col: 28, offset: 2932},
 								name: "CompoundType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 119, col: 43, offset: 2942},
+								pos:  position{line: 119, col: 43, offset: 2947},
 								name: "Union",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 119, col: 51, offset: 2950},
+								pos:  position{line: 119, col: 51, offset: 2955},
 								name: "NamespaceIdent",
 							},
 						},
@@ -468,218 +468,218 @@ var g = &grammar{
 		},
 		{
 			name: "CompoundType",
-			pos:  position{line: 132, col: 1, offset: 3268},
+			pos:  position{line: 132, col: 1, offset: 3274},
 			expr: &choiceExpr{
-				pos: position{line: 132, col: 17, offset: 3284},
+				pos: position{line: 132, col: 17, offset: 3290},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 132, col: 17, offset: 3284},
+						pos: position{line: 132, col: 17, offset: 3290},
 						run: (*parser).callonCompoundType2,
 						expr: &seqExpr{
-							pos: position{line: 132, col: 17, offset: 3284},
+							pos: position{line: 132, col: 17, offset: 3290},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 132, col: 17, offset: 3284},
+									pos:        position{line: 132, col: 17, offset: 3290},
 									val:        "List",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 132, col: 24, offset: 3291},
+									pos:  position{line: 132, col: 24, offset: 3297},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 132, col: 26, offset: 3293},
+									pos:        position{line: 132, col: 26, offset: 3299},
 									val:        "<",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 132, col: 30, offset: 3297},
+									pos:  position{line: 132, col: 30, offset: 3303},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 132, col: 32, offset: 3299},
+									pos:   position{line: 132, col: 32, offset: 3305},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 132, col: 34, offset: 3301},
+										pos:  position{line: 132, col: 34, offset: 3307},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 132, col: 39, offset: 3306},
+									pos:  position{line: 132, col: 39, offset: 3312},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 132, col: 41, offset: 3308},
+									pos:        position{line: 132, col: 41, offset: 3314},
 									val:        ">",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 132, col: 45, offset: 3312},
+									pos:  position{line: 132, col: 45, offset: 3318},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 134, col: 5, offset: 3388},
+						pos: position{line: 134, col: 5, offset: 3395},
 						run: (*parser).callonCompoundType13,
 						expr: &seqExpr{
-							pos: position{line: 134, col: 5, offset: 3388},
+							pos: position{line: 134, col: 5, offset: 3395},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 134, col: 5, offset: 3388},
+									pos:        position{line: 134, col: 5, offset: 3395},
 									val:        "Map",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 134, col: 11, offset: 3394},
+									pos:  position{line: 134, col: 11, offset: 3401},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 134, col: 13, offset: 3396},
+									pos:        position{line: 134, col: 13, offset: 3403},
 									val:        "<",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 134, col: 17, offset: 3400},
+									pos:  position{line: 134, col: 17, offset: 3407},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 134, col: 19, offset: 3402},
+									pos:   position{line: 134, col: 19, offset: 3409},
 									label: "k",
 									expr: &ruleRefExpr{
-										pos:  position{line: 134, col: 21, offset: 3404},
+										pos:  position{line: 134, col: 21, offset: 3411},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 134, col: 26, offset: 3409},
+									pos:  position{line: 134, col: 26, offset: 3416},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 134, col: 28, offset: 3411},
+									pos:        position{line: 134, col: 28, offset: 3418},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 134, col: 32, offset: 3415},
+									pos:  position{line: 134, col: 32, offset: 3422},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 134, col: 34, offset: 3417},
+									pos:   position{line: 134, col: 34, offset: 3424},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 134, col: 36, offset: 3419},
+										pos:  position{line: 134, col: 36, offset: 3426},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 134, col: 41, offset: 3424},
+									pos:  position{line: 134, col: 41, offset: 3431},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 134, col: 43, offset: 3426},
+									pos:        position{line: 134, col: 43, offset: 3433},
 									val:        ">",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 134, col: 47, offset: 3430},
+									pos:  position{line: 134, col: 47, offset: 3437},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 136, col: 5, offset: 3521},
+						pos: position{line: 136, col: 5, offset: 3530},
 						run: (*parser).callonCompoundType29,
 						expr: &seqExpr{
-							pos: position{line: 136, col: 5, offset: 3521},
+							pos: position{line: 136, col: 5, offset: 3530},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 136, col: 5, offset: 3521},
+									pos:        position{line: 136, col: 5, offset: 3530},
 									val:        "Set",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 136, col: 11, offset: 3527},
+									pos:  position{line: 136, col: 11, offset: 3536},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 136, col: 13, offset: 3529},
+									pos:        position{line: 136, col: 13, offset: 3538},
 									val:        "<",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 136, col: 17, offset: 3533},
+									pos:  position{line: 136, col: 17, offset: 3542},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 136, col: 19, offset: 3535},
+									pos:   position{line: 136, col: 19, offset: 3544},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 136, col: 21, offset: 3537},
+										pos:  position{line: 136, col: 21, offset: 3546},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 136, col: 26, offset: 3542},
+									pos:  position{line: 136, col: 26, offset: 3551},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 136, col: 28, offset: 3544},
+									pos:        position{line: 136, col: 28, offset: 3553},
 									val:        ">",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 136, col: 32, offset: 3548},
+									pos:  position{line: 136, col: 32, offset: 3557},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 138, col: 5, offset: 3623},
+						pos: position{line: 138, col: 5, offset: 3633},
 						run: (*parser).callonCompoundType40,
 						expr: &seqExpr{
-							pos: position{line: 138, col: 5, offset: 3623},
+							pos: position{line: 138, col: 5, offset: 3633},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 138, col: 5, offset: 3623},
+									pos:        position{line: 138, col: 5, offset: 3633},
 									val:        "Ref",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 138, col: 11, offset: 3629},
+									pos:  position{line: 138, col: 11, offset: 3639},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 138, col: 13, offset: 3631},
+									pos:        position{line: 138, col: 13, offset: 3641},
 									val:        "<",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 138, col: 17, offset: 3635},
+									pos:  position{line: 138, col: 17, offset: 3645},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 138, col: 19, offset: 3637},
+									pos:   position{line: 138, col: 19, offset: 3647},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 138, col: 21, offset: 3639},
+										pos:  position{line: 138, col: 21, offset: 3649},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 138, col: 26, offset: 3644},
+									pos:  position{line: 138, col: 26, offset: 3654},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 138, col: 28, offset: 3646},
+									pos:        position{line: 138, col: 28, offset: 3656},
 									val:        ">",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 138, col: 32, offset: 3650},
+									pos:  position{line: 138, col: 32, offset: 3660},
 									name: "_",
 								},
 							},
@@ -690,88 +690,88 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 142, col: 1, offset: 3724},
+			pos:  position{line: 142, col: 1, offset: 3735},
 			expr: &actionExpr{
-				pos: position{line: 142, col: 18, offset: 3741},
+				pos: position{line: 142, col: 18, offset: 3752},
 				run: (*parser).callonPrimitiveType1,
 				expr: &labeledExpr{
-					pos:   position{line: 142, col: 18, offset: 3741},
+					pos:   position{line: 142, col: 18, offset: 3752},
 					label: "p",
 					expr: &choiceExpr{
-						pos: position{line: 142, col: 21, offset: 3744},
+						pos: position{line: 142, col: 21, offset: 3755},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 142, col: 21, offset: 3744},
+								pos:        position{line: 142, col: 21, offset: 3755},
 								val:        "Uint64",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 32, offset: 3755},
+								pos:        position{line: 142, col: 32, offset: 3766},
 								val:        "Uint32",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 43, offset: 3766},
+								pos:        position{line: 142, col: 43, offset: 3777},
 								val:        "Uint16",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 54, offset: 3777},
+								pos:        position{line: 142, col: 54, offset: 3788},
 								val:        "Uint8",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 64, offset: 3787},
+								pos:        position{line: 142, col: 64, offset: 3798},
 								val:        "Int64",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 74, offset: 3797},
+								pos:        position{line: 142, col: 74, offset: 3808},
 								val:        "Int32",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 84, offset: 3807},
+								pos:        position{line: 142, col: 84, offset: 3818},
 								val:        "Int16",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 94, offset: 3817},
+								pos:        position{line: 142, col: 94, offset: 3828},
 								val:        "Int8",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 103, offset: 3826},
+								pos:        position{line: 142, col: 103, offset: 3837},
 								val:        "Float64",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 115, offset: 3838},
+								pos:        position{line: 142, col: 115, offset: 3849},
 								val:        "Float32",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 127, offset: 3850},
+								pos:        position{line: 142, col: 127, offset: 3861},
 								val:        "Bool",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 136, offset: 3859},
+								pos:        position{line: 142, col: 136, offset: 3870},
 								val:        "String",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 147, offset: 3870},
+								pos:        position{line: 142, col: 147, offset: 3881},
 								val:        "Blob",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 156, offset: 3879},
+								pos:        position{line: 142, col: 156, offset: 3890},
 								val:        "Value",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 142, col: 166, offset: 3889},
+								pos:        position{line: 142, col: 166, offset: 3900},
 								val:        "Type",
 								ignoreCase: false,
 							},
@@ -782,28 +782,28 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 146, col: 1, offset: 3968},
+			pos:  position{line: 146, col: 1, offset: 3979},
 			expr: &actionExpr{
-				pos: position{line: 146, col: 17, offset: 3984},
+				pos: position{line: 146, col: 17, offset: 3995},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 146, col: 17, offset: 3984},
+					pos: position{line: 146, col: 17, offset: 3995},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 146, col: 17, offset: 3984},
+							pos:        position{line: 146, col: 17, offset: 3995},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 146, col: 21, offset: 3988},
+							pos:   position{line: 146, col: 21, offset: 3999},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 146, col: 23, offset: 3990},
+								pos:  position{line: 146, col: 23, offset: 4001},
 								name: "String",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 146, col: 30, offset: 3997},
+							pos:        position{line: 146, col: 30, offset: 4008},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -813,42 +813,42 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 150, col: 1, offset: 4030},
+			pos:  position{line: 150, col: 1, offset: 4041},
 			expr: &actionExpr{
-				pos: position{line: 150, col: 11, offset: 4040},
+				pos: position{line: 150, col: 11, offset: 4051},
 				run: (*parser).callonString1,
 				expr: &choiceExpr{
-					pos: position{line: 150, col: 12, offset: 4041},
+					pos: position{line: 150, col: 12, offset: 4052},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 150, col: 12, offset: 4041},
+							pos: position{line: 150, col: 12, offset: 4052},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 150, col: 12, offset: 4041},
+									pos:  position{line: 150, col: 12, offset: 4052},
 									name: "StringPiece",
 								},
 								&litMatcher{
-									pos:        position{line: 150, col: 24, offset: 4053},
+									pos:        position{line: 150, col: 24, offset: 4064},
 									val:        "\\\"",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 150, col: 29, offset: 4058},
+									pos:  position{line: 150, col: 29, offset: 4069},
 									name: "StringPiece",
 								},
 								&litMatcher{
-									pos:        position{line: 150, col: 41, offset: 4070},
+									pos:        position{line: 150, col: 41, offset: 4081},
 									val:        "\\\"",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 150, col: 46, offset: 4075},
+									pos:  position{line: 150, col: 46, offset: 4086},
 									name: "StringPiece",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 150, col: 60, offset: 4089},
+							pos:  position{line: 150, col: 60, offset: 4100},
 							name: "StringPiece",
 						},
 					},
@@ -857,24 +857,24 @@ var g = &grammar{
 		},
 		{
 			name: "StringPiece",
-			pos:  position{line: 154, col: 1, offset: 4135},
+			pos:  position{line: 154, col: 1, offset: 4146},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 154, col: 16, offset: 4150},
+				pos: position{line: 154, col: 16, offset: 4161},
 				expr: &choiceExpr{
-					pos: position{line: 154, col: 17, offset: 4151},
+					pos: position{line: 154, col: 17, offset: 4162},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 154, col: 17, offset: 4151},
+							pos: position{line: 154, col: 17, offset: 4162},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 154, col: 17, offset: 4151},
+									pos:        position{line: 154, col: 17, offset: 4162},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 154, col: 21, offset: 4155},
+									pos: position{line: 154, col: 21, offset: 4166},
 									expr: &litMatcher{
-										pos:        position{line: 154, col: 22, offset: 4156},
+										pos:        position{line: 154, col: 22, offset: 4167},
 										val:        "\"",
 										ignoreCase: false,
 									},
@@ -882,7 +882,7 @@ var g = &grammar{
 							},
 						},
 						&charClassMatcher{
-							pos:        position{line: 154, col: 28, offset: 4162},
+							pos:        position{line: 154, col: 28, offset: 4173},
 							val:        "[^\"\\\\]",
 							chars:      []rune{'"', '\\'},
 							ignoreCase: false,
@@ -894,27 +894,27 @@ var g = &grammar{
 		},
 		{
 			name: "NamespaceIdent",
-			pos:  position{line: 156, col: 1, offset: 4172},
+			pos:  position{line: 156, col: 1, offset: 4183},
 			expr: &actionExpr{
-				pos: position{line: 156, col: 19, offset: 4190},
+				pos: position{line: 156, col: 19, offset: 4201},
 				run: (*parser).callonNamespaceIdent1,
 				expr: &seqExpr{
-					pos: position{line: 156, col: 19, offset: 4190},
+					pos: position{line: 156, col: 19, offset: 4201},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 156, col: 19, offset: 4190},
+							pos:   position{line: 156, col: 19, offset: 4201},
 							label: "n",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 156, col: 21, offset: 4192},
+								pos: position{line: 156, col: 21, offset: 4203},
 								expr: &seqExpr{
-									pos: position{line: 156, col: 22, offset: 4193},
+									pos: position{line: 156, col: 22, offset: 4204},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 156, col: 22, offset: 4193},
+											pos:  position{line: 156, col: 22, offset: 4204},
 											name: "Ident",
 										},
 										&litMatcher{
-											pos:        position{line: 156, col: 28, offset: 4199},
+											pos:        position{line: 156, col: 28, offset: 4210},
 											val:        ".",
 											ignoreCase: false,
 										},
@@ -923,10 +923,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 156, col: 34, offset: 4205},
+							pos:   position{line: 156, col: 34, offset: 4216},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 156, col: 37, offset: 4208},
+								pos:  position{line: 156, col: 37, offset: 4219},
 								name: "Ident",
 							},
 						},
@@ -936,15 +936,15 @@ var g = &grammar{
 		},
 		{
 			name: "Ident",
-			pos:  position{line: 165, col: 1, offset: 4406},
+			pos:  position{line: 165, col: 1, offset: 4417},
 			expr: &actionExpr{
-				pos: position{line: 165, col: 10, offset: 4415},
+				pos: position{line: 165, col: 10, offset: 4426},
 				run: (*parser).callonIdent1,
 				expr: &seqExpr{
-					pos: position{line: 165, col: 10, offset: 4415},
+					pos: position{line: 165, col: 10, offset: 4426},
 					exprs: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 165, col: 10, offset: 4415},
+							pos:        position{line: 165, col: 10, offset: 4426},
 							val:        "[\\pL_]",
 							chars:      []rune{'_'},
 							classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -952,9 +952,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 165, col: 17, offset: 4422},
+							pos: position{line: 165, col: 17, offset: 4433},
 							expr: &charClassMatcher{
-								pos:        position{line: 165, col: 17, offset: 4422},
+								pos:        position{line: 165, col: 17, offset: 4433},
 								val:        "[\\pL\\pN_]",
 								chars:      []rune{'_'},
 								classes:    []*unicode.RangeTable{rangeTable("L"), rangeTable("N")},
@@ -969,28 +969,28 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"optional whitespace\"",
-			pos:         position{line: 169, col: 1, offset: 4466},
+			pos:         position{line: 169, col: 1, offset: 4477},
 			expr: &actionExpr{
-				pos: position{line: 169, col: 28, offset: 4493},
+				pos: position{line: 169, col: 28, offset: 4504},
 				run: (*parser).callon_1,
 				expr: &seqExpr{
-					pos: position{line: 169, col: 28, offset: 4493},
+					pos: position{line: 169, col: 28, offset: 4504},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 169, col: 28, offset: 4493},
+							pos:  position{line: 169, col: 28, offset: 4504},
 							name: "WS",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 169, col: 31, offset: 4496},
+							pos: position{line: 169, col: 31, offset: 4507},
 							expr: &seqExpr{
-								pos: position{line: 169, col: 32, offset: 4497},
+								pos: position{line: 169, col: 32, offset: 4508},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 169, col: 32, offset: 4497},
+										pos:  position{line: 169, col: 32, offset: 4508},
 										name: "Comment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 169, col: 40, offset: 4505},
+										pos:  position{line: 169, col: 40, offset: 4516},
 										name: "WS",
 									},
 								},
@@ -1002,11 +1002,11 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 173, col: 1, offset: 4532},
+			pos:  position{line: 173, col: 1, offset: 4543},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 173, col: 7, offset: 4538},
+				pos: position{line: 173, col: 7, offset: 4549},
 				expr: &charClassMatcher{
-					pos:        position{line: 173, col: 7, offset: 4538},
+					pos:        position{line: 173, col: 7, offset: 4549},
 					val:        "[\\r\\n\\t\\pZ]",
 					chars:      []rune{'\r', '\n', '\t'},
 					classes:    []*unicode.RangeTable{rangeTable("Z")},
@@ -1017,22 +1017,22 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 175, col: 1, offset: 4552},
+			pos:  position{line: 175, col: 1, offset: 4563},
 			expr: &choiceExpr{
-				pos: position{line: 175, col: 12, offset: 4563},
+				pos: position{line: 175, col: 12, offset: 4574},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 175, col: 12, offset: 4563},
+						pos: position{line: 175, col: 12, offset: 4574},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 175, col: 12, offset: 4563},
+								pos:        position{line: 175, col: 12, offset: 4574},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 175, col: 17, offset: 4568},
+								pos: position{line: 175, col: 17, offset: 4579},
 								expr: &charClassMatcher{
-									pos:        position{line: 175, col: 17, offset: 4568},
+									pos:        position{line: 175, col: 17, offset: 4579},
 									val:        "[^\\n]",
 									chars:      []rune{'\n'},
 									ignoreCase: false,
@@ -1042,7 +1042,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 175, col: 26, offset: 4577},
+						pos:  position{line: 175, col: 26, offset: 4588},
 						name: "MultilineComment",
 					},
 				},
@@ -1050,32 +1050,32 @@ var g = &grammar{
 		},
 		{
 			name: "MultilineComment",
-			pos:  position{line: 177, col: 1, offset: 4595},
+			pos:  position{line: 177, col: 1, offset: 4606},
 			expr: &seqExpr{
-				pos: position{line: 177, col: 21, offset: 4615},
+				pos: position{line: 177, col: 21, offset: 4626},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 177, col: 21, offset: 4615},
+						pos:        position{line: 177, col: 21, offset: 4626},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 177, col: 26, offset: 4620},
+						pos: position{line: 177, col: 26, offset: 4631},
 						expr: &choiceExpr{
-							pos: position{line: 177, col: 27, offset: 4621},
+							pos: position{line: 177, col: 27, offset: 4632},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 177, col: 27, offset: 4621},
+									pos: position{line: 177, col: 27, offset: 4632},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 177, col: 27, offset: 4621},
+											pos:        position{line: 177, col: 27, offset: 4632},
 											val:        "*",
 											ignoreCase: false,
 										},
 										&notExpr{
-											pos: position{line: 177, col: 31, offset: 4625},
+											pos: position{line: 177, col: 31, offset: 4636},
 											expr: &litMatcher{
-												pos:        position{line: 177, col: 32, offset: 4626},
+												pos:        position{line: 177, col: 32, offset: 4637},
 												val:        "/",
 												ignoreCase: false,
 											},
@@ -1083,7 +1083,7 @@ var g = &grammar{
 									},
 								},
 								&charClassMatcher{
-									pos:        position{line: 177, col: 38, offset: 4632},
+									pos:        position{line: 177, col: 38, offset: 4643},
 									val:        "[^*]",
 									chars:      []rune{'*'},
 									ignoreCase: false,
@@ -1093,7 +1093,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 177, col: 45, offset: 4639},
+						pos:        position{line: 177, col: 45, offset: 4650},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -1102,18 +1102,18 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 179, col: 1, offset: 4645},
+			pos:  position{line: 179, col: 1, offset: 4656},
 			expr: &seqExpr{
-				pos: position{line: 179, col: 8, offset: 4652},
+				pos: position{line: 179, col: 8, offset: 4663},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 179, col: 8, offset: 4652},
+						pos:  position{line: 179, col: 8, offset: 4663},
 						name: "_",
 					},
 					&notExpr{
-						pos: position{line: 179, col: 10, offset: 4654},
+						pos: position{line: 179, col: 10, offset: 4665},
 						expr: &anyMatcher{
-							line: 179, col: 11, offset: 4655,
+							line: 179, col: 11, offset: 4666,
 						},
 					},
 				},
@@ -1124,9 +1124,9 @@ var g = &grammar{
 
 func (c *current) onPackage1(dd interface{}) (interface{}, error) {
 	aliases := map[string]string{}
-	usings := []types.Type{}
+	usings := []*types.Type{}
 	seenTypes := map[string]bool{}
-	orderedTypes := []types.Type{}
+	orderedTypes := []*types.Type{}
 	for _, d := range dd.([]interface{}) {
 		switch d := d.(type) {
 		default:
@@ -1136,7 +1136,7 @@ func (c *current) onPackage1(dd interface{}) (interface{}, error) {
 				return nil, fmt.Errorf("Redefinition of " + d.Name)
 			}
 			aliases[d.Name] = d.Target
-		case types.Type:
+		case *types.Type:
 			switch d.Kind() {
 			default:
 				return nil, fmt.Errorf("%v can't be defined at the top-level", d)
@@ -1243,7 +1243,7 @@ func (p *parser) callonUnion1() (interface{}, error) {
 }
 
 func (c *current) onField1(i, o, t interface{}) (interface{}, error) {
-	return types.Field{i.(string), t.(types.Type), o != nil}, nil
+	return types.Field{i.(string), t.(*types.Type), o != nil}, nil
 }
 
 func (p *parser) callonField1() (interface{}, error) {
@@ -1253,7 +1253,7 @@ func (p *parser) callonField1() (interface{}, error) {
 }
 
 func (c *current) onUnionField1(i, t interface{}) (interface{}, error) {
-	return types.Field{i.(string), t.(types.Type), false}, nil
+	return types.Field{i.(string), t.(*types.Type), false}, nil
 }
 
 func (p *parser) callonUnionField1() (interface{}, error) {
@@ -1264,7 +1264,7 @@ func (p *parser) callonUnionField1() (interface{}, error) {
 
 func (c *current) onType1(t interface{}) (interface{}, error) {
 	switch t := t.(type) {
-	case types.Type:
+	case *types.Type:
 		return t, nil
 	case []types.Field:
 		return types.MakeStructType("", nil, t), nil
@@ -1282,7 +1282,7 @@ func (p *parser) callonType1() (interface{}, error) {
 }
 
 func (c *current) onCompoundType2(t interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.ListKind, t.(types.Type)), nil
+	return types.MakeCompoundType(types.ListKind, t.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType2() (interface{}, error) {
@@ -1292,7 +1292,7 @@ func (p *parser) callonCompoundType2() (interface{}, error) {
 }
 
 func (c *current) onCompoundType13(k, v interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.MapKind, k.(types.Type), v.(types.Type)), nil
+	return types.MakeCompoundType(types.MapKind, k.(*types.Type), v.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType13() (interface{}, error) {
@@ -1302,7 +1302,7 @@ func (p *parser) callonCompoundType13() (interface{}, error) {
 }
 
 func (c *current) onCompoundType29(t interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.SetKind, t.(types.Type)), nil
+	return types.MakeCompoundType(types.SetKind, t.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType29() (interface{}, error) {
@@ -1312,7 +1312,7 @@ func (p *parser) callonCompoundType29() (interface{}, error) {
 }
 
 func (c *current) onCompoundType40(t interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.RefKind, t.(types.Type)), nil
+	return types.MakeCompoundType(types.RefKind, t.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType40() (interface{}, error) {

--- a/nomdl/pkg/imports_test.go
+++ b/nomdl/pkg/imports_test.go
@@ -35,7 +35,7 @@ func (suite *ImportTestSuite) SetupTest() {
 		types.Field{"b", types.MakePrimitiveType(types.BoolKind), false},
 		types.Field{"i", types.MakePrimitiveType(types.Int8Kind), false},
 	})
-	suite.nested = types.NewPackage([]types.Type{ns}, []ref.Ref{})
+	suite.nested = types.NewPackage([]*types.Type{ns}, []ref.Ref{})
 	suite.nestedRef = suite.vrw.WriteValue(suite.nested).TargetRef()
 
 	fs := types.MakeStructType("ForeignStruct", []types.Field{
@@ -43,7 +43,7 @@ func (suite *ImportTestSuite) SetupTest() {
 		types.Field{"n", types.MakeType(suite.nestedRef, 0), false},
 	},
 		[]types.Field{})
-	suite.imported = types.NewPackage([]types.Type{fs}, []ref.Ref{suite.nestedRef})
+	suite.imported = types.NewPackage([]*types.Type{fs}, []ref.Ref{suite.nestedRef})
 	suite.importRef = suite.vrw.WriteValue(suite.imported).TargetRef()
 }
 
@@ -73,13 +73,13 @@ func (suite *ImportTestSuite) TestDetectFreeVariable() {
 	},
 		[]types.Field{})
 	suite.Panics(func() {
-		inter := intermediate{Types: []types.Type{ls}}
+		inter := intermediate{Types: []*types.Type{ls}}
 		resolveLocalOrdinals(&inter)
 	})
 }
 
 func (suite *ImportTestSuite) TestImports() {
-	find := func(n string, typ types.Type) types.Field {
+	find := func(n string, typ *types.Type) types.Field {
 		suite.Equal(types.StructKind, typ.Kind())
 		for _, f := range typ.Desc.(types.StructDesc).Fields {
 			if f.Name == n {
@@ -89,7 +89,7 @@ func (suite *ImportTestSuite) TestImports() {
 		suite.Fail("Could not find field", "%s not present", n)
 		return types.Field{}
 	}
-	findChoice := func(n string, typ types.Type) types.Field {
+	findChoice := func(n string, typ *types.Type) types.Field {
 		suite.Equal(types.StructKind, typ.Kind())
 		for _, f := range typ.Desc.(types.StructDesc).Union {
 			if f.Name == n {

--- a/nomdl/pkg/parse_test.go
+++ b/nomdl/pkg/parse_test.go
@@ -267,14 +267,14 @@ type testField struct {
 }
 
 func (t testField) toField() types.Field {
-	return types.Field{t.Name, t.D.(types.Type), t.Optional}
+	return types.Field{t.Name, t.D.(*types.Type), t.Optional}
 }
 
 type describable interface {
 	Describe() string
 }
 
-func (suite *ParsedResultTestSuite) findTypeByName(n string, ts []types.Type) types.Type {
+func (suite *ParsedResultTestSuite) findTypeByName(n string, ts []*types.Type) *types.Type {
 	for _, t := range ts {
 		if n == t.Name() {
 			return t

--- a/types/assert.go
+++ b/types/assert.go
@@ -2,7 +2,7 @@ package types
 
 import "github.com/attic-labs/noms/d"
 
-func assertType(t Type, v ...Value) {
+func assertType(t *Type, v ...Value) {
 	if t.Kind() != ValueKind {
 		for _, v := range v {
 			d.Chk.True(t.Equals(v.Type()), "Invalid type. Expected: %s, found: %s", t.Describe(), v.Type().Describe())

--- a/types/blob_leaf.go
+++ b/types/blob_leaf.go
@@ -40,7 +40,7 @@ func (bl blobLeaf) ChildValues() []Value {
 	return nil
 }
 
-func (bl blobLeaf) Type() Type {
+func (bl blobLeaf) Type() *Type {
 	return typeForBlob
 }
 

--- a/types/compound_blob.go
+++ b/types/compound_blob.go
@@ -21,7 +21,7 @@ func newCompoundBlob(tuples metaSequenceData, vr ValueReader) compoundBlob {
 	return buildCompoundBlob(tuples, typeForBlob, vr).(compoundBlob)
 }
 
-func buildCompoundBlob(tuples metaSequenceData, t Type, vr ValueReader) Value {
+func buildCompoundBlob(tuples metaSequenceData, t *Type, vr ValueReader) Value {
 	d.Chk.True(t.Equals(typeForBlob))
 	return compoundBlob{metaSequenceObject{tuples, typeForBlob}, tuples.uint64ValuesSum(), &ref.Ref{}, vr}
 }

--- a/types/compound_list.go
+++ b/types/compound_list.go
@@ -22,7 +22,7 @@ type compoundList struct {
 	vr     ValueReader
 }
 
-func buildCompoundList(tuples metaSequenceData, t Type, vr ValueReader) Value {
+func buildCompoundList(tuples metaSequenceData, t *Type, vr ValueReader) Value {
 	cl := compoundList{metaSequenceObject{tuples, t}, tuples.uint64ValuesSum(), &ref.Ref{}, vr}
 	return valueFromType(cl, t)
 }
@@ -146,7 +146,7 @@ func (cl compoundList) MapP(concurrency int, mf MapFunc) []interface{} {
 	return results
 }
 
-func (cl compoundList) elemType() Type {
+func (cl compoundList) elemType() *Type {
 	return cl.Type().Desc.(CompoundDesc).ElemTypes[0]
 }
 
@@ -255,7 +255,7 @@ func newListLeafBoundaryChecker() boundaryChecker {
 
 // If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are
 // written when the root is written.
-func makeListLeafChunkFn(t Type, sink ValueWriter) makeChunkFn {
+func makeListLeafChunkFn(t *Type, sink ValueWriter) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		values := make([]Value, len(items))
 

--- a/types/compound_list_test.go
+++ b/types/compound_list_test.go
@@ -633,7 +633,7 @@ func TestCompoundListRefOfStructFirstNNumbers(t *testing.T) {
 	structTypeDef := MakeStructType("num", []Field{
 		Field{"n", MakePrimitiveType(Int64Kind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{structTypeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{structTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	structType := MakeType(pkgRef, 0)
 	refOfTypeStructType := MakeCompoundType(RefKind, structType)

--- a/types/compound_map.go
+++ b/types/compound_map.go
@@ -17,7 +17,7 @@ type compoundMap struct {
 	vr        ValueReader
 }
 
-func buildCompoundMap(tuples metaSequenceData, t Type, vr ValueReader) Value {
+func buildCompoundMap(tuples metaSequenceData, t *Type, vr ValueReader) Value {
 	cm := compoundMap{metaSequenceObject{tuples, t}, tuples.numLeavesSum(), &ref.Ref{}, vr}
 	return valueFromType(cm, t)
 }
@@ -159,6 +159,6 @@ func (cm compoundMap) IterAll(cb mapIterAllCallback) {
 	})
 }
 
-func (cm compoundMap) elemTypes() []Type {
+func (cm compoundMap) elemTypes() []*Type {
 	return cm.Type().Desc.(CompoundDesc).ElemTypes
 }

--- a/types/compound_map_test.go
+++ b/types/compound_map_test.go
@@ -12,7 +12,7 @@ import (
 type testMap struct {
 	entries     []mapEntry
 	less        testMapLessFn
-	tr          Type
+	tr          *Type
 	knownBadKey Value
 }
 
@@ -63,7 +63,7 @@ func (tm testMap) toCompoundMap() compoundMap {
 
 type testMapGenFn func(v Int64) Value
 
-func newTestMap(length int, gen testMapGenFn, less testMapLessFn, tr Type) testMap {
+func newTestMap(length int, gen testMapGenFn, less testMapLessFn, tr *Type) testMap {
 	s := rand.NewSource(4242)
 	used := map[int64]bool{}
 
@@ -370,7 +370,7 @@ func TestCompoundMapRefOfStructFirstNNumbers(t *testing.T) {
 	structTypeDef := MakeStructType("num", []Field{
 		Field{"n", MakePrimitiveType(Int64Kind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{structTypeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{structTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	structType := MakeType(pkgRef, 0)
 	refOfTypeStructType := MakeRefType(structType)

--- a/types/compound_set.go
+++ b/types/compound_set.go
@@ -18,7 +18,7 @@ type compoundSet struct {
 	vr        ValueReader
 }
 
-func buildCompoundSet(tuples metaSequenceData, t Type, vr ValueReader) Value {
+func buildCompoundSet(tuples metaSequenceData, t *Type, vr ValueReader) Value {
 	s := compoundSet{metaSequenceObject{tuples, t}, tuples.numLeavesSum(), &ref.Ref{}, vr}
 	return valueFromType(s, t)
 }
@@ -167,7 +167,7 @@ func (cs compoundSet) IterAllP(concurrency int, f setIterAllCallback) {
 	})
 }
 
-func (cs compoundSet) elemType() Type {
+func (cs compoundSet) elemType() *Type {
 	return cs.t.Desc.(CompoundDesc).ElemTypes[0]
 }
 

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -12,7 +12,7 @@ import (
 type testSet struct {
 	values []Value
 	less   testSetLessFn
-	tr     Type
+	tr     *Type
 }
 
 type testSetLessFn func(x, y Value) bool
@@ -42,7 +42,7 @@ func (ts testSet) toCompoundSet() compoundSet {
 
 type testSetGenFn func(v Int64) Value
 
-func newTestSet(length int, gen testSetGenFn, less testSetLessFn, tr Type) testSet {
+func newTestSet(length int, gen testSetGenFn, less testSetLessFn, tr *Type) testSet {
 	s := rand.NewSource(4242)
 	used := map[int64]bool{}
 
@@ -367,7 +367,7 @@ func TestCompoundSetRefOfStructFirstNNumbers(t *testing.T) {
 	structTypeDef := MakeStructType("num", []Field{
 		Field{"n", MakePrimitiveType(Int64Kind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{structTypeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{structTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	structType := MakeType(pkgRef, 0)
 	refOfTypeStructType := MakeCompoundType(RefKind, structType)

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -37,7 +37,7 @@ func parseJson(s string, vs ...interface{}) (v []interface{}) {
 func TestReadTypeAsTag(t *testing.T) {
 	cs := NewTestValueStore()
 
-	test := func(expected Type, s string, vs ...interface{}) {
+	test := func(expected *Type, s string, vs ...interface{}) {
 		a := parseJson(s, vs...)
 		r := newJsonArrayReader(a, cs)
 		tr := r.readTypeAsTag()
@@ -250,7 +250,7 @@ func TestReadStruct(t *testing.T) {
 		Field{"s", MakePrimitiveType(StringKind), false},
 		Field{"b", MakePrimitiveType(BoolKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", "0", "42", "hi", true]`, UnresolvedKind, pkgRef.String())
@@ -272,7 +272,7 @@ func TestReadStructUnion(t *testing.T) {
 		Field{"b", MakePrimitiveType(BoolKind), false},
 		Field{"s", MakePrimitiveType(StringKind), false},
 	})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", "0", "42", "1", "hi"]`, UnresolvedKind, pkgRef.String())
@@ -302,7 +302,7 @@ func TestReadStructOptional(t *testing.T) {
 		Field{"s", MakePrimitiveType(StringKind), true},
 		Field{"b", MakePrimitiveType(BoolKind), true},
 	}, []Field{})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", "0", "42", false, true, false]`, UnresolvedKind, pkgRef.String())
@@ -333,7 +333,7 @@ func TestReadStructWithList(t *testing.T) {
 		Field{"l", MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind)), false},
 		Field{"s", MakePrimitiveType(StringKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", "0", true, false, ["0", "1", "2"], "hi"]`, UnresolvedKind, pkgRef.String())
@@ -362,7 +362,7 @@ func TestReadStructWithValue(t *testing.T) {
 		Field{"v", MakePrimitiveType(ValueKind), false},
 		Field{"s", MakePrimitiveType(StringKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", "0", true, %d, "42", "hi"]`, UnresolvedKind, pkgRef.String(), Uint8Kind)
@@ -389,7 +389,7 @@ func TestReadValueStruct(t *testing.T) {
 		Field{"s", MakePrimitiveType(StringKind), false},
 		Field{"b", MakePrimitiveType(BoolKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, %d, "%s", "0", "42", "hi", true]`, ValueKind, UnresolvedKind, pkgRef.String())
@@ -436,7 +436,7 @@ func TestReadStructWithBlob(t *testing.T) {
 	typ := MakeStructType("A5", []Field{
 		Field{"b", MakePrimitiveType(BlobKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typ}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typ}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
 	a := parseJson(`[%d, "%s", "0", false, "AAE="]`, UnresolvedKind, pkgRef.String())
@@ -451,7 +451,7 @@ func TestReadTypeValue(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	test := func(expected Type, json string, vs ...interface{}) {
+	test := func(expected *Type, json string, vs ...interface{}) {
 		a := parseJson(json, vs...)
 		r := newJsonArrayReader(a, cs)
 		tr := r.readTopLevelValue()
@@ -494,7 +494,7 @@ func TestReadPackage2(t *testing.T) {
 
 	rr := ref.Parse("sha1-a9993e364706816aba3e25717850c26c9cd0d89d")
 	setTref := MakeCompoundType(SetKind, MakePrimitiveType(Uint32Kind))
-	pkg := NewPackage([]Type{setTref}, []ref.Ref{rr})
+	pkg := NewPackage([]*Type{setTref}, []ref.Ref{rr})
 
 	a := []interface{}{float64(PackageKind), []interface{}{float64(SetKind), []interface{}{float64(Uint32Kind)}}, []interface{}{rr.String()}}
 	r := newJsonArrayReader(a, cs)
@@ -506,7 +506,7 @@ func TestReadPackageThroughChunkSource(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	pkg := NewPackage([]Type{
+	pkg := NewPackage([]*Type{
 		MakeStructType("S", []Field{
 			Field{"X", MakePrimitiveType(Int32Kind), false},
 		}, []Field{}),

--- a/types/encode_human_readable.go
+++ b/types/encode_human_readable.go
@@ -135,7 +135,7 @@ func (w *hrsWriter) Write(v Value) {
 		w.write("}")
 
 	case TypeKind:
-		w.writeTypeAsValue(v.(Type))
+		w.writeTypeAsValue(v.(*Type))
 
 	case UnresolvedKind:
 		w.writeUnresolved(v, true)
@@ -218,7 +218,7 @@ func (w *hrsWriter) WriteTagged(v Value) {
 	}
 }
 
-func (w *hrsWriter) writeTypeAsValue(t Type) {
+func (w *hrsWriter) writeTypeAsValue(t *Type) {
 	switch t.Kind() {
 	case BlobKind, BoolKind, Float32Kind, Float64Kind, Int16Kind, Int32Kind, Int64Kind, Int8Kind, StringKind, TypeKind, Uint16Kind, Uint32Kind, Uint64Kind, Uint8Kind, ValueKind, PackageKind:
 		w.write(KindToString[t.Kind()])
@@ -272,7 +272,7 @@ func (w *hrsWriter) writeTypeAsValue(t Type) {
 	}
 }
 
-func (w *hrsWriter) writeUnresolvedTypeRef(t Type, printStructName bool) {
+func (w *hrsWriter) writeUnresolvedTypeRef(t *Type, printStructName bool) {
 	if !t.HasPackageRef() {
 		if t.Namespace() != "" {
 			w.write(t.Namespace())

--- a/types/encode_human_readable_test.go
+++ b/types/encode_human_readable_test.go
@@ -154,7 +154,7 @@ func TestWriteHumanReadableNested(t *testing.T) {
 }
 
 func TestWriteHumanReadableStruct(t *testing.T) {
-	pkg := NewPackage([]Type{
+	pkg := NewPackage([]*Type{
 		MakeStructType("S1", []Field{
 			Field{Name: "x", T: Int32Type, Optional: false},
 			Field{Name: "y", T: Int32Type, Optional: true},
@@ -179,7 +179,7 @@ func TestWriteHumanReadableStruct(t *testing.T) {
 }
 
 func TestWriteHumanReadableStructWithUnion(t *testing.T) {
-	pkg := NewPackage([]Type{
+	pkg := NewPackage([]*Type{
 		MakeStructType("S2", []Field{}, []Field{
 			Field{Name: "x", T: Int32Type, Optional: false},
 			Field{Name: "y", T: Int32Type, Optional: false},
@@ -203,7 +203,7 @@ func TestWriteHumanReadableStructWithUnion(t *testing.T) {
 }
 
 func TestWriteHumanReadableListOfStruct(t *testing.T) {
-	pkg := NewPackage([]Type{
+	pkg := NewPackage([]*Type{
 		MakeStructType("S3", []Field{}, []Field{
 			Field{Name: "x", T: Int32Type, Optional: false},
 		}),
@@ -302,7 +302,7 @@ func TestWriteHumanReadableType(t *testing.T) {
 	assertWriteHRSEqual(t, "Ref<Int32>", MakeRefType(Int32Type))
 	assertWriteHRSEqual(t, "Map<Int64, String>", MakeMapType(Int64Type, StringType))
 
-	pkg := NewPackage([]Type{
+	pkg := NewPackage([]*Type{
 		MakeStructType("Str", []Field{
 			Field{Name: "c", T: MakeType(ref.Ref{}, 0), Optional: false},
 			Field{Name: "o", T: StringType, Optional: true},

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -62,7 +62,7 @@ func (w *jsonArrayWriter) writeRef(r ref.Ref) {
 	w.write(r.String())
 }
 
-func (w *jsonArrayWriter) writeTypeAsTag(t Type) {
+func (w *jsonArrayWriter) writeTypeAsTag(t *Type) {
 	k := t.Kind()
 	w.write(k)
 	switch k {
@@ -91,7 +91,7 @@ func (w *jsonArrayWriter) writeTopLevelValue(v Value) {
 	w.writeValue(v, tr, nil)
 }
 
-func (w *jsonArrayWriter) maybeWriteMetaSequence(v Value, tr Type, pkg *Package) bool {
+func (w *jsonArrayWriter) maybeWriteMetaSequence(v Value, tr *Type, pkg *Package) bool {
 	ms, ok := v.(metaSequence)
 	if !ok {
 		w.write(false) // not a meta sequence
@@ -114,7 +114,7 @@ func (w *jsonArrayWriter) maybeWriteMetaSequence(v Value, tr Type, pkg *Package)
 	return true
 }
 
-func (w *jsonArrayWriter) writeValue(v Value, tr Type, pkg *Package) {
+func (w *jsonArrayWriter) writeValue(v Value, tr *Type, pkg *Package) {
 	switch tr.Kind() {
 	case BlobKind:
 		if w.maybeWriteMetaSequence(v, tr, pkg) {
@@ -212,7 +212,7 @@ func (w *jsonArrayWriter) writeValue(v Value, tr Type, pkg *Package) {
 	}
 }
 
-func (w *jsonArrayWriter) writeTypeAsValue(t Type, pkg *Package) {
+func (w *jsonArrayWriter) writeTypeAsValue(t *Type, pkg *Package) {
 	k := t.Kind()
 	w.write(k)
 	switch k {
@@ -267,13 +267,14 @@ func (w *jsonArrayWriter) writeTypeAsValue(t Type, pkg *Package) {
 }
 
 // writeTypeKindValue writes either a struct or a Type value
-func (w *jsonArrayWriter) writeTypeKindValue(v Value, tr Type, pkg *Package) {
-	d.Chk.IsType(Type{}, v)
-	w.writeTypeAsValue(v.(Type), pkg)
+func (w *jsonArrayWriter) writeTypeKindValue(v Value, tr *Type, pkg *Package) {
+	_, ok := v.(*Type)
+	d.Chk.True(ok)
+	w.writeTypeAsValue(v.(*Type), pkg)
 }
 
 // writeUnresolvedKindValue writes a struct.
-func (w *jsonArrayWriter) writeUnresolvedKindValue(v Value, tr Type, pkg *Package) {
+func (w *jsonArrayWriter) writeUnresolvedKindValue(v Value, tr *Type, pkg *Package) {
 	d.Chk.NotNil(pkg)
 	typeDef := pkg.types[tr.Ordinal()]
 	switch typeDef.Kind() {
@@ -294,7 +295,7 @@ func (w *jsonArrayWriter) writeBlob(b Blob) {
 	w.write(buf.String())
 }
 
-func (w *jsonArrayWriter) writeStruct(v Value, typ, typeDef Type, pkg *Package) {
+func (w *jsonArrayWriter) writeStruct(v Value, typ, typeDef *Type, pkg *Package) {
 	i := 0
 	values := structReaderForType(v, typ, typeDef)
 	desc := typeDef.Desc.(StructDesc)

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -146,7 +146,7 @@ func TestWriteEmptyStruct(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 	v := NewStruct(typ, typeDef, nil)
@@ -163,7 +163,7 @@ func TestWriteStruct(t *testing.T) {
 		Field{"x", MakePrimitiveType(Int8Kind), false},
 		Field{"b", MakePrimitiveType(BoolKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 	v := NewStruct(typ, typeDef, structData{"x": Int8(42), "b": Bool(true)})
@@ -180,7 +180,7 @@ func TestWriteStructOptionalField(t *testing.T) {
 		Field{"x", MakePrimitiveType(Int8Kind), true},
 		Field{"b", MakePrimitiveType(BoolKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 	v := NewStruct(typ, typeDef, structData{"x": Int8(42), "b": Bool(true)})
@@ -205,7 +205,7 @@ func TestWriteStructWithUnion(t *testing.T) {
 		Field{"b", MakePrimitiveType(BoolKind), false},
 		Field{"s", MakePrimitiveType(StringKind), false},
 	})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 	v := NewStruct(typ, typeDef, structData{"x": Int8(42), "s": NewString("hi")})
@@ -227,7 +227,7 @@ func TestWriteStructWithList(t *testing.T) {
 	typeDef := MakeStructType("S", []Field{
 		Field{"l", MakeCompoundType(ListKind, MakePrimitiveType(StringKind)), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -251,7 +251,7 @@ func TestWriteStructWithStruct(t *testing.T) {
 	sTypeDef := MakeStructType("S", []Field{
 		Field{"s", MakeType(ref.Ref{}, 0), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{s2TypeDef, sTypeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{s2TypeDef, sTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	s2Type := MakeType(pkgRef, 0)
 	sType := MakeType(pkgRef, 1)
@@ -268,7 +268,7 @@ func TestWriteStructWithBlob(t *testing.T) {
 	typeDef := MakeStructType("S", []Field{
 		Field{"b", MakePrimitiveType(BlobKind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 	b := NewBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
@@ -358,7 +358,7 @@ func TestWriteListOfValueWithStruct(t *testing.T) {
 	typeDef := MakeStructType("S", []Field{
 		Field{"x", MakePrimitiveType(Int32Kind), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	listType := MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))
 	structType := MakeType(pkgRef, 0)
@@ -372,7 +372,7 @@ func TestWriteListOfValueWithStruct(t *testing.T) {
 func TestWriteListOfValueWithType(t *testing.T) {
 	assert := assert.New(t)
 
-	pkg := NewPackage([]Type{
+	pkg := NewPackage([]*Type{
 		MakeStructType("S", []Field{
 			Field{"x", MakePrimitiveType(Int32Kind), false},
 		}, []Field{})}, []ref.Ref{})
@@ -398,10 +398,10 @@ func TestWriteListOfValueWithType(t *testing.T) {
 
 type testRef struct {
 	Value
-	t Type
+	t *Type
 }
 
-func (r testRef) Type() Type {
+func (r testRef) Type() *Type {
 	return r.t
 }
 
@@ -424,7 +424,7 @@ func TestWriteRef(t *testing.T) {
 func TestWriteTypeValue(t *testing.T) {
 	assert := assert.New(t)
 
-	test := func(expected []interface{}, v Type) {
+	test := func(expected []interface{}, v *Type) {
 		w := newJSONArrayWriter(NewTestValueStore())
 		w.writeTopLevelValue(v)
 		assert.EqualValues(expected, w.toArray())
@@ -478,7 +478,7 @@ func TestWritePackage(t *testing.T) {
 
 	setTref := MakeCompoundType(SetKind, MakePrimitiveType(Uint32Kind))
 	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
-	v := Package{[]Type{setTref}, []ref.Ref{r}, &ref.Ref{}}
+	v := Package{[]*Type{setTref}, []ref.Ref{r}, &ref.Ref{}}
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeTopLevelValue(v)

--- a/types/fixup_type.go
+++ b/types/fixup_type.go
@@ -1,13 +1,13 @@
 package types
 
 // FixupType goes trough the object graph of tr and updates the PackageRef to pkg if the the old PackageRef was an empty ref.
-func FixupType(tr Type, pkg *Package) Type {
+func FixupType(tr *Type, pkg *Package) *Type {
 	switch desc := tr.Desc.(type) {
 	case PrimitiveDesc:
 		return tr
 
 	case CompoundDesc:
-		elemTypes := make([]Type, len(desc.ElemTypes))
+		elemTypes := make([]*Type, len(desc.ElemTypes))
 		for i, elemType := range desc.ElemTypes {
 			elemTypes[i] = FixupType(elemType, pkg)
 		}

--- a/types/gen/primitive.tmpl
+++ b/types/gen/primitive.tmpl
@@ -22,7 +22,7 @@ func (v {{.NomsType}}) ToPrimitive() interface{} {
 
 var typeFor{{.NomsType}} = MakePrimitiveType({{.NomsType}}Kind)
 
-func (v {{.NomsType}}) Type() Type {
+func (v {{.NomsType}}) Type() *Type {
 	return typeFor{{.NomsType}}
 }
 {{if .IsOrdered}}

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -11,7 +11,7 @@ func newIndexedMetaSequenceBoundaryChecker() boundaryChecker {
 
 // If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are
 // written when the root is written.
-func newIndexedMetaSequenceChunkFn(t Type, source ValueReader, sink ValueWriter) makeChunkFn {
+func newIndexedMetaSequenceChunkFn(t *Type, source ValueReader, sink ValueWriter) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		tuples := make(metaSequenceData, len(items))
 		numLeaves := uint64(0)

--- a/types/list.go
+++ b/types/list.go
@@ -34,7 +34,7 @@ func NewList(v ...Value) List {
 }
 
 // NewTypedList creates a new List with type t, populated with values, chunking if and when needed.
-func NewTypedList(t Type, values ...Value) List {
+func NewTypedList(t *Type, values ...Value) List {
 	d.Chk.Equal(ListKind, t.Kind(), "Invalid type. Expected: ListKind, found: %s", t.Describe())
 	seq := newEmptySequenceChunker(makeListLeafChunkFn(t, nil), newIndexedMetaSequenceChunkFn(t, nil, nil), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)
 	for _, v := range values {
@@ -44,7 +44,7 @@ func NewTypedList(t Type, values ...Value) List {
 }
 
 // NewStreamingTypedList creates a new List with type t, populated with values, chunking if and when needed. As chunks are created, they're written to vrw -- including the root chunk of the list. Once the caller has closed values, she can read the completed List from the returned channel.
-func NewStreamingTypedList(t Type, vrw ValueReadWriter, values <-chan Value) <-chan List {
+func NewStreamingTypedList(t *Type, vrw ValueReadWriter, values <-chan Value) <-chan List {
 	out := make(chan List)
 	go func() {
 		seq := newEmptySequenceChunker(makeListLeafChunkFn(t, vrw), newIndexedMetaSequenceChunkFn(t, vrw, vrw), newListLeafBoundaryChecker(), newIndexedMetaSequenceBoundaryChecker)

--- a/types/list_leaf.go
+++ b/types/list_leaf.go
@@ -10,11 +10,11 @@ import (
 
 type listLeaf struct {
 	values []Value
-	t      Type
+	t      *Type
 	ref    *ref.Ref
 }
 
-func newListLeaf(t Type, v ...Value) List {
+func newListLeaf(t *Type, v ...Value) List {
 	d.Chk.Equal(ListKind, t.Kind())
 	return listLeaf{v, t, &ref.Ref{}}
 }
@@ -183,10 +183,10 @@ func (l listLeaf) ChildValues() []Value {
 	return append([]Value{}, l.values...)
 }
 
-func (l listLeaf) Type() Type {
+func (l listLeaf) Type() *Type {
 	return l.t
 }
 
-func (l listLeaf) elemType() Type {
+func (l listLeaf) elemType() *Type {
 	return l.t.Desc.(CompoundDesc).ElemTypes[0]
 }

--- a/types/map.go
+++ b/types/map.go
@@ -17,7 +17,7 @@ type Map interface {
 	IterAll(cb mapIterAllCallback)
 	IterAllP(concurrency int, f mapIterAllCallback)
 	Filter(cb mapFilterCallback) Map
-	elemTypes() []Type
+	elemTypes() []*Type
 }
 
 type indexOfMapFn func(m mapData, v Value) int
@@ -31,12 +31,12 @@ func NewMap(kv ...Value) Map {
 	return NewTypedMap(mapType, kv...)
 }
 
-func NewTypedMap(t Type, kv ...Value) Map {
+func NewTypedMap(t *Type, kv ...Value) Map {
 	d.Chk.Equal(MapKind, t.Kind(), "Invalid type. Expected: MapKind, found: %s", t.Describe())
 	return newTypedMap(t, buildMapData(mapData{}, kv, t)...)
 }
 
-func newTypedMap(t Type, entries ...mapEntry) Map {
+func newTypedMap(t *Type, entries ...mapEntry) Map {
 	seq := newEmptySequenceChunker(makeMapLeafChunkFn(t, nil), newOrderedMetaSequenceChunkFn(t, nil), newMapLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
 
 	for _, entry := range entries {

--- a/types/map_leaf.go
+++ b/types/map_leaf.go
@@ -13,7 +13,7 @@ import (
 type mapLeaf struct {
 	data    mapData // sorted by entry.key.Ref()
 	indexOf indexOfMapFn
-	t       Type
+	t       *Type
 	ref     *ref.Ref
 }
 
@@ -24,7 +24,7 @@ type mapEntry struct {
 	value Value
 }
 
-func newMapLeaf(t Type, data ...mapEntry) Map {
+func newMapLeaf(t *Type, data ...mapEntry) Map {
 	return mapLeaf{data, getIndexFnForMapType(t), t, &ref.Ref{}}
 }
 
@@ -164,15 +164,15 @@ func (m mapLeaf) ChildValues() []Value {
 	return res
 }
 
-func (m mapLeaf) Type() Type {
+func (m mapLeaf) Type() *Type {
 	return m.t
 }
 
-func (m mapLeaf) elemTypes() []Type {
+func (m mapLeaf) elemTypes() []*Type {
 	return m.t.Desc.(CompoundDesc).ElemTypes
 }
 
-func buildMapData(oldData mapData, values []Value, t Type) mapData {
+func buildMapData(oldData mapData, values []Value, t *Type) mapData {
 	idxFn := getIndexFnForMapType(t)
 	elemTypes := t.Desc.(CompoundDesc).ElemTypes
 
@@ -202,7 +202,7 @@ func buildMapData(oldData mapData, values []Value, t Type) mapData {
 	return data
 }
 
-func getIndexFnForMapType(t Type) indexOfMapFn {
+func getIndexFnForMapType(t *Type) indexOfMapFn {
 	orderByValue := t.Desc.(CompoundDesc).ElemTypes[0].IsOrdered()
 	if orderByValue {
 		return indexOfOrderedMapValue
@@ -232,7 +232,7 @@ func newMapLeafBoundaryChecker() boundaryChecker {
 	})
 }
 
-func makeMapLeafChunkFn(t Type, vr ValueReader) makeChunkFn {
+func makeMapLeafChunkFn(t *Type, vr ValueReader) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		mapData := make([]mapEntry, len(items), len(items))
 

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -251,7 +251,7 @@ func TestMapNotStringKeys(t *testing.T) {
 	assert.Nil(m1.Get(Int32(42)))
 }
 
-func testMapOrder(assert *assert.Assertions, keyType, valueType Type, tuples []Value, expectOrdering []Value) {
+func testMapOrder(assert *assert.Assertions, keyType, valueType *Type, tuples []Value, expectOrdering []Value) {
 	mapTr := MakeCompoundType(MapKind, keyType, valueType)
 	m := NewTypedMap(mapTr, tuples...)
 	i := 0

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -64,7 +64,7 @@ func (msd metaSequenceData) last() metaTuple {
 
 type metaSequenceObject struct {
 	tuples metaSequenceData
-	t      Type
+	t      *Type
 }
 
 func (ms metaSequenceObject) tupleAt(idx int) metaTuple {
@@ -100,11 +100,11 @@ func (ms metaSequenceObject) Chunks() (chunks []RefBase) {
 	return
 }
 
-func (ms metaSequenceObject) Type() Type {
+func (ms metaSequenceObject) Type() *Type {
 	return ms.t
 }
 
-type metaBuilderFunc func(tuples metaSequenceData, t Type, vr ValueReader) Value
+type metaBuilderFunc func(tuples metaSequenceData, t *Type, vr ValueReader) Value
 
 var metaFuncMap = map[NomsKind]metaBuilderFunc{}
 
@@ -112,7 +112,7 @@ func registerMetaValue(k NomsKind, bf metaBuilderFunc) {
 	metaFuncMap[k] = bf
 }
 
-func newMetaSequenceFromData(tuples metaSequenceData, t Type, vr ValueReader) Value {
+func newMetaSequenceFromData(tuples metaSequenceData, t *Type, vr ValueReader) Value {
 	if bf, ok := metaFuncMap[t.Kind()]; ok {
 		return bf(tuples, t, vr)
 	}

--- a/types/ordered_sequences.go
+++ b/types/ordered_sequences.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 )
 
-func isSequenceOrderedByIndexedType(t Type) bool {
+func isSequenceOrderedByIndexedType(t *Type) bool {
 	return t.Desc.(CompoundDesc).ElemTypes[0].IsOrdered()
 }
 
@@ -13,7 +13,7 @@ func isSequenceOrderedByIndexedType(t Type) bool {
 type getLeafOrderedValuesFn func(Value) []Value
 
 // Returns a cursor to |key| in |ms|, plus the leaf + index that |key| is in. |t| is the type of the ordered values.
-func findLeafInOrderedSequence(ms metaSequence, t Type, key Value, getValues getLeafOrderedValuesFn, vr ValueReader) (cursor *sequenceCursor, leaf Value, idx int) {
+func findLeafInOrderedSequence(ms metaSequence, t *Type, key Value, getValues getLeafOrderedValuesFn, vr ValueReader) (cursor *sequenceCursor, leaf Value, idx int) {
 	cursor, leaf = newMetaSequenceCursor(ms, vr)
 
 	if isSequenceOrderedByIndexedType(t) {
@@ -54,7 +54,7 @@ func newOrderedMetaSequenceBoundaryChecker() boundaryChecker {
 	})
 }
 
-func newOrderedMetaSequenceChunkFn(t Type, vr ValueReader) makeChunkFn {
+func newOrderedMetaSequenceChunkFn(t *Type, vr ValueReader) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		tuples := make(metaSequenceData, len(items))
 		numLeaves := uint64(0)

--- a/types/package.go
+++ b/types/package.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Package struct {
-	types        []Type
+	types        []*Type
 	dependencies ref.RefSlice
 	ref          *ref.Ref
 }
 
-func NewPackage(types []Type, dependencies ref.RefSlice) Package {
+func NewPackage(types []*Type, dependencies ref.RefSlice) Package {
 	p := Package{types: types}
 	// The order |Package.dependencies| must be stable for the Package to have a stable ref.
 	// See https://github.com/attic-labs/noms/issues/814 for stable ordering of |Package.types|.
@@ -21,7 +21,7 @@ func NewPackage(types []Type, dependencies ref.RefSlice) Package {
 	r := getRef(p)
 	p.ref = &r
 
-	newTypes := make([]Type, len(types))
+	newTypes := make([]*Type, len(types))
 	for i, t := range types {
 		newTypes[i] = FixupType(t, &p)
 	}
@@ -60,7 +60,7 @@ func (p Package) ChildValues() (res []Value) {
 
 var typeForPackage = PackageType
 
-func (p Package) Type() Type {
+func (p Package) Type() *Type {
 	return typeForPackage
 }
 
@@ -78,7 +78,7 @@ func (p Package) Dependencies() (dependencies []ref.Ref) {
 	return
 }
 
-func (p Package) Types() (types []Type) {
+func (p Package) Types() (types []*Type) {
 	types = append(types, p.types...)
 	return
 }

--- a/types/package_registry.go
+++ b/types/package_registry.go
@@ -48,25 +48,25 @@ func ReadPackage(r ref.Ref, vr ValueReader) *Package {
 	return &p
 }
 
-func RegisterStruct(t Type, bf structBuilderFunc, rf structReaderFunc) {
+func RegisterStruct(t *Type, bf structBuilderFunc, rf structReaderFunc) {
 	structFuncMap[t.Ref()] = structFuncs{bf, rf}
 }
 
-func structBuilderForType(values []Value, typ, typeDef Type) Value {
+func structBuilderForType(values []Value, typ, typeDef *Type) Value {
 	if s, ok := structFuncMap[typ.Ref()]; ok {
 		return s.builder(values)
 	}
 	return structBuilder(values, typ, typeDef)
 }
 
-func structReaderForType(v Value, typ, typeDef Type) []Value {
+func structReaderForType(v Value, typ, typeDef *Type) []Value {
 	if s, ok := structFuncMap[typ.Ref()]; ok {
 		return s.reader(v)
 	}
 	return structReader(v.(Struct), typ, typeDef)
 }
 
-func RegisterValue(t Type, bf valueBuilderFunc, rf valueReaderFunc) {
+func RegisterValue(t *Type, bf valueBuilderFunc, rf valueReaderFunc) {
 	switch t.Kind() {
 	case MapKind, ListKind, SetKind:
 		valueFuncMap[t.Ref()] = valueFuncs{bf, rf}
@@ -75,7 +75,7 @@ func RegisterValue(t Type, bf valueBuilderFunc, rf valueReaderFunc) {
 	}
 }
 
-func valueFromType(v Value, t Type) Value {
+func valueFromType(v Value, t *Type) Value {
 	switch t.Kind() {
 	case MapKind, ListKind, SetKind:
 		if s, ok := valueFuncMap[t.Ref()]; ok {
@@ -86,7 +86,7 @@ func valueFromType(v Value, t Type) Value {
 	return v
 }
 
-func internalValueFromType(v Value, t Type) Value {
+func internalValueFromType(v Value, t *Type) Value {
 	switch t.Kind() {
 	case MapKind, ListKind, SetKind:
 		if s, ok := valueFuncMap[t.Ref()]; ok {
@@ -97,11 +97,11 @@ func internalValueFromType(v Value, t Type) Value {
 	return v
 }
 
-func RegisterRef(t Type, bf refBuilderFunc) {
+func RegisterRef(t *Type, bf refBuilderFunc) {
 	refFuncMap[t.Ref()] = bf
 }
 
-func refFromType(target ref.Ref, t Type) RefBase {
+func refFromType(target ref.Ref, t *Type) RefBase {
 	if f, ok := refFuncMap[t.Ref()]; ok {
 		return f(target)
 	}

--- a/types/package_test.go
+++ b/types/package_test.go
@@ -10,7 +10,7 @@ import (
 func TestType(t *testing.T) {
 	assert := assert.New(t)
 
-	st := NewPackage([]Type{}, []ref.Ref{})
+	st := NewPackage([]*Type{}, []ref.Ref{})
 	typ := st.Type()
 	assert.Equal(PackageKind, typ.Kind())
 }

--- a/types/primitives.go
+++ b/types/primitives.go
@@ -31,7 +31,7 @@ func (v Bool) ToPrimitive() interface{} {
 
 var typeForBool = MakePrimitiveType(BoolKind)
 
-func (v Bool) Type() Type {
+func (v Bool) Type() *Type {
 	return typeForBool
 }
 
@@ -59,7 +59,7 @@ func (v Float32) ToPrimitive() interface{} {
 
 var typeForFloat32 = MakePrimitiveType(Float32Kind)
 
-func (v Float32) Type() Type {
+func (v Float32) Type() *Type {
 	return typeForFloat32
 }
 
@@ -91,7 +91,7 @@ func (v Float64) ToPrimitive() interface{} {
 
 var typeForFloat64 = MakePrimitiveType(Float64Kind)
 
-func (v Float64) Type() Type {
+func (v Float64) Type() *Type {
 	return typeForFloat64
 }
 
@@ -123,7 +123,7 @@ func (v Int16) ToPrimitive() interface{} {
 
 var typeForInt16 = MakePrimitiveType(Int16Kind)
 
-func (v Int16) Type() Type {
+func (v Int16) Type() *Type {
 	return typeForInt16
 }
 
@@ -155,7 +155,7 @@ func (v Int32) ToPrimitive() interface{} {
 
 var typeForInt32 = MakePrimitiveType(Int32Kind)
 
-func (v Int32) Type() Type {
+func (v Int32) Type() *Type {
 	return typeForInt32
 }
 
@@ -187,7 +187,7 @@ func (v Int64) ToPrimitive() interface{} {
 
 var typeForInt64 = MakePrimitiveType(Int64Kind)
 
-func (v Int64) Type() Type {
+func (v Int64) Type() *Type {
 	return typeForInt64
 }
 
@@ -219,7 +219,7 @@ func (v Int8) ToPrimitive() interface{} {
 
 var typeForInt8 = MakePrimitiveType(Int8Kind)
 
-func (v Int8) Type() Type {
+func (v Int8) Type() *Type {
 	return typeForInt8
 }
 
@@ -251,7 +251,7 @@ func (v Uint16) ToPrimitive() interface{} {
 
 var typeForUint16 = MakePrimitiveType(Uint16Kind)
 
-func (v Uint16) Type() Type {
+func (v Uint16) Type() *Type {
 	return typeForUint16
 }
 
@@ -283,7 +283,7 @@ func (v Uint32) ToPrimitive() interface{} {
 
 var typeForUint32 = MakePrimitiveType(Uint32Kind)
 
-func (v Uint32) Type() Type {
+func (v Uint32) Type() *Type {
 	return typeForUint32
 }
 
@@ -315,7 +315,7 @@ func (v Uint64) ToPrimitive() interface{} {
 
 var typeForUint64 = MakePrimitiveType(Uint64Kind)
 
-func (v Uint64) Type() Type {
+func (v Uint64) Type() *Type {
 	return typeForUint64
 }
 
@@ -347,7 +347,7 @@ func (v Uint8) ToPrimitive() interface{} {
 
 var typeForUint8 = MakePrimitiveType(Uint8Kind)
 
-func (v Uint8) Type() Type {
+func (v Uint8) Type() *Type {
 	return typeForUint8
 }
 

--- a/types/ref.go
+++ b/types/ref.go
@@ -7,7 +7,7 @@ import (
 
 type Ref struct {
 	target ref.Ref
-	t      Type
+	t      *Type
 	ref    *ref.Ref
 }
 
@@ -20,7 +20,7 @@ func NewRef(target ref.Ref) Ref {
 	return NewTypedRef(refType, target)
 }
 
-func NewTypedRef(t Type, target ref.Ref) Ref {
+func NewTypedRef(t *Type, target ref.Ref) Ref {
 	d.Chk.Equal(RefKind, t.Kind(), "Invalid type. Expected: RefKind, found: %s", t.Describe())
 	return Ref{target, t, &ref.Ref{}}
 }
@@ -51,7 +51,7 @@ func (r Ref) TargetRef() ref.Ref {
 
 var refType = MakeCompoundType(RefKind, MakePrimitiveType(ValueKind))
 
-func (r Ref) Type() Type {
+func (r Ref) Type() *Type {
 	return r.t
 }
 

--- a/types/set.go
+++ b/types/set.go
@@ -15,7 +15,7 @@ type Set interface {
 	IterAll(cb setIterAllCallback)
 	IterAllP(concurrency int, f setIterAllCallback)
 	Filter(cb setFilterCallback) Set
-	elemType() Type
+	elemType() *Type
 	sequenceCursorAtFirst() *sequenceCursor
 	valueReader() ValueReader
 }
@@ -31,12 +31,12 @@ func NewSet(v ...Value) Set {
 	return NewTypedSet(setType, v...)
 }
 
-func NewTypedSet(t Type, v ...Value) Set {
+func NewTypedSet(t *Type, v ...Value) Set {
 	d.Chk.Equal(SetKind, t.Kind(), "Invalid type. Expected:SetKind, found: %s", t.Describe())
 	return newTypedSet(t, buildSetData(setData{}, v, t)...)
 }
 
-func newTypedSet(t Type, data ...Value) Set {
+func newTypedSet(t *Type, data ...Value) Set {
 	seq := newEmptySequenceChunker(makeSetLeafChunkFn(t, nil), newOrderedMetaSequenceChunkFn(t, nil), newSetLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
 
 	for _, v := range data {

--- a/types/set_leaf.go
+++ b/types/set_leaf.go
@@ -13,13 +13,13 @@ import (
 type setLeaf struct {
 	data    setData // sorted by Ref()
 	indexOf indexOfSetFn
-	t       Type
+	t       *Type
 	ref     *ref.Ref
 }
 
 type setData []Value
 
-func newSetLeaf(t Type, m ...Value) setLeaf {
+func newSetLeaf(t *Type, m ...Value) setLeaf {
 	return setLeaf{m, getIndexFnForSetType(t), t, &ref.Ref{}}
 }
 
@@ -131,11 +131,11 @@ func (s setLeaf) ChildValues() []Value {
 	return append([]Value{}, s.data...)
 }
 
-func (s setLeaf) Type() Type {
+func (s setLeaf) Type() *Type {
 	return s.t
 }
 
-func (s setLeaf) elemType() Type {
+func (s setLeaf) elemType() *Type {
 	return s.t.Desc.(CompoundDesc).ElemTypes[0]
 }
 
@@ -145,7 +145,7 @@ func copySetData(m setData) setData {
 	return r
 }
 
-func buildSetData(old setData, values []Value, t Type) setData {
+func buildSetData(old setData, values []Value, t *Type) setData {
 	idxFn := getIndexFnForSetType(t)
 	elemType := t.Desc.(CompoundDesc).ElemTypes[0]
 
@@ -166,7 +166,7 @@ func buildSetData(old setData, values []Value, t Type) setData {
 	return data
 }
 
-func getIndexFnForSetType(t Type) indexOfSetFn {
+func getIndexFnForSetType(t *Type) indexOfSetFn {
 	orderByValue := t.Desc.(CompoundDesc).ElemTypes[0].IsOrdered()
 	if orderByValue {
 		return indexOfOrderedSetValue
@@ -196,7 +196,7 @@ func newSetLeafBoundaryChecker() boundaryChecker {
 	})
 }
 
-func makeSetLeafChunkFn(t Type, vr ValueReader) makeChunkFn {
+func makeSetLeafChunkFn(t *Type, vr ValueReader) makeChunkFn {
 	return func(items []sequenceItem) (sequenceItem, Value) {
 		setData := make([]Value, len(items), len(items))
 

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -203,7 +203,7 @@ func TestSetIterAllP(t *testing.T) {
 	testIter(64, 200)
 }
 
-func testSetOrder(assert *assert.Assertions, valueType Type, value []Value, expectOrdering []Value) {
+func testSetOrder(assert *assert.Assertions, valueType *Type, value []Value, expectOrdering []Value) {
 	mapTr := MakeCompoundType(SetKind, valueType)
 	m := NewTypedSet(mapTr, value...)
 	i := 0

--- a/types/string.go
+++ b/types/string.go
@@ -40,6 +40,6 @@ func (fs String) ChildValues() []Value {
 
 var typeForString = MakePrimitiveType(StringKind)
 
-func (fs String) Type() Type {
+func (fs String) Type() *Type {
 	return typeForString
 }

--- a/types/struct.go
+++ b/types/struct.go
@@ -9,14 +9,14 @@ type structData map[string]Value
 
 type Struct struct {
 	data       structData
-	t          Type
-	typeDef    Type
+	t          *Type
+	typeDef    *Type
 	unionIndex uint32
 	unionValue Value
 	ref        *ref.Ref
 }
 
-func newStructFromData(data structData, unionIndex uint32, unionValue Value, typ, typeDef Type) Struct {
+func newStructFromData(data structData, unionIndex uint32, unionValue Value, typ, typeDef *Type) Struct {
 	d.Chk.Equal(typ.Kind(), UnresolvedKind)
 	d.Chk.True(typ.HasPackageRef())
 	d.Chk.True(typ.HasOrdinal())
@@ -24,7 +24,7 @@ func newStructFromData(data structData, unionIndex uint32, unionValue Value, typ
 	return Struct{data, typ, typeDef, unionIndex, unionValue, &ref.Ref{}}
 }
 
-func NewStruct(typ, typeDef Type, data structData) Struct {
+func NewStruct(typ, typeDef *Type, data structData) Struct {
 	newData := make(structData)
 	unionIndex := uint32(0)
 	var unionValue Value
@@ -88,7 +88,7 @@ func (s Struct) ChildValues() (res []Value) {
 	return
 }
 
-func (s Struct) Type() Type {
+func (s Struct) Type() *Type {
 	return s.t
 }
 
@@ -170,7 +170,7 @@ func (s Struct) findField(n string) (Field, int32, bool) {
 	return Field{}, -1, false
 }
 
-func structBuilder(values []Value, typ, typeDef Type) Value {
+func structBuilder(values []Value, typ, typeDef *Type) Value {
 	i := 0
 	desc := typeDef.Desc.(StructDesc)
 	data := structData{}
@@ -200,7 +200,7 @@ func structBuilder(values []Value, typ, typeDef Type) Value {
 	return newStructFromData(data, unionIndex, unionValue, typ, typeDef)
 }
 
-func structReader(s Struct, typ, typeDef Type) []Value {
+func structReader(s Struct, typ, typeDef *Type) []Value {
 	values := []Value{}
 
 	desc := typeDef.Desc.(StructDesc)

--- a/types/struct_test.go
+++ b/types/struct_test.go
@@ -14,7 +14,7 @@ func TestGenericStructEquals(t *testing.T) {
 		Field{"x", MakePrimitiveType(BoolKind), false},
 		Field{"o", MakePrimitiveType(StringKind), true},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -33,7 +33,7 @@ func TestGenericStructChunks(t *testing.T) {
 	typeDef := MakeStructType("S1", []Field{
 		Field{"r", MakeCompoundType(RefKind, MakePrimitiveType(BoolKind)), false},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -53,7 +53,7 @@ func TestGenericStructChunksOptional(t *testing.T) {
 	typeDef := MakeStructType("S1", []Field{
 		Field{"r", MakeCompoundType(RefKind, MakePrimitiveType(BoolKind)), true},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -80,7 +80,7 @@ func TestGenericStructChunksUnion(t *testing.T) {
 		Field{"r", MakeCompoundType(RefKind, MakePrimitiveType(BoolKind)), false},
 		Field{"s", MakePrimitiveType(StringKind), false},
 	})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -105,7 +105,7 @@ func TestGenericStructNew(t *testing.T) {
 		Field{"b", MakePrimitiveType(BoolKind), false},
 		Field{"o", MakePrimitiveType(StringKind), true},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -134,7 +134,7 @@ func TestGenericStructNewUnion(t *testing.T) {
 		Field{"b", MakePrimitiveType(BoolKind), false},
 		Field{"o", MakePrimitiveType(StringKind), false},
 	})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -151,7 +151,7 @@ func TestGenericStructSet(t *testing.T) {
 		Field{"b", MakePrimitiveType(BoolKind), false},
 		Field{"o", MakePrimitiveType(StringKind), true},
 	}, []Field{})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 
@@ -172,7 +172,7 @@ func TestGenericStructSetUnion(t *testing.T) {
 		Field{"b", MakePrimitiveType(BoolKind), false},
 		Field{"s", MakePrimitiveType(StringKind), false},
 	})
-	pkg := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	typ := MakeType(pkgRef, 0)
 

--- a/types/type.go
+++ b/types/type.go
@@ -12,6 +12,7 @@ import (
 // If Kind() refers to List, Map, Set or Ref, then Desc is a list of Types describing the element type(s).
 // If Kind() refers to Struct, then Desc contains a []Field and Choices.
 // If Kind() refers to an UnresolvedKind, then Desc contains a PackageRef, which is the Ref of the package where the type definition is defined. The ordinal, if not -1, is the index into the Types list of the package. If the Name is set then the ordinal needs to be found.
+
 type Type struct {
 	name name
 	Desc TypeDesc
@@ -35,25 +36,25 @@ func (n name) compose() (out string) {
 }
 
 // IsUnresolved returns true if t doesn't contain description information. The caller should look the type up by Ordinal in the Types of the appropriate Package.
-func (t Type) IsUnresolved() bool {
+func (t *Type) IsUnresolved() bool {
 	_, ok := t.Desc.(UnresolvedDesc)
 	return ok
 }
 
-func (t Type) HasPackageRef() bool {
+func (t *Type) HasPackageRef() bool {
 	return t.IsUnresolved() && !t.PackageRef().IsEmpty()
 }
 
 // Describe generate text that should parse into the struct being described.
-func (t Type) Describe() (out string) {
+func (t *Type) Describe() (out string) {
 	return WriteHRS(t)
 }
 
-func (t Type) Kind() NomsKind {
+func (t *Type) Kind() NomsKind {
 	return t.Desc.Kind()
 }
 
-func (t Type) IsOrdered() bool {
+func (t *Type) IsOrdered() bool {
 	switch t.Desc.Kind() {
 	case Float32Kind, Float64Kind, Int8Kind, Int16Kind, Int32Kind, Int64Kind, Uint8Kind, Uint16Kind, Uint32Kind, Uint64Kind, StringKind, RefKind:
 		return true
@@ -62,38 +63,38 @@ func (t Type) IsOrdered() bool {
 	}
 }
 
-func (t Type) PackageRef() ref.Ref {
+func (t *Type) PackageRef() ref.Ref {
 	desc, ok := t.Desc.(UnresolvedDesc)
 	d.Chk.True(ok, "PackageRef only works on unresolved types")
 	return desc.pkgRef
 }
 
-func (t Type) Ordinal() int16 {
+func (t *Type) Ordinal() int16 {
 	d.Chk.True(t.HasOrdinal(), "Ordinal has not been set")
 	return t.Desc.(UnresolvedDesc).ordinal
 }
 
-func (t Type) HasOrdinal() bool {
+func (t *Type) HasOrdinal() bool {
 	return t.IsUnresolved() && t.Desc.(UnresolvedDesc).ordinal >= 0
 }
 
-func (t Type) Name() string {
+func (t *Type) Name() string {
 	return t.name.name
 }
 
-func (t Type) Namespace() string {
+func (t *Type) Namespace() string {
 	return t.name.namespace
 }
 
-func (t Type) Ref() ref.Ref {
+func (t *Type) Ref() ref.Ref {
 	return EnsureRef(t.ref, t)
 }
 
-func (t Type) Equals(other Value) (res bool) {
+func (t *Type) Equals(other Value) (res bool) {
 	return other != nil && t.Ref() == other.Ref()
 }
 
-func (t Type) Chunks() (chunks []RefBase) {
+func (t *Type) Chunks() (chunks []RefBase) {
 	if t.IsUnresolved() {
 		if t.HasPackageRef() {
 			chunks = append(chunks, refFromType(t.PackageRef(), MakeRefType(typeForPackage)))
@@ -108,7 +109,7 @@ func (t Type) Chunks() (chunks []RefBase) {
 	return
 }
 
-func (t Type) ChildValues() (res []Value) {
+func (t *Type) ChildValues() (res []Value) {
 	if t.HasPackageRef() {
 		res = append(res, NewTypedRef(MakeRefType(PackageType), t.PackageRef()))
 	}
@@ -138,19 +139,19 @@ func (t Type) ChildValues() (res []Value) {
 
 var typeForType = MakePrimitiveType(TypeKind)
 
-func (t Type) Type() Type {
+func (t *Type) Type() *Type {
 	return typeForType
 }
 
-func MakePrimitiveType(k NomsKind) Type {
+func MakePrimitiveType(k NomsKind) *Type {
 	return buildType("", PrimitiveDesc(k))
 }
 
-func MakePrimitiveTypeByString(p string) Type {
+func MakePrimitiveTypeByString(p string) *Type {
 	return buildType("", primitiveToDesc(p))
 }
 
-func MakeCompoundType(kind NomsKind, elemTypes ...Type) Type {
+func MakeCompoundType(kind NomsKind, elemTypes ...*Type) *Type {
 	if len(elemTypes) == 1 {
 		d.Chk.NotEqual(MapKind, kind, "MapKind requires 2 element types.")
 		d.Chk.True(kind == RefKind || kind == ListKind || kind == SetKind)
@@ -161,42 +162,42 @@ func MakeCompoundType(kind NomsKind, elemTypes ...Type) Type {
 	return buildType("", CompoundDesc{kind, elemTypes})
 }
 
-func MakeStructType(name string, fields []Field, choices []Field) Type {
+func MakeStructType(name string, fields []Field, choices []Field) *Type {
 	return buildType(name, StructDesc{fields, choices})
 }
 
-func MakeType(pkgRef ref.Ref, ordinal int16) Type {
+func MakeType(pkgRef ref.Ref, ordinal int16) *Type {
 	d.Chk.True(ordinal >= 0)
-	return Type{Desc: UnresolvedDesc{pkgRef, ordinal}, ref: &ref.Ref{}}
+	return &Type{Desc: UnresolvedDesc{pkgRef, ordinal}, ref: &ref.Ref{}}
 }
 
-func MakeUnresolvedType(namespace, n string) Type {
-	return Type{name: name{namespace, n}, Desc: UnresolvedDesc{ordinal: -1}, ref: &ref.Ref{}}
+func MakeUnresolvedType(namespace, n string) *Type {
+	return &Type{name: name{namespace, n}, Desc: UnresolvedDesc{ordinal: -1}, ref: &ref.Ref{}}
 }
 
-func MakeListType(elemType Type) Type {
-	return buildType("", CompoundDesc{ListKind, []Type{elemType}})
+func MakeListType(elemType *Type) *Type {
+	return buildType("", CompoundDesc{ListKind, []*Type{elemType}})
 }
 
-func MakeSetType(elemType Type) Type {
-	return buildType("", CompoundDesc{SetKind, []Type{elemType}})
+func MakeSetType(elemType *Type) *Type {
+	return buildType("", CompoundDesc{SetKind, []*Type{elemType}})
 }
 
-func MakeMapType(keyType, valType Type) Type {
-	return buildType("", CompoundDesc{MapKind, []Type{keyType, valType}})
+func MakeMapType(keyType, valType *Type) *Type {
+	return buildType("", CompoundDesc{MapKind, []*Type{keyType, valType}})
 }
 
-func MakeRefType(elemType Type) Type {
-	return buildType("", CompoundDesc{RefKind, []Type{elemType}})
+func MakeRefType(elemType *Type) *Type {
+	return buildType("", CompoundDesc{RefKind, []*Type{elemType}})
 }
 
-func buildType(n string, desc TypeDesc) Type {
+func buildType(n string, desc TypeDesc) *Type {
 	if IsPrimitiveKind(desc.Kind()) {
-		return Type{name: name{name: n}, Desc: desc, ref: &ref.Ref{}}
+		return &Type{name: name{name: n}, Desc: desc, ref: &ref.Ref{}}
 	}
 	switch desc.Kind() {
 	case ListKind, RefKind, SetKind, MapKind, StructKind, UnresolvedKind:
-		return Type{name: name{name: n}, Desc: desc, ref: &ref.Ref{}}
+		return &Type{name: name{name: n}, Desc: desc, ref: &ref.Ref{}}
 	default:
 		d.Exp.Fail("Unrecognized Kind:", "%v", desc.Kind())
 		panic("unreachable")

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -92,7 +92,7 @@ func (u UnresolvedDesc) Equals(other TypeDesc) bool {
 // ElemTypes indicates what type or types are in the container indicated by kind, e.g. Map key and value or Set element.
 type CompoundDesc struct {
 	kind      NomsKind
-	ElemTypes []Type
+	ElemTypes []*Type
 }
 
 func (c CompoundDesc) Kind() NomsKind {
@@ -143,7 +143,7 @@ func (s StructDesc) Equals(other TypeDesc) bool {
 // Neither Name nor T is allowed to be a zero-value, though T may be an unresolved Type.
 type Field struct {
 	Name     string
-	T        Type
+	T        *Type
 	Optional bool
 }
 

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -24,7 +24,7 @@ func TestTypes(t *testing.T) {
 		Field{"StructField", mahType, false},
 		Field{"StringField", stringType, false},
 	})
-	pkgRef := vs.WriteValue(NewPackage([]Type{}, ref.RefSlice{})).TargetRef()
+	pkgRef := vs.WriteValue(NewPackage([]*Type{}, ref.RefSlice{})).TargetRef()
 	trType := MakeType(pkgRef, 42)
 
 	mRef := vs.WriteValue(mapType).TargetRef()
@@ -44,7 +44,7 @@ func TestTypeWithPkgRef(t *testing.T) {
 	assert := assert.New(t)
 	vs := NewTestValueStore()
 
-	pkg := NewPackage([]Type{MakePrimitiveType(Float64Kind)}, []ref.Ref{})
+	pkg := NewPackage([]*Type{MakePrimitiveType(Float64Kind)}, []ref.Ref{})
 
 	pkgRef := RegisterPackage(&pkg)
 	unresolvedType := MakeType(pkgRef, 42)

--- a/types/validating_batching_sink.go
+++ b/types/validating_batching_sink.go
@@ -34,7 +34,7 @@ func (vbs *ValidatingBatchingSink) Enqueue(c chunks.Chunk) chunks.BackpressureEr
 	v := DecodeChunk(c, vbs.vs)
 	d.Exp.NotNil(v, "Chunk with hash %s failed to decode", r)
 	vbs.vs.checkChunksInCache(v)
-	vbs.vs.set(r, presentChunk(v.Type()))
+	vbs.vs.set(r, (*presentChunk)(v.Type()))
 
 	vbs.batch[vbs.count] = c
 	vbs.count++

--- a/types/value.go
+++ b/types/value.go
@@ -11,7 +11,7 @@ type Value interface {
 	// Returns the immediate children of this value in the DAG, if any, not including Type().
 	ChildValues() []Value
 	Chunks() []RefBase
-	Type() Type
+	Type() *Type
 }
 
 type OrderedValue interface {

--- a/types/value_store.go
+++ b/types/value_store.go
@@ -22,7 +22,7 @@ type ValueStore struct {
 type chunkCacheEntry interface {
 	Present() bool
 	Hint() ref.Ref
-	Type() Type
+	Type() *Type
 }
 
 // NewTestValueStore creates a simple struct that satisfies ValueReadWriter and is backed by a chunks.TestStore.
@@ -72,7 +72,7 @@ func (lvs *ValueStore) WriteValue(v Value) RefBase {
 	c := EncodeValue(v, lvs)
 
 	hints := lvs.checkChunksInCache(v)
-	lvs.set(targetRef, presentChunk(v.Type()))
+	lvs.set(targetRef, (*presentChunk)(v.Type()))
 	lvs.bs.SchedulePut(c, hints)
 
 	return r
@@ -152,7 +152,7 @@ func (lvs *ValueStore) checkChunksInCache(v Value) map[ref.Ref]struct{} {
 	return hints
 }
 
-func getTargetType(refBase RefBase) Type {
+func getTargetType(refBase RefBase) *Type {
 	refType := refBase.Type()
 	d.Chk.Equal(RefKind, refType.Kind())
 	return refType.Desc.(CompoundDesc).ElemTypes[0]
@@ -160,20 +160,20 @@ func getTargetType(refBase RefBase) Type {
 
 type presentChunk Type
 
-func (p presentChunk) Present() bool {
+func (p *presentChunk) Present() bool {
 	return true
 }
 
-func (p presentChunk) Hint() (r ref.Ref) {
+func (p *presentChunk) Hint() (r ref.Ref) {
 	return
 }
 
-func (p presentChunk) Type() Type {
-	return Type(p)
+func (p *presentChunk) Type() *Type {
+	return (*Type)(p)
 }
 
 type hintedChunk struct {
-	t    Type
+	t    *Type
 	hint ref.Ref
 }
 
@@ -185,7 +185,7 @@ func (h hintedChunk) Hint() (r ref.Ref) {
 	return h.hint
 }
 
-func (h hintedChunk) Type() Type {
+func (h hintedChunk) Type() *Type {
 	return h.t
 }
 
@@ -199,6 +199,6 @@ func (a absentChunk) Hint() (r ref.Ref) {
 	return
 }
 
-func (a absentChunk) Type() Type {
+func (a absentChunk) Type() *Type {
 	panic("Not reached. Should never call Type() on an absentChunk.")
 }

--- a/types/value_store_test.go
+++ b/types/value_store_test.go
@@ -50,9 +50,9 @@ func TestWriteValue(t *testing.T) {
 
 	testEncode(fmt.Sprintf("t [%d,\"hi\"]", StringKind), NewString("hi"))
 
-	testEncode(fmt.Sprintf("t [%d,[],[]]", PackageKind), Package{types: []Type{}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
-	ref1 := testEncode(fmt.Sprintf("t [%d,[%d],[]]", PackageKind, BoolKind), Package{types: []Type{MakePrimitiveType(BoolKind)}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
-	testEncode(fmt.Sprintf("t [%d,[],[\"%s\"]]", PackageKind, ref1), Package{types: []Type{}, dependencies: []ref.Ref{ref1}, ref: &ref.Ref{}})
+	testEncode(fmt.Sprintf("t [%d,[],[]]", PackageKind), Package{types: []*Type{}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
+	ref1 := testEncode(fmt.Sprintf("t [%d,[%d],[]]", PackageKind, BoolKind), Package{types: []*Type{MakePrimitiveType(BoolKind)}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
+	testEncode(fmt.Sprintf("t [%d,[],[\"%s\"]]", PackageKind, ref1), Package{types: []*Type{}, dependencies: []ref.Ref{ref1}, ref: &ref.Ref{}})
 }
 
 func TestWriteBlobLeaf(t *testing.T) {
@@ -83,7 +83,7 @@ func TestWritePackageWhenValueIsWritten(t *testing.T) {
 	typeDef := MakeStructType("S", []Field{
 		Field{"X", MakePrimitiveType(Int32Kind), false},
 	}, []Field{})
-	pkg1 := NewPackage([]Type{typeDef}, []ref.Ref{})
+	pkg1 := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	// Don't write package
 	pkgRef1 := RegisterPackage(&pkg1)
 	typ := MakeType(pkgRef1, 0)
@@ -99,11 +99,11 @@ func TestWritePackageDepWhenPackageIsWritten(t *testing.T) {
 	assert := assert.New(t)
 	vs := NewTestValueStore()
 
-	pkg1 := NewPackage([]Type{}, []ref.Ref{})
+	pkg1 := NewPackage([]*Type{}, []ref.Ref{})
 	// Don't write package
 	pkgRef1 := RegisterPackage(&pkg1)
 
-	pkg2 := NewPackage([]Type{}, []ref.Ref{pkgRef1})
+	pkg2 := NewPackage([]*Type{}, []ref.Ref{pkgRef1})
 	vs.WriteValue(pkg2)
 
 	pkg3 := vs.ReadValue(pkgRef1)
@@ -117,7 +117,7 @@ func TestCheckChunksInCache(t *testing.T) {
 
 	b := NewEmptyBlob()
 	cs.Put(EncodeValue(b, nil))
-	cvs.set(b.Ref(), presentChunk(b.Type()))
+	cvs.set(b.Ref(), (*presentChunk)(b.Type()))
 
 	bref := NewTypedRefFromValue(b)
 	assert.NotPanics(func() { cvs.checkChunksInCache(bref) })


### PR DESCRIPTION
This is in preparation of allowing back references which requires
pointers to be able to compare that the structs are the same.
