### PR TITLE
Return io.Writer errors from WriteEncodedValueWithTags instead of panic

### DIFF
--- a/types/encode_human_readable_test.go
+++ b/types/encode_human_readable_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -328,4 +329,19 @@ func TestRecursiveStruct(t *testing.T) {
     d: Parent<1>
   }
 })`, d)
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w *errorWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestWriteHumanReadableWriterError(t *testing.T) {
+	assert := assert.New(t)
+	err := errors.New("test")
+	w := &errorWriter{err}
+	assert.Equal(err, WriteEncodedValueWithTags(w, Number(42)))
 }


### PR DESCRIPTION
A common case for io.Writer errors is during noms-log or noms-show when
piped through head, i.e. "noms log ldb:/path/to:noms | head".

noms-log handles this itself by recovering from the panic, but rather
than porting this logic to noms-show, just make it so that you don't
need to recover in the first place.

This is similar to how errors from fmt.Println etc don't panic.
Non-write errors (like crashes) will continue to panic.
