### PR TITLE
Go: Back datas.unwrittenPutCache with a LevelDB

### DIFF
--- a/datas/http_batch_store.go
+++ b/datas/http_batch_store.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -70,7 +69,7 @@ type httpDoer interface {
 }
 
 type writeRequest struct {
-	c     chunks.Chunk
+	hash  ref.Ref
 	hints types.Hints
 }
 
@@ -93,6 +92,7 @@ func (bhcs *httpBatchStore) Flush() {
 
 func (bhcs *httpBatchStore) Close() (e error) {
 	close(bhcs.finishedChan)
+	bhcs.unwrittenPuts.Destroy()
 	bhcs.requestWg.Wait()
 	bhcs.workerWg.Wait()
 
@@ -203,7 +203,7 @@ func (bhcs *httpBatchStore) SchedulePut(c chunks.Chunk, hints types.Hints) {
 	}
 
 	bhcs.requestWg.Add(1)
-	bhcs.writeQueue <- writeRequest{c, hints}
+	bhcs.writeQueue <- writeRequest{c.Ref(), hints}
 }
 
 func (bhcs *httpBatchStore) batchPutRequests() {
@@ -211,14 +211,10 @@ func (bhcs *httpBatchStore) batchPutRequests() {
 	go func() {
 		defer bhcs.workerWg.Done()
 
-		numChunks := 0
 		hints := types.Hints{}
-		buf := makeBuffer()
-		gw := gzip.NewWriter(buf)
-		sz := chunks.NewSerializer(gw)
+		hashes := ref.RefSlice{}
 		handleRequest := func(wr writeRequest) {
-			numChunks++
-			sz.Put(wr.c)
+			hashes = append(hashes, wr.hash)
 			for hint := range wr.hints {
 				hints[hint] = struct{}{}
 			}
@@ -242,15 +238,10 @@ func (bhcs *httpBatchStore) batchPutRequests() {
 						handleRequest(wr)
 					default:
 						drained = true
-						d.Chk.NoError(sz.Close())
-						d.Chk.NoError(gw.Close())
-						bhcs.sendWriteRequests(buf, numChunks, hints) // Takes ownership of buf, hints
+						bhcs.sendWriteRequests(hashes, hints) // Takes ownership of hashes, hints
 
-						numChunks = 0
 						hints = types.Hints{}
-						buf = makeBuffer()
-						gw = gzip.NewWriter(buf)
-						sz = chunks.NewSerializer(gw)
+						hashes = ref.RefSlice{}
 					}
 				}
 			}
@@ -258,27 +249,24 @@ func (bhcs *httpBatchStore) batchPutRequests() {
 	}()
 }
 
-func makeBuffer() *os.File {
-	f, err := ioutil.TempFile("", "http_hinted_chunk_store_")
-	d.Chk.NoError(err, "Cannot create filesystem buffer for Chunks.")
-	return f
-}
-
-func (bhcs *httpBatchStore) sendWriteRequests(serializedChunks *os.File, numChunks int, hints types.Hints) {
+func (bhcs *httpBatchStore) sendWriteRequests(hashes ref.RefSlice, hints types.Hints) {
+	if len(hashes) == 0 {
+		return
+	}
 	bhcs.rateLimit <- struct{}{}
+	serializedChunks := bhcs.unwrittenPuts.GzipReader(hashes[0], hashes[len(hashes)-1])
 	go func() {
 		defer func() {
 			<-bhcs.rateLimit
-			bhcs.unwrittenPuts = newUnwrittenPutCache()
-			bhcs.requestWg.Add(-numChunks)
-			d.Chk.NoError(serializedChunks.Close(), "Cannot close filesystem buffer.")
-			d.Chk.NoError(os.Remove(serializedChunks.Name()), "Cannot remove filesystem buffer.")
+			serializedChunks.Close()
+			bhcs.unwrittenPuts.Clear(hashes)
+			bhcs.requestWg.Add(-len(hashes))
 		}()
 
 		var res *http.Response
+		var err error
 		for tryAgain := true; tryAgain; {
-			_, err := serializedChunks.Seek(0, 0)
-			d.Chk.NoError(err, "Could not reset filesystem buffer to offset 0.")
+			serializedChunks.Reset()
 			body := buildWriteValueRequest(serializedChunks, hints)
 
 			url := *bhcs.host

--- a/datas/put_cache.go
+++ b/datas/put_cache.go
@@ -1,52 +1,178 @@
 package datas
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/filter"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 func newUnwrittenPutCache() *unwrittenPutCache {
-	return &unwrittenPutCache{map[ref.Ref]chunks.Chunk{}, &sync.Mutex{}}
+	dir, err := ioutil.TempDir("", "")
+	d.Exp.NoError(err)
+	db, err := leveldb.OpenFile(dir, &opt.Options{
+		Compression:            opt.NoCompression,
+		Filter:                 filter.NewBloomFilter(10), // 10 bits/key
+		OpenFilesCacheCapacity: 24,
+		WriteBuffer:            1 << 24, // 16MiB,
+	})
+	d.Chk.NoError(err, "opening put cache in %s", dir)
+	return &unwrittenPutCache{
+		orderedChunks: db,
+		chunkIndex:    map[ref.Ref][]byte{},
+		dbDir:         dir,
+		mu:            &sync.Mutex{},
+	}
 }
 
 type unwrittenPutCache struct {
-	unwrittenPuts map[ref.Ref]chunks.Chunk
+	orderedChunks *leveldb.DB
+	chunkIndex    map[ref.Ref][]byte
+	dbDir         string
 	mu            *sync.Mutex
+	next          uint64
 }
 
 func (p *unwrittenPutCache) Add(c chunks.Chunk) bool {
+	hash := c.Ref()
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if _, ok := p.unwrittenPuts[c.Ref()]; !ok {
-		p.unwrittenPuts[c.Ref()] = c
+	// Don't use defer p.mu.Unlock() here, because I want writing to orderedChunks NOT to be guarded by the lock. LevelDB handles its own goroutine-safety.
+	if _, ok := p.chunkIndex[hash]; !ok {
+		key := toKey(p.next)
+		p.next++
+		p.chunkIndex[hash] = key
+		p.mu.Unlock()
+
+		buf := &bytes.Buffer{}
+		gw := gzip.NewWriter(buf)
+		sz := chunks.NewSerializer(gw)
+		sz.Put(c)
+		sz.Close()
+		gw.Close()
+		d.Chk.NoError(p.orderedChunks.Put(key, buf.Bytes(), nil))
 		return true
 	}
-
+	p.mu.Unlock()
 	return false
 }
 
-func (p *unwrittenPutCache) Has(c chunks.Chunk) (has bool) {
+func (p *unwrittenPutCache) Has(hash ref.Ref) (has bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	_, has = p.unwrittenPuts[c.Ref()]
+	_, has = p.chunkIndex[hash]
 	return
 }
 
-func (p *unwrittenPutCache) Get(r ref.Ref) chunks.Chunk {
+func (p *unwrittenPutCache) Get(hash ref.Ref) chunks.Chunk {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if c, ok := p.unwrittenPuts[r]; ok {
-		return c
+	// Don't use defer p.mu.Unlock() here, because I want reading from orderedChunks NOT to be guarded by the lock. LevelDB handles its own goroutine-safety.
+	if key, ok := p.chunkIndex[hash]; ok {
+		p.mu.Unlock()
+
+		data, err := p.orderedChunks.Get(key, nil)
+		d.Chk.NoError(err)
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		d.Chk.NoError(err)
+		defer reader.Close()
+		chunkChan := make(chan chunks.Chunk)
+		go chunks.DeserializeToChan(reader, chunkChan)
+		return <-chunkChan
 	}
+	p.mu.Unlock()
 	return chunks.EmptyChunk
 }
 
 func (p *unwrittenPutCache) Clear(hashes ref.RefSlice) {
+	toDelete := make([][]byte, len(hashes))
+	p.mu.Lock()
+	for i, hash := range hashes {
+		toDelete[i] = p.chunkIndex[hash]
+		delete(p.chunkIndex, hash)
+	}
+	p.mu.Unlock()
+	for _, key := range toDelete {
+		d.Chk.NoError(p.orderedChunks.Delete(key, nil))
+	}
+	return
+}
+
+func toKey(idx uint64) []byte {
+	buf := &bytes.Buffer{}
+	err := binary.Write(buf, binary.BigEndian, idx)
+	d.Chk.NoError(err)
+	return buf.Bytes()
+}
+
+func fromKey(key []byte) (idx uint64) {
+	err := binary.Read(bytes.NewReader(key), binary.BigEndian, &idx)
+	d.Chk.NoError(err)
+	return
+}
+
+type resettableReadCloser interface {
+	io.ReadCloser
+	Reset()
+}
+
+type putCacheReader struct {
+	iterator.Iterator
+	remaining []byte
+}
+
+func (p *unwrittenPutCache) GzipReader(start, end ref.Ref) resettableReadCloser {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for _, hash := range hashes {
-		delete(p.unwrittenPuts, hash)
+	iterRange := &util.Range{Start: p.chunkIndex[start], Limit: toKey(fromKey(p.chunkIndex[end]) + 1)}
+	return &putCacheReader{Iterator: p.orderedChunks.NewIterator(iterRange, nil)}
+}
+
+func (p *unwrittenPutCache) Destroy() error {
+	d.Chk.NoError(p.orderedChunks.Close())
+	return os.RemoveAll(p.dbDir)
+}
+
+func (r *putCacheReader) Reset() {
+	r.First()
+	// First() sets r back to the first item in the iteration. In order to avoid having to detect this case in Read(), set r back to BEFORE the first item. This way, Read() can just always call Next() when it wants another item.
+	r.Prev()
+}
+
+func (r *putCacheReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return
 	}
+
+	// if anything in r.remaining, Copy up to len(p) bytes into p, reslice r.remaining and return.
+	if len(r.remaining) > 0 {
+		n = copy(p, r.remaining)
+		r.remaining = r.remaining[n:]
+		return
+	}
+
+	// if not, get the next thing, return up to len(p), and put the rest in r.remaining
+	if r.Next() {
+		d := r.Value()
+		n = copy(p, d)
+		r.remaining = d[n:]
+		return
+	}
+
+	return 0, io.EOF
+}
+
+func (r *putCacheReader) Close() error {
+	r.Release()
+	return r.Error()
 }

--- a/datas/put_cache_test.go
+++ b/datas/put_cache_test.go
@@ -1,0 +1,186 @@
+package datas
+
+import (
+	"compress/gzip"
+	"sync"
+	"testing"
+
+	"github.com/attic-labs/noms/chunks"
+	"github.com/attic-labs/noms/ref"
+	"github.com/attic-labs/noms/types"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestLevelDBPutCacheSuite(t *testing.T) {
+	suite.Run(t, &LevelDBPutCacheSuite{})
+}
+
+type LevelDBPutCacheSuite struct {
+	suite.Suite
+	cache  *unwrittenPutCache
+	values []types.Value
+	chnx   map[ref.Ref]chunks.Chunk
+}
+
+func (suite *LevelDBPutCacheSuite) SetupTest() {
+	suite.cache = newUnwrittenPutCache()
+	suite.values = []types.Value{
+		types.NewString("abc"),
+		types.NewString("def"),
+		types.NewString("ghi"),
+		types.NewString("jkl"),
+		types.NewString("mno"),
+	}
+	suite.chnx = map[ref.Ref]chunks.Chunk{}
+	for _, v := range suite.values {
+		suite.chnx[v.Ref()] = types.EncodeValue(v, nil)
+	}
+}
+
+func (suite *LevelDBPutCacheSuite) TearDownTest() {
+	suite.cache.Destroy()
+}
+
+func (suite *LevelDBPutCacheSuite) TestAddTwice() {
+	chunk := suite.chnx[suite.values[0].Ref()]
+	suite.True(suite.cache.Add(chunk))
+	suite.False(suite.cache.Add(chunk))
+}
+
+func (suite *LevelDBPutCacheSuite) TestAddParallel() {
+	hashes := make(chan ref.Ref)
+	for _, chunk := range suite.chnx {
+		go func(c chunks.Chunk) {
+			suite.cache.Add(c)
+			hashes <- c.Ref()
+		}(chunk)
+	}
+
+	for i := 0; i < len(suite.values); i++ {
+		hash := <-hashes
+		suite.True(suite.cache.Has(hash))
+		delete(suite.chnx, hash)
+	}
+	close(hashes)
+	suite.Len(suite.chnx, 0)
+}
+
+func (suite *LevelDBPutCacheSuite) TestGetParallel() {
+	for _, c := range suite.chnx {
+		suite.cache.Add(c)
+	}
+
+	chunkChan := make(chan chunks.Chunk)
+	for hash := range suite.chnx {
+		go func(h ref.Ref) {
+			chunkChan <- suite.cache.Get(h)
+		}(hash)
+	}
+
+	for i := 0; i < len(suite.values); i++ {
+		c := <-chunkChan
+		delete(suite.chnx, c.Ref())
+	}
+	close(chunkChan)
+	suite.Len(suite.chnx, 0)
+}
+
+func (suite *LevelDBPutCacheSuite) TestClearParallel() {
+	hashes := ref.RefSlice{}
+	for h, c := range suite.chnx {
+		hashes = append(hashes, h)
+		suite.cache.Add(c)
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	clear := func(hs ref.RefSlice) {
+		suite.cache.Clear(hs)
+		wg.Done()
+	}
+	keepIdx := 2
+	go clear(hashes[:keepIdx])
+	go clear(hashes[keepIdx+1:])
+
+	wg.Wait()
+	for i, hash := range hashes {
+		if i == keepIdx {
+			suite.True(suite.cache.Has(hash))
+			continue
+		}
+		suite.False(suite.cache.Has(hash))
+	}
+}
+
+func (suite *LevelDBPutCacheSuite) TestReaderSubset() {
+	orderedHashes := ref.RefSlice{}
+	for hash, c := range suite.chnx {
+		orderedHashes = append(orderedHashes, hash)
+		suite.cache.Add(c)
+	}
+
+	// Only iterate over the first 2 elements in the DB
+	reader := suite.cache.GzipReader(orderedHashes[0], orderedHashes[1])
+	defer reader.Close()
+	gr, err := gzip.NewReader(reader)
+	suite.NoError(err)
+	defer gr.Close()
+
+	chunkChan := make(chan chunks.Chunk)
+	go chunks.DeserializeToChan(gr, chunkChan)
+
+	origLen := len(orderedHashes)
+	for c := range chunkChan {
+		suite.Equal(orderedHashes[0], c.Ref())
+		orderedHashes = orderedHashes[1:]
+	}
+	suite.Len(orderedHashes, origLen-2)
+}
+
+func (suite *LevelDBPutCacheSuite) TestReaderSnapshot() {
+	hashes := ref.RefSlice{}
+	for h, c := range suite.chnx {
+		hashes = append(hashes, h)
+		suite.cache.Add(c)
+	}
+
+	reader := suite.cache.GzipReader(hashes[0], hashes[len(hashes)-1])
+	defer reader.Close()
+	gr, err := gzip.NewReader(reader)
+	suite.NoError(err)
+	defer gr.Close()
+
+	chunkChan := make(chan chunks.Chunk)
+	go chunks.DeserializeToChan(gr, chunkChan)
+
+	// Clear chunks from suite.cache. Should still be enumerated by reader
+	suite.cache.Clear(hashes)
+
+	for c := range chunkChan {
+		delete(suite.chnx, c.Ref())
+	}
+	suite.Len(suite.chnx, 0)
+}
+
+func (suite *LevelDBPutCacheSuite) TestReaderOrder() {
+	orderedHashes := ref.RefSlice{}
+	for hash, c := range suite.chnx {
+		orderedHashes = append(orderedHashes, hash)
+		suite.cache.Add(c)
+	}
+
+	reader := suite.cache.GzipReader(orderedHashes[0], orderedHashes[len(orderedHashes)-1])
+	defer reader.Close()
+	gr, err := gzip.NewReader(reader)
+	suite.NoError(err)
+	defer gr.Close()
+
+	chunkChan := make(chan chunks.Chunk)
+	go chunks.DeserializeToChan(gr, chunkChan)
+
+	for c := range chunkChan {
+		suite.Equal(orderedHashes[0], c.Ref())
+		orderedHashes = orderedHashes[1:]
+	}
+	suite.Len(orderedHashes, 0)
+}


### PR DESCRIPTION
httpBatchStore was caching as-yet-unwritten Chunks both in memory and
on disk. To avoid this, the in-memory cache is now backed by a
LevelDB, which handles spilling to disk when it needs to. When it's
time to send Chunks to the server, the cache is enumerated in
insert-order so that the payload of the write request is properly
structured.

Fixes #1348
