### PR TITLE
updating to go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5
+- 1.6
 before_install:
 - npm version
 - nvm install stable
@@ -22,7 +22,6 @@ before_script:
 - popd
 script:
 - export GODEBUG=invalidptr=0
-- export GO15VENDOREXPERIMENT=1
 - go test `go list ./... | grep -v vendor`
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This repository contains two reference implementations of the noms protocol - on
 # Set environment variables
 
 * Ensure [`$GOPATH` is set correctly](https://golang.org/doc/code.html#GOPATH)
-* Set `GO15VENDOREXPERIMENT=1` in your environment - all our code requires this
 
 # Get the code
 


### PR DESCRIPTION
README.md was updated, but the travis builds were not. Go 1.6 has the GO15VENDOREXPERIMENT enabled by default.
