### PR TITLE
Parameterize the Type type

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "16.0.0",
+  "version": "16.1.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/data-store.js
+++ b/js/src/data-store.js
@@ -18,7 +18,6 @@ import {
   Type,
   stringType,
   valueType,
-  StructDesc,
 } from './type.js';
 import {newMap} from './map.js';
 import {newSet} from './set.js';
@@ -54,7 +53,6 @@ export function getDatasTypes(): DatasTypes {
     ]);
     const refOfCommitType = makeRefType(commitType);
     const commitSetType = makeSetType(refOfCommitType);
-    invariant(commitType.desc instanceof StructDesc);
     commitType.desc.fields.push(new Field('parents', commitSetType));
     const commitMapType = makeMapType(stringType, refOfCommitType);
     datasTypes = {

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -23,7 +23,6 @@ import {
   Type,
   typeType,
   valueType,
-  StructDesc,
 } from './type.js';
 import {encode as encodeBase64} from './base64.js';
 import {IndexedMetaSequence, MetaTuple, OrderedMetaSequence} from './meta-sequence.js';
@@ -506,10 +505,8 @@ suite('Decode', () => {
 
     const ta = makeStructType('A', []);
     const tb = makeStructType('B', []);
-    invariant(ta.desc instanceof StructDesc);
     ta.desc.fields.push(new Field('b', tb));
 
-    invariant(tb.desc instanceof StructDesc);
     const {fields} = tb.desc;
     fields.push(new Field('a', makeListType(ta)), new Field('b', makeListType(tb)));
 

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -319,7 +319,6 @@ export class JsonArrayReader {
 
     // Mutate the already created structType since when looking for the cycle we compare
     // by identity.
-    invariant(structType.desc instanceof StructDesc);
     structType.desc.fields = newFields;
     parentStructTypes.pop();
     return structType;

--- a/js/src/defs-test.js
+++ b/js/src/defs-test.js
@@ -12,7 +12,6 @@ import {
   stringType,
   numberType,
   valueType,
-  StructDesc,
 } from './type.js';
 import {defToNoms} from './defs.js';
 import {newList} from './list.js';
@@ -151,7 +150,6 @@ suite('defs', () => {
       new Field('children', valueType /* placeholder */),
     ]);
     const listType = makeListType(type);
-    invariant(type.desc instanceof StructDesc);
     type.desc.fields[0].t = listType;
 
     const a = await newList([], listType);

--- a/js/src/defs.js
+++ b/js/src/defs.js
@@ -2,7 +2,7 @@
 
 import type {valueOrPrimitive} from './value.js';
 import {Value} from './value.js';
-import {Type, CompoundDesc, StructDesc} from './type.js';
+import {Type, CompoundDesc} from './type.js';
 import type {Field} from './type.js';
 import {invariant} from './assert.js';
 import {Kind} from './noms-kind.js';
@@ -75,7 +75,6 @@ export async function defToNoms(v: DefType, t: Type): Promise<valueOrPrimitive> 
 
 async function structDefToNoms<T: Struct>(data: StructDefType, type: Type): Promise<T> {
   const {desc} = type;
-  invariant(desc instanceof StructDesc);
   const keys = [];
   const ps: Array<Promise<valueOrPrimitive>> = [];
   const add = (f: Field) => {

--- a/js/src/encode-human-readable-test.js
+++ b/js/src/encode-human-readable-test.js
@@ -4,7 +4,6 @@ import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
 import {TypeWriter} from './encode-human-readable.js';
-import {invariant} from './assert.js';
 import {
   blobType,
   boolType,
@@ -18,7 +17,6 @@ import {
   stringType,
   valueType,
   Type,
-  StructDesc,
 } from './type.js';
 
 suite('Encode human readable types', () => {
@@ -84,9 +82,7 @@ suite('Encode human readable types', () => {
       new Field('f', a),
     ]);
     const aDesc = a.desc;
-    invariant(aDesc instanceof StructDesc);
     const dDesc = d.desc;
-    invariant(dDesc instanceof StructDesc);
     aDesc.fields[0].t = a;
     aDesc.fields[2].t = d;
     dDesc.fields[0].t = d;

--- a/js/src/encode-human-readable.js
+++ b/js/src/encode-human-readable.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {getTypeOfValue, StructDesc, ParentDesc, CompoundDesc} from './type.js';
+import {getTypeOfValue, ParentDesc, CompoundDesc} from './type.js';
 import type {Field, Type} from './type.js';
 import {Kind, kindToString} from './noms-kind.js';
 import type {NomsKind} from './noms-kind.js';
@@ -121,7 +121,6 @@ export class TypeWriter {
     parentStructTypes.push(t);
 
     const desc = t.desc;
-    invariant(desc instanceof StructDesc);
     this._w.write('struct ');
     this._w.write(desc.name);
     this._w.write(' {');

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -22,7 +22,6 @@ import {
   stringType,
   Type,
   valueType,
-  StructDesc,
 } from './type.js';
 import {IndexedMetaSequence, MetaTuple, OrderedMetaSequence} from './meta-sequence.js';
 import {Kind} from './noms-kind.js';
@@ -31,7 +30,6 @@ import {newMap, MapLeafSequence, NomsMap} from './map.js';
 import {newSet, NomsSet, SetLeafSequence} from './set.js';
 import {newBlob} from './blob.js';
 import DataStore from './data-store.js';
-import {invariant} from './assert.js';
 import type {valueOrPrimitive} from './value.js';
 
 suite('Encode', () => {
@@ -302,7 +300,6 @@ suite('Encode', () => {
       new Field('cs', valueType /* placeholder */),
     ]);
     const lt = makeListType(st);
-    invariant(st.desc instanceof StructDesc);
     st.desc.fields[1].t = lt;
 
     test([Kind.Type, Kind.Struct, 'A6', ['v', Kind.Number, 'cs', Kind.List, Kind.Parent, 0]], st);

--- a/js/src/encode.js
+++ b/js/src/encode.js
@@ -67,7 +67,7 @@ export class JsonArrayWriter {
     this.write(r.toString());
   }
 
-  writeTypeAsTag(t: Type, parentStructTypes: Type[]) {
+  writeTypeAsTag(t: Type, parentStructTypes: Type<StructDesc>[]) {
     const k = t.kind;
     switch (k) {
       case Kind.List:
@@ -228,7 +228,7 @@ export class JsonArrayWriter {
     }
   }
 
-  writeTypeAsValue(t: Type, parentStructTypes: Type[]) {
+  writeTypeAsValue(t: Type, parentStructTypes: Type<StructDesc>[]) {
     const k = t.kind;
     switch (k) {
       case Kind.List:
@@ -251,17 +251,15 @@ export class JsonArrayWriter {
     }
   }
 
-  writeStructType(t: Type, parentStructTypes: Type[]) {
+  writeStructType(t: Type<StructDesc>, parentStructTypes: Type<StructDesc>[]) {
     const i = parentStructTypes.indexOf(t);
     if (i !== -1) {
       this.writeParent(parentStructTypes.length - i - 1);
       return;
     }
 
-
-    parentStructTypes = parentStructTypes.concat(t);  // we want a new array here.
+    parentStructTypes.push(t);
     const desc = t.desc;
-    invariant(desc instanceof StructDesc);
     this.writeKind(t.kind);
     this.write(t.name);
     const fieldWriter = new JsonArrayWriter(this._ds);
@@ -270,6 +268,7 @@ export class JsonArrayWriter {
       fieldWriter.writeTypeAsTag(field.t, parentStructTypes);
     });
     this.write(fieldWriter.array);
+    parentStructTypes.pop();
   }
 
   writeParent(i: number) {

--- a/js/src/struct-test.js
+++ b/js/src/struct-test.js
@@ -12,11 +12,9 @@ import {
   makeListType,
   stringType,
   valueType,
-  StructDesc,
 } from './type.js';
 import {suite, test} from 'mocha';
 import DataStore from './data-store.js';
-import {invariant} from './assert.js';
 import {newList} from './list.js';
 
 suite('Struct', () => {
@@ -147,7 +145,6 @@ suite('Struct', () => {
       new Field('l', valueType /* placeholder */),
     ]);
     const listType = makeListType(type);
-    invariant(type.desc instanceof StructDesc);
     type.desc.fields[1].t = listType;
 
     const emptyList = await newList([], listType);

--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -73,9 +73,7 @@ export default class Struct extends Value {
 }
 
 function validate(type: Type, data: StructData): void {
-  // TODO: Validate field values match field types.
   const {desc} = type;
-  invariant(desc instanceof StructDesc);
   const {fields} = desc;
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i];
@@ -104,7 +102,7 @@ type FieldCallback = (f: StructFieldMirror) => void;
 
 export class StructMirror<T: Struct> {
   _data: StructData;
-  type :Type;
+  type: Type<StructDesc>;
 
   constructor(s: Struct) {
     this._data = s._data;
@@ -112,7 +110,6 @@ export class StructMirror<T: Struct> {
   }
 
   get desc(): StructDesc {
-    invariant(this.type.desc instanceof StructDesc);
     return this.type.desc;
   }
 
@@ -144,7 +141,7 @@ function setterName(name) {
   return `set${name[0].toUpperCase()}${name.slice(1)}`;
 }
 
-export function createStructClass<T: Struct>(type: Type): Class<T> {
+export function createStructClass<T: Struct>(type: Type<StructDesc>): Class<T> {
   const k = type.ref.toString();
   if (cache[k]) {
     return cache[k];
@@ -157,7 +154,6 @@ export function createStructClass<T: Struct>(type: Type): Class<T> {
   };
 
   const {desc} = type;
-  invariant(desc instanceof StructDesc);
 
   const {fields} = desc;
   for (const field of fields) {

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -106,11 +106,11 @@ export class Field {
   }
 }
 
-export class Type extends Value {
-  _desc: TypeDesc;
+export class Type<T: TypeDesc> extends Value {
+  _desc: T;
   _ref: ?Ref;
 
-  constructor(desc: TypeDesc) {
+  constructor(desc: T) {
     super();
     this._desc = desc;
   }
@@ -138,7 +138,7 @@ export class Type extends Value {
     }
   }
 
-  get desc(): TypeDesc {
+  get desc(): T {
     return this._desc;
   }
 
@@ -153,7 +153,7 @@ export class Type extends Value {
   }
 }
 
-function buildType(desc: TypeDesc): Type {
+function buildType<T: TypeDesc>(desc: T): Type<T> {
   return new Type(desc);
 }
 
@@ -173,23 +173,23 @@ export function makeCompoundType(k: NomsKind, ...elemTypes: Array<Type>): Type {
   return buildType(new CompoundDesc(k, elemTypes));
 }
 
-export function makeListType(elemType: Type): Type {
+export function makeListType(elemType: Type): Type<CompoundDesc> {
   return buildType(new CompoundDesc(Kind.List, [elemType]));
 }
 
-export function makeSetType(elemType: Type): Type {
+export function makeSetType(elemType: Type): Type<CompoundDesc> {
   return buildType(new CompoundDesc(Kind.Set, [elemType]));
 }
 
-export function makeMapType(keyType: Type, valueType: Type): Type {
+export function makeMapType(keyType: Type, valueType: Type): Type<CompoundDesc> {
   return buildType(new CompoundDesc(Kind.Map, [keyType, valueType]));
 }
 
-export function makeRefType(elemType: Type): Type {
+export function makeRefType(elemType: Type): Type<CompoundDesc> {
   return buildType(new CompoundDesc(Kind.Ref, [elemType]));
 }
 
-export function makeStructType(name: string, fields: Array<Field>): Type {
+export function makeStructType(name: string, fields: Array<Field>): Type<StructDesc> {
   return buildType(new StructDesc(name, fields));
 }
 


### PR DESCRIPTION
The Type type is now parameterized with a `T: TypeDesc`. This means
that we almost always know the type of `t.desc` and we can remove
invariants.
