### PR TITLE
JS: In BatchStore, order outgoing chunks by ref-height

### DIFF
--- a/js/src/batch-store-test.js
+++ b/js/src/batch-store-test.js
@@ -14,7 +14,7 @@ suite('BatchStore', () => {
     const input = 'abc';
 
     const c = encodeNomsValue(input);
-    bs.schedulePut(c, new Set());
+    bs.schedulePut(c, 1, new Set());
 
     const chunk = await bs.get(c.ref);
     assert.isTrue(c.ref.equals(chunk.ref));
@@ -26,7 +26,7 @@ suite('BatchStore', () => {
     const input = 'abc';
 
     const c = encodeNomsValue(input);
-    bs.schedulePut(c, new Set());
+    bs.schedulePut(c, 1, new Set());
 
     let chunk = await bs.get(c.ref);
     assert.isTrue(c.ref.equals(chunk.ref));

--- a/js/src/database-test.js
+++ b/js/src/database-test.js
@@ -22,7 +22,7 @@ suite('Database', () => {
     const v1 = await ds.readValue(c.ref);
     assert.equal(null, v1);
 
-    bs.schedulePut(c, new Set());
+    bs.schedulePut(c, 1, new Set());
     bs.flush();
 
     const v2 = await ds.readValue(c.ref);

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -448,7 +448,7 @@ suite('Decode', () => {
       ], false, [],
       Kind.Number, '1']);
     const commitRef = commitChunk.ref;
-    bs.schedulePut(commitChunk, new Set());
+    bs.schedulePut(commitChunk, 1, new Set());
 
     // Root
     const rootChunk = makeChunk([
@@ -465,7 +465,7 @@ suite('Decode', () => {
       ],
     ]);
     const rootRef = rootChunk.ref;
-    bs.schedulePut(rootChunk, new Set());
+    bs.schedulePut(rootChunk, 2, new Set());
 
     await bs.flush();
     const rootMap = await ds.readValue(rootRef);

--- a/js/src/put-cache-test.js
+++ b/js/src/put-cache-test.js
@@ -7,32 +7,32 @@ import OrderedPutCache from './put-cache.js';
 import Chunk from './chunk.js';
 
 suite('OrderedPutCache', () => {
-  test('append', async () => {
+  test('insert', async () => {
     const canned = [Chunk.fromString('abc'), Chunk.fromString('def')];
     const cache = new OrderedPutCache();
-    assert.isTrue(cache.append(canned[0]));
-    assert.isTrue(cache.append(canned[1]));
+    assert.isTrue(cache.insert(canned[0], 1));
+    assert.isTrue(cache.insert(canned[1], 1));
     await cache.destroy();
   });
 
-  test('repeated append returns false', async () => {
+  test('repeated insert returns false', async () => {
     const canned = [Chunk.fromString('abc'), Chunk.fromString('def')];
     const cache = new OrderedPutCache();
-    assert.isTrue(cache.append(canned[0]));
-    assert.isTrue(cache.append(canned[1]));
-    assert.isFalse(cache.append(canned[0]));
+    assert.isTrue(cache.insert(canned[0], 1));
+    assert.isTrue(cache.insert(canned[1], 1));
+    assert.isFalse(cache.insert(canned[0], 1));
     await cache.destroy();
   });
 
   test('get', async () => {
     const canned = [Chunk.fromString('abc'), Chunk.fromString('def')];
     const cache = new OrderedPutCache();
-    assert.isTrue(cache.append(canned[0]));
+    assert.isTrue(cache.insert(canned[0], 1));
 
     let p = cache.get(canned[1].ref.toString());
     assert.isNull(p);
 
-    assert.isTrue(cache.append(canned[1]));
+    assert.isTrue(cache.insert(canned[1], 1));
     p = cache.get(canned[1].ref.toString());
     assert.isNotNull(p);
     const chunk = await notNull(p);
@@ -42,18 +42,23 @@ suite('OrderedPutCache', () => {
   });
 
   test('dropUntil', async () => {
-    const canned = [Chunk.fromString('abc'), Chunk.fromString('def'), Chunk.fromString('ghi')];
+    const canned = [Chunk.fromString('abc'), Chunk.fromString('def')];
     const cache = new OrderedPutCache();
     for (const chunk of canned) {
-      assert.isTrue(cache.append(chunk));
+      assert.isTrue(cache.insert(chunk, 1));
     }
+    const firstGen = cache.gen;
+    cache.gen++;
 
-    await cache.dropUntil(canned[1].ref.toString());
+    const extraChunk = Chunk.fromString('ghi');
+    assert.isTrue(cache.insert(extraChunk, 1));
 
-    let p = cache.get(canned[2].ref.toString());
+    await cache.dropGeneration(firstGen);
+
+    let p = cache.get(extraChunk.ref.toString());
     assert.isNotNull(p);
     const chunk = await notNull(p);
-    assert.isTrue(canned[2].ref.equals(chunk.ref));
+    assert.isTrue(extraChunk.ref.equals(chunk.ref));
 
     p = cache.get(canned[0].ref.toString());
     assert.isNull(p);
@@ -66,15 +71,39 @@ suite('OrderedPutCache', () => {
   test('extractChunks', async () => {
     const canned = [Chunk.fromString('abc'), Chunk.fromString('def'), Chunk.fromString('ghi')];
     const cache = new OrderedPutCache();
-    for (const chunk of canned) {
-      assert.isTrue(cache.append(chunk));
-    }
+    // Insert chunks with different refHeights, so we can be sure they come out in the right order.
+    assert.isTrue(cache.insert(canned[2], 1));
+    assert.isTrue(cache.insert(canned[0], 1));
+    assert.isTrue(cache.insert(canned[1], 2));
 
-    const chunkStream = await cache.extractChunks(canned[0].ref.toString(),
-      canned[2].ref.toString());
+    const chunkStream = await cache.extractChunks(cache.gen);
     const chunks = [];
     await chunkStream(chunk => { chunks.push(chunk); });
 
+    assert.isTrue(canned[2].ref.equals(chunks[0].ref));
+    assert.isTrue(canned[0].ref.equals(chunks[1].ref));
+    assert.isTrue(canned[1].ref.equals(chunks[2].ref));
+
+    await cache.destroy();
+  });
+
+  test('extractChunks one generation only', async () => {
+    const canned = [Chunk.fromString('abc'), Chunk.fromString('def'), Chunk.fromString('ghi')];
+    const cache = new OrderedPutCache();
+    for (const chunk of canned) {
+      assert.isTrue(cache.insert(chunk, 1));
+    }
+    const firstGen = cache.gen;
+    cache.gen++;
+
+    const extraChunk = Chunk.fromString('123');
+    assert.isTrue(cache.insert(extraChunk, 1));
+
+    const chunkStream = await cache.extractChunks(firstGen);
+    const chunks = [];
+    await chunkStream(chunk => { chunks.push(chunk); });
+
+    assert.equal(canned.length, chunks.length);
     for (let i = 0; i < canned.length; i++) {
       assert.isTrue(canned[i].ref.equals(chunks[i].ref));
     }

--- a/js/src/value-store.js
+++ b/js/src/value-store.js
@@ -81,12 +81,12 @@ export default class ValueStore {
       return refValue;
     }
     const hints = this._knownRefs.checkChunksInCache(v);
-    this._bs.schedulePut(chunk, hints);
+    this._bs.schedulePut(chunk, refValue.height, hints);
     this._knownRefs.add(ref, new RefCacheEntry(true, t));
     return refValue;
   }
 
-  async flush(): Promise<void> {
+  flush(): Promise<void> {
     return this._bs.flush();
   }
 


### PR DESCRIPTION
When handing a stream of chunks to a BatchStore Delegate for writing,
send them in ref-height order instead of insertion order. Only Chunks
that are put into the BatchStore _before_ the call to flush() wind up
in the stream. Calls to get() and schedulePut() are still allowed while
a flush is ongoing; newly put Chunks are guaranteed not to wind up in
the stream.

Fixes #1510
