### PR TITLE
Clear dist before publish

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -37,7 +37,7 @@
     "pretest": "eslint src/ && flow src/",
     "ts": "mocha --ui tdd --timeout=3000 --reporter spec --slow=50 --invert --grep='LONG:' --compilers js:babel-core/register src/*-test.js",
     "test": "mocha --ui tdd --timeout=3000 --reporter dot --compilers js:babel-core/register src/*-test.js",
-    "prepublish": "npm run compile && npm run copy-flow-files",
+    "prepublish": "rm -rf dist/ && npm run compile && npm run copy-flow-files",
     "compile": "npm run compile-to-commonjs && npm run compile-to-es6",
     "compile-to-commonjs": "BABEL_ENV=production babel -d dist/commonjs src/",
     "compile-to-es6": "BABEL_ENV=es6 babel -d dist/es6 src/",


### PR DESCRIPTION
This is so that we do not keep old files around.

Fixes #1380
