### PR TITLE
counter-js using DatasetSpec to parse command line args

### DIFF
--- a/clients/counter-js/.gitignore
+++ b/clients/counter-js/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-out.js

--- a/clients/counter-js/package.json
+++ b/clients/counter-js/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@attic/counter-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "noms example javascript client with a counter",
   "dependencies": {
-    "@attic/noms": "^13.0.0",
+    "@attic/noms": "^15.3.0",
     "babel-regenerator-runtime": "6.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating counter-js to use the new DatasetSpec functionality
