### PR TITLE
Go: change Datastore/Dataset Commit to use Ref<Commit> for parents

### DIFF
--- a/datas/datastore.go
+++ b/datas/datastore.go
@@ -17,8 +17,14 @@ type DataStore interface {
 	// MaybeHead returns the current Head Commit of this Datastore, which contains the current root of the DataStore's value tree, if available. If not, it returns a new Commit and 'false'.
 	MaybeHead(datasetID string) (types.Struct, bool)
 
+	// MaybeHeadRef returns the types.Ref of the Head Commit of this Datastore, and true, if available. If not, it returns an invalid types.Ref and false.
+	MaybeHeadRef(datasetID string) (types.Ref, bool)
+
 	// Head returns the current head Commit, which contains the current root of the DataStore's value tree.
 	Head(datasetID string) types.Struct
+
+	// HeadRef returns the ref of the current head Commit. See Head(datasetID).
+	HeadRef(datasetID string) types.Ref
 
 	// Datasets returns the root of the datastore which is a MapOfStringToRefOfCommit where string is a datasetID.
 	Datasets() types.Map

--- a/datas/datastore_test.go
+++ b/datas/datastore_test.go
@@ -121,10 +121,13 @@ func (suite *DataStoreSuite) TestDataStoreCommit() {
 	// The old datastore still has no head.
 	_, ok := suite.ds.MaybeHead(datasetID)
 	suite.False(ok)
+	_, ok = suite.ds.MaybeHeadRef(datasetID)
+	suite.False(ok)
 
 	// The new datastore has |a|.
 	aCommit1 := ds2.Head(datasetID)
 	suite.True(aCommit1.Get(ValueField).Equals(a))
+	suite.Equal(aCommit1.Ref(), ds2.HeadRef(datasetID).TargetRef())
 	suite.ds = ds2
 
 	// |a| <- |b|


### PR DESCRIPTION
The goal is to remove places where we construct a types.Ref from a
ref.Ref, so that we can attach a height to it later. This should also
make it unnecessary to read in the Commit values at all (which is the
case in the JS SDK) but commit validation prevents that for now.
