### PR TITLE
Add union types

### DIFF
--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -15,6 +15,7 @@ import {
   makeRefType,
   makeSetType,
   makeStructType,
+  makeUnionType,
   StructDesc,
   Type,
   typeType,
@@ -81,14 +82,16 @@ export class JsonArrayReader {
     return v;
   }
 
+  readUint16(): number {
+    const v = this.read();
+    invariant((v & 0xffff) === v);
+    return v;
+  }
+
   readFloat(): number {
     const next = this.read();
     invariant(typeof next === 'string');
     return parseFloat(next);
-  }
-
-  readOrdinal(): number {
-    return this.readInt();
   }
 
   readArray(): Array<any> {
@@ -121,6 +124,14 @@ export class JsonArrayReader {
       case Kind.Ref:
         return makeRefType(this.readType(parentStructTypes));
 
+      case Kind.Union: {
+        const len = this.readUint16();
+        const types: Type[] = new Array(len);
+        for (let i = 0; i < len; i++) {
+          types[i] = this.readType(parentStructTypes);
+        }
+        return makeUnionType(types);
+      }
       case Kind.Type:
         return typeType;
       case Kind.Struct:

--- a/js/src/encode-human-readable-test.js
+++ b/js/src/encode-human-readable-test.js
@@ -13,6 +13,7 @@ import {
   makeMapType,
   makeSetType,
   makeStructType,
+  makeUnionType,
   stringType,
   valueType,
   Type,
@@ -43,6 +44,12 @@ suite('Encode human readable types', () => {
     assertWriteType('Set<Number>', makeSetType(numberType));
     assertWriteType('Ref<Number>', makeRefType(numberType));
     assertWriteType('Map<Number, String>', makeMapType(numberType, stringType));
+
+    assertWriteType('Number | String', makeUnionType([numberType, stringType]));
+    assertWriteType('Bool', makeUnionType([boolType]));
+    assertWriteType('', makeUnionType([]));
+    assertWriteType('List<Number | String>', makeListType(makeUnionType([numberType, stringType])));
+    assertWriteType('List<>', makeListType(makeUnionType([])));
   });
 
   test('struct', () => {

--- a/js/src/encode-human-readable.js
+++ b/js/src/encode-human-readable.js
@@ -79,23 +79,28 @@ export class TypeWriter {
       case Kind.List:
       case Kind.Ref:
       case Kind.Set:
+      case Kind.Map:
         this._w.writeKind(t.kind);
         this._w.write('<');
         invariant(t.desc instanceof CompoundDesc);
-        this._writeType(t.desc.elemTypes[0], parentStructTypes);
+        t.desc.elemTypes.forEach((t, i) => {
+          if (i !== 0) {
+            this._w.write(', ');
+          }
+          this._writeType(t, parentStructTypes);
+        });
         this._w.write('>');
         break;
-      case Kind.Map: {
-        this._w.writeKind(t.kind);
-        this._w.write('<');
+      case Kind.Union:
         invariant(t.desc instanceof CompoundDesc);
-        const [keyType, valueType] = t.desc.elemTypes;
-        this._writeType(keyType, parentStructTypes);
-        this._w.write(', ');
-        this._writeType(valueType, parentStructTypes);
-        this._w.write('>');
+        t.desc.elemTypes.forEach((t, i) => {
+          if (i !== 0) {
+            this._w.write(' | ');
+          }
+          this._writeType(t, parentStructTypes);
+        });
         break;
-      }
+
       case Kind.Struct:
         this._writeStructType(t, parentStructTypes);
         break;

--- a/js/src/encode.js
+++ b/js/src/encode.js
@@ -58,6 +58,10 @@ export class JsonArrayWriter {
     this.write(n);
   }
 
+  writeUint16(n: number) {
+    this.write(n);
+  }
+
   writeKind(k: NomsKind) {
     this.write(k);
   }
@@ -75,6 +79,11 @@ export class JsonArrayWriter {
       case Kind.Ref:
       case Kind.Set:
         this.writeKind(k);
+        t.elemTypes.forEach(elemType => this.writeType(elemType, parentStructTypes));
+        break;
+      case Kind.Union:
+        this.writeKind(k);
+        this.writeUint16(t.elemTypes.length);
         t.elemTypes.forEach(elemType => this.writeType(elemType, parentStructTypes));
         break;
       case Kind.Struct:

--- a/js/src/noms-kind.js
+++ b/js/src/noms-kind.js
@@ -15,6 +15,7 @@ export const Kind: {
   Struct: NomsKind,
   Type: NomsKind,
   Parent: NomsKind,
+  Union: NomsKind,
 } = {
   Bool: 0,
   Number: 1,
@@ -28,6 +29,7 @@ export const Kind: {
   Struct: 9,
   Type: 10,
   Parent: 11,  // Only used in encoding/decoding.
+  Union: 12,
 };
 
 const kindToStringMap: { [key: number]: string } = Object.create(null);
@@ -43,6 +45,7 @@ kindToStringMap[Kind.Set] = 'Set';
 kindToStringMap[Kind.Struct] = 'Struct';
 kindToStringMap[Kind.Type] = 'Type';
 kindToStringMap[Kind.Parent] = 'Parent';
+kindToStringMap[Kind.Union] = 'Union';
 
 export function kindToString(kind: NomsKind): string {
   return kindToStringMap[kind];

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -183,6 +183,15 @@ export function makeStructType(name: string, fields: {[key: string]: Type}): Typ
   return buildType(new StructDesc(name, fields));
 }
 
+function compareTypeByRef(a: Type, b: Type): number {
+  return a.ref.less(b.ref) ? -1 : 1;
+}
+
+export function makeUnionType(types: Type[]): Type<CompoundDesc> {
+  types.sort(compareTypeByRef);
+  return buildType(new CompoundDesc(Kind.Union, types));
+}
+
 export const boolType = makePrimitiveType(Kind.Bool);
 export const numberType = makePrimitiveType(Kind.Number);
 export const stringType = makePrimitiveType(Kind.String);

--- a/js/src/validate-type-test.js
+++ b/js/src/validate-type-test.js
@@ -17,6 +17,7 @@ import {
   makeMapType,
   makeSetType,
   makeStructType,
+  makeUnionType,
   mapOfValueType,
   numberType,
   setOfValueType,
@@ -125,5 +126,27 @@ suite('validate type', () => {
     assertAll(type, v);
 
     validateType(valueType, v);
+  });
+
+  test('union', async () => {
+    validateType(makeUnionType([numberType]), 42);
+    validateType(makeUnionType([numberType, stringType]), 42);
+    validateType(makeUnionType([numberType, stringType]), 'hi');
+    validateType(makeUnionType([numberType, stringType, boolType]), 555);
+    validateType(makeUnionType([numberType, stringType, boolType]), 'hi');
+    validateType(makeUnionType([numberType, stringType, boolType]), true);
+
+    const lt = makeListType(makeUnionType([numberType, stringType]));
+    validateType(lt, await newList([1, 'hi', 2, 'bye'], lt));
+
+    const st = makeSetType(stringType);
+    validateType(makeUnionType([st, numberType]), 42);
+    validateType(makeUnionType([st, numberType]), await newSet(['a', 'b'], st));
+
+    assertInvalid(makeUnionType([]), 42);
+    assertInvalid(makeUnionType([stringType]), 42);
+    assertInvalid(makeUnionType([stringType, boolType]), 42);
+    assertInvalid(makeUnionType([st, stringType]), 42);
+    assertInvalid(makeUnionType([st, numberType]), await newSet([1, 2], makeSetType(numberType)));
   });
 });

--- a/types/encode_human_readable.go
+++ b/types/encode_human_readable.go
@@ -185,18 +185,23 @@ func (w *hrsWriter) writeType(t *Type, parentStructTypes []*Type) {
 	switch t.Kind() {
 	case BlobKind, BoolKind, NumberKind, StringKind, TypeKind, ValueKind:
 		w.write(KindToString[t.Kind()])
-	case ListKind, RefKind, SetKind:
+	case ListKind, RefKind, SetKind, MapKind:
 		w.write(KindToString[t.Kind()])
 		w.write("<")
-		w.writeType(t.Desc.(CompoundDesc).ElemTypes[0], parentStructTypes)
+		for i, et := range t.Desc.(CompoundDesc).ElemTypes {
+			if i != 0 {
+				w.write(", ")
+			}
+			w.writeType(et, parentStructTypes)
+		}
 		w.write(">")
-	case MapKind:
-		w.write(KindToString[t.Kind()])
-		w.write("<")
-		w.writeType(t.Desc.(CompoundDesc).ElemTypes[0], parentStructTypes)
-		w.write(", ")
-		w.writeType(t.Desc.(CompoundDesc).ElemTypes[1], parentStructTypes)
-		w.write(">")
+	case UnionKind:
+		for i, et := range t.Desc.(CompoundDesc).ElemTypes {
+			if i != 0 {
+				w.write(" | ")
+			}
+			w.writeType(et, parentStructTypes)
+		}
 	case StructKind:
 		w.writeStructType(t, parentStructTypes)
 	case ParentKind:

--- a/types/encode_human_readable_test.go
+++ b/types/encode_human_readable_test.go
@@ -223,6 +223,11 @@ func TestWriteHumanReadableType(t *testing.T) {
 	assertWriteHRSEqual(t, "Set<Number>", MakeSetType(NumberType))
 	assertWriteHRSEqual(t, "Ref<Number>", MakeRefType(NumberType))
 	assertWriteHRSEqual(t, "Map<Number, String>", MakeMapType(NumberType, StringType))
+	assertWriteHRSEqual(t, "Number | String", MakeUnionType(NumberType, StringType))
+	assertWriteHRSEqual(t, "Bool", MakeUnionType(BoolType))
+	assertWriteHRSEqual(t, "", MakeUnionType())
+	assertWriteHRSEqual(t, "List<Number | String>", MakeListType(MakeUnionType(NumberType, StringType)))
+	assertWriteHRSEqual(t, "List<>", MakeListType(MakeUnionType()))
 }
 
 func TestWriteHumanReadableTaggedPrimitiveValues(t *testing.T) {

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -356,6 +356,10 @@ func TestWriteTypeValue(t *testing.T) {
 			"x": NumberType,
 			"v": ValueType,
 		}))
+
+	test([]interface{}{TypeKind, UnionKind, uint16(0)}, MakeUnionType())
+	test([]interface{}{TypeKind, UnionKind, uint16(2), NumberKind, StringKind}, MakeUnionType(NumberType, StringType))
+	test([]interface{}{TypeKind, ListKind, UnionKind, uint16(0)}, MakeListType(MakeUnionType()))
 }
 
 func TestWriteListOfTypes(t *testing.T) {
@@ -418,5 +422,23 @@ func TestWriteRecursiveStruct(t *testing.T) {
 			}, false, []interface{}{}, NumberKind, "555",
 		}, NumberKind, "42",
 	}, w.toArray())
+}
 
+func TestWriteUnionList(t *testing.T) {
+	assert := assert.New(t)
+
+	w := newJSONArrayWriter(NewTestValueStore())
+	v := NewTypedList(MakeListType(MakeUnionType(StringType, NumberType)), NewString("hi"), Number(42))
+	w.writeValue(v)
+	assert.Equal([]interface{}{ListKind, UnionKind, uint16(2), NumberKind, StringKind,
+		false, []interface{}{StringKind, "hi", NumberKind, "42"}}, w.toArray())
+}
+
+func TestWriteEmptyUnionList(t *testing.T) {
+	assert := assert.New(t)
+
+	w := newJSONArrayWriter(NewTestValueStore())
+	v := NewTypedList(MakeListType(MakeUnionType()))
+	w.writeValue(v)
+	assert.Equal([]interface{}{ListKind, UnionKind, uint16(0), false, []interface{}{}}, w.toArray())
 }

--- a/types/noms_kind.go
+++ b/types/noms_kind.go
@@ -17,6 +17,7 @@ const (
 	StructKind
 	TypeKind
 	ParentKind // Only used in encoding/decoding.
+	UnionKind
 )
 
 // IsPrimitiveKind returns true if k represents a Noms primitive type, which excludes collections (List, Map, Set), Refs, Structs, Symbolic and Unresolved types.

--- a/types/type.go
+++ b/types/type.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"sort"
+
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
 )
@@ -139,6 +141,17 @@ func MakeMapType(keyType, valType *Type) *Type {
 
 func MakeRefType(elemType *Type) *Type {
 	return buildType(CompoundDesc{RefKind, []*Type{elemType}})
+}
+
+type unionTypes []*Type
+
+func (uts unionTypes) Len() int           { return len(uts) }
+func (uts unionTypes) Less(i, j int) bool { return uts[i].Ref().Less(uts[j].Ref()) }
+func (uts unionTypes) Swap(i, j int)      { uts[i], uts[j] = uts[j], uts[i] }
+
+func MakeUnionType(elemType ...*Type) *Type {
+	sort.Sort(unionTypes(elemType))
+	return buildType(CompoundDesc{UnionKind, elemType})
 }
 
 func buildType(desc TypeDesc) *Type {

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -38,6 +38,7 @@ var KindToString = map[NomsKind]string{
 	TypeKind:   "Type",
 	ValueKind:  "Value",
 	ParentKind: "Parent",
+	UnionKind:  "Union",
 }
 
 // CompoundDesc describes a List, Map, Set or Ref type.


### PR DESCRIPTION
A union type is a compound type with 0 or more types.

Its noms serialization is `UnionKind, <number-of-types>, T0, ..., TN`

Its HRS is `T0 | T1 | ... | TN`

Towards #1311

Remaining work includes making the order deterministic and update the
collection APIs to refine the type.
