### PR TITLE
Cleanup serialization of types

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "22.0.0",
+  "version": "23.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -65,11 +65,11 @@ suite('Decode', () => {
     assert.isTrue(r.atEnd());
   });
 
-  test('read type as tag', () => {
+  test('read type', () => {
     const ds = new DataStore(makeTestingBatchStore());
     function doTest(expected: Type, a: Array<any>) {
       const r = new JsonArrayReader(a, ds);
-      const tr = r.readTypeAsTag([]);
+      const tr = r.readType([]);
       assert.isTrue(expected.equals(tr));
     }
 

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -12,9 +12,9 @@ import {encodeNomsValue, JsonArrayWriter} from './encode.js';
 import {
   blobType,
   boolType,
-  makeCompoundType,
   makeListType,
   makeMapType,
+  makeRefType,
   makeSetType,
   makeStructType,
   numberType,
@@ -64,7 +64,7 @@ suite('Encode', () => {
     const ds = new DataStore(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const tr = makeCompoundType(Kind.List, numberType);
+    const tr = makeListType(numberType);
     const l = new NomsList(tr, new ListLeafSequence(ds, tr, [0, 1, 2, 3]));
     w.writeValue(l);
     assert.deepEqual([Kind.List, Kind.Number, false,
@@ -75,7 +75,7 @@ suite('Encode', () => {
     const ds = new DataStore(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const tr = makeCompoundType(Kind.List, valueType);
+    const tr = makeListType(valueType);
     const l = new NomsList(tr, new ListLeafSequence(ds, tr, ['0', 1, '2', true]));
     w.writeValue(l);
     assert.deepEqual([Kind.List, Kind.Value, false, [
@@ -107,7 +107,7 @@ suite('Encode', () => {
     const ds = new DataStore(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const tr = makeCompoundType(Kind.Set, numberType);
+    const tr = makeSetType(numberType);
     const v = new NomsSet(tr, new SetLeafSequence(ds, tr, [0, 1, 2, 3]));
     w.writeValue(v);
     assert.deepEqual([Kind.Set, Kind.Number, false,
@@ -117,7 +117,7 @@ suite('Encode', () => {
   test('write compound set', async () => {
     const ds = new DataStore(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
-    const ltr = makeCompoundType(Kind.Set, numberType);
+    const ltr = makeSetType(numberType);
     const r1 = ds.writeValue(new NomsSet(ltr, new SetLeafSequence(ds, ltr, [0])));
     const r2 = ds.writeValue(new NomsSet(ltr, new SetLeafSequence(ds, ltr, [1, 2])));
     const r3 = ds.writeValue(new NomsSet(ltr, new SetLeafSequence(ds, ltr, [3, 4, 5])));
@@ -157,7 +157,7 @@ suite('Encode', () => {
     const ds = new DataStore(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const tr = makeCompoundType(Kind.Map, stringType, boolType);
+    const tr = makeMapType(stringType, boolType);
     const v = new NomsMap(tr, new MapLeafSequence(ds, tr, [{key: 'a', value: false},
         {key:'b', value:true}]));
     w.writeValue(v);
@@ -300,10 +300,10 @@ suite('Encode', () => {
     };
 
     test([Kind.Type, Kind.Number], numberType);
-    test([Kind.Type, Kind.List, [Kind.Bool]],
-         makeCompoundType(Kind.List, boolType));
-    test([Kind.Type, Kind.Map, [Kind.Bool, Kind.String]],
-         makeCompoundType(Kind.Map, boolType, stringType));
+    test([Kind.Type, Kind.List, Kind.Bool],
+         makeListType(boolType));
+    test([Kind.Type, Kind.Map, Kind.Bool, Kind.String],
+         makeMapType(boolType, stringType));
     test([Kind.Type, Kind.Struct, 'S', ['v', Kind.Value, 'x', Kind.Number]],
          makeStructType('S', {
            'x': numberType,
@@ -360,7 +360,7 @@ suite('Encode', () => {
     const ds = new DataStore(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
     const ref = Ref.parse('sha1-0123456789abcdef0123456789abcdef01234567');
-    const t = makeCompoundType(Kind.Ref, blobType);
+    const t = makeRefType(blobType);
     const v = new RefValue(ref, t);
     w.writeValue(v);
 

--- a/js/src/meta-sequence.js
+++ b/js/src/meta-sequence.js
@@ -6,7 +6,7 @@ import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type {ValueReader} from './value-store.js';
 import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
 import type {Collection} from './collection.js';
-import {CompoundDesc, makeCompoundType, makeRefType, numberType, valueType} from './type.js';
+import {makeRefType} from './type.js';
 import type {Type} from './type.js';
 import {IndexedSequence} from './indexed-sequence.js';
 import {invariant, notNull} from './assert.js';
@@ -187,29 +187,6 @@ export function newMetaSequenceFromData(vr: ValueReader, type: Type, tuples: Arr
     default:
       throw new Error('Not reached');
   }
-}
-
-const indexedSequenceIndexType = numberType;
-
-export function indexTypeForMetaSequence(t: Type): Type {
-  switch (t.kind) {
-    case Kind.Map:
-    case Kind.Set: {
-      const desc = t.desc;
-      invariant(desc instanceof CompoundDesc);
-      const elemType = desc.elemTypes[0];
-      if (elemType.ordered) {
-        return elemType;
-      } else {
-        return makeCompoundType(Kind.Ref, valueType);
-      }
-    }
-    case Kind.Blob:
-    case Kind.List:
-      return indexedSequenceIndexType;
-  }
-
-  throw new Error('Not reached');
 }
 
 export function newOrderedMetaSequenceChunkFn(t: Type, vr: ?ValueReader = null): makeChunkFn {

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -30,7 +30,6 @@ export {
   blobType,
   boolType,
   CompoundDesc,
-  makeCompoundType,
   makeListType,
   makeMapType,
   makeRefType,

--- a/js/src/ordered-sequence-diff-test.js
+++ b/js/src/ordered-sequence-diff-test.js
@@ -3,8 +3,7 @@
 import {suite, test} from 'mocha';
 import {assert} from 'chai';
 import {fastForward} from './ordered-sequence-diff.js';
-import {makeCompoundType, numberType} from './type.js';
-import {Kind} from './noms-kind.js';
+import {makeSetType, numberType} from './type.js';
 import {newSet} from './set.js';
 
 suite('OrderedSequenceCursor', () => {
@@ -18,7 +17,7 @@ suite('OrderedSequenceCursor', () => {
     };
 
     const newMetaSequenceCursor = async (nums) => {
-      const tr = makeCompoundType(Kind.Set, numberType);
+      const tr = makeSetType(numberType);
       const lst = await newSet(nums, tr);
       assert.isTrue(lst.sequence.isMeta);
       return await lst.sequence.newCursorAt(0);

--- a/js/src/sequence-test.js
+++ b/js/src/sequence-test.js
@@ -4,12 +4,11 @@ import {suite, test} from 'mocha';
 import {assert} from 'chai';
 import {Sequence, SequenceCursor} from './sequence.js';
 import {notNull} from './assert.js';
-import {makeCompoundType, valueType} from './type.js';
-import {Kind} from './noms-kind.js';
+import {makeListType, valueType} from './type.js';
 
 class TestSequence extends Sequence<any> {
   constructor(items: Array<any>) {
-    super(null, makeCompoundType(Kind.List, valueType), items);
+    super(null, makeListType(valueType), items);
   }
 
   getChildSequence(idx: number): // eslint-disable-line no-unused-vars

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -163,18 +163,6 @@ function makePrimitiveType(k: NomsKind): Type<PrimitiveDesc> {
   return buildType(new PrimitiveDesc(k));
 }
 
-export function makeCompoundType(k: NomsKind, ...elemTypes: Array<Type>): Type {
-  if (elemTypes.length === 1) {
-    invariant(k !== Kind.Map, 'Map requires 2 element types');
-    invariant(k === Kind.Ref || k === Kind.List || k === Kind.Set);
-  } else {
-    invariant(k === Kind.Map, 'Only Map can have multiple element types');
-    invariant(elemTypes.length === 2, 'Map requires 2 element types');
-  }
-
-  return buildType(new CompoundDesc(k, elemTypes));
-}
-
 export function makeListType(elemType: Type): Type<CompoundDesc> {
   return buildType(new CompoundDesc(Kind.List, [elemType]));
 }
@@ -203,10 +191,10 @@ export const typeType = makePrimitiveType(Kind.Type);
 export const valueType = makePrimitiveType(Kind.Value);
 
 export const refOfBlobType = makeRefType(blobType);
-export const refOfValueType = makeCompoundType(Kind.Ref, valueType);
-export const listOfValueType = makeCompoundType(Kind.List, valueType);
-export const setOfValueType = makeCompoundType(Kind.Set, valueType);
-export const mapOfValueType = makeCompoundType(Kind.Map, valueType, valueType);
+export const refOfValueType = makeRefType(valueType);
+export const listOfValueType = makeListType(valueType);
+export const setOfValueType = makeSetType(valueType);
+export const mapOfValueType = makeMapType(valueType, valueType);
 
 /**
  * Gives the existing primitive Type value for a NomsKind.

--- a/nomdl/pkg/parse_test.go
+++ b/nomdl/pkg/parse_test.go
@@ -195,7 +195,8 @@ func (suite *ParsedResultTestSuite) assertTypes(source string, ts ...*types.Type
 	err := d.Try(func() {
 		i := runParser("", strings.NewReader(source))
 		for idx, t := range i.Types {
-			suite.True(t.Equals(ts[idx]))
+			// Cannot use t.Equals here since the parser generates a Type that cannot be serialized.
+			suite.Equal(ts[idx], t)
 		}
 	})
 	suite.NoError(err, source)

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -56,13 +56,13 @@ func parseJSON(s string, vs ...interface{}) (v []interface{}) {
 	return
 }
 
-func TestReadTypeAsTag(t *testing.T) {
+func TestReadType(t *testing.T) {
 	cs := NewTestValueStore()
 
 	test := func(expected *Type, s string, vs ...interface{}) {
 		a := parseJSON(s, vs...)
 		r := newJSONArrayReader(a, cs)
-		tr := r.readTypeAsTag(nil)
+		tr := r.readType(nil)
 		assert.True(t, expected.Equals(tr))
 	}
 
@@ -458,17 +458,17 @@ func TestReadTypeValue(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	test := func(expected *Type, json string, vs ...interface{}) {
-		a := parseJSON(json, vs...)
+	test := func(expected *Type, json string) {
+		a := parseJSON(json)
 		r := newJSONArrayReader(a, cs)
 		tr := r.readValue()
 		assert.True(expected.Equals(tr))
 	}
 
 	test(NumberType,
-		`[%d, %d]`, TypeKind, NumberKind)
+		`[TypeKind, NumberKind]`)
 	test(MakeListType(BoolType),
-		`[%d, %d, [%d]]`, TypeKind, ListKind, BoolKind)
+		`[TypeKind, ListKind, BoolKind]`)
 	test(MakeMapType(BoolType, StringType),
-		`[%d, %d, [%d, %d]]`, TypeKind, MapKind, BoolKind, StringKind)
+		`[TypeKind, MapKind, BoolKind, StringKind]`)
 }

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -348,10 +348,8 @@ func TestWriteTypeValue(t *testing.T) {
 	}
 
 	test([]interface{}{TypeKind, NumberKind}, NumberType)
-	test([]interface{}{TypeKind, ListKind, []interface{}{BoolKind}},
-		MakeListType(BoolType))
-	test([]interface{}{TypeKind, MapKind, []interface{}{BoolKind, StringKind}},
-		MakeMapType(BoolType, StringType))
+	test([]interface{}{TypeKind, ListKind, BoolKind}, MakeListType(BoolType))
+	test([]interface{}{TypeKind, MapKind, BoolKind, StringKind}, MakeMapType(BoolType, StringType))
 
 	test([]interface{}{TypeKind, StructKind, "S", []interface{}{"v", ValueKind, "x", NumberKind}},
 		MakeStructType("S", TypeMap{

--- a/types/type.go
+++ b/types/type.go
@@ -121,17 +121,6 @@ func MakePrimitiveTypeByString(p string) *Type {
 	return nil
 }
 
-func makeCompoundType(kind NomsKind, elemTypes ...*Type) *Type {
-	if len(elemTypes) == 1 {
-		d.Chk.NotEqual(MapKind, kind, "MapKind requires 2 element types.")
-		d.Chk.True(kind == RefKind || kind == ListKind || kind == SetKind)
-	} else {
-		d.Chk.Equal(MapKind, kind)
-		d.Chk.Len(elemTypes, 2, "MapKind requires 2 element types.")
-	}
-	return buildType(CompoundDesc{kind, elemTypes})
-}
-
 func MakeStructType(name string, fields map[string]*Type) *Type {
 	return buildType(StructDesc{name, fields})
 }


### PR DESCRIPTION
We used to serialize types in two different ways, depending on whether
the type was used as a tag or as a value. Now we serialize it the same
way.

Also, remove makeCompoundType completely.

And remove some dead code.
