### PR TITLE
change Number type to be a golang math/big.Float type

### DIFF
--- a/types/assert_type_test.go
+++ b/types/assert_type_test.go
@@ -36,20 +36,20 @@ func assertAll(tt *testing.T, t *Type, v Value) {
 func TestAssertTypePrimitives(t *testing.T) {
 	assertSubtype(BoolType, Bool(true))
 	assertSubtype(BoolType, Bool(false))
-	assertSubtype(NumberType, Number(42))
+	assertSubtype(NumberType, NewNumber(42))
 	assertSubtype(StringType, NewString("abc"))
 
-	assertInvalid(t, BoolType, Number(1))
+	assertInvalid(t, BoolType, NewNumber(1))
 	assertInvalid(t, BoolType, NewString("abc"))
 	assertInvalid(t, NumberType, Bool(true))
-	assertInvalid(t, StringType, Number(42))
+	assertInvalid(t, StringType, NewNumber(42))
 }
 
 func TestAssertTypeValue(t *testing.T) {
 	assertSubtype(ValueType, Bool(true))
-	assertSubtype(ValueType, Number(1))
+	assertSubtype(ValueType, NewNumber(1))
 	assertSubtype(ValueType, NewString("abc"))
-	l := NewList(Number(0), Number(1), Number(2), Number(3))
+	l := NewList(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assertSubtype(ValueType, l)
 }
 
@@ -60,7 +60,7 @@ func TestAssertTypeBlob(t *testing.T) {
 
 func TestAssertTypeList(tt *testing.T) {
 	listOfNumberType := MakeListType(NumberType)
-	l := NewList(Number(0), Number(1), Number(2), Number(3))
+	l := NewList(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assertSubtype(listOfNumberType, l)
 	assertAll(tt, listOfNumberType, l)
 	assertSubtype(MakeListType(ValueType), l)
@@ -68,7 +68,7 @@ func TestAssertTypeList(tt *testing.T) {
 
 func TestAssertTypeMap(tt *testing.T) {
 	mapOfNumberToStringType := MakeMapType(NumberType, StringType)
-	m := NewMap(Number(0), NewString("a"), Number(2), NewString("b"))
+	m := NewMap(NewNumber(0), NewString("a"), NewNumber(2), NewString("b"))
 	assertSubtype(mapOfNumberToStringType, m)
 	assertAll(tt, mapOfNumberToStringType, m)
 	assertSubtype(MakeMapType(ValueType, ValueType), m)
@@ -76,7 +76,7 @@ func TestAssertTypeMap(tt *testing.T) {
 
 func TestAssertTypeSet(tt *testing.T) {
 	setOfNumberType := MakeSetType(NumberType)
-	s := NewSet(Number(0), Number(1), Number(2), Number(3))
+	s := NewSet(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assertSubtype(setOfNumberType, s)
 	assertAll(tt, setOfNumberType, s)
 	assertSubtype(MakeSetType(ValueType), s)
@@ -101,25 +101,25 @@ func TestAssertTypeStruct(tt *testing.T) {
 }
 
 func TestAssertTypeUnion(tt *testing.T) {
-	assertSubtype(MakeUnionType(NumberType), Number(42))
-	assertSubtype(MakeUnionType(NumberType, StringType), Number(42))
+	assertSubtype(MakeUnionType(NumberType), NewNumber(42))
+	assertSubtype(MakeUnionType(NumberType, StringType), NewNumber(42))
 	assertSubtype(MakeUnionType(NumberType, StringType), NewString("hi"))
-	assertSubtype(MakeUnionType(NumberType, StringType, BoolType), Number(555))
+	assertSubtype(MakeUnionType(NumberType, StringType, BoolType), NewNumber(555))
 	assertSubtype(MakeUnionType(NumberType, StringType, BoolType), NewString("hi"))
 	assertSubtype(MakeUnionType(NumberType, StringType, BoolType), Bool(true))
 
 	lt := MakeListType(MakeUnionType(NumberType, StringType))
-	assertSubtype(lt, NewList(Number(1), NewString("hi"), Number(2), NewString("bye")))
+	assertSubtype(lt, NewList(NewNumber(1), NewString("hi"), NewNumber(2), NewString("bye")))
 
 	st := MakeSetType(StringType)
-	assertSubtype(MakeUnionType(st, NumberType), Number(42))
+	assertSubtype(MakeUnionType(st, NumberType), NewNumber(42))
 	assertSubtype(MakeUnionType(st, NumberType), NewSet(NewString("a"), NewString("b")))
 
-	assertInvalid(tt, MakeUnionType(), Number(42))
-	assertInvalid(tt, MakeUnionType(StringType), Number(42))
-	assertInvalid(tt, MakeUnionType(StringType, BoolType), Number(42))
-	assertInvalid(tt, MakeUnionType(st, StringType), Number(42))
-	assertInvalid(tt, MakeUnionType(st, NumberType), NewSet(Number(1), Number(2)))
+	assertInvalid(tt, MakeUnionType(), NewNumber(42))
+	assertInvalid(tt, MakeUnionType(StringType), NewNumber(42))
+	assertInvalid(tt, MakeUnionType(StringType, BoolType), NewNumber(42))
+	assertInvalid(tt, MakeUnionType(st, StringType), NewNumber(42))
+	assertInvalid(tt, MakeUnionType(st, NumberType), NewSet(NewNumber(1), NewNumber(2)))
 }
 
 func TestAssertTypeEmptyListUnion(tt *testing.T) {
@@ -132,7 +132,7 @@ func TestAssertTypeEmptyList(tt *testing.T) {
 	assertSubtype(lt, NewList())
 
 	// List<> not a subtype of List<Number>
-	assertInvalid(tt, MakeListType(MakeUnionType()), NewList(Number(1)))
+	assertInvalid(tt, MakeListType(MakeUnionType()), NewList(NewNumber(1)))
 }
 
 func TestAssertTypeEmptySet(tt *testing.T) {
@@ -140,7 +140,7 @@ func TestAssertTypeEmptySet(tt *testing.T) {
 	assertSubtype(st, NewSet())
 
 	// Set<> not a subtype of Set<Number>
-	assertInvalid(tt, MakeSetType(MakeUnionType()), NewSet(Number(1)))
+	assertInvalid(tt, MakeSetType(MakeUnionType()), NewSet(NewNumber(1)))
 }
 
 func TestAssertTypeEmptyMap(tt *testing.T) {
@@ -148,15 +148,15 @@ func TestAssertTypeEmptyMap(tt *testing.T) {
 	assertSubtype(mt, NewMap())
 
 	// Map<> not a subtype of Map<Number, Number>
-	assertInvalid(tt, MakeMapType(MakeUnionType(), MakeUnionType()), NewMap(Number(1), Number(2)))
+	assertInvalid(tt, MakeMapType(MakeUnionType(), MakeUnionType()), NewMap(NewNumber(1), NewNumber(2)))
 }
 
 func TestAssertTypeStructSubtypeByName(tt *testing.T) {
 	namedT := MakeStructType("Name", TypeMap{"x": NumberType})
 	anonT := MakeStructType("", TypeMap{"x": NumberType})
-	namedV := NewStruct("Name", structData{"x": Number(42)})
-	name2V := NewStruct("foo", structData{"x": Number(42)})
-	anonV := NewStruct("", structData{"x": Number(42)})
+	namedV := NewStruct("Name", structData{"x": NewNumber(42)})
+	name2V := NewStruct("foo", structData{"x": NewNumber(42)})
+	anonV := NewStruct("", structData{"x": NewNumber(42)})
 
 	assertSubtype(namedT, namedV)
 	assertInvalid(tt, namedT, name2V)
@@ -172,8 +172,8 @@ func TestAssertTypeStructSubtypeExtraFields(tt *testing.T) {
 	bt := MakeStructType("", TypeMap{"x": NumberType})
 	ct := MakeStructType("", TypeMap{"x": NumberType, "s": StringType})
 	av := NewStruct("", structData{})
-	bv := NewStruct("", structData{"x": Number(1)})
-	cv := NewStruct("", structData{"x": Number(2), "s": NewString("hi")})
+	bv := NewStruct("", structData{"x": NewNumber(1)})
+	cv := NewStruct("", structData{"x": NewNumber(2), "s": NewString("hi")})
 
 	assertSubtype(at, av)
 	assertInvalid(tt, bt, av)
@@ -190,7 +190,7 @@ func TestAssertTypeStructSubtypeExtraFields(tt *testing.T) {
 
 func TestAssertTypeStructSubtype(tt *testing.T) {
 	c1 := NewStruct("Commit", structData{
-		"value":   Number(1),
+		"value":   NewNumber(1),
 		"parents": NewSet(),
 	})
 	t1 := MakeStructType("Commit", TypeMap{
@@ -207,7 +207,7 @@ func TestAssertTypeStructSubtype(tt *testing.T) {
 	assertSubtype(t11, c1)
 
 	c2 := NewStruct("Commit", structData{
-		"value":   Number(2),
+		"value":   NewNumber(2),
 		"parents": NewSet(NewRef(c1)),
 	})
 	assertSubtype(t11, c2)

--- a/types/blob.go
+++ b/types/blob.go
@@ -143,7 +143,7 @@ func newBlobLeafChunkFn(vr ValueReader) makeChunkFn {
 		}
 
 		blob := newBlob(newBlobLeafSequence(vr, buff))
-		return newMetaTuple(Number(len(buff)), blob, NewRef(blob), uint64(len(buff))), blob
+		return newMetaTuple(NewNumber(len(buff)), blob, NewRef(blob), uint64(len(buff))), blob
 	}
 }
 

--- a/types/bool.go
+++ b/types/bool.go
@@ -33,8 +33,3 @@ func (v Bool) Chunks() []Ref {
 func (v Bool) Type() *Type {
 	return BoolType
 }
-
-// ValueWriter - primitive interface
-func (v Bool) ToPrimitive() interface{} {
-	return bool(v)
-}

--- a/types/compare_test.go
+++ b/types/compare_test.go
@@ -14,17 +14,17 @@ func TestTotalOrdering(t *testing.T) {
 	// values in increasing order. Some of these are compared by ref so changing the serialization might change the ordering.
 	values := []Value{
 		Bool(false), Bool(true),
-		Number(-10), Number(0), Number(10),
+		NewNumber(-10), NewNumber(0), NewNumber(10),
 		NewString("a"), NewString("b"), NewString("c"),
 
 		// The order of these are done by the hash.
-		vs.WriteValue(Number(10)),
-		NewSet(Number(0), Number(1), Number(2), Number(3)),
-		NewMap(Number(0), Number(1), Number(2), Number(3)),
+		vs.WriteValue(NewNumber(10)),
+		NewSet(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3)),
+		NewMap(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3)),
 		BoolType,
 		NewBlob(bytes.NewBuffer([]byte{0x00, 0x01, 0x02, 0x03})),
-		NewList(Number(0), Number(1), Number(2), Number(3)),
-		NewStruct("a", structData{"x": Number(1), "s": NewString("a")}),
+		NewList(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3)),
+		NewStruct("a", structData{"x": NewNumber(1), "s": NewString("a")}),
 
 		// Value - values cannot be value
 		// Parent - values cannot be parent

--- a/types/decode_noms_value.go
+++ b/types/decode_noms_value.go
@@ -187,7 +187,7 @@ func (r *jsonArrayReader) readValue() Value {
 	case BoolKind:
 		return Bool(r.read().(bool))
 	case NumberKind:
-		return Number(r.readFloat())
+		return NewNumber(r.readFloat())
 	case StringKind:
 		return NewString(r.readString())
 	case ListKind:

--- a/types/decode_noms_value_test.go
+++ b/types/decode_noms_value_test.go
@@ -18,10 +18,10 @@ func TestRead(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	a := []interface{}{Number(1), "hi", true}
+	a := []interface{}{NewNumber(1), "hi", true}
 	r := newJSONArrayReader(a, cs)
 
-	assert.Equal(Number(1), r.read().(Number))
+	assert.Equal(NewNumber(1), r.read().(Number))
 	assert.False(r.atEnd())
 
 	assert.Equal("hi", r.readString())
@@ -88,7 +88,7 @@ func TestReadPrimitives(t *testing.T) {
 
 	test(Bool(true), "[BoolKind, true]")
 	test(Bool(false), "[BoolKind, false]")
-	test(Number(0), `[NumberKind, "0"]`)
+	test(NewNumber(0), `[NumberKind, "0"]`)
 	test(NewString("hi"), `[StringKind, "hi"]`)
 
 	blob := NewBlob(bytes.NewBuffer([]byte{0x00, 0x01}))
@@ -103,7 +103,7 @@ func TestReadListOfNumber(t *testing.T) {
 	r := newJSONArrayReader(a, cs)
 
 	l := r.readValue()
-	l2 := NewList(Number(0), Number(1), Number(2), Number(3))
+	l2 := NewList(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assert.True(l2.Equals(l))
 }
 
@@ -121,7 +121,8 @@ func TestReadListOfMixedTypes(t *testing.T) {
 
 	tr := MakeListType(MakeUnionType(BoolType, NumberType, StringType))
 	assert.True(v.Type().Equals(tr))
-	assert.Equal(Number(1), v.Get(0))
+	assert.True(NewNumber(1).Equals(v.Get(0)))
+	//	assert.Equal(NewNumber(1), v.Get(0))
 	assert.Equal(NewString("hi"), v.Get(1))
 	assert.Equal(Bool(true), v.Get(2))
 }
@@ -140,7 +141,7 @@ func TestReadSetOfMixedTypes(t *testing.T) {
 
 	tr := MakeSetType(MakeUnionType(BoolType, NumberType, StringType))
 	assert.True(v.Type().Equals(tr))
-	assert.True(v.Has(Number(1)))
+	assert.True(v.Has(NewNumber(1)))
 	assert.True(v.Has(NewString("hi")))
 	assert.True(v.Has(Bool(true)))
 }
@@ -161,19 +162,19 @@ func TestReadMapOfMixedTypes(t *testing.T) {
 
 	tr := MakeMapType(MakeUnionType(BoolType, NumberType), MakeUnionType(NumberType, StringType))
 	assert.True(v.Type().Equals(tr))
-	assert.True(v.Get(Bool(true)).Equals(Number(1)))
-	assert.True(v.Get(Number(2)).Equals(NewString("hi")))
+	assert.True(v.Get(Bool(true)).Equals(NewNumber(1)))
+	assert.True(v.Get(NewNumber(2)).Equals(NewString("hi")))
 }
 
 func TestReadCompoundList(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	list1 := newList(newListLeafSequence(cs, Number(0)))
-	list2 := newList(newListLeafSequence(cs, Number(1), Number(2), Number(3)))
+	list1 := newList(newListLeafSequence(cs, NewNumber(0)))
+	list2 := newList(newListLeafSequence(cs, NewNumber(1), NewNumber(2), NewNumber(3)))
 	l2 := newList(newListMetaSequence([]metaTuple{
-		newMetaTuple(Number(1), list1, NewRef(list1), 1),
-		newMetaTuple(Number(4), list2, NewRef(list2), 4),
+		newMetaTuple(NewNumber(1), list1, NewRef(list1), 1),
+		newMetaTuple(NewNumber(4), list2, NewRef(list2), 4),
 	}, cs))
 
 	a := parseJSON(`[
@@ -192,11 +193,11 @@ func TestReadCompoundSet(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	set1 := newSet(newSetLeafSequence(cs, Number(0), Number(1)))
-	set2 := newSet(newSetLeafSequence(cs, Number(2), Number(3), Number(4)))
+	set1 := newSet(newSetLeafSequence(cs, NewNumber(0), NewNumber(1)))
+	set2 := newSet(newSetLeafSequence(cs, NewNumber(2), NewNumber(3), NewNumber(4)))
 	l2 := newSet(newSetMetaSequence([]metaTuple{
-		newMetaTuple(Number(1), set1, NewRef(set1), 2),
-		newMetaTuple(Number(4), set2, NewRef(set2), 3),
+		newMetaTuple(NewNumber(1), set1, NewRef(set1), 2),
+		newMetaTuple(NewNumber(4), set2, NewRef(set2), 3),
 	}, cs))
 
 	a := parseJSON(`[
@@ -219,7 +220,7 @@ func TestReadMapOfNumberToNumber(t *testing.T) {
 	r := newJSONArrayReader(a, cs)
 
 	m := r.readValue()
-	m2 := NewMap(Number(0), Number(1), Number(2), Number(3))
+	m2 := NewMap(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assert.True(m2.Equals(m))
 }
 
@@ -231,7 +232,7 @@ func TestReadSetOfNumber(t *testing.T) {
 	r := newJSONArrayReader(a, cs)
 
 	s := r.readValue()
-	s2 := NewSet(Number(0), Number(1), Number(2), Number(3))
+	s2 := NewSet(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assert.True(s2.Equals(s))
 }
 
@@ -240,9 +241,9 @@ func TestReadCompoundBlob(t *testing.T) {
 	cs := NewTestValueStore()
 
 	// Arbitrary valid refs.
-	r1 := Number(1).Ref()
-	r2 := Number(2).Ref()
-	r3 := Number(3).Ref()
+	r1 := NewNumber(1).Ref()
+	r2 := NewNumber(2).Ref()
+	r3 := NewNumber(3).Ref()
 	a := parseJSON(`[
 		BlobKind, true, [
 			RefKind, BlobKind, "%s", "1", NumberKind, "20", "20",
@@ -256,9 +257,9 @@ func TestReadCompoundBlob(t *testing.T) {
 	_, ok := m.(Blob)
 	assert.True(ok)
 	m2 := newBlob(newBlobMetaSequence([]metaTuple{
-		newMetaTuple(Number(20), nil, constructRef(RefOfBlobType, r1, 1), 20),
-		newMetaTuple(Number(40), nil, constructRef(RefOfBlobType, r2, 1), 40),
-		newMetaTuple(Number(60), nil, constructRef(RefOfBlobType, r3, 1), 60),
+		newMetaTuple(NewNumber(20), nil, constructRef(RefOfBlobType, r1, 1), 20),
+		newMetaTuple(NewNumber(40), nil, constructRef(RefOfBlobType, r2, 1), 40),
+		newMetaTuple(NewNumber(60), nil, constructRef(RefOfBlobType, r3, 1), 60),
 	}, cs))
 
 	assert.True(m.Type().Equals(m2.Type()))
@@ -280,7 +281,7 @@ func TestReadStruct(t *testing.T) {
 	v := r.readValue().(Struct)
 
 	assert.True(v.Type().Equals(typ))
-	assert.True(v.Get("x").Equals(Number(42)))
+	assert.True(v.Get("x").Equals(NewNumber(42)))
 	assert.True(v.Get("s").Equals(NewString("hi")))
 	assert.True(v.Get("b").Equals(Bool(true)))
 }
@@ -307,7 +308,7 @@ func TestReadStructWithList(t *testing.T) {
 
 	assert.True(v.Type().Equals(typ))
 	assert.True(v.Get("b").Equals(Bool(true)))
-	l := NewList(Number(0), Number(1), Number(2))
+	l := NewList(NewNumber(0), NewNumber(1), NewNumber(2))
 	assert.True(v.Get("l").Equals(l))
 	assert.True(v.Get("s").Equals(NewString("hi")))
 }
@@ -334,7 +335,7 @@ func TestReadStructWithValue(t *testing.T) {
 
 	assert.True(v.Type().Equals(typ))
 	assert.True(v.Get("b").Equals(Bool(true)))
-	assert.True(v.Get("v").Equals(Number(42)))
+	assert.True(v.Get("v").Equals(NewNumber(42)))
 	assert.True(v.Get("s").Equals(NewString("hi")))
 }
 
@@ -452,7 +453,7 @@ func TestReadUnionList(t *testing.T) {
 
 	r := newJSONArrayReader(a, cs)
 	v := r.readValue().(List)
-	v2 := NewList(NewString("hi"), Number(42))
+	v2 := NewList(NewString("hi"), NewNumber(42))
 	assert.True(v.Equals(v2))
 }
 

--- a/types/encode_human_readable.go
+++ b/types/encode_human_readable.go
@@ -55,7 +55,7 @@ func (w *hrsWriter) Write(v Value) {
 	case BoolKind:
 		w.write(strconv.FormatBool(bool(v.(Bool))))
 	case NumberKind:
-		w.write(strconv.FormatFloat(float64(v.(Number)), 'g', -1, 64))
+		w.write(strconv.FormatFloat(float64(v.(Number).ToFloat64()), 'g', -1, 64))
 
 	case StringKind:
 		w.write(strconv.Quote(v.(String).String()))

--- a/types/encode_human_readable_test.go
+++ b/types/encode_human_readable_test.go
@@ -28,14 +28,14 @@ func TestWriteHumanReadablePrimitiveValues(t *testing.T) {
 	assertWriteHRSEqual(t, "true", Bool(true))
 	assertWriteHRSEqual(t, "false", Bool(false))
 
-	assertWriteHRSEqual(t, "0", Number(0))
-	assertWriteHRSEqual(t, "42", Number(42))
+	assertWriteHRSEqual(t, "0", NewNumber(0))
+	assertWriteHRSEqual(t, "42", NewNumber(42))
 
-	assertWriteHRSEqual(t, "-42", Number(-42))
+	assertWriteHRSEqual(t, "-42", NewNumber(-42))
 
-	assertWriteHRSEqual(t, "3.1415926535", Number(3.1415926535))
-	assertWriteHRSEqual(t, "314159.26535", Number(3.1415926535e5))
-	assertWriteHRSEqual(t, "3.1415926535e+20", Number(3.1415926535e20))
+	assertWriteHRSEqual(t, "3.1415926535", NewNumber(3.1415926535))
+	assertWriteHRSEqual(t, "314159.26535", NewNumber(3.1415926535e5))
+	assertWriteHRSEqual(t, "3.1415926535e+20", NewNumber(3.1415926535e20))
 
 	assertWriteHRSEqual(t, `"abc"`, NewString("abc"))
 	assertWriteHRSEqual(t, `" "`, NewString(" "))
@@ -56,29 +56,29 @@ func TestWriteHumanReadablePrimitiveValues(t *testing.T) {
 func TestWriteHumanReadableRef(t *testing.T) {
 	vs := NewTestValueStore()
 
-	x := Number(42)
+	x := NewNumber(42)
 	rv := vs.WriteValue(x)
 	assertWriteHRSEqual(t, "sha1-bd0b7d4cb11321762f4206f0d6c6fdf820f8556e", rv)
 	assertWriteTaggedHRSEqual(t, "Ref<Number>(sha1-bd0b7d4cb11321762f4206f0d6c6fdf820f8556e)", rv)
 }
 
 func TestWriteHumanReadableCollections(t *testing.T) {
-	l := NewList(Number(0), Number(1), Number(2), Number(3))
+	l := NewList(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assertWriteHRSEqual(t, "[\n  0,\n  1,\n  2,\n  3,\n]", l)
 	assertWriteTaggedHRSEqual(t, "List<Number>([\n  0,\n  1,\n  2,\n  3,\n])", l)
 
-	s := NewSet(Number(0), Number(1), Number(2), Number(3))
+	s := NewSet(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 	assertWriteHRSEqual(t, "{\n  0,\n  1,\n  2,\n  3,\n}", s)
 	assertWriteTaggedHRSEqual(t, "Set<Number>({\n  0,\n  1,\n  2,\n  3,\n})", s)
 
-	m := NewMap(Number(0), Bool(false), Number(1), Bool(true))
+	m := NewMap(NewNumber(0), Bool(false), NewNumber(1), Bool(true))
 	assertWriteHRSEqual(t, "{\n  0: false,\n  1: true,\n}", m)
 	assertWriteTaggedHRSEqual(t, "Map<Number, Bool>({\n  0: false,\n  1: true,\n})", m)
 }
 
 func TestWriteHumanReadableNested(t *testing.T) {
-	l := NewList(Number(0), Number(1))
-	l2 := NewList(Number(2), Number(3))
+	l := NewList(NewNumber(0), NewNumber(1))
+	l2 := NewList(NewNumber(2), NewNumber(3))
 
 	s := NewSet(NewString("a"), NewString("b"))
 	s2 := NewSet(NewString("c"), NewString("d"))
@@ -120,8 +120,8 @@ func TestWriteHumanReadableNested(t *testing.T) {
 
 func TestWriteHumanReadableStruct(t *testing.T) {
 	str := NewStruct("S1", map[string]Value{
-		"x": Number(1),
-		"y": Number(2),
+		"x": NewNumber(1),
+		"y": NewNumber(2),
 	})
 	assertWriteHRSEqual(t, "S1 {\n  x: 1,\n  y: 2,\n}", str)
 	assertWriteTaggedHRSEqual(t, "struct S1 {\n  x: Number\n  y: Number\n}({\n  x: 1,\n  y: 2,\n})", str)
@@ -129,13 +129,13 @@ func TestWriteHumanReadableStruct(t *testing.T) {
 
 func TestWriteHumanReadableListOfStruct(t *testing.T) {
 	str1 := NewStruct("S3", map[string]Value{
-		"x": Number(1),
+		"x": NewNumber(1),
 	})
 	str2 := NewStruct("S3", map[string]Value{
-		"x": Number(2),
+		"x": NewNumber(2),
 	})
 	str3 := NewStruct("S3", map[string]Value{
-		"x": Number(3),
+		"x": NewNumber(3),
 	})
 	l := NewList(str1, str2, str3)
 	assertWriteHRSEqual(t, `[
@@ -218,15 +218,15 @@ func TestWriteHumanReadableTaggedPrimitiveValues(t *testing.T) {
 	assertWriteHRSEqual(t, "true", Bool(true))
 	assertWriteHRSEqual(t, "false", Bool(false))
 
-	assertWriteTaggedHRSEqual(t, "Number(0)", Number(0))
-	assertWriteTaggedHRSEqual(t, "Number(42)", Number(42))
-	assertWriteTaggedHRSEqual(t, "Number(-42)", Number(-42))
+	assertWriteTaggedHRSEqual(t, "Number(0)", NewNumber(0))
+	assertWriteTaggedHRSEqual(t, "Number(42)", NewNumber(42))
+	assertWriteTaggedHRSEqual(t, "Number(-42)", NewNumber(-42))
 
-	assertWriteTaggedHRSEqual(t, "Number(3.1415926535)", Number(3.1415926535))
+	assertWriteTaggedHRSEqual(t, "Number(3.1415926535)", NewNumber(3.1415926535))
 
-	assertWriteTaggedHRSEqual(t, "Number(314159.26535)", Number(3.1415926535e5))
+	assertWriteTaggedHRSEqual(t, "Number(314159.26535)", NewNumber(3.1415926535e5))
 
-	assertWriteTaggedHRSEqual(t, "Number(3.1415926535e+20)", Number(3.1415926535e20))
+	assertWriteTaggedHRSEqual(t, "Number(3.1415926535e+20)", NewNumber(3.1415926535e20))
 
 	assertWriteTaggedHRSEqual(t, `"abc"`, NewString("abc"))
 	assertWriteTaggedHRSEqual(t, `" "`, NewString(" "))
@@ -326,5 +326,5 @@ func TestWriteHumanReadableWriterError(t *testing.T) {
 	assert := assert.New(t)
 	err := errors.New("test")
 	w := &errorWriter{err}
-	assert.Equal(err, WriteEncodedValueWithTags(w, Number(42)))
+	assert.Equal(err, WriteEncodedValueWithTags(w, NewNumber(42)))
 }

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -136,7 +136,7 @@ func (w *jsonArrayWriter) writeValue(v Value) {
 	case BoolKind:
 		w.writeBool(bool(v.(Bool)))
 	case NumberKind:
-		w.writeFloat(float64(v.(Number)))
+		w.writeFloat(float64(v.(Number).ToFloat64()))
 	case ListKind:
 		seq := v.(List).sequence()
 		if w.maybeWriteMetaSequence(seq, t) {

--- a/types/encode_noms_value_test.go
+++ b/types/encode_noms_value_test.go
@@ -21,11 +21,11 @@ func TestWritePrimitives(t *testing.T) {
 	f(BoolKind, Bool(true), true)
 	f(BoolKind, Bool(false), false)
 
-	f(NumberKind, Number(0), "0")
-	f(NumberKind, Number(1e18), "1000000000000000000")
-	f(NumberKind, Number(1e19), "10000000000000000000")
-	f(NumberKind, Number(float64(1e19)), "10000000000000000000")
-	f(NumberKind, Number(float64(1e20)), "1e+20")
+	f(NumberKind, NewNumber(0), "0")
+	f(NumberKind, NewNumber(1e18), "1000000000000000000")
+	f(NumberKind, NewNumber(1e19), "10000000000000000000")
+	f(NumberKind, NewNumber(float64(1e19)), "10000000000000000000")
+	f(NumberKind, NewNumber(float64(1e20)), "1e+20")
 
 	f(StringKind, NewString("hi"), "hi")
 }
@@ -40,7 +40,7 @@ func TestWriteSimpleBlob(t *testing.T) {
 func TestWriteList(t *testing.T) {
 	assert := assert.New(t)
 
-	v := NewList(Number(0), Number(1), Number(2), Number(3))
+	v := NewList(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3))
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
@@ -50,8 +50,8 @@ func TestWriteList(t *testing.T) {
 func TestWriteListOfList(t *testing.T) {
 	assert := assert.New(t)
 
-	l1 := NewList(Number(0))
-	l2 := NewList(Number(1), Number(2), Number(3))
+	l1 := NewList(NewNumber(0))
+	l2 := NewList(NewNumber(1), NewNumber(2), NewNumber(3))
 	v := NewList(l1, l2)
 
 	w := newJSONArrayWriter(NewTestValueStore())
@@ -65,7 +65,7 @@ func TestWriteListOfList(t *testing.T) {
 func TestWriteSet(t *testing.T) {
 	assert := assert.New(t)
 
-	v := NewSet(Number(3), Number(1), Number(2), Number(0))
+	v := NewSet(NewNumber(3), NewNumber(1), NewNumber(2), NewNumber(0))
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
@@ -76,7 +76,7 @@ func TestWriteSet(t *testing.T) {
 func TestWriteSetOfSet(t *testing.T) {
 	assert := assert.New(t)
 
-	v := NewSet(NewSet(Number(0)), NewSet(Number(1), Number(2), Number(3)))
+	v := NewSet(NewSet(NewNumber(0)), NewSet(NewNumber(1), NewNumber(2), NewNumber(3)))
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
@@ -103,7 +103,7 @@ func TestWriteMapOfMap(t *testing.T) {
 
 	// Map<Map<String, Number>, Set<Bool>>
 	// { {"a": 0}: {true} }
-	v := NewMap(NewMap(NewString("a"), Number(0)), NewSet(Bool(true)))
+	v := NewMap(NewMap(NewString("a"), NewNumber(0)), NewSet(Bool(true)))
 
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
@@ -121,9 +121,9 @@ func TestWriteCompoundBlob(t *testing.T) {
 	r3 := ref.Parse("sha1-0000000000000000000000000000000000000003")
 
 	v := newBlob(newBlobMetaSequence([]metaTuple{
-		newMetaTuple(Number(20), nil, constructRef(RefOfBlobType, r1, 11), 20),
-		newMetaTuple(Number(40), nil, constructRef(RefOfBlobType, r2, 22), 40),
-		newMetaTuple(Number(60), nil, constructRef(RefOfBlobType, r3, 33), 60),
+		newMetaTuple(NewNumber(20), nil, constructRef(RefOfBlobType, r1, 11), 20),
+		newMetaTuple(NewNumber(40), nil, constructRef(RefOfBlobType, r2, 22), 40),
+		newMetaTuple(NewNumber(60), nil, constructRef(RefOfBlobType, r3, 33), 60),
 	}, NewTestValueStore()))
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
@@ -150,7 +150,7 @@ func TestWriteEmptyStruct(t *testing.T) {
 func TestWriteStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	v := NewStruct("S", structData{"x": Number(42), "b": Bool(true)})
+	v := NewStruct("S", structData{"x": NewNumber(42), "b": Bool(true)})
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
 	assert.EqualValues([]interface{}{StructKind, "S", []interface{}{"b", BoolKind, "x", NumberKind}, BoolKind, true, NumberKind, "42"}, w.toArray())
@@ -185,7 +185,7 @@ func TestWriteStructWithStruct(t *testing.T) {
 	// }
 
 	// {s: {x: 42}}
-	v := NewStruct("S", structData{"s": NewStruct("S2", structData{"x": Number(42)})})
+	v := NewStruct("S", structData{"s": NewStruct("S2", structData{"x": NewNumber(42)})})
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
 	assert.EqualValues([]interface{}{StructKind, "S", []interface{}{"s", StructKind, "S2", []interface{}{"x", NumberKind}}, StructKind, "S2", []interface{}{"x", NumberKind}, NumberKind, "42"}, w.toArray())
@@ -205,11 +205,11 @@ func TestWriteCompoundList(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
 
-	list1 := newList(newListLeafSequence(cs, Number(0)))
-	list2 := newList(newListLeafSequence(cs, Number(1), Number(2), Number(3)))
+	list1 := newList(newListLeafSequence(cs, NewNumber(0)))
+	list2 := newList(newListLeafSequence(cs, NewNumber(1), NewNumber(2), NewNumber(3)))
 	cl := newList(newListMetaSequence([]metaTuple{
-		newMetaTuple(Number(1), list1, NewRef(list1), 1),
-		newMetaTuple(Number(4), list2, NewRef(list2), 4),
+		newMetaTuple(NewNumber(1), list1, NewRef(list1), 1),
+		newMetaTuple(NewNumber(4), list2, NewRef(list2), 4),
 	}, cs))
 
 	w := newJSONArrayWriter(cs)
@@ -225,11 +225,11 @@ func TestWriteCompoundList(t *testing.T) {
 func TestWriteCompoundSet(t *testing.T) {
 	assert := assert.New(t)
 	cs := NewTestValueStore()
-	set1 := newSet(newSetLeafSequence(cs, Number(0), Number(1)))
-	set2 := newSet(newSetLeafSequence(cs, Number(2), Number(3), Number(4)))
+	set1 := newSet(newSetLeafSequence(cs, NewNumber(0), NewNumber(1)))
+	set2 := newSet(newSetLeafSequence(cs, NewNumber(2), NewNumber(3), NewNumber(4)))
 	cl := newSet(newSetMetaSequence([]metaTuple{
-		newMetaTuple(Number(1), set1, NewRef(set1), 2),
-		newMetaTuple(Number(4), set2, NewRef(set2), 3),
+		newMetaTuple(NewNumber(1), set1, NewRef(set1), 2),
+		newMetaTuple(NewNumber(4), set2, NewRef(set2), 3),
 	}, cs))
 
 	w := newJSONArrayWriter(cs)
@@ -247,7 +247,7 @@ func TestWriteListOfValue(t *testing.T) {
 
 	v := NewList(
 		NewString("0"),
-		Number(1),
+		NewNumber(1),
 		NewString("2"),
 		Bool(true),
 	)
@@ -266,7 +266,7 @@ func TestWriteListOfValue(t *testing.T) {
 func TestWriteListOfValueWithStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	v := NewList(NewStruct("S", structData{"x": Number(42)}))
+	v := NewList(NewStruct("S", structData{"x": NewNumber(42)}))
 	w := newJSONArrayWriter(NewTestValueStore())
 	w.writeValue(v)
 	assert.EqualValues([]interface{}{ListKind,
@@ -363,7 +363,7 @@ func TestWriteRecursiveStruct(t *testing.T) {
 
 	// {v: 42, cs: [{v: 555, cs: []}]}
 	v := NewStructWithType(structType, structData{
-		"v":  Number(42),
+		"v":  NewNumber(42),
 		"cs": NewList(),
 	})
 
@@ -383,7 +383,7 @@ func TestWriteUnionList(t *testing.T) {
 	assert := assert.New(t)
 
 	w := newJSONArrayWriter(NewTestValueStore())
-	v := NewList(NewString("hi"), Number(42))
+	v := NewList(NewString("hi"), NewNumber(42))
 	w.writeValue(v)
 	assert.Equal([]interface{}{ListKind, UnionKind, uint16(2), NumberKind, StringKind,
 		false, []interface{}{StringKind, "hi", NumberKind, "42"}}, w.toArray())

--- a/types/equals_test.go
+++ b/types/equals_test.go
@@ -14,9 +14,9 @@ func TestValueEquals(t *testing.T) {
 		func() Value { return nil },
 		func() Value { return Bool(false) },
 		func() Value { return Bool(true) },
-		func() Value { return Number(0) },
-		func() Value { return Number(-1) },
-		func() Value { return Number(1) },
+		func() Value { return NewNumber(0) },
+		func() Value { return NewNumber(-1) },
+		func() Value { return NewNumber(1) },
 		func() Value { return NewString("") },
 		func() Value { return NewString("hi") },
 		func() Value { return NewString("bye") },
@@ -33,8 +33,8 @@ func TestValueEquals(t *testing.T) {
 			b1 := NewBlob(bytes.NewBufferString("hi"))
 			b2 := NewBlob(bytes.NewBufferString("bye"))
 			return newBlob(newBlobMetaSequence([]metaTuple{
-				newMetaTuple(Number(uint64(2)), b1, NewRef(b1), 2),
-				newMetaTuple(Number(uint64(5)), b2, NewRef(b2), 5),
+				newMetaTuple(NewNumber(uint64(2)), b1, NewRef(b1), 2),
+				newMetaTuple(NewNumber(uint64(5)), b2, NewRef(b2), 5),
 			}, nil))
 		},
 		func() Value { return NewList() },

--- a/types/get_ref_test.go
+++ b/types/get_ref_test.go
@@ -42,11 +42,11 @@ func TestEnsureRef(t *testing.T) {
 	}()
 
 	bl := newBlob(newBlobLeafSequence(nil, []byte("hi")))
-	cb := newBlob(newBlobMetaSequence([]metaTuple{{bl, Ref{}, Number(2), 2}}, vs))
+	cb := newBlob(newBlobMetaSequence([]metaTuple{{bl, Ref{}, NewNumber(2), 2}}, vs))
 
 	ll := newList(newListLeafSequence(nil, NewString("foo")))
 	lt := MakeListType(StringType)
-	cl := newList(newIndexedMetaSequence([]metaTuple{{ll, Ref{}, Number(1), 1}}, lt, vs))
+	cl := newList(newIndexedMetaSequence([]metaTuple{{ll, Ref{}, NewNumber(1), 1}}, lt, vs))
 
 	ml := newMap(newMapLeafSequence(nil, mapEntry{NewString("foo"), NewString("bar")}))
 	cm := newMap(newOrderedMetaSequence([]metaTuple{{ml, Ref{}, NewString("foo"), 1}}, MakeMapType(StringType, StringType), vs))
@@ -75,7 +75,7 @@ func TestEnsureRef(t *testing.T) {
 	count = byte(1)
 	values = []Value{
 		Bool(false),
-		Number(0),
+		NewNumber(0),
 	}
 	for i := 0; i < 2; i++ {
 		for j, v := range values {

--- a/types/incremental_test.go
+++ b/types/incremental_test.go
@@ -11,7 +11,7 @@ import (
 var (
 	testVals = []Value{
 		Bool(true),
-		Number(1),
+		NewNumber(1),
 		NewString("hi"),
 		NewBlob(bytes.NewReader([]byte("hi"))),
 		// compoundBlob
@@ -103,7 +103,7 @@ func SkipTestIncrementalAddRef(t *testing.T) {
 	cs := chunks.NewTestStore()
 	vs := newLocalValueStore(cs)
 
-	expectedItem := Number(42)
+	expectedItem := NewNumber(42)
 	ref := vs.WriteValue(expectedItem)
 
 	expected := NewList(ref)

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -123,8 +123,8 @@ func newIndexedMetaSequenceChunkFn(kind NomsKind, source ValueReader, sink Value
 		}
 		if sink != nil {
 			r := sink.WriteValue(col)
-			return newMetaTuple(Number(tuples.uint64ValuesSum()), nil, r, numLeaves), col
+			return newMetaTuple(NewNumber(tuples.uint64ValuesSum()), nil, r, numLeaves), col
 		}
-		return newMetaTuple(Number(tuples.uint64ValuesSum()), col, NewRef(col), numLeaves), col
+		return newMetaTuple(NewNumber(tuples.uint64ValuesSum()), col, NewRef(col), numLeaves), col
 	}
 }

--- a/types/list.go
+++ b/types/list.go
@@ -197,8 +197,8 @@ func makeListLeafChunkFn(vr ValueReader, sink ValueWriter) makeChunkFn {
 
 		list := newList(newListLeafSequence(vr, values...))
 		if sink != nil {
-			return newMetaTuple(Number(len(values)), nil, sink.WriteValue(list), uint64(len(values))), list
+			return newMetaTuple(NewNumber(len(values)), nil, sink.WriteValue(list), uint64(len(values))), list
 		}
-		return newMetaTuple(Number(len(values)), list, NewRef(list), uint64(len(values))), list
+		return newMetaTuple(NewNumber(len(values)), list, NewRef(list), uint64(len(values))), list
 	}
 }

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -32,7 +32,7 @@ func (mt metaTuple) ChildRef() Ref {
 }
 
 func (mt metaTuple) uint64Value() uint64 {
-	return uint64(mt.value.(Number))
+	return uint64(mt.value.(Number).ToUint64())
 }
 
 type metaSequenceData []metaTuple

--- a/types/number.go
+++ b/types/number.go
@@ -1,19 +1,44 @@
 package types
 
 import (
+	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/ref"
+	"math/big"
 )
 
-type Number float64
+type Number struct {
+	n *big.Float
+}
+
+func NewNumber(n interface{}) Number {
+	switch t := n.(type) {
+	case int:
+		return Number{new(big.Float).SetInt64(int64(n.(int)))}
+	case int64:
+		return Number{new(big.Float).SetInt64(n.(int64))}
+	case uint64:
+		return Number{new(big.Float).SetUint64(n.(uint64))}
+	case float64:
+		return Number{big.NewFloat(n.(float64))}
+	case *big.Float:
+		return Number{new(big.Float).Set(n.(*big.Float))}
+	default:
+		d.Chk.Fail("unknown type in NewNumber - %T", t)
+		return Number{new(big.Float).SetInf(true)}
+	}
+}
 
 // Value interface
 func (v Number) Equals(other Value) bool {
-	return v == other
+	if other, ok := other.(Number); ok {
+		return 0 == v.n.Cmp(other.n)
+	}
+	return false
 }
 
 func (v Number) Less(other Value) bool {
 	if v2, ok := other.(Number); ok {
-		return float64(v) < float64(v2)
+		return -1 == v.n.Cmp(v2.n)
 	}
 	return NumberKind < other.Type().Kind()
 }
@@ -34,7 +59,14 @@ func (v Number) Type() *Type {
 	return NumberType
 }
 
-// ValueWriter - primitive interface
-func (v Number) ToPrimitive() interface{} {
-	return float64(v)
+func (v Number) ToUint64() uint64 {
+	n, accuracy := v.n.Uint64()
+	d.Chk.True(accuracy == big.Exact, "number conversion to uint64 not exact")
+	return n
+}
+
+func (v Number) ToFloat64() float64 {
+	n, accuracy := v.n.Float64()
+	d.Chk.True(accuracy == big.Exact, "number conversion to float64 not exact")
+	return n
 }

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumberEquals(t *testing.T) {
+	assert := assert.New(t)
+	n1 := NewNumber(2)
+	n2 := NewNumber(2.0)
+	n3 := n2
+	n4 := NewNumber(uint64(3))
+	assert.True(n1.Equals(n2))
+	assert.True(n2.Equals(n1))
+	assert.True(n1.Equals(n3))
+	assert.True(n3.Equals(n1))
+	assert.False(n1.Equals(n4))
+	assert.False(n4.Equals(n1))
+}

--- a/types/primitives_test.go
+++ b/types/primitives_test.go
@@ -9,8 +9,8 @@ import (
 func TestPrimitives(t *testing.T) {
 	data := []Value{
 		Bool(true), Bool(false),
-		Number(0), Number(-1),
-		Number(-0.1), Number(0.1),
+		NewNumber(0), NewNumber(-1),
+		NewNumber(-0.1), NewNumber(0.1),
 	}
 
 	for i := range data {
@@ -30,7 +30,7 @@ func TestPrimitivesType(t *testing.T) {
 		k NomsKind
 	}{
 		{Bool(false), BoolKind},
-		{Number(0), NumberKind},
+		{NewNumber(0), NumberKind},
 	}
 
 	for _, d := range data {

--- a/types/ref_test.go
+++ b/types/ref_test.go
@@ -31,12 +31,12 @@ func TestRefInMap(t *testing.T) {
 
 	m := NewMap()
 	r := NewRef(m)
-	m = m.Set(Number(0), r).Set(r, Number(1))
-	r2 := m.Get(Number(0))
+	m = m.Set(NewNumber(0), r).Set(r, NewNumber(1))
+	r2 := m.Get(NewNumber(0))
 	assert.True(r.Equals(r2))
 
 	i := m.Get(r)
-	assert.Equal(int32(1), int32(i.(Number)))
+	assert.Equal(int32(1), int32(i.(Number).ToUint64()))
 }
 
 func TestRefChunks(t *testing.T) {

--- a/types/sequence_chunker_test.go
+++ b/types/sequence_chunker_test.go
@@ -21,7 +21,7 @@ func (b modBoundaryChecker) WindowSize() int {
 func listFromInts(ints []int) List {
 	vals := make([]Value, len(ints))
 	for i, v := range ints {
-		vals[i] = Number(v)
+		vals[i] = NewNumber(v)
 	}
 
 	return NewList(vals...)

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -44,7 +44,7 @@ func (ts testSet) toSet() Set {
 func newTestSet(length int) testSet {
 	var values []Value
 	for i := 0; i < length; i++ {
-		values = append(values, Number(i))
+		values = append(values, NewNumber(i))
 	}
 
 	return testSet{values, MakeSetType(NumberType)}
@@ -58,7 +58,7 @@ func newTestSetWithGen(length int, gen testSetGenFn, tr *Type) testSet {
 	for len(values) < length {
 		v := s.Int63() & 0xffffff
 		if _, ok := used[v]; !ok {
-			values = append(values, gen(Number(v)))
+			values = append(values, gen(NewNumber(v)))
 			used[v] = true
 		}
 	}
@@ -95,14 +95,14 @@ func newSetTestSuite(size uint, expectRefStr string, expectChunkCount int, expec
 			},
 			prependOne: func() Collection {
 				dup := make([]Value, length+1)
-				dup[0] = Number(-1)
+				dup[0] = NewNumber(-1)
 				copy(dup[1:], elems.values)
 				return NewSet(dup...)
 			},
 			appendOne: func() Collection {
 				dup := make([]Value, length+1)
 				copy(dup, elems.values)
-				dup[len(dup)-1] = Number(length + 1)
+				dup[len(dup)-1] = NewNumber(length + 1)
 				return NewSet(dup...)
 			},
 		},
@@ -152,13 +152,13 @@ func TestNewSet(t *testing.T) {
 	assert.True(MakeSetType(MakeUnionType()).Equals(s.Type()))
 	assert.Equal(uint64(0), s.Len())
 
-	s = NewSet(Number(0))
+	s = NewSet(NewNumber(0))
 	assert.True(MakeSetType(NumberType).Equals(s.Type()))
 
 	s = NewSet()
 	assert.IsType(MakeSetType(NumberType), s.Type())
 
-	s2 := s.Remove(Number(1))
+	s2 := s.Remove(NewNumber(1))
 	assert.IsType(s.Type(), s2.Type())
 }
 
@@ -166,7 +166,7 @@ func TestSetLen(t *testing.T) {
 	assert := assert.New(t)
 	s0 := NewSet()
 	assert.Equal(uint64(0), s0.Len())
-	s1 := NewSet(Bool(true), Number(1), NewString("hi"))
+	s1 := NewSet(Bool(true), NewNumber(1), NewString("hi"))
 	assert.Equal(uint64(3), s1.Len())
 	s2 := s1.Insert(Bool(false))
 	assert.Equal(uint64(4), s2.Len())
@@ -205,7 +205,7 @@ func TestSetEmptyInsertRemove(t *testing.T) {
 // BUG 98
 func TestSetDuplicateInsert(t *testing.T) {
 	assert := assert.New(t)
-	s1 := NewSet(Bool(true), Number(42), Number(42))
+	s1 := NewSet(Bool(true), NewNumber(42), NewNumber(42))
 	assert.Equal(uint64(2), s1.Len())
 }
 
@@ -218,24 +218,24 @@ func TestSetUniqueKeysString(t *testing.T) {
 	assert.False(s1.Has(NewString("foo")))
 }
 
-func TestSetUniqueKeysNumber(t *testing.T) {
+func TestSetUniqueKeysNewNumber(t *testing.T) {
 	assert := assert.New(t)
-	s1 := NewSet(Number(4), Number(1), Number(0), Number(0), Number(1), Number(3))
+	s1 := NewSet(NewNumber(4), NewNumber(1), NewNumber(0), NewNumber(0), NewNumber(1), NewNumber(3))
 	assert.Equal(uint64(4), s1.Len())
-	assert.True(s1.Has(Number(4)))
-	assert.True(s1.Has(Number(1)))
-	assert.True(s1.Has(Number(0)))
-	assert.True(s1.Has(Number(3)))
-	assert.False(s1.Has(Number(2)))
+	assert.True(s1.Has(NewNumber(4)))
+	assert.True(s1.Has(NewNumber(1)))
+	assert.True(s1.Has(NewNumber(0)))
+	assert.True(s1.Has(NewNumber(3)))
+	assert.False(s1.Has(NewNumber(2)))
 }
 
 func TestSetHas(t *testing.T) {
 	assert := assert.New(t)
-	s1 := NewSet(Bool(true), Number(1), NewString("hi"))
+	s1 := NewSet(Bool(true), NewNumber(1), NewString("hi"))
 	assert.True(s1.Has(Bool(true)))
 	assert.False(s1.Has(Bool(false)))
-	assert.True(s1.Has(Number(1)))
-	assert.False(s1.Has(Number(0)))
+	assert.True(s1.Has(NewNumber(1)))
+	assert.False(s1.Has(NewNumber(0)))
 	assert.True(s1.Has(NewString("hi")))
 	assert.False(s1.Has(NewString("ho")))
 
@@ -274,7 +274,7 @@ func TestSetInsert(t *testing.T) {
 	s := NewSet()
 	v1 := Bool(false)
 	v2 := Bool(true)
-	v3 := Number(0)
+	v3 := NewNumber(0)
 
 	assert.False(s.Has(v1))
 	s = s.Insert(v1)
@@ -332,7 +332,7 @@ func TestSetRemove(t *testing.T) {
 	assert := assert.New(t)
 	v1 := Bool(false)
 	v2 := Bool(true)
-	v3 := Number(0)
+	v3 := NewNumber(0)
 	s := NewSet(v1, v2, v3)
 	assert.True(s.Has(v1))
 	assert.True(s.Has(v2))
@@ -383,7 +383,7 @@ func TestSetRemoveNonexistentValue(t *testing.T) {
 
 	ts := getTestNativeOrderSet(2)
 	original := ts.toSet()
-	actual := original.Remove(Number(-1)) // rand.Int63 returns non-negative values.
+	actual := original.Remove(NewNumber(-1)) // rand.Int63 returns non-negative values.
 
 	assert.Equal(original.Len(), actual.Len())
 	assert.True(original.Equals(actual))
@@ -393,13 +393,13 @@ func TestSetFirst(t *testing.T) {
 	assert := assert.New(t)
 	s := NewSet()
 	assert.Nil(s.First())
-	s = s.Insert(Number(1))
+	s = s.Insert(NewNumber(1))
 	assert.NotNil(s.First())
-	s = s.Insert(Number(2))
+	s = s.Insert(NewNumber(2))
 	assert.NotNil(s.First())
-	s2 := s.Remove(Number(1))
+	s2 := s.Remove(NewNumber(1))
 	assert.NotNil(s2.First())
-	s2 = s2.Remove(Number(2))
+	s2 = s2.Remove(NewNumber(2))
 	assert.Nil(s2.First())
 }
 
@@ -412,7 +412,7 @@ func TestSetOfStruct(t *testing.T) {
 
 	elems := []Value{}
 	for i := 0; i < 200; i++ {
-		elems = append(elems, newStructFromData(structData{"o": Number(i)}, typ))
+		elems = append(elems, newStructFromData(structData{"o": NewNumber(i)}, typ))
 	}
 
 	s := NewSet(elems...)
@@ -423,7 +423,7 @@ func TestSetOfStruct(t *testing.T) {
 
 func TestSetIter(t *testing.T) {
 	assert := assert.New(t)
-	s := NewSet(Number(0), Number(1), Number(2), Number(3), Number(4))
+	s := NewSet(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3), NewNumber(4))
 	acc := NewSet()
 	s.Iter(func(v Value) bool {
 		_, ok := v.(Number)
@@ -469,7 +469,7 @@ func TestSetIter2(t *testing.T) {
 
 func TestSetIterAll(t *testing.T) {
 	assert := assert.New(t)
-	s := NewSet(Number(0), Number(1), Number(2), Number(3), Number(4))
+	s := NewSet(NewNumber(0), NewNumber(1), NewNumber(2), NewNumber(3), NewNumber(4))
 	acc := NewSet()
 	s.IterAll(func(v Value) {
 		_, ok := v.(Number)
@@ -534,60 +534,60 @@ func TestSetOrdering(t *testing.T) {
 	testSetOrder(assert,
 		NumberType,
 		[]Value{
-			Number(0),
-			Number(1000),
-			Number(1),
-			Number(100),
-			Number(2),
-			Number(10),
+			NewNumber(0),
+			NewNumber(1000),
+			NewNumber(1),
+			NewNumber(100),
+			NewNumber(2),
+			NewNumber(10),
 		},
 		[]Value{
-			Number(0),
-			Number(1),
-			Number(2),
-			Number(10),
-			Number(100),
-			Number(1000),
-		},
-	)
-
-	testSetOrder(assert,
-		NumberType,
-		[]Value{
-			Number(0),
-			Number(-30),
-			Number(25),
-			Number(1002),
-			Number(-5050),
-			Number(23),
-		},
-		[]Value{
-			Number(-5050),
-			Number(-30),
-			Number(0),
-			Number(23),
-			Number(25),
-			Number(1002),
+			NewNumber(0),
+			NewNumber(1),
+			NewNumber(2),
+			NewNumber(10),
+			NewNumber(100),
+			NewNumber(1000),
 		},
 	)
 
 	testSetOrder(assert,
 		NumberType,
 		[]Value{
-			Number(0.0001),
-			Number(0.000001),
-			Number(1),
-			Number(25.01e3),
-			Number(-32.231123e5),
-			Number(23),
+			NewNumber(0),
+			NewNumber(-30),
+			NewNumber(25),
+			NewNumber(1002),
+			NewNumber(-5050),
+			NewNumber(23),
 		},
 		[]Value{
-			Number(-32.231123e5),
-			Number(0.000001),
-			Number(0.0001),
-			Number(1),
-			Number(23),
-			Number(25.01e3),
+			NewNumber(-5050),
+			NewNumber(-30),
+			NewNumber(0),
+			NewNumber(23),
+			NewNumber(25),
+			NewNumber(1002),
+		},
+	)
+
+	testSetOrder(assert,
+		NumberType,
+		[]Value{
+			NewNumber(0.0001),
+			NewNumber(0.000001),
+			NewNumber(1),
+			NewNumber(25.01e3),
+			NewNumber(-32.231123e5),
+			NewNumber(23),
+		},
+		[]Value{
+			NewNumber(-32.231123e5),
+			NewNumber(0.000001),
+			NewNumber(0.0001),
+			NewNumber(1),
+			NewNumber(23),
+			NewNumber(25.01e3),
 		},
 	)
 
@@ -632,29 +632,29 @@ func TestSetType(t *testing.T) {
 	s := NewSet()
 	assert.True(s.Type().Equals(MakeSetType(MakeUnionType())))
 
-	s = NewSet(Number(0))
+	s = NewSet(NewNumber(0))
 	assert.True(s.Type().Equals(MakeSetType(NumberType)))
 
-	s2 := s.Remove(Number(1))
+	s2 := s.Remove(NewNumber(1))
 	assert.True(s2.Type().Equals(MakeSetType(NumberType)))
 
-	s2 = s.Insert(Number(0), Number(1))
+	s2 = s.Insert(NewNumber(0), NewNumber(1))
 	assert.True(s.Type().Equals(s2.Type()))
 
 	s3 := s.Insert(Bool(true))
 	assert.True(s3.Type().Equals(MakeSetType(MakeUnionType(BoolType, NumberType))))
-	s4 := s.Insert(Number(3), Bool(true))
+	s4 := s.Insert(NewNumber(3), Bool(true))
 	assert.True(s4.Type().Equals(MakeSetType(MakeUnionType(BoolType, NumberType))))
 }
 
 func TestSetChunks(t *testing.T) {
 	assert := assert.New(t)
 
-	l1 := NewSet(Number(0))
+	l1 := NewSet(NewNumber(0))
 	c1 := l1.Chunks()
 	assert.Len(c1, 0)
 
-	l2 := NewSet(NewRef(Number(0)))
+	l2 := NewSet(NewRef(NewNumber(0)))
 	c2 := l2.Chunks()
 	assert.Len(c2, 1)
 }

--- a/types/struct_test.go
+++ b/types/struct_test.go
@@ -67,8 +67,8 @@ func TestGenericStructSet(t *testing.T) {
 	s := NewStruct("S3", map[string]Value{"b": Bool(true), "o": NewString("hi")})
 	s2 := s.Set("b", Bool(false))
 
-	assert.Panics(func() { s.Set("b", Number(1)) })
-	assert.Panics(func() { s.Set("x", Number(1)) })
+	assert.Panics(func() { s.Set("b", NewNumber(1)) })
+	assert.Panics(func() { s.Set("x", NewNumber(1)) })
 
 	s3 := s2.Set("b", Bool(true))
 	assert.True(s.Equals(s3))

--- a/types/util_test.go
+++ b/types/util_test.go
@@ -9,7 +9,7 @@ var generateNumbersAsValues = func(n int) []Value {
 	d.Chk.True(n > 0, "must be an integer greater than zero")
 	nums := []Value{}
 	for i := 0; i < n; i++ {
-		nums = append(nums, Number(i))
+		nums = append(nums, NewNumber(i))
 	}
 	return nums
 }
@@ -18,7 +18,7 @@ var generateNumbersAsStructs = func(n int) []Value {
 	d.Chk.True(n > 0, "must be an integer greater than zero")
 	nums := []Value{}
 	for i := 0; i < n; i++ {
-		nums = append(nums, NewStruct("num", structData{"n": Number(i)}))
+		nums = append(nums, NewStruct("num", structData{"n": NewNumber(i)}))
 	}
 	return nums
 }
@@ -28,7 +28,7 @@ var generateNumbersAsRefOfStructs = func(n int) []Value {
 	vs := NewTestValueStore()
 	nums := []Value{}
 	for i := 0; i < n; i++ {
-		r := vs.WriteValue(NewStruct("num", structData{"n": Number(i)}))
+		r := vs.WriteValue(NewStruct("num", structData{"n": NewNumber(i)}))
 		nums = append(nums, r)
 	}
 	return nums

--- a/types/write_value.go
+++ b/types/write_value.go
@@ -7,10 +7,6 @@ type ValueWriter interface {
 	WriteValue(v Value) Ref
 }
 
-type primitive interface {
-	ToPrimitive() interface{}
-}
-
 // EncodeValue takes a Value and encodes it to a Chunk, if |vw| is non-nill, it will vw.WriteValue reachable unwritten sub-chunks.
 func EncodeValue(v Value, vw ValueWriter) chunks.Chunk {
 	e := toEncodeable(v, vw)

--- a/types/xp_test.go
+++ b/types/xp_test.go
@@ -21,9 +21,9 @@ func newTestSuite() *testSuite {
 	testValues := []*testValue{
 		&testValue{Bool(true), "sha1-b6c4dd02a2f17ae9693627f03f642b988b4d5b63", "bool - true"},
 		&testValue{Bool(false), "sha1-dd1259720743f53a411788282c556662db14c758", "bool - false"},
-		&testValue{Number(-1), "sha1-4cff7171b2664044dc02d304e8aba7fc733681a0", "num - -1"},
-		&testValue{Number(0), "sha1-99b6938ab3aa497b1392fdbcb34b63bf4fe75c3c", "num - 0"},
-		&testValue{Number(1), "sha1-fef7b450ff9b1e5a34dbfa9702bb78ebff1c2730", "num - 1"},
+		&testValue{NewNumber(-1), "sha1-4cff7171b2664044dc02d304e8aba7fc733681a0", "num - -1"},
+		&testValue{NewNumber(0), "sha1-99b6938ab3aa497b1392fdbcb34b63bf4fe75c3c", "num - 0"},
+		&testValue{NewNumber(1), "sha1-fef7b450ff9b1e5a34dbfa9702bb78ebff1c2730", "num - 1"},
 		&testValue{NewString(""), "sha1-9f4895d88ceab0d09962d84f6d5a93d3451ae9a3", "str - empty"},
 		&testValue{NewString("0"), "sha1-e557fdd1c0b2661daac19b40446ffd4bafde793a", "str - 0"},
 		&testValue{NewString("false"), "sha1-9fe813b27cf8ae1ca5d258c5299caa4f749e86c4", "str - false"},


### PR DESCRIPTION
This does not change any of the output, serialization, digests or functionality, but does internally store noms Number as a golang math package *big.Float in memory. Serialization hasn't changed - it is writing a float64. This PR includes some changes for places where we were not using Value.Equals to compare Number types. The largest portion of the PR is updating tests to use NewNumber() instead of Number() - similar to NewString() usage. This PR is the golang side only and does not touch JS. 

This is meant to be an option for #1138 - bignum support in noms and to further that discussion. Consider it a proposal that if accepted would next move to creating a similar change in JS and then changing both JS and Go serialization to match and read/write full arbitrary precision numbers.

@rafael-atticlabs PTAL
