### PR TITLE
Make MakeCompoundType package private

### DIFF
--- a/clients/common/date.noms.go
+++ b/clients/common/date.noms.go
@@ -14,7 +14,7 @@ func init() {
 	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("Date",
 			[]types.Field{
-				types.Field{"MsSinceEpoch", types.MakePrimitiveType(types.Int64Kind), false},
+				types.Field{"MsSinceEpoch", types.Int64Type, false},
 			},
 			[]types.Field{},
 		),

--- a/clients/common/geo.noms.go
+++ b/clients/common/geo.noms.go
@@ -14,8 +14,8 @@ func init() {
 	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("Geoposition",
 			[]types.Field{
-				types.Field{"Latitude", types.MakePrimitiveType(types.Float32Kind), false},
-				types.Field{"Longitude", types.MakePrimitiveType(types.Float32Kind), false},
+				types.Field{"Latitude", types.Float32Type, false},
+				types.Field{"Longitude", types.Float32Type, false},
 			},
 			[]types.Field{},
 		),

--- a/clients/common/photo.noms.go
+++ b/clients/common/photo.noms.go
@@ -14,30 +14,30 @@ func init() {
 	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("RemotePhoto",
 			[]types.Field{
-				types.Field{"Id", types.MakePrimitiveType(types.StringKind), false},
-				types.Field{"Title", types.MakePrimitiveType(types.StringKind), false},
+				types.Field{"Id", types.StringType, false},
+				types.Field{"Title", types.StringType, false},
 				types.Field{"Date", types.MakeType(ref.Parse("sha1-0b4ac7cb0583d7fecd71a1584a3f846e5d8b08eb"), 0), false},
 				types.Field{"Geoposition", types.MakeType(ref.Parse("sha1-0cac0f1ed4777b6965548b0dfe6965a9f23af76c"), 0), false},
-				types.Field{"Sizes", types.MakeCompoundType(types.MapKind, types.MakeType(ref.Ref{}, 2), types.MakePrimitiveType(types.StringKind)), false},
-				types.Field{"Tags", types.MakeCompoundType(types.SetKind, types.MakePrimitiveType(types.StringKind)), false},
-				types.Field{"Faces", types.MakeCompoundType(types.SetKind, types.MakeType(ref.Ref{}, 1)), false},
+				types.Field{"Sizes", types.MakeMapType(types.MakeType(ref.Ref{}, 2), types.StringType), false},
+				types.Field{"Tags", types.MakeSetType(types.StringType), false},
+				types.Field{"Faces", types.MakeSetType(types.MakeType(ref.Ref{}, 1)), false},
 			},
 			[]types.Field{},
 		),
 		types.MakeStructType("Face",
 			[]types.Field{
-				types.Field{"Top", types.MakePrimitiveType(types.Float32Kind), false},
-				types.Field{"Left", types.MakePrimitiveType(types.Float32Kind), false},
-				types.Field{"Width", types.MakePrimitiveType(types.Float32Kind), false},
-				types.Field{"Height", types.MakePrimitiveType(types.Float32Kind), false},
-				types.Field{"PersonName", types.MakePrimitiveType(types.StringKind), false},
+				types.Field{"Top", types.Float32Type, false},
+				types.Field{"Left", types.Float32Type, false},
+				types.Field{"Width", types.Float32Type, false},
+				types.Field{"Height", types.Float32Type, false},
+				types.Field{"PersonName", types.StringType, false},
 			},
 			[]types.Field{},
 		),
 		types.MakeStructType("Size",
 			[]types.Field{
-				types.Field{"Width", types.MakePrimitiveType(types.Uint32Kind), false},
-				types.Field{"Height", types.MakePrimitiveType(types.Uint32Kind), false},
+				types.Field{"Width", types.Uint32Type, false},
+				types.Field{"Height", types.Uint32Type, false},
 			},
 			[]types.Field{},
 		),
@@ -576,7 +576,7 @@ func (m MapOfSizeToString) Type() *types.Type {
 }
 
 func init() {
-	__typeForMapOfSizeToString = types.MakeCompoundType(types.MapKind, types.MakeType(ref.Parse("sha1-10004087fdbc623873c649d28aa59f4e066d374e"), 2), types.MakePrimitiveType(types.StringKind))
+	__typeForMapOfSizeToString = types.MakeMapType(types.MakeType(ref.Parse("sha1-10004087fdbc623873c649d28aa59f4e066d374e"), 2), types.StringType)
 	types.RegisterValue(__typeForMapOfSizeToString, builderForMapOfSizeToString, readerForMapOfSizeToString)
 }
 
@@ -711,7 +711,7 @@ func (m SetOfString) Type() *types.Type {
 }
 
 func init() {
-	__typeForSetOfString = types.MakeCompoundType(types.SetKind, types.MakePrimitiveType(types.StringKind))
+	__typeForSetOfString = types.MakeSetType(types.StringType)
 	types.RegisterValue(__typeForSetOfString, builderForSetOfString, readerForSetOfString)
 }
 
@@ -856,7 +856,7 @@ func (m SetOfFace) Type() *types.Type {
 }
 
 func init() {
-	__typeForSetOfFace = types.MakeCompoundType(types.SetKind, types.MakeType(ref.Parse("sha1-10004087fdbc623873c649d28aa59f4e066d374e"), 1))
+	__typeForSetOfFace = types.MakeSetType(types.MakeType(ref.Parse("sha1-10004087fdbc623873c649d28aa59f4e066d374e"), 1))
 	types.RegisterValue(__typeForSetOfFace, builderForSetOfFace, readerForSetOfFace)
 }
 

--- a/clients/csv/exporter/exporter_test.go
+++ b/clients/csv/exporter/exporter_test.go
@@ -45,7 +45,7 @@ func (s *testSuite) TestCSVExporter() {
 	for _, key := range header {
 		f = append(f, types.Field{
 			Name: key,
-			T:    types.MakePrimitiveType(types.StringKind),
+			T:    types.StringType,
 		})
 	}
 
@@ -65,7 +65,7 @@ func (s *testSuite) TestCSVExporter() {
 		structs[i] = types.NewStruct(typeRef, typeDef, fields)
 	}
 
-	listType := types.MakeCompoundType(types.ListKind, typeRef)
+	listType := types.MakeListType(typeRef)
 	ds.Commit(types.NewTypedList(listType, structs...))
 	ds.Store().Close()
 

--- a/clients/csv/read.go
+++ b/clients/csv/read.go
@@ -96,7 +96,7 @@ func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSl
 func Read(r *csv.Reader, structName string, headers []string, kinds KindSlice, vrw types.ValueReadWriter) (l types.List, typeRef, typeDef *types.Type) {
 	typeRef, typeDef = MakeStructTypeFromHeaders(headers, structName, kinds)
 	valueChan := make(chan types.Value, 128) // TODO: Make this a function param?
-	listType := types.MakeCompoundType(types.ListKind, typeRef)
+	listType := types.MakeListType(typeRef)
 	listChan := types.NewStreamingTypedList(listType, vrw, valueChan)
 
 	structFields := typeDef.Desc.(types.StructDesc).Fields

--- a/clients/util/string_value_map.go
+++ b/clients/util/string_value_map.go
@@ -6,6 +6,6 @@ import (
 
 func NewMapOfStringToValue(kv ...types.Value) types.Map {
 	return types.NewTypedMap(
-		types.MakeCompoundType(types.MapKind, types.MakePrimitiveType(types.StringKind), types.MakePrimitiveType(types.ValueKind)),
+		types.MakeMapType(types.StringType, types.ValueType),
 		kv...)
 }

--- a/clients/xml_importer/xml_importer.go
+++ b/clients/xml_importer/xml_importer.go
@@ -130,11 +130,11 @@ func main() {
 		}
 
 		rl := types.NewTypedList(
-			types.MakeCompoundType(types.ListKind, 
-				types.MakeCompoundType(types.RefKind, 
-					types.MakeCompoundType(types.MapKind,
-						types.MakePrimitiveType(types.StringKind),
-						types.MakePrimitiveType(types.ValueKind)))), refs...)
+			types.MakeListType(
+				types.MakeRefType(
+					types.MakeMapType(
+						types.StringType,
+						types.ValueType))), refs...)
 
 		if !*noIO {
 			_, err := ds.Commit(rl)

--- a/datas/commit.go
+++ b/datas/commit.go
@@ -14,8 +14,8 @@ func init() {
 	p := types.NewPackage([]*types.Type{
 		types.MakeStructType("Commit",
 			[]types.Field{
-				types.Field{"value", types.MakePrimitiveType(types.ValueKind), false},
-				types.Field{"parents", types.MakeCompoundType(types.SetKind, types.MakeCompoundType(types.RefKind, types.MakeType(ref.Ref{}, 0))), false},
+				types.Field{"value", types.ValueType, false},
+				types.Field{"parents", types.MakeSetType(types.MakeRefType(types.MakeType(ref.Ref{}, 0))), false},
 			},
 			[]types.Field{},
 		),

--- a/nomdl/codegen/README.md
+++ b/nomdl/codegen/README.md
@@ -48,7 +48,7 @@ Here is the diff:
 --- a/nomdl/pkg/grammar.peg
 +++ b/nomdl/pkg/grammar.peg
 @@ -159,7 +159,7 @@ CompoundType <- `List` _ `(` _ t:Type _ `)` _ {
-        return types.MakeCompoundType(types.RefKind, t.(types.Type)), nil
+        return types.MakeRefType(t.(*types.Type)), nil
  }
 
 -PrimitiveType <- p:(`Uint64` / `Uint32` / `Uint16` / `Uint8` / `Int64` / `Int32` / `Int16` / `Int8` / `Float64` / `Float32` / `Bool` / `String` / `Blob` / `Value` / `Type`) {

--- a/nomdl/codegen/code/generate_test.go
+++ b/nomdl/codegen/code/generate_test.go
@@ -36,7 +36,7 @@ func TestUserName(t *testing.T) {
 
 	imported := types.NewPackage([]*types.Type{
 		types.MakeStructType("S1", []types.Field{
-			types.Field{"f", types.MakePrimitiveType(types.BoolKind), false},
+			types.Field{"f", types.BoolType, false},
 		}, []types.Field{}),
 	}, []ref.Ref{})
 
@@ -44,7 +44,7 @@ func TestUserName(t *testing.T) {
 
 	localStructName := "Local"
 	resolved := types.MakeStructType(localStructName, []types.Field{
-		types.Field{"a", types.MakePrimitiveType(types.Int8Kind), false},
+		types.Field{"a", types.Int8Type, false},
 	}, []types.Field{})
 
 	g := Generator{R: &res, Package: &imported}

--- a/nomdl/codegen/codegen_test.go
+++ b/nomdl/codegen/codegen_test.go
@@ -72,13 +72,13 @@ func TestSkipDuplicateTypes(t *testing.T) {
 
 	leaf1 := types.NewPackage([]*types.Type{
 		types.MakeStructType("S1", []types.Field{
-			types.Field{"f", types.MakeCompoundType(types.ListKind, types.MakePrimitiveType(types.Uint16Kind)), false},
+			types.Field{"f", types.MakeListType(types.Uint16Type), false},
 			types.Field{"e", types.MakeType(ref.Ref{}, 0), false},
 		}, []types.Field{}),
 	}, []ref.Ref{})
 	leaf2 := types.NewPackage([]*types.Type{
 		types.MakeStructType("S2", []types.Field{
-			types.Field{"f", types.MakeCompoundType(types.ListKind, types.MakePrimitiveType(types.Uint16Kind)), false},
+			types.Field{"f", types.MakeListType(types.Uint16Type), false},
 		}, []types.Field{}),
 	}, []ref.Ref{})
 

--- a/nomdl/pkg/grammar.peg
+++ b/nomdl/pkg/grammar.peg
@@ -130,13 +130,13 @@ Type <- t:(PrimitiveType / CompoundType / Union / NamespaceIdent) {
 }
 
 CompoundType <- `List` _ `<` _ t:Type _ `>` _ {
-	return types.MakeCompoundType(types.ListKind, t.(*types.Type)), nil
+	return types.MakeListType(t.(*types.Type)), nil
 } / `Map` _ `<` _ k:Type _ `,` _ v:Type _ `>` _ {
-	return types.MakeCompoundType(types.MapKind, k.(*types.Type), v.(*types.Type)), nil
+	return types.MakeMapType(k.(*types.Type), v.(*types.Type)), nil
 } / `Set` _ `<` _ t:Type _ `>` _ {
-	return types.MakeCompoundType(types.SetKind, t.(*types.Type)), nil
+	return types.MakeSetType(t.(*types.Type)), nil
 } / `Ref` _ `<` _ t:Type _ `>` _ {
-	return types.MakeCompoundType(types.RefKind, t.(*types.Type)), nil
+	return types.MakeRefType(t.(*types.Type)), nil
 }
 
 PrimitiveType <- p:(`Uint64` / `Uint32` / `Uint16` / `Uint8` / `Int64` / `Int32` / `Int16` / `Int8` / `Float64` / `Float32` / `Bool` / `String` / `Blob` / `Value` / `Type`) {

--- a/nomdl/pkg/grammar.peg.go
+++ b/nomdl/pkg/grammar.peg.go
@@ -1282,7 +1282,7 @@ func (p *parser) callonType1() (interface{}, error) {
 }
 
 func (c *current) onCompoundType2(t interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.ListKind, t.(*types.Type)), nil
+	return types.MakeListType(t.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType2() (interface{}, error) {
@@ -1292,7 +1292,7 @@ func (p *parser) callonCompoundType2() (interface{}, error) {
 }
 
 func (c *current) onCompoundType13(k, v interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.MapKind, k.(*types.Type), v.(*types.Type)), nil
+	return types.MakeMapType(k.(*types.Type), v.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType13() (interface{}, error) {
@@ -1302,7 +1302,7 @@ func (p *parser) callonCompoundType13() (interface{}, error) {
 }
 
 func (c *current) onCompoundType29(t interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.SetKind, t.(*types.Type)), nil
+	return types.MakeSetType(t.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType29() (interface{}, error) {
@@ -1312,7 +1312,7 @@ func (p *parser) callonCompoundType29() (interface{}, error) {
 }
 
 func (c *current) onCompoundType40(t interface{}) (interface{}, error) {
-	return types.MakeCompoundType(types.RefKind, t.(*types.Type)), nil
+	return types.MakeRefType(t.(*types.Type)), nil
 }
 
 func (p *parser) callonCompoundType40() (interface{}, error) {

--- a/nomdl/pkg/imports_test.go
+++ b/nomdl/pkg/imports_test.go
@@ -32,8 +32,8 @@ func (suite *ImportTestSuite) SetupTest() {
 	suite.vrw = datas.NewDataStore(chunks.NewMemoryStore())
 
 	ns := types.MakeStructType("NestedDepStruct", []types.Field{}, []types.Field{
-		types.Field{"b", types.MakePrimitiveType(types.BoolKind), false},
-		types.Field{"i", types.MakePrimitiveType(types.Int8Kind), false},
+		types.Field{"b", types.BoolType, false},
+		types.Field{"i", types.Int8Type, false},
 	})
 	suite.nested = types.NewPackage([]*types.Type{ns}, []ref.Ref{})
 	suite.nestedRef = suite.vrw.WriteValue(suite.nested).TargetRef()
@@ -68,7 +68,7 @@ func (suite *ImportTestSuite) TestUnknownImportedType() {
 
 func (suite *ImportTestSuite) TestDetectFreeVariable() {
 	ls := types.MakeStructType("Local", []types.Field{
-		types.Field{"b", types.MakePrimitiveType(types.BoolKind), false},
+		types.Field{"b", types.BoolType, false},
 		types.Field{"n", types.MakeUnresolvedType("", "OtherLocal"), false},
 	},
 		[]types.Field{})

--- a/nomdl/pkg/parse.go
+++ b/nomdl/pkg/parse.go
@@ -81,11 +81,15 @@ func resolveLocalOrdinals(p *intermediate) {
 		}
 
 		switch t.Kind() {
-		case types.ListKind, types.SetKind, types.RefKind:
-			return types.MakeCompoundType(t.Kind(), rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+		case types.ListKind:
+			return types.MakeListType(rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+		case types.SetKind:
+			return types.MakeSetType(rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+		case types.RefKind:
+			return types.MakeRefType(rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
 		case types.MapKind:
 			elemTypes := t.Desc.(types.CompoundDesc).ElemTypes
-			return types.MakeCompoundType(t.Kind(), rec(elemTypes[0]), rec(elemTypes[1]))
+			return types.MakeMapType(rec(elemTypes[0]), rec(elemTypes[1]))
 		case types.StructKind:
 			resolveFields(t.Desc.(types.StructDesc).Fields)
 			resolveFields(t.Desc.(types.StructDesc).Union)
@@ -137,11 +141,15 @@ func resolveNamespaces(p *intermediate, aliases map[string]ref.Ref, deps map[ref
 		switch t.Kind() {
 		case types.UnresolvedKind:
 			d.Chk.True(t.HasPackageRef(), "should resolve again")
-		case types.ListKind, types.SetKind, types.RefKind:
-			return types.MakeCompoundType(t.Kind(), rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+		case types.ListKind:
+			return types.MakeListType(rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+		case types.SetKind:
+			return types.MakeSetType(rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
+		case types.RefKind:
+			return types.MakeRefType(rec(t.Desc.(types.CompoundDesc).ElemTypes[0]))
 		case types.MapKind:
 			elemTypes := t.Desc.(types.CompoundDesc).ElemTypes
-			return types.MakeCompoundType(t.Kind(), rec(elemTypes[0]), rec(elemTypes[1]))
+			return types.MakeMapType(rec(elemTypes[0]), rec(elemTypes[1]))
 		case types.StructKind:
 			resolveFields(t.Desc.(types.StructDesc).Fields)
 			resolveFields(t.Desc.(types.StructDesc).Union)

--- a/nomdl/pkg/parse_test.go
+++ b/nomdl/pkg/parse_test.go
@@ -54,7 +54,7 @@ using List<Noms.Commit>
 	suite.Len(pkg.UsingDeclarations, 2)
 
 	suite.Equal(types.MapKind, pkg.UsingDeclarations[0].Desc.Kind())
-	suite.True(types.MakePrimitiveType(types.StringKind).Equals(pkg.UsingDeclarations[0].Desc.(types.CompoundDesc).ElemTypes[0]))
+	suite.True(types.StringType.Equals(pkg.UsingDeclarations[0].Desc.(types.CompoundDesc).ElemTypes[0]))
 	suite.True(types.MakeUnresolvedType("", "Simple").Equals(pkg.UsingDeclarations[0].Desc.(types.CompoundDesc).ElemTypes[1]))
 
 	suite.Equal(types.ListKind, pkg.UsingDeclarations[1].Desc.Kind())
@@ -196,16 +196,15 @@ func (c testChoices) Describe() string {
 }
 
 func (suite *ParsedResultTestSuite) SetupTest() {
-	suite.primField = testField{"a", types.MakePrimitiveType(types.Int64Kind), false}
-	suite.primOptionalField = testField{"b", types.MakePrimitiveType(types.Float64Kind), true}
-	suite.compoundField = testField{"set", types.MakeCompoundType(types.SetKind, types.MakePrimitiveType(types.StringKind)), false}
+	suite.primField = testField{"a", types.Int64Type, false}
+	suite.primOptionalField = testField{"b", types.Float64Type, true}
+	suite.compoundField = testField{"set", types.MakeSetType(types.StringType), false}
 	suite.compoundOfCompoundField = testField{
 		"listOfSet",
-		types.MakeCompoundType(types.ListKind,
-			types.MakeCompoundType(types.SetKind, types.MakePrimitiveType(types.StringKind))), false}
+		types.MakeListType(types.MakeSetType(types.StringType)), false}
 	suite.mapOfNamedTypeField = testField{
 		"mapOfStructToOther",
-		types.MakeCompoundType(types.MapKind,
+		types.MakeMapType(
 			types.MakeUnresolvedType("", "Struct"),
 			types.MakeUnresolvedType("Elsewhere", "Other"),
 		),
@@ -213,9 +212,9 @@ func (suite *ParsedResultTestSuite) SetupTest() {
 	suite.namedTypeField = testField{"otherStruct", types.MakeUnresolvedType("", "Other"), false}
 	suite.namespacedTypeField = testField{"namespacedStruct", types.MakeUnresolvedType("Elsewhere", "Other"), false}
 	suite.union = testChoices{
-		types.Field{"a", types.MakePrimitiveType(types.Int32Kind), false},
+		types.Field{"a", types.Int32Type, false},
 		types.Field{"n", types.MakeUnresolvedType("NN", "Other"), false},
-		types.Field{"c", types.MakePrimitiveType(types.Uint32Kind), false},
+		types.Field{"c", types.Uint32Type, false},
 	}
 }
 

--- a/types/blob.go
+++ b/types/blob.go
@@ -16,7 +16,7 @@ const (
 	blobWindowSize = 64
 )
 
-var typeForBlob = MakePrimitiveType(BlobKind)
+var typeForBlob = BlobType
 
 type Blob interface {
 	Value

--- a/types/blob_leaf_test.go
+++ b/types/blob_leaf_test.go
@@ -39,5 +39,5 @@ func TestBlobLeafChunks(t *testing.T) {
 func TestBlobLeafType(t *testing.T) {
 	assert := assert.New(t)
 	b := newBlobLeaf([]byte{})
-	assert.True(b.Type().Equals(MakePrimitiveType(BlobKind)))
+	assert.True(b.Type().Equals(BlobType))
 }

--- a/types/compound_blob_test.go
+++ b/types/compound_blob_test.go
@@ -273,5 +273,5 @@ func TestCompoundBlobType(t *testing.T) {
 	assert := assert.New(t)
 
 	cb := getTestCompoundBlob("hello", "world")
-	assert.True(cb.Type().Equals(MakePrimitiveType(BlobKind)))
+	assert.True(cb.Type().Equals(BlobType))
 }

--- a/types/compound_list_test.go
+++ b/types/compound_list_test.go
@@ -82,7 +82,7 @@ func TestStreamingCompoundListCreation(t *testing.T) {
 	vs := NewTestValueStore()
 	simpleList := getTestSimpleList()
 
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...)
 	valueChan := make(chan Value)
 	listChan := NewStreamingTypedList(tr, vs, valueChan)
@@ -111,7 +111,7 @@ func TestCompoundListGet(t *testing.T) {
 		}
 	}
 
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...).(compoundList)
 	testGet(cl)
 	testGet(vs.ReadValue(vs.WriteValue(cl).TargetRef()).(compoundList))
@@ -121,7 +121,7 @@ func TestCompoundListIter(t *testing.T) {
 	assert := assert.New(t)
 
 	simpleList := getTestSimpleList()
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...)
 
 	expectIdx := uint64(0)
@@ -140,7 +140,7 @@ func TestCompoundListIterAll(t *testing.T) {
 	assert := assert.New(t)
 
 	simpleList := getTestSimpleList()
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...)
 
 	expectIdx := uint64(0)
@@ -159,7 +159,7 @@ func TestCompoundListIterAllP(t *testing.T) {
 	mu := sync.Mutex{}
 
 	simpleList := getTestSimpleListUnique()
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...)
 
 	indexes := map[Value]uint64{}
@@ -183,7 +183,7 @@ func TestCompoundListMap(t *testing.T) {
 	assert := assert.New(t)
 
 	simpleList := getTestSimpleList()
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...)
 
 	l := cl.Map(func(v Value, i uint64) interface{} {
@@ -201,7 +201,7 @@ func TestCompoundListMapP(t *testing.T) {
 	assert := assert.New(t)
 
 	simpleList := getTestSimpleList()
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, simpleList...)
 
 	l := cl.MapP(64, func(v Value, i uint64) interface{} {
@@ -218,7 +218,7 @@ func TestCompoundListMapP(t *testing.T) {
 func TestCompoundListLen(t *testing.T) {
 	assert := assert.New(t)
 
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 
 	cl := NewTypedList(tr, getTestSimpleList()...).(compoundList)
 	assert.Equal(getTestSimpleListLen(), cl.Len())
@@ -231,7 +231,7 @@ func TestCompoundListCursorAt(t *testing.T) {
 
 	listLen := func(at uint64, next func(*sequenceCursor) bool) (size uint64) {
 		cs := NewTestValueStore()
-		tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+		tr := MakeListType(Int64Type)
 		cl := NewTypedList(tr, getTestSimpleList()...).(compoundList)
 		cur, _, _ := cl.cursorAt(at)
 		for {
@@ -254,7 +254,7 @@ func TestCompoundListAppend(t *testing.T) {
 	assert := assert.New(t)
 
 	newCompoundList := func(items testSimpleList) compoundList {
-		tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+		tr := MakeListType(Int64Type)
 		return NewTypedList(tr, items...).(compoundList)
 	}
 
@@ -430,7 +430,7 @@ func TestCompoundListInsertTypeError(t *testing.T) {
 	assert := assert.New(t)
 
 	testList := getTestSimpleList()
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl := NewTypedList(tr, testList...)
 	assert.Panics(func() {
 		cl.Insert(2, Bool(true))
@@ -531,7 +531,7 @@ func TestCompoundListSet(t *testing.T) {
 		testIdx(i, false)
 	}
 
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	cl2 := NewTypedList(tr, testList...)
 	assert.Panics(func() {
 		cl2.Set(0, Bool(true))
@@ -541,7 +541,7 @@ func TestCompoundListSet(t *testing.T) {
 func TestCompoundListSlice(t *testing.T) {
 	assert := assert.New(t)
 
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	tr := MakeListType(Int64Type)
 	testList := getTestSimpleList()
 
 	cl := NewTypedList(tr, testList...)
@@ -610,7 +610,7 @@ func TestCompoundListFilter(t *testing.T) {
 func TestCompoundListFirstNNumbers(t *testing.T) {
 	assert := assert.New(t)
 
-	listType := MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind))
+	listType := MakeListType(Int64Type)
 
 	firstNNumbers := func(n int) []Value {
 		nums := []Value{}
@@ -631,13 +631,13 @@ func TestCompoundListRefOfStructFirstNNumbers(t *testing.T) {
 	vs := NewTestValueStore()
 
 	structTypeDef := MakeStructType("num", []Field{
-		Field{"n", MakePrimitiveType(Int64Kind), false},
+		Field{"n", Int64Type, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{structTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	structType := MakeType(pkgRef, 0)
-	refOfTypeStructType := MakeCompoundType(RefKind, structType)
-	listType := MakeCompoundType(ListKind, refOfTypeStructType)
+	refOfTypeStructType := MakeRefType(structType)
+	listType := MakeListType(refOfTypeStructType)
 
 	firstNNumbers := func(n int) []Value {
 		nums := []Value{}

--- a/types/compound_map_test.go
+++ b/types/compound_map_test.go
@@ -78,7 +78,7 @@ func newTestMap(length int, gen testMapGenFn, less testMapLessFn, tr *Type) test
 		}
 	}
 
-	return testMap{entries, less, MakeCompoundType(MapKind, tr, tr), gen(Int64(mask + 1))}
+	return testMap{entries, less, MakeMapType(tr, tr), gen(Int64(mask + 1))}
 }
 
 func getTestNativeOrderMap(scale int) testMap {
@@ -86,11 +86,11 @@ func getTestNativeOrderMap(scale int) testMap {
 		return v
 	}, func(x, y Value) bool {
 		return !y.(OrderedValue).Less(x.(OrderedValue))
-	}, MakePrimitiveType(Int64Kind))
+	}, Int64Type)
 }
 
 func getTestRefValueOrderMap(scale int) testMap {
-	setType := MakeCompoundType(SetKind, MakePrimitiveType(Int64Kind))
+	setType := MakeSetType(Int64Type)
 	return newTestMap(int(mapPattern)*scale, func(v Int64) Value {
 		return NewTypedSet(setType, v)
 	}, func(x, y Value) bool {
@@ -99,7 +99,7 @@ func getTestRefValueOrderMap(scale int) testMap {
 }
 
 func getTestRefToNativeOrderMap(scale int, vw ValueWriter) testMap {
-	refType := MakeRefType(MakePrimitiveType(Int64Kind))
+	refType := MakeRefType(Int64Type)
 	return newTestMap(int(mapPattern)*scale, func(v Int64) Value {
 		return vw.WriteValue(v)
 	}, func(x, y Value) bool {
@@ -108,7 +108,7 @@ func getTestRefToNativeOrderMap(scale int, vw ValueWriter) testMap {
 }
 
 func getTestRefToValueOrderMap(scale int, vw ValueWriter) testMap {
-	setType := MakeCompoundType(SetKind, MakePrimitiveType(Int64Kind))
+	setType := MakeSetType(Int64Type)
 	refType := MakeRefType(setType)
 	return newTestMap(int(mapPattern)*scale, func(v Int64) Value {
 		return vw.WriteValue(NewTypedSet(setType, v))
@@ -351,7 +351,7 @@ func TestCompoundMapFilter(t *testing.T) {
 func TestCompoundMapFirstNNumbers(t *testing.T) {
 	assert := assert.New(t)
 
-	mapType := MakeCompoundType(MapKind, MakePrimitiveType(Int64Kind), MakePrimitiveType(Int64Kind))
+	mapType := MakeMapType(Int64Type, Int64Type)
 
 	kvs := []Value{}
 	n := 5000
@@ -368,14 +368,14 @@ func TestCompoundMapRefOfStructFirstNNumbers(t *testing.T) {
 	vs := NewTestValueStore()
 
 	structTypeDef := MakeStructType("num", []Field{
-		Field{"n", MakePrimitiveType(Int64Kind), false},
+		Field{"n", Int64Type, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{structTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	structType := MakeType(pkgRef, 0)
 	refOfTypeStructType := MakeRefType(structType)
 
-	mapType := MakeCompoundType(MapKind, refOfTypeStructType, refOfTypeStructType)
+	mapType := MakeMapType(refOfTypeStructType, refOfTypeStructType)
 
 	kvs := []Value{}
 	n := 5000

--- a/types/compound_set_test.go
+++ b/types/compound_set_test.go
@@ -55,7 +55,7 @@ func newTestSet(length int, gen testSetGenFn, less testSetLessFn, tr *Type) test
 		}
 	}
 
-	return testSet{values, less, MakeCompoundType(SetKind, tr)}
+	return testSet{values, less, MakeSetType(tr)}
 }
 
 func getTestNativeOrderSet(scale int) testSet {
@@ -63,11 +63,11 @@ func getTestNativeOrderSet(scale int) testSet {
 		return v
 	}, func(x, y Value) bool {
 		return !y.(OrderedValue).Less(x.(OrderedValue))
-	}, MakePrimitiveType(Int64Kind))
+	}, Int64Type)
 }
 
 func getTestRefValueOrderSet(scale int) testSet {
-	setType := MakeCompoundType(SetKind, MakePrimitiveType(Int64Kind))
+	setType := MakeSetType(Int64Type)
 	return newTestSet(int(setPattern)*scale, func(v Int64) Value {
 		return NewTypedSet(setType, v)
 	}, func(x, y Value) bool {
@@ -76,7 +76,7 @@ func getTestRefValueOrderSet(scale int) testSet {
 }
 
 func getTestRefToNativeOrderSet(scale int, vw ValueWriter) testSet {
-	refType := MakeRefType(MakePrimitiveType(Int64Kind))
+	refType := MakeRefType(Int64Type)
 	return newTestSet(int(setPattern)*scale, func(v Int64) Value {
 		return vw.WriteValue(v)
 	}, func(x, y Value) bool {
@@ -85,7 +85,7 @@ func getTestRefToNativeOrderSet(scale int, vw ValueWriter) testSet {
 }
 
 func getTestRefToValueOrderSet(scale int, vw ValueWriter) testSet {
-	setType := MakeCompoundType(SetKind, MakePrimitiveType(Int64Kind))
+	setType := MakeSetType(Int64Type)
 	refType := MakeRefType(setType)
 	return newTestSet(int(setPattern)*scale, func(v Int64) Value {
 		return vw.WriteValue(NewTypedSet(setType, v))
@@ -344,7 +344,7 @@ func TestCompoundSetUnion(t *testing.T) {
 func TestCompoundSetFirstNNumbers(t *testing.T) {
 	assert := assert.New(t)
 
-	setType := MakeCompoundType(SetKind, MakePrimitiveType(Int64Kind))
+	setType := MakeSetType(Int64Type)
 
 	firstNNumbers := func(n int) []Value {
 		nums := []Value{}
@@ -365,14 +365,14 @@ func TestCompoundSetRefOfStructFirstNNumbers(t *testing.T) {
 	vs := NewTestValueStore()
 
 	structTypeDef := MakeStructType("num", []Field{
-		Field{"n", MakePrimitiveType(Int64Kind), false},
+		Field{"n", Int64Type, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{structTypeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 	structType := MakeType(pkgRef, 0)
-	refOfTypeStructType := MakeCompoundType(RefKind, structType)
+	refOfTypeStructType := MakeRefType(structType)
 
-	setType := MakeCompoundType(SetKind, refOfTypeStructType)
+	setType := MakeSetType(refOfTypeStructType)
 
 	firstNNumbers := func(n int) []Value {
 		nums := []Value{}

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -169,7 +169,7 @@ func (w *jsonArrayWriter) writeValue(v Value, tr *Type, pkg *Package) {
 		})
 		w.write(w2.toArray())
 	case PackageKind:
-		ptr := MakePrimitiveType(TypeKind)
+		ptr := TypeType
 		w2 := newJSONArrayWriter(w.vw)
 		p := v.(Package)
 		for _, t := range p.types {

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -50,7 +50,7 @@ func TestWriteSimpleBlob(t *testing.T) {
 func TestWriteList(t *testing.T) {
 	assert := assert.New(t)
 
-	typ := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
+	typ := MakeListType(Int32Type)
 	v := NewTypedList(typ, Int32(0), Int32(1), Int32(2), Int32(3))
 
 	w := newJSONArrayWriter(NewTestValueStore())
@@ -61,8 +61,8 @@ func TestWriteList(t *testing.T) {
 func TestWriteListOfList(t *testing.T) {
 	assert := assert.New(t)
 
-	it := MakeCompoundType(ListKind, MakePrimitiveType(Int16Kind))
-	typ := MakeCompoundType(ListKind, it)
+	it := MakeListType(Int16Type)
+	typ := MakeListType(it)
 	l1 := NewTypedList(it, Int16(0))
 	l2 := NewTypedList(it, Int16(1), Int16(2), Int16(3))
 	v := NewTypedList(typ, l1, l2)
@@ -75,7 +75,7 @@ func TestWriteListOfList(t *testing.T) {
 func TestWriteSet(t *testing.T) {
 	assert := assert.New(t)
 
-	typ := MakeCompoundType(SetKind, MakePrimitiveType(Uint32Kind))
+	typ := MakeSetType(Uint32Type)
 	v := NewTypedSet(typ, Uint32(3), Uint32(1), Uint32(2), Uint32(0))
 
 	w := newJSONArrayWriter(NewTestValueStore())
@@ -87,8 +87,8 @@ func TestWriteSet(t *testing.T) {
 func TestWriteSetOfSet(t *testing.T) {
 	assert := assert.New(t)
 
-	st := MakeCompoundType(SetKind, MakePrimitiveType(Int32Kind))
-	typ := MakeCompoundType(SetKind, st)
+	st := MakeSetType(Int32Type)
+	typ := MakeSetType(st)
 	v := NewTypedSet(typ, NewTypedSet(st, Int32(0)), NewTypedSet(st, Int32(1), Int32(2), Int32(3)))
 
 	w := newJSONArrayWriter(NewTestValueStore())
@@ -100,7 +100,7 @@ func TestWriteSetOfSet(t *testing.T) {
 func TestWriteMap(t *testing.T) {
 	assert := assert.New(t)
 
-	typ := MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(BoolKind))
+	typ := MakeMapType(StringType, BoolType)
 	v := newMapLeaf(typ, mapEntry{NewString("a"), Bool(false)}, mapEntry{NewString("b"), Bool(true)})
 
 	w := newJSONArrayWriter(NewTestValueStore())
@@ -112,9 +112,9 @@ func TestWriteMap(t *testing.T) {
 func TestWriteMapOfMap(t *testing.T) {
 	assert := assert.New(t)
 
-	kt := MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(Int64Kind))
-	vt := MakeCompoundType(SetKind, MakePrimitiveType(BoolKind))
-	typ := MakeCompoundType(MapKind, kt, vt)
+	kt := MakeMapType(StringType, Int64Type)
+	vt := MakeSetType(BoolType)
+	typ := MakeMapType(kt, vt)
 	v := NewTypedMap(typ, NewTypedMap(kt, NewString("a"), Int64(0)), NewTypedSet(vt, Bool(true)))
 
 	w := newJSONArrayWriter(NewTestValueStore())
@@ -160,8 +160,8 @@ func TestWriteStruct(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"x", MakePrimitiveType(Int8Kind), false},
-		Field{"b", MakePrimitiveType(BoolKind), false},
+		Field{"x", Int8Type, false},
+		Field{"b", BoolType, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -177,8 +177,8 @@ func TestWriteStructOptionalField(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"x", MakePrimitiveType(Int8Kind), true},
-		Field{"b", MakePrimitiveType(BoolKind), false},
+		Field{"x", Int8Type, true},
+		Field{"b", BoolType, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -200,10 +200,10 @@ func TestWriteStructWithUnion(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"x", MakePrimitiveType(Int8Kind), false},
+		Field{"x", Int8Type, false},
 	}, []Field{
-		Field{"b", MakePrimitiveType(BoolKind), false},
-		Field{"s", MakePrimitiveType(StringKind), false},
+		Field{"b", BoolType, false},
+		Field{"s", StringType, false},
 	})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -225,7 +225,7 @@ func TestWriteStructWithList(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"l", MakeCompoundType(ListKind, MakePrimitiveType(StringKind)), false},
+		Field{"l", MakeListType(StringType), false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -246,7 +246,7 @@ func TestWriteStructWithStruct(t *testing.T) {
 	assert := assert.New(t)
 
 	s2TypeDef := MakeStructType("S2", []Field{
-		Field{"x", MakePrimitiveType(Int32Kind), false},
+		Field{"x", Int32Type, false},
 	}, []Field{})
 	sTypeDef := MakeStructType("S", []Field{
 		Field{"s", MakeType(ref.Ref{}, 0), false},
@@ -266,7 +266,7 @@ func TestWriteStructWithBlob(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"b", MakePrimitiveType(BlobKind), false},
+		Field{"b", BlobType, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -282,7 +282,7 @@ func TestWriteStructWithBlob(t *testing.T) {
 func TestWriteCompoundList(t *testing.T) {
 	assert := assert.New(t)
 
-	ltr := MakeCompoundType(ListKind, MakePrimitiveType(Int32Kind))
+	ltr := MakeListType(Int32Type)
 	leaf1 := newListLeaf(ltr, Int32(0))
 	leaf2 := newListLeaf(ltr, Int32(1), Int32(2), Int32(3))
 	cl := buildCompoundList([]metaTuple{
@@ -298,7 +298,7 @@ func TestWriteCompoundList(t *testing.T) {
 func TestWriteCompoundSet(t *testing.T) {
 	assert := assert.New(t)
 
-	ltr := MakeCompoundType(SetKind, MakePrimitiveType(Int32Kind))
+	ltr := MakeSetType(Int32Type)
 	leaf1 := newSetLeaf(ltr, Int32(0), Int32(1))
 	leaf2 := newSetLeaf(ltr, Int32(2), Int32(3), Int32(4))
 	cl := buildCompoundSet([]metaTuple{
@@ -314,7 +314,7 @@ func TestWriteCompoundSet(t *testing.T) {
 func TestWriteListOfValue(t *testing.T) {
 	assert := assert.New(t)
 
-	typ := MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))
+	typ := MakeListType(ValueType)
 	blob := NewBlob(bytes.NewBuffer([]byte{0x01}))
 	v := NewTypedList(typ,
 		Bool(true),
@@ -356,11 +356,11 @@ func TestWriteListOfValueWithStruct(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"x", MakePrimitiveType(Int32Kind), false},
+		Field{"x", Int32Type, false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
-	listType := MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))
+	listType := MakeListType(ValueType)
 	structType := MakeType(pkgRef, 0)
 	v := NewTypedList(listType, NewStruct(structType, typeDef, structData{"x": Int32(42)}))
 
@@ -374,15 +374,15 @@ func TestWriteListOfValueWithType(t *testing.T) {
 
 	pkg := NewPackage([]*Type{
 		MakeStructType("S", []Field{
-			Field{"x", MakePrimitiveType(Int32Kind), false},
+			Field{"x", Int32Type, false},
 		}, []Field{})}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
 
-	typ := MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))
+	typ := MakeListType(ValueType)
 	v := NewTypedList(typ,
 		Bool(true),
-		MakePrimitiveType(Int32Kind),
-		MakePrimitiveType(TypeKind),
+		Int32Type,
+		TypeType,
 		MakeType(pkgRef, 0),
 	)
 
@@ -412,7 +412,7 @@ func (r testRef) TargetRef() ref.Ref {
 func TestWriteRef(t *testing.T) {
 	assert := assert.New(t)
 
-	typ := MakeCompoundType(RefKind, MakePrimitiveType(Uint32Kind))
+	typ := MakeRefType(Uint32Type)
 	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
 	v := NewRef(r)
 
@@ -430,22 +430,22 @@ func TestWriteTypeValue(t *testing.T) {
 		assert.EqualValues(expected, w.toArray())
 	}
 
-	test([]interface{}{TypeKind, Int32Kind}, MakePrimitiveType(Int32Kind))
+	test([]interface{}{TypeKind, Int32Kind}, Int32Type)
 	test([]interface{}{TypeKind, ListKind, []interface{}{BoolKind}},
-		MakeCompoundType(ListKind, MakePrimitiveType(BoolKind)))
+		MakeListType(BoolType))
 	test([]interface{}{TypeKind, MapKind, []interface{}{BoolKind, StringKind}},
-		MakeCompoundType(MapKind, MakePrimitiveType(BoolKind), MakePrimitiveType(StringKind)))
+		MakeMapType(BoolType, StringType))
 
 	test([]interface{}{TypeKind, StructKind, "S", []interface{}{"x", Int16Kind, false, "v", ValueKind, true}, []interface{}{}},
 		MakeStructType("S", []Field{
-			Field{"x", MakePrimitiveType(Int16Kind), false},
-			Field{"v", MakePrimitiveType(ValueKind), true},
+			Field{"x", Int16Type, false},
+			Field{"v", ValueType, true},
 		}, []Field{}))
 
 	test([]interface{}{TypeKind, StructKind, "S", []interface{}{}, []interface{}{"x", Int16Kind, false, "v", ValueKind, false}},
 		MakeStructType("S", []Field{}, []Field{
-			Field{"x", MakePrimitiveType(Int16Kind), false},
-			Field{"v", MakePrimitiveType(ValueKind), false},
+			Field{"x", Int16Type, false},
+			Field{"v", ValueType, false},
 		}))
 
 	pkgRef := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
@@ -455,7 +455,7 @@ func TestWriteTypeValue(t *testing.T) {
 	test([]interface{}{TypeKind, StructKind, "S", []interface{}{"e", UnresolvedKind, pkgRef.String(), "123", false, "x", Int64Kind, false}, []interface{}{}},
 		MakeStructType("S", []Field{
 			Field{"e", MakeType(pkgRef, 123), false},
-			Field{"x", MakePrimitiveType(Int64Kind), false},
+			Field{"x", Int64Type, false},
 		}, []Field{}))
 
 	test([]interface{}{TypeKind, UnresolvedKind, ref.Ref{}.String(), "-1", "ns", "n"},
@@ -465,8 +465,8 @@ func TestWriteTypeValue(t *testing.T) {
 func TestWriteListOfTypes(t *testing.T) {
 	assert := assert.New(t)
 
-	typ := MakeCompoundType(ListKind, MakePrimitiveType(TypeKind))
-	v := NewTypedList(typ, MakePrimitiveType(BoolKind), MakePrimitiveType(StringKind))
+	typ := MakeListType(TypeType)
+	v := NewTypedList(typ, BoolType, StringType)
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeTopLevelValue(v)
@@ -476,7 +476,7 @@ func TestWriteListOfTypes(t *testing.T) {
 func TestWritePackage(t *testing.T) {
 	assert := assert.New(t)
 
-	setTref := MakeCompoundType(SetKind, MakePrimitiveType(Uint32Kind))
+	setTref := MakeSetType(Uint32Type)
 	r := ref.Parse("sha1-0123456789abcdef0123456789abcdef01234567")
 	v := Package{[]*Type{setTref}, []ref.Ref{r}, &ref.Ref{}}
 

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -71,21 +71,21 @@ func TestValueEquals(t *testing.T) {
 		func() Value { return NewSet() },
 		func() Value { return NewSet(NewString("hi")) },
 
-		func() Value { return MakePrimitiveType(BoolKind) },
-		func() Value { return MakePrimitiveType(StringKind) },
+		func() Value { return BoolType },
+		func() Value { return StringType },
 		func() Value { return MakeStructType("a", []Field{}, []Field{}) },
 		func() Value { return MakeStructType("b", []Field{}, []Field{}) },
-		func() Value { return MakeCompoundType(ListKind, MakePrimitiveType(Uint64Kind)) },
-		func() Value { return MakeCompoundType(ListKind, MakePrimitiveType(Int64Kind)) },
-		func() Value { return MakeCompoundType(SetKind, MakePrimitiveType(Uint32Kind)) },
-		func() Value { return MakeCompoundType(SetKind, MakePrimitiveType(Int32Kind)) },
-		func() Value { return MakeCompoundType(RefKind, MakePrimitiveType(Uint16Kind)) },
-		func() Value { return MakeCompoundType(RefKind, MakePrimitiveType(Int16Kind)) },
+		func() Value { return MakeListType(Uint64Type) },
+		func() Value { return MakeListType(Int64Type) },
+		func() Value { return MakeSetType(Uint32Type) },
+		func() Value { return MakeSetType(Int32Type) },
+		func() Value { return MakeRefType(Uint16Type) },
+		func() Value { return MakeRefType(Int16Type) },
 		func() Value {
-			return MakeCompoundType(MapKind, MakePrimitiveType(Uint8Kind), MakePrimitiveType(ValueKind))
+			return MakeMapType(Uint8Type, ValueType)
 		},
 		func() Value {
-			return MakeCompoundType(MapKind, MakePrimitiveType(Int8Kind), MakePrimitiveType(ValueKind))
+			return MakeMapType(Int8Type, ValueType)
 		},
 		func() Value { return MakeType(r1, 0) },
 		func() Value { return MakeType(r1, 1) },

--- a/types/fixup_type.go
+++ b/types/fixup_type.go
@@ -11,7 +11,7 @@ func FixupType(tr *Type, pkg *Package) *Type {
 		for i, elemType := range desc.ElemTypes {
 			elemTypes[i] = FixupType(elemType, pkg)
 		}
-		return MakeCompoundType(tr.Kind(), elemTypes...)
+		return makeCompoundType(tr.Kind(), elemTypes...)
 
 	case UnresolvedDesc:
 		if tr.HasPackageRef() {

--- a/types/list.go
+++ b/types/list.go
@@ -26,7 +26,7 @@ type listIterAllFunc func(v Value, index uint64)
 type listFilterCallback func(v Value, index uint64) (keep bool)
 type MapFunc func(v Value, index uint64) interface{}
 
-var listType = MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))
+var listType = MakeListType(ValueType)
 
 // NewList creates a new untyped List, populated with values, chunking if and when needed.
 func NewList(v ...Value) List {

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -341,9 +341,9 @@ func TestListType(t *testing.T) {
 	assert := assert.New(t)
 
 	l := NewList(Int32(0))
-	assert.True(l.Type().Equals(MakeCompoundType(ListKind, MakePrimitiveType(ValueKind))))
+	assert.True(l.Type().Equals(MakeListType(ValueType)))
 
-	tr := MakeCompoundType(ListKind, MakePrimitiveType(Uint8Kind))
+	tr := MakeListType(Uint8Type)
 	l2 := newListLeaf(tr, []Value{Uint8(0), Uint8(1)}...)
 	assert.Equal(tr, l2.Type())
 

--- a/types/map.go
+++ b/types/map.go
@@ -25,7 +25,7 @@ type mapIterCallback func(key, value Value) (stop bool)
 type mapIterAllCallback func(key, value Value)
 type mapFilterCallback func(key, value Value) (keep bool)
 
-var mapType = MakeCompoundType(MapKind, MakePrimitiveType(ValueKind), MakePrimitiveType(ValueKind))
+var mapType = MakeMapType(ValueType, ValueType)
 
 func NewMap(kv ...Value) Map {
 	return NewTypedMap(mapType, kv...)

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -252,7 +252,7 @@ func TestMapNotStringKeys(t *testing.T) {
 }
 
 func testMapOrder(assert *assert.Assertions, keyType, valueType *Type, tuples []Value, expectOrdering []Value) {
-	mapTr := MakeCompoundType(MapKind, keyType, valueType)
+	mapTr := MakeMapType(keyType, valueType)
 	m := NewTypedMap(mapTr, tuples...)
 	i := 0
 	m.IterAll(func(key, value Value) {
@@ -265,7 +265,7 @@ func TestMapOrdering(t *testing.T) {
 	assert := assert.New(t)
 
 	testMapOrder(assert,
-		MakePrimitiveType(StringKind), MakePrimitiveType(StringKind),
+		StringType, StringType,
 		[]Value{
 			NewString("a"), NewString("unused"),
 			NewString("z"), NewString("unused"),
@@ -285,7 +285,7 @@ func TestMapOrdering(t *testing.T) {
 	)
 
 	testMapOrder(assert,
-		MakePrimitiveType(Uint64Kind), MakePrimitiveType(StringKind),
+		Uint64Type, StringType,
 		[]Value{
 			Uint64(0), NewString("unused"),
 			Uint64(1000), NewString("unused"),
@@ -305,7 +305,7 @@ func TestMapOrdering(t *testing.T) {
 	)
 
 	testMapOrder(assert,
-		MakePrimitiveType(Int16Kind), MakePrimitiveType(StringKind),
+		Int16Type, StringType,
 		[]Value{
 			Int16(0), NewString("unused"),
 			Int16(-30), NewString("unused"),
@@ -325,7 +325,7 @@ func TestMapOrdering(t *testing.T) {
 	)
 
 	testMapOrder(assert,
-		MakePrimitiveType(Float32Kind), MakePrimitiveType(StringKind),
+		Float32Type, StringType,
 		[]Value{
 			Float32(0.0001), NewString("unused"),
 			Float32(0.000001), NewString("unused"),
@@ -345,7 +345,7 @@ func TestMapOrdering(t *testing.T) {
 	)
 
 	testMapOrder(assert,
-		MakePrimitiveType(ValueKind), MakePrimitiveType(StringKind),
+		ValueType, StringType,
 		[]Value{
 			NewString("a"), NewString("unused"),
 			NewString("z"), NewString("unused"),
@@ -366,7 +366,7 @@ func TestMapOrdering(t *testing.T) {
 	)
 
 	testMapOrder(assert,
-		MakePrimitiveType(BoolKind), MakePrimitiveType(StringKind),
+		BoolType, StringType,
 		[]Value{
 			Bool(true), NewString("unused"),
 			Bool(false), NewString("unused"),
@@ -394,9 +394,9 @@ func TestMapType(t *testing.T) {
 	assert := assert.New(t)
 
 	m := newMapLeaf(mapType)
-	assert.True(m.Type().Equals(MakeCompoundType(MapKind, MakePrimitiveType(ValueKind), MakePrimitiveType(ValueKind))))
+	assert.True(m.Type().Equals(MakeMapType(ValueType, ValueType)))
 
-	tr := MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(Uint64Kind))
+	tr := MakeMapType(StringType, Uint64Type)
 	m = newMapLeaf(tr)
 	assert.Equal(tr, m.Type())
 

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -85,7 +85,7 @@ func (ms metaSequenceObject) data() metaSequenceData {
 
 func (ms metaSequenceObject) ChildValues() []Value {
 	leafType := ms.t.Desc.(CompoundDesc).ElemTypes[0]
-	refOfLeafType := MakeCompoundType(RefKind, leafType)
+	refOfLeafType := MakeRefType(leafType)
 	res := make([]Value, len(ms.tuples))
 	for i, t := range ms.tuples {
 		res[i] = refFromType(t.ChildRef().TargetRef(), refOfLeafType)

--- a/types/primitives.go
+++ b/types/primitives.go
@@ -29,7 +29,7 @@ func (v Bool) ToPrimitive() interface{} {
 	return bool(v)
 }
 
-var typeForBool = MakePrimitiveType(BoolKind)
+var typeForBool = BoolType
 
 func (v Bool) Type() *Type {
 	return typeForBool
@@ -57,7 +57,7 @@ func (v Float32) ToPrimitive() interface{} {
 	return float32(v)
 }
 
-var typeForFloat32 = MakePrimitiveType(Float32Kind)
+var typeForFloat32 = Float32Type
 
 func (v Float32) Type() *Type {
 	return typeForFloat32
@@ -89,7 +89,7 @@ func (v Float64) ToPrimitive() interface{} {
 	return float64(v)
 }
 
-var typeForFloat64 = MakePrimitiveType(Float64Kind)
+var typeForFloat64 = Float64Type
 
 func (v Float64) Type() *Type {
 	return typeForFloat64
@@ -121,7 +121,7 @@ func (v Int16) ToPrimitive() interface{} {
 	return int16(v)
 }
 
-var typeForInt16 = MakePrimitiveType(Int16Kind)
+var typeForInt16 = Int16Type
 
 func (v Int16) Type() *Type {
 	return typeForInt16
@@ -153,7 +153,7 @@ func (v Int32) ToPrimitive() interface{} {
 	return int32(v)
 }
 
-var typeForInt32 = MakePrimitiveType(Int32Kind)
+var typeForInt32 = Int32Type
 
 func (v Int32) Type() *Type {
 	return typeForInt32
@@ -185,7 +185,7 @@ func (v Int64) ToPrimitive() interface{} {
 	return int64(v)
 }
 
-var typeForInt64 = MakePrimitiveType(Int64Kind)
+var typeForInt64 = Int64Type
 
 func (v Int64) Type() *Type {
 	return typeForInt64
@@ -217,7 +217,7 @@ func (v Int8) ToPrimitive() interface{} {
 	return int8(v)
 }
 
-var typeForInt8 = MakePrimitiveType(Int8Kind)
+var typeForInt8 = Int8Type
 
 func (v Int8) Type() *Type {
 	return typeForInt8
@@ -249,7 +249,7 @@ func (v Uint16) ToPrimitive() interface{} {
 	return uint16(v)
 }
 
-var typeForUint16 = MakePrimitiveType(Uint16Kind)
+var typeForUint16 = Uint16Type
 
 func (v Uint16) Type() *Type {
 	return typeForUint16
@@ -281,7 +281,7 @@ func (v Uint32) ToPrimitive() interface{} {
 	return uint32(v)
 }
 
-var typeForUint32 = MakePrimitiveType(Uint32Kind)
+var typeForUint32 = Uint32Type
 
 func (v Uint32) Type() *Type {
 	return typeForUint32
@@ -313,7 +313,7 @@ func (v Uint64) ToPrimitive() interface{} {
 	return uint64(v)
 }
 
-var typeForUint64 = MakePrimitiveType(Uint64Kind)
+var typeForUint64 = Uint64Type
 
 func (v Uint64) Type() *Type {
 	return typeForUint64
@@ -345,7 +345,7 @@ func (v Uint8) ToPrimitive() interface{} {
 	return uint8(v)
 }
 
-var typeForUint8 = MakePrimitiveType(Uint8Kind)
+var typeForUint8 = Uint8Type
 
 func (v Uint8) Type() *Type {
 	return typeForUint8

--- a/types/ref.go
+++ b/types/ref.go
@@ -49,7 +49,7 @@ func (r Ref) TargetRef() ref.Ref {
 	return r.target
 }
 
-var refType = MakeCompoundType(RefKind, MakePrimitiveType(ValueKind))
+var refType = MakeRefType(ValueType)
 
 func (r Ref) Type() *Type {
 	return r.t

--- a/types/set.go
+++ b/types/set.go
@@ -25,7 +25,7 @@ type setIterCallback func(v Value) bool
 type setIterAllCallback func(v Value)
 type setFilterCallback func(v Value) (keep bool)
 
-var setType = MakeCompoundType(SetKind, MakePrimitiveType(ValueKind))
+var setType = MakeSetType(ValueType)
 
 func NewSet(v ...Value) Set {
 	return NewTypedSet(setType, v...)

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -204,7 +204,7 @@ func TestSetIterAllP(t *testing.T) {
 }
 
 func testSetOrder(assert *assert.Assertions, valueType *Type, value []Value, expectOrdering []Value) {
-	mapTr := MakeCompoundType(SetKind, valueType)
+	mapTr := MakeSetType(valueType)
 	m := NewTypedSet(mapTr, value...)
 	i := 0
 	m.IterAll(func(value Value) {
@@ -217,7 +217,7 @@ func TestSetOrdering(t *testing.T) {
 	assert := assert.New(t)
 
 	testSetOrder(assert,
-		MakePrimitiveType(StringKind),
+		StringType,
 		[]Value{
 			NewString("a"),
 			NewString("z"),
@@ -237,7 +237,7 @@ func TestSetOrdering(t *testing.T) {
 	)
 
 	testSetOrder(assert,
-		MakePrimitiveType(Uint64Kind),
+		Uint64Type,
 		[]Value{
 			Uint64(0),
 			Uint64(1000),
@@ -257,7 +257,7 @@ func TestSetOrdering(t *testing.T) {
 	)
 
 	testSetOrder(assert,
-		MakePrimitiveType(Int16Kind),
+		Int16Type,
 		[]Value{
 			Int16(0),
 			Int16(-30),
@@ -277,7 +277,7 @@ func TestSetOrdering(t *testing.T) {
 	)
 
 	testSetOrder(assert,
-		MakePrimitiveType(Float32Kind),
+		Float32Type,
 		[]Value{
 			Float32(0.0001),
 			Float32(0.000001),
@@ -297,7 +297,7 @@ func TestSetOrdering(t *testing.T) {
 	)
 
 	testSetOrder(assert,
-		MakePrimitiveType(ValueKind),
+		ValueType,
 		[]Value{
 			NewString("a"),
 			NewString("z"),
@@ -318,7 +318,7 @@ func TestSetOrdering(t *testing.T) {
 	)
 
 	testSetOrder(assert,
-		MakePrimitiveType(BoolKind),
+		BoolType,
 		[]Value{
 			Bool(true),
 			Bool(false),
@@ -348,9 +348,9 @@ func TestSetType(t *testing.T) {
 	assert := assert.New(t)
 
 	s := newSetLeaf(setType)
-	assert.True(s.Type().Equals(MakeCompoundType(SetKind, MakePrimitiveType(ValueKind))))
+	assert.True(s.Type().Equals(MakeSetType(ValueType)))
 
-	tr := MakeCompoundType(SetKind, MakePrimitiveType(Uint64Kind))
+	tr := MakeSetType(Uint64Type)
 
 	s = newSetLeaf(tr)
 	assert.Equal(tr, s.Type())

--- a/types/string.go
+++ b/types/string.go
@@ -38,7 +38,7 @@ func (fs String) ChildValues() []Value {
 	return nil
 }
 
-var typeForString = MakePrimitiveType(StringKind)
+var typeForString = StringType
 
 func (fs String) Type() *Type {
 	return typeForString

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -29,5 +29,5 @@ func TestStringString(t *testing.T) {
 }
 
 func TestStringType(t *testing.T) {
-	assert.True(t, NewString("hi").Type().Equals(MakePrimitiveType(StringKind)))
+	assert.True(t, NewString("hi").Type().Equals(StringType))
 }

--- a/types/struct_test.go
+++ b/types/struct_test.go
@@ -11,8 +11,8 @@ func TestGenericStructEquals(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S1", []Field{
-		Field{"x", MakePrimitiveType(BoolKind), false},
-		Field{"o", MakePrimitiveType(StringKind), true},
+		Field{"x", BoolType, false},
+		Field{"o", StringType, true},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -31,7 +31,7 @@ func TestGenericStructChunks(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S1", []Field{
-		Field{"r", MakeCompoundType(RefKind, MakePrimitiveType(BoolKind)), false},
+		Field{"r", MakeRefType(BoolType), false},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -51,7 +51,7 @@ func TestGenericStructChunksOptional(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S1", []Field{
-		Field{"r", MakeCompoundType(RefKind, MakePrimitiveType(BoolKind)), true},
+		Field{"r", MakeRefType(BoolType), true},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -77,8 +77,8 @@ func TestGenericStructChunksUnion(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S1", []Field{}, []Field{
-		Field{"r", MakeCompoundType(RefKind, MakePrimitiveType(BoolKind)), false},
-		Field{"s", MakePrimitiveType(StringKind), false},
+		Field{"r", MakeRefType(BoolType), false},
+		Field{"s", StringType, false},
 	})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -102,8 +102,8 @@ func TestGenericStructNew(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S2", []Field{
-		Field{"b", MakePrimitiveType(BoolKind), false},
-		Field{"o", MakePrimitiveType(StringKind), true},
+		Field{"b", BoolType, false},
+		Field{"o", StringType, true},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -131,8 +131,8 @@ func TestGenericStructNewUnion(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S3", []Field{}, []Field{
-		Field{"b", MakePrimitiveType(BoolKind), false},
-		Field{"o", MakePrimitiveType(StringKind), false},
+		Field{"b", BoolType, false},
+		Field{"o", StringType, false},
 	})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -148,8 +148,8 @@ func TestGenericStructSet(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S3", []Field{
-		Field{"b", MakePrimitiveType(BoolKind), false},
-		Field{"o", MakePrimitiveType(StringKind), true},
+		Field{"b", BoolType, false},
+		Field{"o", StringType, true},
 	}, []Field{})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)
@@ -169,8 +169,8 @@ func TestGenericStructSetUnion(t *testing.T) {
 	assert := assert.New(t)
 
 	typeDef := MakeStructType("S3", []Field{}, []Field{
-		Field{"b", MakePrimitiveType(BoolKind), false},
-		Field{"s", MakePrimitiveType(StringKind), false},
+		Field{"b", BoolType, false},
+		Field{"s", StringType, false},
 	})
 	pkg := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	pkgRef := RegisterPackage(&pkg)

--- a/types/type.go
+++ b/types/type.go
@@ -137,21 +137,95 @@ func (t *Type) ChildValues() (res []Value) {
 	return
 }
 
-var typeForType = MakePrimitiveType(TypeKind)
+var typeForType = makePrimitiveType(TypeKind)
 
 func (t *Type) Type() *Type {
 	return typeForType
 }
 
 func MakePrimitiveType(k NomsKind) *Type {
+	switch k {
+	case BoolKind:
+		return BoolType
+	case Int8Kind:
+		return Int8Type
+	case Int16Kind:
+		return Int16Type
+	case Int32Kind:
+		return Int32Type
+	case Int64Kind:
+		return Int64Type
+	case Float32Kind:
+		return Float32Type
+	case Float64Kind:
+		return Float64Type
+	case Uint8Kind:
+		return Uint8Type
+	case Uint16Kind:
+		return Uint16Type
+	case Uint32Kind:
+		return Uint32Type
+	case Uint64Kind:
+		return Uint64Type
+	case StringKind:
+		return StringType
+	case BlobKind:
+		return BlobType
+	case ValueKind:
+		return ValueType
+	case TypeKind:
+		return TypeType
+	case PackageKind:
+		return PackageType
+	}
+	d.Chk.Fail("invalid NomsKind: %d", k)
+	return nil
+}
+
+func makePrimitiveType(k NomsKind) *Type {
 	return buildType("", PrimitiveDesc(k))
 }
 
 func MakePrimitiveTypeByString(p string) *Type {
-	return buildType("", primitiveToDesc(p))
+	switch p {
+	case "Bool":
+		return BoolType
+	case "Int8":
+		return Int8Type
+	case "Int16":
+		return Int16Type
+	case "Int32":
+		return Int32Type
+	case "Int64":
+		return Int64Type
+	case "Float32":
+		return Float32Type
+	case "Float64":
+		return Float64Type
+	case "Uint8":
+		return Uint8Type
+	case "Uint16":
+		return Uint16Type
+	case "Uint32":
+		return Uint32Type
+	case "Uint64":
+		return Uint64Type
+	case "String":
+		return StringType
+	case "Blob":
+		return BlobType
+	case "Value":
+		return ValueType
+	case "Type":
+		return TypeType
+	case "Package":
+		return PackageType
+	}
+	d.Chk.Fail("invalid type string: %s", p)
+	return nil
 }
 
-func MakeCompoundType(kind NomsKind, elemTypes ...*Type) *Type {
+func makeCompoundType(kind NomsKind, elemTypes ...*Type) *Type {
 	if len(elemTypes) == 1 {
 		d.Chk.NotEqual(MapKind, kind, "MapKind requires 2 element types.")
 		d.Chk.True(kind == RefKind || kind == ListKind || kind == SetKind)
@@ -204,17 +278,19 @@ func buildType(n string, desc TypeDesc) *Type {
 	}
 }
 
-var Uint8Type = MakePrimitiveType(Uint8Kind)
-var Uint16Type = MakePrimitiveType(Uint16Kind)
-var Uint32Type = MakePrimitiveType(Uint32Kind)
-var Uint64Type = MakePrimitiveType(Uint64Kind)
-var Int8Type = MakePrimitiveType(Int8Kind)
-var Int16Type = MakePrimitiveType(Int16Kind)
-var Int32Type = MakePrimitiveType(Int32Kind)
-var Int64Type = MakePrimitiveType(Int64Kind)
-var Float32Type = MakePrimitiveType(Float32Kind)
-var Float64Type = MakePrimitiveType(Float64Kind)
-var BoolType = MakePrimitiveType(BoolKind)
-var StringType = MakePrimitiveType(StringKind)
-var BlobType = MakePrimitiveType(BlobKind)
-var PackageType = MakePrimitiveType(PackageKind)
+var Uint8Type = makePrimitiveType(Uint8Kind)
+var Uint16Type = makePrimitiveType(Uint16Kind)
+var Uint32Type = makePrimitiveType(Uint32Kind)
+var Uint64Type = makePrimitiveType(Uint64Kind)
+var Int8Type = makePrimitiveType(Int8Kind)
+var Int16Type = makePrimitiveType(Int16Kind)
+var Int32Type = makePrimitiveType(Int32Kind)
+var Int64Type = makePrimitiveType(Int64Kind)
+var Float32Type = makePrimitiveType(Float32Kind)
+var Float64Type = makePrimitiveType(Float64Kind)
+var BoolType = makePrimitiveType(BoolKind)
+var StringType = makePrimitiveType(StringKind)
+var BlobType = makePrimitiveType(BlobKind)
+var PackageType = makePrimitiveType(PackageKind)
+var TypeType = makePrimitiveType(TypeKind)
+var ValueType = makePrimitiveType(ValueKind)

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -1,9 +1,6 @@
 package types
 
-import (
-	"github.com/attic-labs/noms/d"
-	"github.com/attic-labs/noms/ref"
-)
+import "github.com/attic-labs/noms/ref"
 
 // TypeDesc describes a type of the kind returned by Kind(), e.g. Map, Int32, or a custom type.
 type TypeDesc interface {
@@ -59,17 +56,6 @@ var KindToString = map[NomsKind]string{
 	Uint64Kind:  "Uint64",
 	Uint8Kind:   "Uint8",
 	ValueKind:   "Value",
-}
-
-func primitiveToDesc(p string) PrimitiveDesc {
-	for k, v := range KindToString {
-		if p == v {
-			d.Chk.True(IsPrimitiveKind(k), "Kind must be primitive, not %s", KindToString[k])
-			return PrimitiveDesc(k)
-		}
-	}
-	d.Chk.Fail("Tried to create PrimitiveDesc from bad string", "%s", p)
-	panic("Unreachable")
 }
 
 type UnresolvedDesc struct {

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -11,11 +11,11 @@ func TestTypes(t *testing.T) {
 	assert := assert.New(t)
 	vs := NewTestValueStore()
 
-	boolType := MakePrimitiveType(BoolKind)
-	uint8Type := MakePrimitiveType(Uint8Kind)
-	stringType := MakePrimitiveType(StringKind)
-	mapType := MakeCompoundType(MapKind, stringType, uint8Type)
-	setType := MakeCompoundType(SetKind, stringType)
+	boolType := BoolType
+	uint8Type := Uint8Type
+	stringType := StringType
+	mapType := MakeMapType(stringType, uint8Type)
+	setType := MakeSetType(stringType)
 	mahType := MakeStructType("MahStruct", []Field{
 		Field{"Field1", stringType, false},
 		Field{"Field2", boolType, true},
@@ -44,7 +44,7 @@ func TestTypeWithPkgRef(t *testing.T) {
 	assert := assert.New(t)
 	vs := NewTestValueStore()
 
-	pkg := NewPackage([]*Type{MakePrimitiveType(Float64Kind)}, []ref.Ref{})
+	pkg := NewPackage([]*Type{Float64Type}, []ref.Ref{})
 
 	pkgRef := RegisterPackage(&pkg)
 	unresolvedType := MakeType(pkgRef, 42)
@@ -56,16 +56,16 @@ func TestTypeWithPkgRef(t *testing.T) {
 }
 
 func TestTypeType(t *testing.T) {
-	assert.True(t, MakePrimitiveType(BoolKind).Type().Equals(MakePrimitiveType(TypeKind)))
+	assert.True(t, BoolType.Type().Equals(TypeType))
 }
 
 func TestTypeRefDescribe(t *testing.T) {
 	assert := assert.New(t)
-	boolType := MakePrimitiveType(BoolKind)
-	uint8Type := MakePrimitiveType(Uint8Kind)
-	stringType := MakePrimitiveType(StringKind)
-	mapType := MakeCompoundType(MapKind, stringType, uint8Type)
-	setType := MakeCompoundType(SetKind, stringType)
+	boolType := BoolType
+	uint8Type := Uint8Type
+	stringType := StringType
+	mapType := MakeMapType(stringType, uint8Type)
+	setType := MakeSetType(stringType)
 
 	assert.Equal("Bool", boolType.Describe())
 	assert.Equal("Uint8", uint8Type.Describe())
@@ -92,22 +92,22 @@ func TestTypeRefDescribe(t *testing.T) {
 
 func TestTypeOrdered(t *testing.T) {
 	assert := assert.New(t)
-	assert.False(MakePrimitiveType(BoolKind).IsOrdered())
-	assert.True(MakePrimitiveType(Uint8Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Uint16Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Uint32Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Uint64Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Int8Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Int16Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Int32Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Int64Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Float32Kind).IsOrdered())
-	assert.True(MakePrimitiveType(Float64Kind).IsOrdered())
-	assert.True(MakePrimitiveType(StringKind).IsOrdered())
-	assert.False(MakePrimitiveType(BlobKind).IsOrdered())
-	assert.False(MakePrimitiveType(ValueKind).IsOrdered())
-	assert.False(MakeCompoundType(ListKind, MakePrimitiveType(StringKind)).IsOrdered())
-	assert.False(MakeCompoundType(SetKind, MakePrimitiveType(StringKind)).IsOrdered())
-	assert.False(MakeCompoundType(MapKind, MakePrimitiveType(StringKind), MakePrimitiveType(ValueKind)).IsOrdered())
-	assert.True(MakeCompoundType(RefKind, MakePrimitiveType(StringKind)).IsOrdered())
+	assert.False(BoolType.IsOrdered())
+	assert.True(Uint8Type.IsOrdered())
+	assert.True(Uint16Type.IsOrdered())
+	assert.True(Uint32Type.IsOrdered())
+	assert.True(Uint64Type.IsOrdered())
+	assert.True(Int8Type.IsOrdered())
+	assert.True(Int16Type.IsOrdered())
+	assert.True(Int32Type.IsOrdered())
+	assert.True(Int64Type.IsOrdered())
+	assert.True(Float32Type.IsOrdered())
+	assert.True(Float64Type.IsOrdered())
+	assert.True(StringType.IsOrdered())
+	assert.False(BlobType.IsOrdered())
+	assert.False(ValueType.IsOrdered())
+	assert.False(MakeListType(StringType).IsOrdered())
+	assert.False(MakeSetType(StringType).IsOrdered())
+	assert.False(MakeMapType(StringType, ValueType).IsOrdered())
+	assert.True(MakeRefType(StringType).IsOrdered())
 }

--- a/types/value_store.go
+++ b/types/value_store.go
@@ -144,7 +144,7 @@ func (lvs *ValueStore) checkChunksInCache(v Value) map[ref.Ref]struct{} {
 		// though it's possible that the Type is actually correct. We wouldn't be able to verify
 		// without reading it, though, so we'll dig into this later.
 		targetType := getTargetType(reachable)
-		if targetType.Equals(MakePrimitiveType(ValueKind)) {
+		if targetType.Equals(ValueType) {
 			continue
 		}
 		d.Exp.True(entry.Type().Equals(targetType), "Value to write contains ref %s, which points to a value of a different type: %+v != %+v", reachable.TargetRef(), entry.Type(), targetType)

--- a/types/value_store_test.go
+++ b/types/value_store_test.go
@@ -51,7 +51,7 @@ func TestWriteValue(t *testing.T) {
 	testEncode(fmt.Sprintf("t [%d,\"hi\"]", StringKind), NewString("hi"))
 
 	testEncode(fmt.Sprintf("t [%d,[],[]]", PackageKind), Package{types: []*Type{}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
-	ref1 := testEncode(fmt.Sprintf("t [%d,[%d],[]]", PackageKind, BoolKind), Package{types: []*Type{MakePrimitiveType(BoolKind)}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
+	ref1 := testEncode(fmt.Sprintf("t [%d,[%d],[]]", PackageKind, BoolKind), Package{types: []*Type{BoolType}, dependencies: []ref.Ref{}, ref: &ref.Ref{}})
 	testEncode(fmt.Sprintf("t [%d,[],[\"%s\"]]", PackageKind, ref1), Package{types: []*Type{}, dependencies: []ref.Ref{ref1}, ref: &ref.Ref{}})
 }
 
@@ -81,7 +81,7 @@ func TestWritePackageWhenValueIsWritten(t *testing.T) {
 	vs := NewTestValueStore()
 
 	typeDef := MakeStructType("S", []Field{
-		Field{"X", MakePrimitiveType(Int32Kind), false},
+		Field{"X", Int32Type, false},
 	}, []Field{})
 	pkg1 := NewPackage([]*Type{typeDef}, []ref.Ref{})
 	// Don't write package


### PR DESCRIPTION
And same for MakePrimitiveType. This also makes sure that we return
the same primitive type every single time.

Fixes #1271
