### PR TITLE
encode untagged numbers as - numbers, fixing #1318

### DIFF
--- a/clients/counter-js/src/main.js
+++ b/clients/counter-js/src/main.js
@@ -45,8 +45,6 @@ async function increment(ds: Dataset): Promise<Dataset> {
   const newVal = lastVal + 1;
 
   process.stdout.write(`\nincrementing counter to ${ newVal }\n`);
-  // TODO: fix this to use a number instead of a string, bug
-  // https://github.com/attic-labs/noms/issues/1318
   return ds.commit(newVal);
 }
 


### PR DESCRIPTION
With the removal of all of the various numeric types, now we can encode untagged numbers.
