### PR TITLE
Revert "Limit struct field names to ascii identifiers"

### DIFF
--- a/js/src/type-test.js
+++ b/js/src/type-test.js
@@ -47,29 +47,4 @@ suite('Type', () => {
     assert.equal(stringType, getTypeOfValue('abc'));
     assert.equal(typeType, getTypeOfValue(stringType));
   });
-
-  test('verify field name', () => {
-    function assertInvalid(n: string) {
-      assert.throw(() => {
-        makeStructType('S', {[n]: stringType});
-      });
-    }
-    assertInvalid('');
-    assertInvalid(' ');
-    assertInvalid(' a');
-    assertInvalid('a ');
-    assertInvalid('0');
-    assertInvalid('_');
-    assertInvalid('0a');
-    assertInvalid('_a');
-
-    function assertValid(n: string) {
-      makeStructType('S', {[n]: stringType});
-    }
-    assertValid('a');
-    assertValid('A');
-    assertValid('a0');
-    assertValid('a_');
-    assertValid('a0_');
-  });
 });

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -180,16 +180,7 @@ export function makeRefType(elemType: Type): Type<CompoundDesc> {
 }
 
 export function makeStructType(name: string, fields: {[key: string]: Type}): Type<StructDesc> {
-  Object.keys(fields).forEach(verifyFieldName);
   return buildType(new StructDesc(name, fields));
-}
-
-const fieldNameRe = /^[a-zA-Z][a-zA-Z0-9_]*$/;
-
-function verifyFieldName(name: string) {
-  if (!fieldNameRe.test(name)) {
-    throw new Error(`Invalid struct field name: ${name}`);
-  }
 }
 
 function compareTypeByRef(a: Type, b: Type): number {

--- a/types/type.go
+++ b/types/type.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"regexp"
 	"sort"
 
 	"github.com/attic-labs/noms/d"
@@ -125,16 +124,7 @@ func MakePrimitiveTypeByString(p string) *Type {
 }
 
 func MakeStructType(name string, fields map[string]*Type) *Type {
-	for fn := range fields {
-		verifyFieldName(fn)
-	}
 	return buildType(StructDesc{name, fields})
-}
-
-var fieldNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
-
-func verifyFieldName(name string) {
-	d.Exp.True(fieldNameRe.MatchString(name), "Invalid struct field name: %s", name)
 }
 
 func MakeListType(elemType *Type) *Type {

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -66,30 +66,3 @@ func TestTypeOrdered(t *testing.T) {
 	assert.False(MakeMapType(StringType, ValueType).IsOrdered())
 	assert.True(MakeRefType(StringType).IsOrdered())
 }
-
-func TestVerifyFieldName(t *testing.T) {
-	assert := assert.New(t)
-
-	assertInvalid := func(n string) {
-		assert.Panics(func() {
-			MakeStructType("S", TypeMap{n: StringType})
-		})
-	}
-	assertInvalid("")
-	assertInvalid(" ")
-	assertInvalid(" a")
-	assertInvalid("a ")
-	assertInvalid("0")
-	assertInvalid("_")
-	assertInvalid("0a")
-	assertInvalid("_a")
-
-	assertValid := func(n string) {
-		MakeStructType("S", TypeMap{n: StringType})
-	}
-	assertValid("a")
-	assertValid("A")
-	assertValid("a0")
-	assertValid("a_")
-	assertValid("a0_")
-}


### PR DESCRIPTION
Reverts attic-labs/noms#1469

The CSV importer generates names which aren't valid identifiers.
