### PR TITLE
Make OrderedPutCache throw in browsers

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "32.0.0",
+  "version": "32.1.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",
@@ -55,6 +55,9 @@
     "./dist/es6/sha1.js": "./dist/es6/browser/sha1.js",
     "./src/utf8.js": "./src/browser/utf8.js",
     "./dist/commonjs/utf8.js": "./dist/commonjs/browser/utf8.js",
-    "./dist/es6/utf8.js": "./dist/es6/browser/utf8.js"
+    "./dist/es6/utf8.js": "./dist/es6/browser/utf8.js",
+    "./src/put-cache.js": "./src/browser/put-cache.js",
+    "./dist/commonjs/put-cache.js": "./dist/commonjs/browser/put-cache.js",
+    "./dist/es6/put-cache.js": "./dist/es6/browser/put-cache.js"
   }
 }

--- a/js/src/browser/put-cache.js
+++ b/js/src/browser/put-cache.js
@@ -1,0 +1,30 @@
+// @flow
+
+import type Chunk from '../chunk.js';
+
+type ChunkStream = (cb: (chunk: Chunk) => void) => Promise<void>
+
+const err = () => new Error('not implemented');
+const rej = () => Promise.reject(err());
+
+export default class OrderedPutCache {
+  append(): boolean {
+    throw err();
+  }
+
+  get(): ?Promise<Chunk> {
+    throw err();
+  }
+
+  dropUntil(): Promise<void> {
+    return rej();
+  }
+
+  extractChunks(): Promise<ChunkStream> {
+    return rej();
+  }
+
+  destroy(): Promise<void> {
+    return rej();
+  }
+}


### PR DESCRIPTION
This is a stop gap to ensure that the browser version does not depend
on nodejs modules.

Fixes #1531
