### PR TITLE
Go: replace httpBatchStore overall timeout with idle-timeout

### DIFF
--- a/cmd/noms-serve/.gitignore
+++ b/cmd/noms-serve/.gitignore
@@ -1,0 +1,1 @@
+noms-serve

--- a/datas/http_batch_store.go
+++ b/datas/http_batch_store.go
@@ -77,11 +77,10 @@ type writeRequest struct {
 func makeHTTPClient(requestLimit int) *http.Client {
 	t := http.Transport(*http.DefaultTransport.(*http.Transport))
 	t.MaxIdleConnsPerHost = requestLimit
+	// This sets, essentially, an idle-timeout. The timer starts counting AFTER the client has finished sending the entire request to the server. As soon as the client receives the server's response headers, the timeout is canceled.
+	t.ResponseHeaderTimeout = time.Duration(2) * time.Minute
 
-	return &http.Client{
-		Transport: &t,
-		Timeout:   time.Duration(30) * time.Second,
-	}
+	return &http.Client{Transport: &t}
 }
 
 func (bhcs *httpBatchStore) Flush() {


### PR DESCRIPTION
The old timeout mechanism started counting when the client
began trying to connect to the server. This meant that sending
a large batch of chunks could cause the request to fail before
all the data even made it to the server. What we actually want
is to timeout when the connection has been idle for some amount
of time. This means that long server processing times can still
cause clients to time out, but that's probably as it should be.

Towards #1414
