### PR TITLE
Update makeUnionType type to flatten and remove duplicates

### DIFF
--- a/js/src/type-test.js
+++ b/js/src/type-test.js
@@ -7,6 +7,7 @@ import {
   makeMapType,
   makeSetType,
   makeStructType,
+  makeUnionType,
   numberType,
   stringType,
   typeType,
@@ -47,5 +48,24 @@ suite('Type', () => {
     assert.equal(numberType, getTypeOfValue(0));
     assert.equal(stringType, getTypeOfValue('abc'));
     assert.equal(typeType, getTypeOfValue(stringType));
+  });
+
+  test('flatten union types', () => {
+    assert.equal(makeUnionType([boolType]), boolType);
+    assert.deepEqual(makeUnionType([]), makeUnionType([]));
+    assert.deepEqual(makeUnionType([boolType, makeUnionType([stringType])]),
+                     makeUnionType([boolType, stringType]));
+    assert.deepEqual(makeUnionType([boolType, makeUnionType([stringType, numberType])]),
+                     makeUnionType([boolType, stringType, numberType]));
+    assert.equal(makeUnionType([boolType, boolType]), boolType);
+    assert.equal(makeUnionType([boolType, makeUnionType([])]), boolType);
+    assert.equal(makeUnionType([makeUnionType([]), boolType]), boolType);
+    assert.isTrue(equals(makeUnionType([makeUnionType([]), makeUnionType([])]), makeUnionType([])));
+    assert.deepEqual(makeUnionType([boolType, numberType]), makeUnionType([boolType, numberType]));
+    assert.deepEqual(makeUnionType([numberType, boolType]), makeUnionType([boolType, numberType]));
+    assert.deepEqual(makeUnionType([boolType, numberType, boolType]),
+                     makeUnionType([boolType, numberType]));
+    assert.deepEqual(makeUnionType([makeUnionType([boolType, numberType]), numberType, boolType]),
+                     makeUnionType([boolType, numberType]));
   });
 });

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -66,3 +66,19 @@ func TestTypeOrdered(t *testing.T) {
 	assert.False(isKindOrderedByValue(MakeMapType(StringType, ValueType).Kind()))
 	assert.False(isKindOrderedByValue(MakeRefType(StringType).Kind()))
 }
+
+func TestFlattenUnionTypes(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(BoolType, MakeUnionType(BoolType))
+	assert.Equal(MakeUnionType(), MakeUnionType())
+	assert.Equal(MakeUnionType(BoolType, StringType), MakeUnionType(BoolType, MakeUnionType(StringType)))
+	assert.Equal(MakeUnionType(BoolType, StringType, NumberType), MakeUnionType(BoolType, MakeUnionType(StringType, NumberType)))
+	assert.Equal(BoolType, MakeUnionType(BoolType, BoolType))
+	assert.Equal(BoolType, MakeUnionType(BoolType, MakeUnionType()))
+	assert.Equal(BoolType, MakeUnionType(MakeUnionType(), BoolType))
+	assert.True(MakeUnionType(MakeUnionType(), MakeUnionType()).Equals(MakeUnionType()))
+	assert.Equal(MakeUnionType(BoolType, NumberType), MakeUnionType(BoolType, NumberType))
+	assert.Equal(MakeUnionType(BoolType, NumberType), MakeUnionType(NumberType, BoolType))
+	assert.Equal(MakeUnionType(BoolType, NumberType), MakeUnionType(BoolType, NumberType, BoolType))
+	assert.Equal(MakeUnionType(BoolType, NumberType), MakeUnionType(MakeUnionType(BoolType, NumberType), NumberType, BoolType))
+}


### PR DESCRIPTION
makeUnionType now flattens and removes duplicate types. With this
change makeUnionType might no longer actually create a union
type in the case there is only one type in the union.

Towards #1491
