### PR TITLE
JS: No need to compute the union type in decode

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "29.0.0",
+  "version": "30.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -545,7 +545,7 @@ suite('Decode', () => {
   });
 
   test('recursive struct', () => {
-    const ds = new Database(makeTestingBatchStore());
+    const db = new Database(makeTestingBatchStore());
 
     // struct A {
     //   b: struct B {
@@ -554,16 +554,15 @@ suite('Decode', () => {
     //   }
     // }
 
-    const ta = makeStructType('A', {
+    const at = makeStructType('A', {
       'b': valueType,  // placeholder
     });
-    const tb = makeStructType('B', {
-      'a': valueType,  // placeholder
+    const bt = makeStructType('B', {
+      'a': makeListType(at),
       'b': valueType,  // placeholder
     });
-    ta.desc.fields['b'] = tb;
-    tb.desc.fields['a'] = makeListType(ta);
-    tb.desc.fields['b'] = makeListType(tb);
+    at.desc.fields['b'] = bt;
+    bt.desc.fields['b'] = makeListType(bt);
 
     const a = parseJson(`[
       StructKind, "A", [
@@ -590,11 +589,12 @@ suite('Decode', () => {
         ],
         "b", ListKind, ParentKind, 0
       ], false, []]`);
-    const r = new JsonArrayReader(a, ds);
+
+    const r = new JsonArrayReader(a, db);
     const v = r.readValue();
 
-    assert.isTrue(equals(v.type, ta));
-    assert.isTrue(equals(v.b.type, tb));
+    assert.isTrue(equals(v.type, at));
+    assert.isTrue(equals(v.b.type, bt));
   });
 
   test('read union list', async () => {

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -26,10 +26,10 @@ import {encode as encodeBase64} from './base64.js';
 import {newListMetaSequence, MetaTuple, newSetMetaSequence} from './meta-sequence.js';
 import {invariant, notNull} from './assert.js';
 import {Kind} from './noms-kind.js';
-import {ListLeafSequence, NomsList} from './list.js';
-import {MapLeafSequence, NomsMap} from './map.js';
+import {newListLeafSequence, NomsList} from './list.js';
+import {newMapLeafSequence, NomsMap} from './map.js';
 import {NomsBlob, newBlob} from './blob.js';
-import {NomsSet, SetLeafSequence} from './set.js';
+import {NomsSet, newSetLeafSequence} from './set.js';
 import {suite, test} from 'mocha';
 import {equals} from './compare.js';
 
@@ -112,7 +112,7 @@ suite('Decode', () => {
     const v: NomsList<number> = r.readValue();
     invariant(v instanceof NomsList);
 
-    const l = new NomsList(new ListLeafSequence(ds, [0, 1, 2, 3]));
+    const l = new NomsList(newListLeafSequence(ds, [0, 1, 2, 3]));
     assert.isTrue(equals(l, v));
   });
 
@@ -174,15 +174,15 @@ suite('Decode', () => {
     const v = r.readValue();
     invariant(v instanceof NomsList);
 
-    const l = new NomsList(new ListLeafSequence(ds, [0, 1, 2]));
+    const l = new NomsList(newListLeafSequence(ds, [0, 1, 2]));
     assert.isTrue(equals(l, v));
   });
 
   test('read compound list', () => {
     const ds = new Database(makeTestingBatchStore());
-    const r1 = ds.writeValue(new NomsList(new ListLeafSequence(ds, [0])));
-    const r2 = ds.writeValue(new NomsList(new ListLeafSequence(ds, [1, 2])));
-    const r3 = ds.writeValue(new NomsList(new ListLeafSequence(ds, [3, 4, 5])));
+    const r1 = ds.writeValue(new NomsList(newListLeafSequence(ds, [0])));
+    const r2 = ds.writeValue(new NomsList(newListLeafSequence(ds, [1, 2])));
+    const r3 = ds.writeValue(new NomsList(newListLeafSequence(ds, [3, 4, 5])));
     const tuples = [
       new MetaTuple(r1, 1, 1),
       new MetaTuple(r2, 2, 2),
@@ -212,7 +212,7 @@ suite('Decode', () => {
     const v: NomsMap<number, number> = r.readValue();
     invariant(v instanceof NomsMap);
 
-    const m = new NomsMap(new MapLeafSequence(ds, [{key: 0, value: 1}, {key: 2, value: 3}]));
+    const m = new NomsMap(newMapLeafSequence(ds, [{key: 0, value: 1}, {key: 2, value: 3}]));
     assert.isTrue(equals(v, m));
   });
 
@@ -221,7 +221,7 @@ suite('Decode', () => {
     const rv1 = ds.writeValue(true);
     const rv2 = ds.writeValue('hi');
     const a = [
-      Kind.Map, Kind.Ref, Kind.Value, Kind.Number, false, [
+      Kind.Map, Kind.Union, 2, Kind.Ref, Kind.String, Kind.Ref, Kind.Bool, Kind.Number, false, [
         Kind.Ref, Kind.Bool, rv1.targetRef.toString(), '1', Kind.Number, '2',
         Kind.Ref, Kind.String, rv2.targetRef.toString(), '1', Kind.Number, '4',
       ],
@@ -230,7 +230,7 @@ suite('Decode', () => {
     const v: NomsMap<RefValue<Value>, number> = r.readValue();
     invariant(v instanceof NomsMap);
 
-    const m = new NomsMap(new MapLeafSequence(ds, [{key: rv1, value: 2}, {key: rv2, value: 4}]));
+    const m = new NomsMap(newMapLeafSequence(ds, [{key: rv1, value: 2}, {key: rv2, value: 4}]));
     assert.isTrue(equals(v, m));
   });
 
@@ -242,7 +242,7 @@ suite('Decode', () => {
     const v: NomsMap<number, number> = r.readValue();
     invariant(v instanceof NomsMap);
 
-    const m = new NomsMap(new MapLeafSequence(ds, [{key: 0, value: 1}, {key: 2, value: 3}]));
+    const m = new NomsMap(newMapLeafSequence(ds, [{key: 0, value: 1}, {key: 2, value: 3}]));
     assert.isTrue(equals(v, m));
   });
 
@@ -254,14 +254,14 @@ suite('Decode', () => {
     const v: NomsSet<number> = r.readValue();
     invariant(v instanceof NomsSet);
 
-    const s = new NomsSet(new SetLeafSequence(ds, [0, 1, 2, 3]));
+    const s = new NomsSet(newSetLeafSequence(ds, [0, 1, 2, 3]));
     assert.isTrue(equals(v, s));
   });
 
   test('read compound set', () => {
     const ds = new Database(makeTestingBatchStore());
-    const r1 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [0, 1])));
-    const r2 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [2, 3, 4])));
+    const r1 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [0, 1])));
+    const r2 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [2, 3, 4])));
     const tuples = [
       new MetaTuple(r1, 1, 2),
       new MetaTuple(r2, 4, 3),
@@ -288,7 +288,7 @@ suite('Decode', () => {
     const v: NomsSet<number> = r.readValue();
     invariant(v instanceof NomsSet);
 
-    const s = new NomsSet(new SetLeafSequence(ds, [0, 1, 2, 3]));
+    const s = new NomsSet(newSetLeafSequence(ds, [0, 1, 2, 3]));
     assert.isTrue(equals(v, s));
   });
 
@@ -350,7 +350,7 @@ suite('Decode', () => {
 
     assertStruct(v, tr.desc, {
       b: true,
-      l: new NomsList(new ListLeafSequence(ds, [0, 1, 2])),
+      l: new NomsList(newListLeafSequence(ds, [0, 1, 2])),
       s: 'hi',
     });
   });
@@ -420,7 +420,7 @@ suite('Decode', () => {
     const v = decodeNomsValue(chunk, new Database(makeTestingBatchStore()));
     invariant(v instanceof NomsSet);
 
-    const s: NomsSet<number> = new NomsSet(new SetLeafSequence(ds, [0, 1, 2, 3]));
+    const s: NomsSet<number> = new NomsSet(newSetLeafSequence(ds, [0, 1, 2, 3]));
 
     assert.isTrue(equals(v, s));
   });
@@ -603,7 +603,7 @@ suite('Decode', () => {
       false, [StringKind, "hi", NumberKind, "42"]]`);
     const r = new JsonArrayReader(a, ds);
     const v = r.readValue();
-    const v2 = new NomsList(new ListLeafSequence(ds, ['hi', 42]));
+    const v2 = new NomsList(newListLeafSequence(ds, ['hi', 42]));
     assert.isTrue(equals(v, v2));
   });
 
@@ -612,7 +612,7 @@ suite('Decode', () => {
     const a = parseJson(`[ListKind, UnionKind, 0, false, []]`);
     const r = new JsonArrayReader(a, ds);
     const v = r.readValue();
-    const v2 = new NomsList(new ListLeafSequence(ds, []));
+    const v2 = new NomsList(newListLeafSequence(ds, []));
     assert.isTrue(equals(v, v2));
   });
 });

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -161,19 +161,19 @@ export class JsonArrayReader {
     return list;
   }
 
-  readListLeafSequence(): ListLeafSequence {
+  readListLeafSequence(t: Type): ListLeafSequence {
     const seq = this.readSequence();
     // TODO(arv): Pass along type here so we do not have to compute it again.
-    return new ListLeafSequence(this._ds, seq);
+    return new ListLeafSequence(this._ds, t, seq);
   }
 
-  readSetLeafSequence(): SetLeafSequence {
+  readSetLeafSequence(t: Type): SetLeafSequence {
     const seq = this.readSequence();
     // TODO(arv): Pass along type here so we do not have to compute it again.
-    return new SetLeafSequence(this._ds, seq);
+    return new SetLeafSequence(this._ds, t, seq);
   }
 
-  readMapLeafSequence(): MapLeafSequence {
+  readMapLeafSequence(t: Type): MapLeafSequence {
     const entries = [];
     while (!this.atEnd()) {
       const k = this.readValue();
@@ -182,7 +182,7 @@ export class JsonArrayReader {
     }
 
     // TODO(arv): Pass along type here so we do not have to compute it again.
-    return new MapLeafSequence(this._ds, entries);
+    return new MapLeafSequence(this._ds, t, entries);
   }
 
   readMetaSequence(): Array<MetaTuple> {
@@ -238,7 +238,7 @@ export class JsonArrayReader {
         if (isMeta) {
           return new NomsList(r2.readIndexedMetaSequence(t));
         }
-        return new NomsList(r2.readListLeafSequence());
+        return new NomsList(r2.readListLeafSequence(t));
       }
       case Kind.Map: {
         const isMeta = this.readBool();
@@ -246,7 +246,7 @@ export class JsonArrayReader {
         if (isMeta) {
           return new NomsMap(r2.readOrderedMetaSequence(t));
         }
-        return new NomsMap(r2.readMapLeafSequence());
+        return new NomsMap(r2.readMapLeafSequence(t));
       }
       case Kind.Ref:
         return this.readRefValue(t);
@@ -256,7 +256,7 @@ export class JsonArrayReader {
         if (isMeta) {
           return new NomsSet(r2.readOrderedMetaSequence(t));
         }
-        return new NomsSet(r2.readSetLeafSequence());
+        return new NomsSet(r2.readSetLeafSequence(t));
       }
       case Kind.Struct:
         return this.readStruct(t);

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -163,13 +163,11 @@ export class JsonArrayReader {
 
   readListLeafSequence(t: Type): ListLeafSequence {
     const seq = this.readSequence();
-    // TODO(arv): Pass along type here so we do not have to compute it again.
     return new ListLeafSequence(this._ds, t, seq);
   }
 
   readSetLeafSequence(t: Type): SetLeafSequence {
     const seq = this.readSequence();
-    // TODO(arv): Pass along type here so we do not have to compute it again.
     return new SetLeafSequence(this._ds, t, seq);
   }
 
@@ -181,7 +179,6 @@ export class JsonArrayReader {
       entries.push({key: k, value: v});
     }
 
-    // TODO(arv): Pass along type here so we do not have to compute it again.
     return new MapLeafSequence(this._ds, t, entries);
   }
 

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -24,9 +24,9 @@ import {
 } from './type.js';
 import {newListMetaSequence, MetaTuple, newSetMetaSequence} from './meta-sequence.js';
 import {Kind} from './noms-kind.js';
-import {ListLeafSequence, NomsList} from './list.js';
-import {MapLeafSequence, NomsMap} from './map.js';
-import {NomsSet, SetLeafSequence} from './set.js';
+import {newListLeafSequence, NomsList} from './list.js';
+import {newMapLeafSequence, NomsMap} from './map.js';
+import {NomsSet, newSetLeafSequence} from './set.js';
 import {newBlob} from './blob.js';
 import Database from './database.js';
 import type {valueOrPrimitive} from './value.js';
@@ -64,7 +64,7 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const l = new NomsList(new ListLeafSequence(ds, [0, 1, 2, 3]));
+    const l = new NomsList(newListLeafSequence(ds, [0, 1, 2, 3]));
     w.writeValue(l);
     assert.deepEqual([Kind.List, Kind.Number, false,
       [Kind.Number, '0', Kind.Number, '1', Kind.Number, '2', Kind.Number, '3']], w.array);
@@ -74,7 +74,7 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const l = new NomsList(new ListLeafSequence(ds, ['0', 1, '2', true]));
+    const l = new NomsList(newListLeafSequence(ds, ['0', 1, '2', true]));
     w.writeValue(l);
     assert.deepEqual([Kind.List, Kind.Union, 3, Kind.Bool, Kind.Number, Kind.String, false, [
       Kind.String, '0',
@@ -88,9 +88,9 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const v = new NomsList(new ListLeafSequence(ds, [
-      new NomsList(new ListLeafSequence(ds, [0])),
-      new NomsList(new ListLeafSequence(ds, [1, 2, 3])),
+    const v = new NomsList(newListLeafSequence(ds, [
+      new NomsList(newListLeafSequence(ds, [0])),
+      new NomsList(newListLeafSequence(ds, [1, 2, 3])),
     ]));
     w.writeValue(v);
     assert.deepEqual([Kind.List, Kind.List, Kind.Number, false, [
@@ -103,7 +103,7 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const v = new NomsSet(new SetLeafSequence(ds, [0, 1, 2, 3]));
+    const v = new NomsSet(newSetLeafSequence(ds, [0, 1, 2, 3]));
     w.writeValue(v);
     assert.deepEqual([Kind.Set, Kind.Number, false,
       [Kind.Number, '0', Kind.Number, '1', Kind.Number, '2', Kind.Number, '3']], w.array);
@@ -112,9 +112,9 @@ suite('Encode', () => {
   test('write compound set', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
-    const r1 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [0])));
-    const r2 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [1, 2])));
-    const r3 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [3, 4, 5])));
+    const r1 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [0])));
+    const r2 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [1, 2])));
+    const r3 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [3, 4, 5])));
     const tuples = [
       new MetaTuple(r1, 0, 1),
       new MetaTuple(r2, 2, 2),
@@ -136,9 +136,9 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const v = new NomsSet(new SetLeafSequence(ds, [
-      new NomsSet(new SetLeafSequence(ds, [0])),
-      new NomsSet(new SetLeafSequence(ds, [1, 2, 3])),
+    const v = new NomsSet(newSetLeafSequence(ds, [
+      new NomsSet(newSetLeafSequence(ds, [0])),
+      new NomsSet(newSetLeafSequence(ds, [1, 2, 3])),
     ]));
 
     w.writeValue(v);
@@ -152,7 +152,7 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
 
-    const v = new NomsMap(new MapLeafSequence(ds, [{key: 'a', value: false},
+    const v = new NomsMap(newMapLeafSequence(ds, [{key: 'a', value: false},
         {key:'b', value:true}]));
     w.writeValue(v);
     assert.deepEqual([Kind.Map, Kind.String, Kind.Bool, false,
@@ -164,9 +164,9 @@ suite('Encode', () => {
     const w = new JsonArrayWriter(ds);
 
     // Map<Map<String, Number>, Set<Bool>>({{'a': 0}: {true}})
-    const s = new NomsSet(new SetLeafSequence(ds, [true]));
-    const m1 = new NomsMap(new MapLeafSequence(ds, [{key: 'a', value: 0}]));
-    const v = new NomsMap(new MapLeafSequence(ds, [{key: m1, value: s}]));
+    const s = new NomsSet(newSetLeafSequence(ds, [true]));
+    const m1 = new NomsMap(newMapLeafSequence(ds, [{key: 'a', value: 0}]));
+    const v = new NomsMap(newMapLeafSequence(ds, [{key: m1, value: s}]));
     w.writeValue(v);
     assert.deepEqual([Kind.Map,
       Kind.Map, Kind.String, Kind.Number,
@@ -199,12 +199,12 @@ suite('Encode', () => {
     const ds = new Database(makeTestingBatchStore());
     let w = new JsonArrayWriter(ds);
 
-    let v = newStruct('S', {l: new NomsList(new ListLeafSequence(ds, ['a', 'b']))});
+    let v = newStruct('S', {l: new NomsList(newListLeafSequence(ds, ['a', 'b']))});
     w.writeValue(v);
     assert.deepEqual([Kind.Struct, 'S', ['l', Kind.List, Kind.String],
       Kind.List, Kind.String, false, [Kind.String, 'a', Kind.String, 'b']], w.array);
 
-    v = newStruct('S', {l: new NomsList(new ListLeafSequence(ds, []))});
+    v = newStruct('S', {l: new NomsList(newListLeafSequence(ds, []))});
     w = new JsonArrayWriter(ds);
     w.writeValue(v);
     assert.deepEqual([Kind.Struct, 'S', ['l', Kind.List, Kind.Union, 0],
@@ -225,9 +225,9 @@ suite('Encode', () => {
   test('write compound list', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
-    const r1 = ds.writeValue(new NomsList(new ListLeafSequence(ds, [0])));
-    const r2 = ds.writeValue(new NomsList(new ListLeafSequence(ds, [1, 2])));
-    const r3 = ds.writeValue(new NomsList(new ListLeafSequence(ds, [3, 4, 5])));
+    const r1 = ds.writeValue(new NomsList(newListLeafSequence(ds, [0])));
+    const r2 = ds.writeValue(new NomsList(newListLeafSequence(ds, [1, 2])));
+    const r3 = ds.writeValue(new NomsList(newListLeafSequence(ds, [3, 4, 5])));
     const tuples = [
       new MetaTuple(r1, 1, 1),
       new MetaTuple(r2, 2, 2),
@@ -248,8 +248,8 @@ suite('Encode', () => {
   test('write compound set with bool', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
-    const r1 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [true])));
-    const r2 = ds.writeValue(new NomsSet(new SetLeafSequence(ds, [false])));
+    const r1 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [true])));
+    const r2 = ds.writeValue(new NomsSet(newSetLeafSequence(ds, [false])));
     const tuples = [
       new MetaTuple(r1, true, 1),
       new MetaTuple(r2, false, 1),
@@ -350,7 +350,7 @@ suite('Encode', () => {
   test('write union list', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
-    const v = new NomsList(new ListLeafSequence(ds, ['hi', 42]));
+    const v = new NomsList(newListLeafSequence(ds, ['hi', 42]));
     w.writeValue(v);
     assert.deepEqual([Kind.List, Kind.Union, 2, Kind.Number, Kind.String,
       false, [Kind.String, 'hi', Kind.Number, '42']], w.array);
@@ -359,7 +359,7 @@ suite('Encode', () => {
   test('write empty union list', () => {
     const ds = new Database(makeTestingBatchStore());
     const w = new JsonArrayWriter(ds);
-    const v = new NomsList(new ListLeafSequence(ds, []));
+    const v = new NomsList(newListLeafSequence(ds, []));
     w.writeValue(v);
     assert.deepEqual([Kind.List, Kind.Union, 0, false, []], w.array);
   });

--- a/js/src/list-test.js
+++ b/js/src/list-test.js
@@ -26,7 +26,7 @@ import {
 } from './test-util.js';
 import {newListMetaSequence, MetaTuple} from './meta-sequence.js';
 import {invariant} from './assert.js';
-import {ListLeafSequence, newList, NomsList} from './list.js';
+import {newListLeafSequence, newList, NomsList} from './list.js';
 
 const testListSize = 5000;
 const listOfNRef = 'sha1-aa1605484d993e89dbc0431acb9f2478282f9d94';
@@ -214,7 +214,7 @@ suite('List', () => {
 suite('ListLeafSequence', () => {
   test('Empty list isEmpty', () => {
     const ds = new Database(makeTestingBatchStore());
-    const newList = items => new NomsList(new ListLeafSequence(ds, items));
+    const newList = items => new NomsList(newListLeafSequence(ds, items));
     assert.isTrue(newList([]).isEmpty());
   });
 
@@ -222,7 +222,7 @@ suite('ListLeafSequence', () => {
     const ds = new Database(makeTestingBatchStore());
 
     const test = async items => {
-      const l = new NomsList(new ListLeafSequence(ds, items));
+      const l = new NomsList(newListLeafSequence(ds, items));
       assert.deepEqual(items, await flatten(l.iterator()));
       assert.deepEqual(items, await flattenParallel(l.iterator(), items.length));
     };
@@ -236,7 +236,7 @@ suite('ListLeafSequence', () => {
     const ds = new Database(makeTestingBatchStore());
 
     const test = async items => {
-      const l = new NomsList(new ListLeafSequence(ds, items));
+      const l = new NomsList(newListLeafSequence(ds, items));
       for (let i = 0; i <= items.length; i++) {
         const slice = items.slice(i);
         assert.deepEqual(slice, await flatten(l.iteratorAt(i)));
@@ -253,13 +253,13 @@ suite('ListLeafSequence', () => {
 suite('CompoundList', () => {
   function build(): NomsList {
     const ds = new Database(makeTestingBatchStore());
-    const l1 = new NomsList(new ListLeafSequence(ds, ['a', 'b']));
+    const l1 = new NomsList(newListLeafSequence(ds, ['a', 'b']));
     const r1 = ds.writeValue(l1);
-    const l2 = new NomsList(new ListLeafSequence(ds, ['e', 'f']));
+    const l2 = new NomsList(newListLeafSequence(ds, ['e', 'f']));
     const r2 = ds.writeValue(l2);
-    const l3 = new NomsList(new ListLeafSequence(ds, ['h', 'i']));
+    const l3 = new NomsList(newListLeafSequence(ds, ['h', 'i']));
     const r3 = ds.writeValue(l3);
-    const l4 = new NomsList(new ListLeafSequence(ds, ['m', 'n']));
+    const l4 = new NomsList(newListLeafSequence(ds, ['m', 'n']));
     const r4 = ds.writeValue(l4);
 
     const m1 = new NomsList(newListMetaSequence(ds, [new MetaTuple(r1, 2, 2),

--- a/js/src/list.js
+++ b/js/src/list.js
@@ -26,7 +26,7 @@ const listPattern = ((1 << 6) | 0) - 1;
 
 function newListLeafChunkFn<T: valueOrPrimitive>(vr: ?ValueReader): makeChunkFn {
   return (items: Array<T>) => {
-    const list = new NomsList(new ListLeafSequence(vr, items));
+    const list = new NomsList(newListLeafSequence(vr, items));
     const mt = new MetaTuple(new RefValue(list), items.length, items.length, list);
     return [mt, list];
   };
@@ -124,11 +124,6 @@ export class NomsList<T: valueOrPrimitive> extends Collection<IndexedSequence> {
 }
 
 export class ListLeafSequence<T: valueOrPrimitive> extends IndexedSequence<T> {
-  constructor(vr: ?ValueReader, items: T[]) {
-    const t = makeListType(makeUnionType(items.map(getTypeOfValue)));
-    super(vr, t, items);
-  }
-
   get chunks(): Array<RefValue> {
     return getValueChunks(this.items);
   }
@@ -141,6 +136,12 @@ export class ListLeafSequence<T: valueOrPrimitive> extends IndexedSequence<T> {
     invariant(start >= 0 && end >= 0 && end <= this.items.length);
     return Promise.resolve(this.items.slice(start, end));
   }
+}
+
+export function newListLeafSequence<T: valueOrPrimitive>(vr: ?ValueReader, items: T[]):
+    ListLeafSequence<T> {
+  const t = makeListType(makeUnionType(items.map(getTypeOfValue)));
+  return new ListLeafSequence(vr, t, items);
 }
 
 function clampIndex(idx: number, length: number): number {

--- a/js/src/map-test.js
+++ b/js/src/map-test.js
@@ -12,7 +12,7 @@ import {newStruct, default as Struct} from './struct.js';
 import {flatten, flattenParallel, deriveCollectionHeight} from './test-util.js';
 import {invariant} from './assert.js';
 import Chunk from './chunk.js';
-import {MapLeafSequence, newMap, NomsMap} from './map.js';
+import {newMapLeafSequence, newMap, NomsMap} from './map.js';
 import {MetaTuple, newMapMetaSequence} from './meta-sequence.js';
 import Ref from './ref.js';
 import type {ValueReadWriter} from './value-store.js';
@@ -263,7 +263,7 @@ suite('BuildMap', () => {
 suite('MapLeaf', () => {
   test('isEmpty/size', () => {
     const ds = new Database(makeTestingBatchStore());
-    const newMap = entries => new NomsMap(new MapLeafSequence(ds, entries));
+    const newMap = entries => new NomsMap(newMapLeafSequence(ds, entries));
     let m = newMap([]);
     assert.isTrue(m.isEmpty());
     assert.strictEqual(0, m.size);
@@ -275,7 +275,7 @@ suite('MapLeaf', () => {
   test('has', async () => {
     const ds = new Database(makeTestingBatchStore());
     const m = new NomsMap(
-        new MapLeafSequence(ds, [{key: 'a', value: false}, {key: 'k', value: true}]));
+        newMapLeafSequence(ds, [{key: 'a', value: false}, {key: 'k', value: true}]));
     assert.isTrue(await m.has('a'));
     assert.isFalse(await m.has('b'));
     assert.isTrue(await m.has('k'));
@@ -285,7 +285,7 @@ suite('MapLeaf', () => {
   test('first/last/get', async () => {
     const ds = new Database(makeTestingBatchStore());
     const m = new NomsMap(
-        new MapLeafSequence(ds, [{key: 'a', value: 4}, {key: 'k', value: 8}]));
+        newMapLeafSequence(ds, [{key: 'a', value: 4}, {key: 'k', value: 8}]));
 
     assert.deepEqual(['a', 4], await m.first());
     assert.deepEqual(['k', 8], await m.last());
@@ -299,7 +299,7 @@ suite('MapLeaf', () => {
   test('forEach', async () => {
     const ds = new Database(makeTestingBatchStore());
     const m = new NomsMap(
-        new MapLeafSequence(ds, [{key: 'a', value: 4}, {key: 'k', value: 8}]));
+        newMapLeafSequence(ds, [{key: 'a', value: 4}, {key: 'k', value: 8}]));
 
     const kv = [];
     await m.forEach((v, k) => { kv.push(k, v); });
@@ -310,7 +310,7 @@ suite('MapLeaf', () => {
     const ds = new Database(makeTestingBatchStore());
 
     const test = async entries => {
-      const m = new NomsMap(new MapLeafSequence(ds, entries));
+      const m = new NomsMap(newMapLeafSequence(ds, entries));
       assert.deepEqual(entries, await flatten(m.iterator()));
       assert.deepEqual(entries, await flattenParallel(m.iterator(), entries.length));
     };
@@ -322,7 +322,7 @@ suite('MapLeaf', () => {
 
   test('LONG: iteratorAt', async () => {
     const ds = new Database(makeTestingBatchStore());
-    const build = entries => new NomsMap(new MapLeafSequence(ds, entries));
+    const build = entries => new NomsMap(newMapLeafSequence(ds, entries));
 
     assert.deepEqual([], await flatten(build([]).iteratorAt('a')));
 
@@ -350,7 +350,7 @@ suite('MapLeaf', () => {
     const r3 = ds.writeValue('b');
     const r4 = ds.writeValue(false);
     const m = new NomsMap(
-        new MapLeafSequence(ds, [{key: r1, value: r2}, {key: r3, value: r4}]));
+        newMapLeafSequence(ds, [{key: r1, value: r2}, {key: r3, value: r4}]));
     assert.strictEqual(4, m.chunks.length);
     assert.isTrue(equals(r1, m.chunks[0]));
     assert.isTrue(equals(r2, m.chunks[1]));
@@ -362,16 +362,16 @@ suite('MapLeaf', () => {
 
 suite('CompoundMap', () => {
   function build(vwr: ValueReadWriter): Array<NomsMap> {
-    const l1 = new NomsMap(new MapLeafSequence(vwr, [{key: 'a', value: false},
+    const l1 = new NomsMap(newMapLeafSequence(vwr, [{key: 'a', value: false},
         {key:'b', value:false}]));
     const r1 = vwr.writeValue(l1);
-    const l2 = new NomsMap(new MapLeafSequence(vwr, [{key: 'e', value: true},
+    const l2 = new NomsMap(newMapLeafSequence(vwr, [{key: 'e', value: true},
         {key:'f', value:true}]));
     const r2 = vwr.writeValue(l2);
-    const l3 = new NomsMap(new MapLeafSequence(vwr, [{key: 'h', value: false},
+    const l3 = new NomsMap(newMapLeafSequence(vwr, [{key: 'h', value: false},
         {key:'i', value:true}]));
     const r3 = vwr.writeValue(l3);
-    const l4 = new NomsMap(new MapLeafSequence(vwr, [{key: 'm', value: true},
+    const l4 = new NomsMap(newMapLeafSequence(vwr, [{key: 'm', value: true},
         {key:'n', value:false}]));
     const r4 = vwr.writeValue(l4);
 

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -39,7 +39,7 @@ function newMapLeafChunkFn<K: valueOrPrimitive, V: valueOrPrimitive>(vr: ?ValueR
       }
     }
 
-    const nm = new NomsMap(new MapLeafSequence(vr, items));
+    const nm = new NomsMap(newMapLeafSequence(vr, items));
     const mt = new MetaTuple(new RefValue(nm), indexValue, items.length, nm);
     return [mt, nm];
   };
@@ -190,16 +190,6 @@ export class NomsMap<K: valueOrPrimitive, V: valueOrPrimitive> extends Collectio
 
 export class MapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive> extends
     OrderedSequence<K, MapEntry<K, V>> {
-  constructor(vr: ?ValueReader, items: Array<MapEntry<K, V>>) {
-    const kt = [];
-    const vt = [];
-    for (let i = 0; i < items.length; i++) {
-      kt.push(getTypeOfValue(items[i].key));
-      vt.push(getTypeOfValue(items[i].value));
-    }
-    const t = makeMapType(makeUnionType(kt), makeUnionType(vt));
-    super(vr, t, items);
-  }
   getKey(idx: number): K {
     return this.items[idx].key;
   }
@@ -221,4 +211,16 @@ export class MapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive> extends
     }
     return chunks;
   }
+}
+
+export function newMapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive>(vr: ?ValueReader,
+    items: Array<MapEntry<K, V>>): MapLeafSequence<K, V> {
+  const kt = [];
+  const vt = [];
+  for (let i = 0; i < items.length; i++) {
+    kt.push(getTypeOfValue(items[i].key));
+    vt.push(getTypeOfValue(items[i].value));
+  }
+  const t = makeMapType(makeUnionType(kt), makeUnionType(vt));
+  return new MapLeafSequence(vr, t, items);
 }

--- a/js/src/meta-sequence-test.js
+++ b/js/src/meta-sequence-test.js
@@ -5,19 +5,19 @@ import {suite, test} from 'mocha';
 
 import {makeTestingBatchStore} from './batch-store-adaptor.js';
 import Database from './database.js';
-import {ListLeafSequence, NomsList} from './list.js';
+import {newListLeafSequence, NomsList} from './list.js';
 import {MetaTuple, newOrderedMetaSequenceChunkFn, newIndexedMetaSequenceChunkFn,} from
   './meta-sequence.js';
 import RefValue from './ref-value.js';
-import {SetLeafSequence, NomsSet} from './set.js';
+import {newSetLeafSequence, NomsSet} from './set.js';
 import {Kind} from './noms-kind.js';
 
 suite('MetaSequence', () => {
   test('calculate ordered sequence MetaTuple height', async () => {
     const ds = new Database(makeTestingBatchStore());
 
-    const set1 = new NomsSet(new SetLeafSequence(ds, ['bar', 'baz']));
-    const set2 = new NomsSet(new SetLeafSequence(ds, ['foo', 'qux', 'zoo']));
+    const set1 = new NomsSet(newSetLeafSequence(ds, ['bar', 'baz']));
+    const set2 = new NomsSet(newSetLeafSequence(ds, ['foo', 'qux', 'zoo']));
     const mt1 = new MetaTuple(new RefValue(set1), 'baz', 2, set1);
     const mt2 = new MetaTuple(new RefValue(set2), 'zoo', 3, set2);
 
@@ -36,8 +36,8 @@ suite('MetaSequence', () => {
   test('calculate indexed sequence MetaTuple height', async () => {
     const ds = new Database(makeTestingBatchStore());
 
-    const list1 = new NomsList(new ListLeafSequence(ds, ['bar', 'baz']));
-    const list2 = new NomsList(new ListLeafSequence(ds, ['foo', 'qux', 'zoo']));
+    const list1 = new NomsList(newListLeafSequence(ds, ['bar', 'baz']));
+    const list2 = new NomsList(newListLeafSequence(ds, ['foo', 'qux', 'zoo']));
     const mt1 = new MetaTuple(new RefValue(list1), 2, 2, list1);
     const mt2 = new MetaTuple(new RefValue(list2), 3, 3, list2);
 

--- a/js/src/set-test.js
+++ b/js/src/set-test.js
@@ -13,7 +13,7 @@ import {newStruct} from './struct.js';
 import {flatten, flattenParallel, deriveCollectionHeight} from './test-util.js';
 import {invariant, notNull} from './assert.js';
 import {MetaTuple, newSetMetaSequence} from './meta-sequence.js';
-import {newSet, NomsSet, SetLeafSequence} from './set.js';
+import {newSet, NomsSet, newSetLeafSequence} from './set.js';
 import {OrderedSequence} from './ordered-sequence.js';
 import Ref from './ref.js';
 import type {ValueReadWriter} from './value-store.js';
@@ -209,7 +209,7 @@ suite('BuildSet', () => {
 suite('SetLeaf', () => {
   test('isEmpty/size', () => {
     const ds = new Database(makeTestingBatchStore());
-    const newSet = items => new NomsSet(new SetLeafSequence(ds, items));
+    const newSet = items => new NomsSet(newSetLeafSequence(ds, items));
     let s = newSet([]);
     assert.isTrue(s.isEmpty());
     assert.strictEqual(0, s.size);
@@ -220,7 +220,7 @@ suite('SetLeaf', () => {
 
   test('first/last/has', async () => {
     const ds = new Database(makeTestingBatchStore());
-    const s = new NomsSet(new SetLeafSequence(ds, ['a', 'k']));
+    const s = new NomsSet(newSetLeafSequence(ds, ['a', 'k']));
 
     assert.strictEqual('a', await s.first());
     assert.strictEqual('k', await s.last());
@@ -233,7 +233,7 @@ suite('SetLeaf', () => {
 
   test('forEach', async () => {
     const ds = new Database(makeTestingBatchStore());
-    const m = new NomsSet(new SetLeafSequence(ds, ['a', 'b']));
+    const m = new NomsSet(newSetLeafSequence(ds, ['a', 'b']));
 
     const values = [];
     await m.forEach((k) => { values.push(k); });
@@ -244,7 +244,7 @@ suite('SetLeaf', () => {
     const ds = new Database(makeTestingBatchStore());
 
     const test = async items => {
-      const m = new NomsSet(new SetLeafSequence(ds, items));
+      const m = new NomsSet(newSetLeafSequence(ds, items));
       assert.deepEqual(items, await flatten(m.iterator()));
       assert.deepEqual(items, await flattenParallel(m.iterator(), items.length));
     };
@@ -256,7 +256,7 @@ suite('SetLeaf', () => {
 
   test('LONG: iteratorAt', async () => {
     const ds = new Database(makeTestingBatchStore());
-    const build = items => new NomsSet(new SetLeafSequence(ds, items));
+    const build = items => new NomsSet(newSetLeafSequence(ds, items));
 
     assert.deepEqual([], await flatten(build([]).iteratorAt('a')));
 
@@ -276,7 +276,7 @@ suite('SetLeaf', () => {
     const r1 = ds.writeValue('x');
     const r2 = ds.writeValue('a');
     const r3 = ds.writeValue('b');
-    const l = new NomsSet(new SetLeafSequence(ds, ['z', r1, r2, r3]));
+    const l = new NomsSet(newSetLeafSequence(ds, ['z', r1, r2, r3]));
     assert.strictEqual(3, l.chunks.length);
     assert.isTrue(equals(r1, l.chunks[0]));
     assert.isTrue(equals(r2, l.chunks[1]));
@@ -290,7 +290,7 @@ suite('CompoundSet', () => {
 
     let tuples = [];
     for (let i = 0; i < values.length; i += 2) {
-      const l = new NomsSet(new SetLeafSequence(vwr, [values[i], values[i + 1]]));
+      const l = new NomsSet(newSetLeafSequence(vwr, [values[i], values[i + 1]]));
       const r = vwr.writeValue(l);
       tuples.push(new MetaTuple(r, values[i + 1], 2));
     }
@@ -508,7 +508,7 @@ suite('CompoundSet', () => {
     const ds = new Database(makeTestingBatchStore());
 
     const test = async (expected, items) => {
-      const set = new NomsSet(new SetLeafSequence(ds, items));
+      const set = new NomsSet(newSetLeafSequence(ds, items));
       const iter = set.iteratorAt(0);
       assert.deepEqual(expected, await flatten(iter));
     };

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -28,7 +28,7 @@ const setPattern = ((1 << 6) | 0) - 1;
 
 function newSetLeafChunkFn<T:valueOrPrimitive>(vr: ?ValueReader): makeChunkFn {
   return (items: Array<T>) => {
-    const setLeaf = new SetLeafSequence(vr, items);
+    const setLeaf = newSetLeafSequence(vr, items);
 
     let indexValue: ?(T | RefValue) = null;
     if (items.length > 0) {
@@ -176,7 +176,7 @@ export class NomsSet<T: valueOrPrimitive> extends Collection<OrderedSequence> {
     }
 
     // TODO: Chunk the resulting set.
-    return new NomsSet(new SetLeafSequence(null, values));
+    return new NomsSet(newSetLeafSequence(null, values));
   }
 
   /**
@@ -191,11 +191,6 @@ export class NomsSet<T: valueOrPrimitive> extends Collection<OrderedSequence> {
 }
 
 export class SetLeafSequence<K: valueOrPrimitive> extends OrderedSequence<K, K> {
-  constructor(vr: ?ValueReader, items: K[]) {
-    const t = makeSetType(makeUnionType(items.map(getTypeOfValue)));
-    super(vr, t, items);
-  }
-
   getKey(idx: number): K {
     return this.items[idx];
   }
@@ -207,6 +202,11 @@ export class SetLeafSequence<K: valueOrPrimitive> extends OrderedSequence<K, K> 
   get chunks(): Array<RefValue> {
     return getValueChunks(this.items);
   }
+}
+
+export function newSetLeafSequence<K: valueOrPrimitive>(vr: ?ValueReader, items: K[]) {
+  const t = makeSetType(makeUnionType(items.map(getTypeOfValue)));
+  return new SetLeafSequence(vr, t, items);
 }
 
 type OrderedCursor<K: valueOrPrimitive> = {

--- a/types/blob_leaf_sequence.go
+++ b/types/blob_leaf_sequence.go
@@ -2,12 +2,11 @@ package types
 
 type blobLeafSequence struct {
 	data []byte
-	t    *Type
 	vr   ValueReader
 }
 
 func newBlobLeafSequence(vr ValueReader, data []byte) indexedSequence {
-	return blobLeafSequence{data, BlobType, vr}
+	return blobLeafSequence{data, vr}
 }
 
 func (bl blobLeafSequence) getItem(idx int) sequenceItem {

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -129,8 +129,7 @@ func (r *jsonArrayReader) readListLeafSequence(t *Type) indexedSequence {
 		data = append(data, v)
 	}
 
-	// TODO(arv): Pass down type here too.
-	return newListLeafSequence(r.vr, data...)
+	return listLeafSequence{data, t, r.vr}
 }
 
 func (r *jsonArrayReader) readSetLeafSequence(t *Type) orderedSequence {

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -391,14 +391,6 @@ func TestReadRecursiveStruct(t *testing.T) {
 	at.Desc.(StructDesc).Fields["b"] = bt
 	bt.Desc.(StructDesc).Fields["b"] = MakeListType(bt)
 
-	// {b: {a: [], b: []}}
-	v2 := NewStructWithType(at, structData{
-		"b": NewStructWithType(bt, structData{
-			"a": NewList(),
-			"b": NewList(),
-		}),
-	})
-
 	a := parseJSON(`[
 		StructKind, "A", [
 			"b", StructKind, "B", [
@@ -426,11 +418,10 @@ func TestReadRecursiveStruct(t *testing.T) {
 		], false, []]`)
 
 	r := newJSONArrayReader(a, cs)
-
 	v := r.readValue().(Struct)
+
 	assert.True(v.Type().Equals(at))
 	assert.True(v.Get("b").Type().Equals(bt))
-	assert.True(v.Equals(v2))
 }
 
 func TestReadTypeValue(t *testing.T) {


### PR DESCRIPTION
Instead trust that the serialization is correct

Towards #1491
