### PR TITLE
Remove ParentDesc

### DIFF
--- a/js/src/encode-human-readable.js
+++ b/js/src/encode-human-readable.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {getTypeOfValue, ParentDesc, CompoundDesc} from './type.js';
+import {getTypeOfValue, CompoundDesc} from './type.js';
 import type {Field, Type} from './type.js';
 import {Kind, kindToString} from './noms-kind.js';
 import type {NomsKind} from './noms-kind.js';
@@ -100,9 +100,6 @@ export class TypeWriter {
         this._writeStructType(t, parentStructTypes);
         break;
       case Kind.Parent:
-        invariant(t.desc instanceof ParentDesc);
-        this._writeParent(t.desc.value);
-        break;
       default:
         throw new Error('unreachable');
     }

--- a/js/src/noms-kind.js
+++ b/js/src/noms-kind.js
@@ -27,7 +27,7 @@ export const Kind: {
   Set: 8,
   Struct: 9,
   Type: 10,
-  Parent: 11,
+  Parent: 11,  // Only used in encoding/decoding.
 };
 
 const kindToStringMap: { [key: number]: string } = Object.create(null);

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -246,23 +246,3 @@ export function getTypeOfValue(v: valueOrPrimitive): Type {
       throw new Error('Unknown type');
   }
 }
-
-export class ParentDesc {
-  value: number;
-
-  constructor(value: number) {
-    this.value = value;
-  }
-
-  get kind(): NomsKind {
-    return Kind.Parent;
-  }
-
-  equals(other: TypeDesc): boolean {
-    return other instanceof ParentDesc && other.value === this.value;
-  }
-
-  describe(): string {
-    return `Parent<${this.value}>`;
-  }
-}

--- a/types/encode_human_readable.go
+++ b/types/encode_human_readable.go
@@ -199,7 +199,6 @@ func (w *hrsWriter) writeType(t *Type, parentStructTypes []*Type) {
 	case StructKind:
 		w.writeStructType(t, parentStructTypes)
 	case ParentKind:
-		w.writeParent(uint8(t.Desc.(ParentDesc)))
 	default:
 		panic("unreachable")
 	}

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -169,7 +169,6 @@ func (w *jsonArrayWriter) writeValue(v Value, tr *Type) {
 		w.writeTypeAsTag(vt, nil)
 		w.writeValue(v, v.Type())
 	case ParentKind:
-		w.writeUint8(uint8(v.(*Type).Desc.(ParentDesc)))
 	default:
 		d.Chk.Fail("Unknown NomsKind")
 	}

--- a/types/noms_kind.go
+++ b/types/noms_kind.go
@@ -16,13 +16,13 @@ const (
 	SetKind
 	StructKind
 	TypeKind
-	ParentKind
+	ParentKind // Only used in encoding/decoding.
 )
 
 // IsPrimitiveKind returns true if k represents a Noms primitive type, which excludes collections (List, Map, Set), Refs, Structs, Symbolic and Unresolved types.
 func IsPrimitiveKind(k NomsKind) bool {
 	switch k {
-	case BoolKind, NumberKind, StringKind, BlobKind, ValueKind, TypeKind, ParentKind:
+	case BoolKind, NumberKind, StringKind, BlobKind, ValueKind, TypeKind:
 		return true
 	default:
 		return false

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -1,7 +1,5 @@
 package types
 
-import "fmt"
-
 // TypeDesc describes a type of the kind returned by Kind(), e.g. Map, Number, or a custom type.
 type TypeDesc interface {
 	Kind() NomsKind
@@ -95,19 +93,4 @@ type Field struct {
 
 func (f Field) Equals(other Field) bool {
 	return f.Name == other.Name && f.T.Equals(other.T)
-}
-
-// ParentDesc is used to symbolize back references in recursive struct types
-type ParentDesc uint8
-
-func (b ParentDesc) Kind() NomsKind {
-	return ParentKind
-}
-
-func (b ParentDesc) Equals(other TypeDesc) bool {
-	return b.Kind() == other.Kind() && other.(ParentDesc) == b
-}
-
-func (b ParentDesc) Describe() string {
-	return fmt.Sprintf("%s(%d)", KindToString[b.Kind()], b)
 }


### PR DESCRIPTION
The Parent type pointer is only internally used in encoding/decoding
