### PR TITLE
Make the order of struct fields insignificant

### DIFF
--- a/datas/commit.go
+++ b/datas/commit.go
@@ -13,16 +13,16 @@ func init() {
 	structName := "Commit"
 
 	// struct Commit {
-	//   value: Value
 	//   parents: Set<Ref<Commit>>
+	//   value: Value
 	// }
 
 	fieldTypes := []types.Field{
-		types.Field{Name: ValueField, Type: types.ValueType},
 		types.Field{Name: ParentsField, Type: nil},
+		types.Field{Name: ValueField, Type: types.ValueType},
 	}
 	commitType = types.MakeStructType(structName, fieldTypes)
-	commitType.Desc.(types.StructDesc).Fields[1].Type = types.MakeSetType(types.MakeRefType(commitType))
+	commitType.Desc.(types.StructDesc).Fields[0].Type = types.MakeSetType(types.MakeRefType(commitType))
 }
 
 func NewCommit() types.Struct {

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -30,7 +30,7 @@ func TestDatasetCommitTracker(t *testing.T) {
 	assert.False(ds2.Head().Get(datas.ValueField).Equals(ds1Commit))
 	assert.False(ds1.Head().Get(datas.ValueField).Equals(ds2Commit))
 
-	assert.Equal("sha1-61b7497ae7200c5cafc2149ee9de7cbc8b7ddade", cs.Root().String())
+	assert.Equal("sha1-73b50491e78c3098578941c44ee2f39b236d5eff", cs.Root().String())
 }
 
 func newDS(id string, cs *chunks.MemoryStore) Dataset {

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -276,10 +276,10 @@ suite('Decode', () => {
     ]);
 
     const a = [Kind.Struct, 'A1', [
-      'x', Kind.Number,
-      's', Kind.String,
       'b', Kind.Bool,
-    ], '42', 'hi', true];
+      's', Kind.String,
+      'x', Kind.Number,
+    ], true, 'hi', '42'];
     const r = new JsonArrayReader(a, ds);
     const v = await r.readTopLevelValue();
 
@@ -324,15 +324,15 @@ suite('Decode', () => {
       new Field('s', stringType),
     ]);
 
-    const a = [Kind.Struct, 'A5', ['b', Kind.Bool, 'v', Kind.Value, 's', Kind.String],
-      true, Kind.Number, '42', 'hi'];
+    const a = [Kind.Struct, 'A5', ['b', Kind.Bool, 's', Kind.String, 'v', Kind.Value],
+      true, 'hi', Kind.Number, '42'];
     const r = new JsonArrayReader(a, ds);
     const v = await r.readTopLevelValue();
 
     assertStruct(v, tr.desc, {
       b: true,
-      v: 42,
       s: 'hi',
+      v: 42,
     });
   });
 
@@ -345,8 +345,12 @@ suite('Decode', () => {
       new Field('b', boolType),
     ]);
 
-    const a = [Kind.Value, Kind.Struct, 'A1', ['x', Kind.Number, 's', Kind.String, 'b', Kind.Bool],
-        '42', 'hi', true];
+    const a = [Kind.Value, Kind.Struct, 'A1', [
+      'b', Kind.Bool,
+      's', Kind.String,
+      'x', Kind.Number,
+    ],
+    true, 'hi', '42'];
     const r = new JsonArrayReader(a, ds);
     const v = await r.readTopLevelValue();
 

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -208,7 +208,7 @@ suite('Encode', () => {
     const v = newStruct(type, {x: 42, b: true});
 
     w.writeTopLevel(type, v);
-    assert.deepEqual([Kind.Struct, 'S', ['x', Kind.Number, 'b', Kind.Bool], '42', true], w.array);
+    assert.deepEqual([Kind.Struct, 'S', ['b', Kind.Bool, 'x', Kind.Number], true, '42'], w.array);
   });
 
   test('write struct with list', async() => {
@@ -284,7 +284,7 @@ suite('Encode', () => {
          makeCompoundType(Kind.List, boolType));
     test([Kind.Type, Kind.Map, [Kind.Bool, Kind.String]],
          makeCompoundType(Kind.Map, boolType, stringType));
-    test([Kind.Type, Kind.Struct, 'S', ['x', Kind.Number, 'v', Kind.Value]],
+    test([Kind.Type, Kind.Struct, 'S', ['v', Kind.Value, 'x', Kind.Number]],
          makeStructType('S', [
            new Field('x', numberType),
            new Field('v', valueType),
@@ -296,13 +296,13 @@ suite('Encode', () => {
     // }
 
     const st = makeStructType('A6', [
-      new Field('v', numberType),
       new Field('cs', valueType /* placeholder */),
+      new Field('v', numberType),
     ]);
     const lt = makeListType(st);
-    st.desc.fields[1].type = lt;
+    st.desc.fields[0].type = lt;
 
-    test([Kind.Type, Kind.Struct, 'A6', ['v', Kind.Number, 'cs', Kind.List, Kind.Parent, 0]], st);
+    test([Kind.Type, Kind.Struct, 'A6', ['cs', Kind.List, Kind.Parent, 0, 'v', Kind.Number]], st);
   });
 
   test('top level blob', async () => {

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -54,13 +54,17 @@ export class CompoundDesc {
   }
 }
 
+function compareFields(a, b) {
+  return a.name < b.name ? -1 : 1;  // Cannot be equal.
+}
+
 export class StructDesc {
   name: string;
   fields: Array<Field>;
 
   constructor(name: string, fields: Array<Field>) {
     this.name = name;
-    this.fields = fields;
+    this.fields = fields.sort(compareFields);
   }
 
   get kind(): NomsKind {

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -235,7 +235,7 @@ func TestReadStruct(t *testing.T) {
 		Field{"b", BoolType},
 	})
 
-	a := parseJSON(`[%d, "A1", ["x", %d, "s", %d, "b", %d], "42", "hi", true]`, StructKind, NumberKind, StringKind, BoolKind)
+	a := parseJSON(`[%d, "A1", ["b", %d, "s", %d, "x", %d], true, "hi", "42"]`, StructKind, BoolKind, StringKind, NumberKind)
 	r := newJSONArrayReader(a, cs)
 
 	v := r.readTopLevelValue().(Struct)
@@ -289,7 +289,7 @@ func TestReadStructWithValue(t *testing.T) {
 		Field{"s", StringType},
 	})
 
-	a := parseJSON(`[%d, "A5", ["b", %d, "v", %d, "s", %d], true, %d, "42", "hi"]`, StructKind, BoolKind, ValueKind, StringKind, NumberKind)
+	a := parseJSON(`[%d, "A5", ["b", %d, "s", %d, "v", %d], true, "hi", %d, "42"]`, StructKind, BoolKind, StringKind, ValueKind, NumberKind)
 	r := newJSONArrayReader(a, cs)
 	v := r.readTopLevelValue().(Struct)
 
@@ -315,7 +315,7 @@ func TestReadValueStruct(t *testing.T) {
 		Field{"b", BoolType},
 	})
 
-	a := parseJSON(`[%d, %d, "A1", ["x", %d, "s", %d, "b", %d], "42", "hi", true]`, ValueKind, StructKind, NumberKind, StringKind, BoolKind)
+	a := parseJSON(`[%d, %d, "A1", ["b", %d, "s", %d, "x", %d], true, "hi", "42"]`, ValueKind, StructKind, BoolKind, StringKind, NumberKind)
 	r := newJSONArrayReader(a, cs)
 	v := r.readTopLevelValue().(Struct)
 

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -154,7 +154,7 @@ func TestWriteStruct(t *testing.T) {
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeTopLevelValue(v)
-	assert.EqualValues([]interface{}{StructKind, "S", []interface{}{"x", NumberKind, "b", BoolKind}, "42", true}, w.toArray())
+	assert.EqualValues([]interface{}{StructKind, "S", []interface{}{"b", BoolKind, "x", NumberKind}, true, "42"}, w.toArray())
 }
 
 func TestWriteStructWithList(t *testing.T) {
@@ -334,7 +334,7 @@ func TestWriteTypeValue(t *testing.T) {
 	test([]interface{}{TypeKind, MapKind, []interface{}{BoolKind, StringKind}},
 		MakeMapType(BoolType, StringType))
 
-	test([]interface{}{TypeKind, StructKind, "S", []interface{}{"x", NumberKind, "v", ValueKind}},
+	test([]interface{}{TypeKind, StructKind, "S", []interface{}{"v", ValueKind, "x", NumberKind}},
 		MakeStructType("S", []Field{
 			Field{"x", NumberType},
 			Field{"v", ValueType},
@@ -356,17 +356,18 @@ func TestWriteRecursiveStruct(t *testing.T) {
 	assert := assert.New(t)
 
 	// struct A6 {
-	//   v: Number
 	//   cs: List<A6>
+	//   v: Number
 	// }
 
 	structType := MakeStructType("A6", []Field{
-		Field{"v", NumberType},
 		Field{"cs", nil},
+		Field{"v", NumberType},
 	})
 	listType := MakeListType(structType)
 	// Mutate...
-	structType.Desc.(StructDesc).Fields[1].Type = listType
+
+	structType.Desc.(StructDesc).Fields[0].Type = listType
 
 	NewTypedList(listType)
 
@@ -380,5 +381,5 @@ func TestWriteRecursiveStruct(t *testing.T) {
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeTopLevelValue(v)
-	assert.EqualValues([]interface{}{StructKind, "A6", []interface{}{"v", NumberKind, "cs", ListKind, ParentKind, uint8(0)}, "42", false, []interface{}{"555", false, []interface{}{}}}, w.toArray())
+	assert.EqualValues([]interface{}{StructKind, "A6", []interface{}{"cs", ListKind, ParentKind, uint8(0), "v", NumberKind}, false, []interface{}{false, []interface{}{}, "555"}, "42"}, w.toArray())
 }

--- a/types/type.go
+++ b/types/type.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"sort"
+
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -132,7 +134,14 @@ func makeCompoundType(kind NomsKind, elemTypes ...*Type) *Type {
 	return buildType(CompoundDesc{kind, elemTypes})
 }
 
+type fieldSlice []Field
+
+func (fs fieldSlice) Len() int           { return len(fs) }
+func (fs fieldSlice) Swap(i, j int)      { fs[i], fs[j] = fs[j], fs[i] }
+func (fs fieldSlice) Less(i, j int) bool { return fs[i].Name < fs[j].Name }
+
 func MakeStructType(name string, fields []Field) *Type {
+	sort.Sort(fieldSlice(fields))
 	return buildType(StructDesc{name, fields})
 }
 


### PR DESCRIPTION
The fields are now sorted upon creation

Fixes #814
