### PR TITLE
Make Splore Great Again!

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "32.1.0",
+  "version": "32.2.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/browser/put-cache.js
+++ b/js/src/browser/put-cache.js
@@ -13,7 +13,8 @@ export default class OrderedPutCache {
   }
 
   get(): ?Promise<Chunk> {
-    throw err();
+    // TODO: Implement
+    return null;
   }
 
   dropUntil(): Promise<void> {


### PR DESCRIPTION
Turned out that throwing in `get` was not a good idea. Returning null works better since that is used for "not present".
