### PR TITLE
JS: make sure we call close() on Database most of the time

### DIFF
--- a/js/src/batch-store-test.js
+++ b/js/src/batch-store-test.js
@@ -18,6 +18,7 @@ suite('BatchStore', () => {
 
     const chunk = await bs.get(c.ref);
     assert.isTrue(c.ref.equals(chunk.ref));
+    await bs.close();
   });
 
   test('get after schedulePut works after flush', async () => {
@@ -34,5 +35,6 @@ suite('BatchStore', () => {
     await bs.flush();
     chunk = await bs.get(c.ref);
     assert.isTrue(c.ref.equals(chunk.ref));
+    await bs.close();
   });
 });

--- a/js/src/batch-store.js
+++ b/js/src/batch-store.js
@@ -140,5 +140,7 @@ export default class BatchStore {
 
   // TODO: Should close() call flush() and block until it's done? Maybe closing with outstanding
   // requests should be an error on both sides. TBD.
-  close() {}
+  close(): Promise<void> {
+    return this._pendingWrites.destroy();
+  }
 }

--- a/js/src/compare-test.js
+++ b/js/src/compare-test.js
@@ -57,7 +57,7 @@ suite('compare.js', () => {
     });
 
     test('total ordering', async () => {
-      const ds = new Database(makeTestingBatchStore());
+      const db = new Database(makeTestingBatchStore());
 
       // values in increasing order. Some of these are compared by ref so changing the serialization
       // might change the ordering.
@@ -67,7 +67,7 @@ suite('compare.js', () => {
         'a', 'b', 'c',
 
         // The order of these are done by the hash.
-        ds.writeValue(10),
+        db.writeValue(10),
         await newSet([0, 1, 2, 3]),
         await newMap([[0, 1], [2, 3]]),
         boolType,
@@ -91,6 +91,7 @@ suite('compare.js', () => {
           }
         }
       }
+      await db.close();
     });
   });
 

--- a/js/src/database-test.js
+++ b/js/src/database-test.js
@@ -27,6 +27,7 @@ suite('Database', () => {
 
     const v2 = await ds.readValue(c.ref);
     assert.equal('abc', v2);
+    await ds.close();
   });
 
   test('commit', async () => {
@@ -101,6 +102,7 @@ suite('Database', () => {
     const newDs = new Database(bs);
     assert.strictEqual('d', notNull(await newDs.head(datasetID)).value);
     assert.strictEqual('a', notNull(await newDs.head('otherDs')).value);
+    await ds.close();
   });
 
   test('concurrency', async () => {
@@ -139,6 +141,7 @@ suite('Database', () => {
     }
     assert.strictEqual('Merge needed', message);
     assert.strictEqual('c', notNull(await ds.head(datasetID)).value);
+    await ds.close();
   });
 
 
@@ -146,6 +149,7 @@ suite('Database', () => {
     const ds = new Database(makeTestingBatchStore());
     const datasets = await ds.datasets();
     assert.strictEqual(0, datasets.size);
+    await ds.close();
   });
 
   test('head', async () => {
@@ -166,6 +170,7 @@ suite('Database', () => {
     assert.isTrue(equals(fooHead, commit));
     const barHead = await ds.head('bar');
     assert.isNull(barHead);
+    await ds.close();
   });
 
   test('height of refs', async () => {
@@ -177,6 +182,7 @@ suite('Database', () => {
     const r1 = ds.writeValue(v1);
     assert.strictEqual(2, r1.height);
     assert.strictEqual(3, ds.writeValue(r1).height);
+    await ds.close();
   });
 
   test('height of collections', async() => {
@@ -213,5 +219,6 @@ suite('Database', () => {
     assert.strictEqual(2, ds.writeValue(l4).height);
     const l5 = await newList([ds.writeValue(s1), s3]);
     assert.strictEqual(2, ds.writeValue(l5).height);
+    await ds.close();
   });
 });

--- a/js/src/database.js
+++ b/js/src/database.js
@@ -154,8 +154,8 @@ export default class Database {
     throw new Error('Optimistic lock failed');
   }
 
-  close() {
-    this._vs.close();
+  close(): Promise<void> {
+    return this._vs.close();
   }
 }
 

--- a/js/src/dataset-test.js
+++ b/js/src/dataset-test.js
@@ -57,5 +57,6 @@ suite('Dataset', () => {
     const newStore = new Database(bs);
     assert.strictEqual('d', notNull(await newStore.head('ds1')).value);
     assert.strictEqual('a', notNull(await newStore.head('otherDs')).value);
+    await newStore.close();
   });
 });

--- a/js/src/meta-sequence-test.js
+++ b/js/src/meta-sequence-test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {assert} from 'chai';
-import {suite, test} from 'mocha';
+import {suite, setup, teardown, test} from 'mocha';
 
 import {makeTestingBatchStore} from './batch-store-adaptor.js';
 import Database from './database.js';
@@ -13,11 +13,17 @@ import Set, {newSetLeafSequence} from './set.js';
 import {Kind} from './noms-kind.js';
 
 suite('MetaSequence', () => {
-  test('calculate ordered sequence MetaTuple height', async () => {
-    const ds = new Database(makeTestingBatchStore());
+  let db;
 
-    const set1 = new Set(newSetLeafSequence(ds, ['bar', 'baz']));
-    const set2 = new Set(newSetLeafSequence(ds, ['foo', 'qux', 'zoo']));
+  setup(() => {
+    db = new Database(makeTestingBatchStore());
+  });
+
+  teardown((): Promise<void> => db.close());
+
+  test('calculate ordered sequence MetaTuple height', async () => {
+    const set1 = new Set(newSetLeafSequence(db, ['bar', 'baz']));
+    const set2 = new Set(newSetLeafSequence(db, ['foo', 'qux', 'zoo']));
     const mt1 = new MetaTuple(new RefValue(set1), 'baz', 2, set1);
     const mt2 = new MetaTuple(new RefValue(set2), 'zoo', 3, set2);
 
@@ -34,10 +40,8 @@ suite('MetaSequence', () => {
   });
 
   test('calculate indexed sequence MetaTuple height', async () => {
-    const ds = new Database(makeTestingBatchStore());
-
-    const list1 = new List(newListLeafSequence(ds, ['bar', 'baz']));
-    const list2 = new List(newListLeafSequence(ds, ['foo', 'qux', 'zoo']));
+    const list1 = new List(newListLeafSequence(db, ['bar', 'baz']));
+    const list2 = new List(newListLeafSequence(db, ['foo', 'qux', 'zoo']));
     const mt1 = new MetaTuple(new RefValue(list1), 2, 2, list1);
     const mt2 = new MetaTuple(new RefValue(list2), 3, 3, list2);
 

--- a/js/src/put-cache.js
+++ b/js/src/put-cache.js
@@ -38,7 +38,9 @@ export default class OrderedPutCache {
   }
 
   _init(): Promise<DbCollection> {
+    // invariant(false === true);
     return makeTempDir().then((dir): Promise<DbCollection> => {
+      // console.log('creating', dir);
       this._folder = dir;
       const coll = new DbCollection(dir);
       return coll.ensureIndex({hash: 1}, {unique: true}).then(() => coll);

--- a/js/src/specs.js
+++ b/js/src/specs.js
@@ -92,6 +92,8 @@ export class DatasetSpec {
 
   // Returns the value at the HEAD of this dataset, if any, or null otherwise.
   value(): Promise<any> {
+    // Hm. Calling set() creates a Database that we then toss into the ether, which means we can't
+    // call close() on it. Ideally, we'd fix that.
     return this.set().head()
       .then(commit => commit && commit.value);
   }
@@ -135,7 +137,8 @@ export class RefSpec {
 
   // Returns the value for the spec'd reference, if any, or null otherwise.
   value(): Promise<any> {
-    return this.store.store().readValue(this.ref);
+    const store = this.store.store();
+    return store.readValue(this.ref).then(v => store.close().then(() => v));
   }
 }
 

--- a/js/src/struct-test.js
+++ b/js/src/struct-test.js
@@ -34,13 +34,14 @@ suite('Struct', () => {
   });
 
   test('chunks', () => {
-    const ds = new Database(makeTestingBatchStore());
+    const db = new Database(makeTestingBatchStore());
 
     const b = true;
-    const r = ds.writeValue(b);
+    const r = db.writeValue(b);
     const s1 = newStruct('S1', {r: r});
     assert.strictEqual(1, s1.chunks.length);
     assert.isTrue(equals(r, s1.chunks[0]));
+    return db.close();
   });
 
   test('new', () => {

--- a/js/src/test-util.js
+++ b/js/src/test-util.js
@@ -60,6 +60,7 @@ export async function testRoundTripAndValidate<T: valueOrPrimitive>(v: T,
     assert.strictEqual(v2, v);
   }
   await validateFn(v2);
+  await ds2.close();
 }
 
 export function chunkDiffCount(v1: valueOrPrimitive, v2: valueOrPrimitive): number {

--- a/js/src/type-test.js
+++ b/js/src/type-test.js
@@ -19,7 +19,7 @@ import {equals} from './compare.js';
 
 suite('Type', () => {
   test('types', async () => {
-    const ds = new Database(makeTestingBatchStore());
+    const db = new Database(makeTestingBatchStore());
 
     const mapType = makeMapType(stringType, numberType);
     const setType = makeSetType(stringType);
@@ -28,13 +28,14 @@ suite('Type', () => {
       'Field2': boolType,
     });
 
-    const mapRef = ds.writeValue(mapType).targetRef;
-    const setRef = ds.writeValue(setType).targetRef;
-    const mahRef = ds.writeValue(mahType).targetRef;
+    const mapRef = db.writeValue(mapType).targetRef;
+    const setRef = db.writeValue(setType).targetRef;
+    const mahRef = db.writeValue(mahType).targetRef;
 
-    assert.isTrue(equals(mapType, await ds.readValue(mapRef)));
-    assert.isTrue(equals(setType, await ds.readValue(setRef)));
-    assert.isTrue(equals(mahType, await ds.readValue(mahRef)));
+    assert.isTrue(equals(mapType, await db.readValue(mapRef)));
+    assert.isTrue(equals(setType, await db.readValue(setRef)));
+    assert.isTrue(equals(mahType, await db.readValue(mahRef)));
+    await db.close();
   });
 
   test('type Type', () => {

--- a/js/src/value-store-test.js
+++ b/js/src/value-store-test.js
@@ -30,6 +30,7 @@ suite('ValueStore', () => {
     ms.put(c);
     const v2 = await vs.readValue(c.ref);
     assert.equal('abc', v2);
+    await vs.close();
   });
 
   test('writeValue primitives', async () => {
@@ -45,6 +46,7 @@ suite('ValueStore', () => {
     assert.equal(false, v2);
     const v3 = await vs.readValue(r3);
     assert.equal(2, v3);
+    await vs.close();
   });
 
   test('writeValue rejects invalid', async () => {
@@ -62,6 +64,7 @@ suite('ValueStore', () => {
       ex = e;
     }
     assert.instanceOf(ex, Error);
+    await vs.close();
   });
 
   test('write coalescing', async () => {
@@ -72,6 +75,7 @@ suite('ValueStore', () => {
     (bs: any).schedulePut = () => { assert.fail('unreachable'); };
     const r2 = vs.writeValue('hello').targetRef;
     assert.isTrue(r1.equals(r2));
+    await vs.close();
   });
 
   test('read caching', async () => {
@@ -84,6 +88,7 @@ suite('ValueStore', () => {
     (bs: any).get = () => { throw new Error(); };
     const v2 = await vs.readValue(r1);
     assert.equal(v1, v2);
+    await vs.close();
   });
 
   test('caching eviction', async () => {
@@ -108,6 +113,7 @@ suite('ValueStore', () => {
       ex = e;
     }
     assert.instanceOf(ex, Error);
+    await vs.close();
   });
 
   test('hints on cache', async () => {
@@ -119,5 +125,6 @@ suite('ValueStore', () => {
 
     const v = await vs.readValue(r.targetRef);
     assert.isTrue(equals(l, v));
+    await vs.close();
   });
 });

--- a/js/src/value-store.js
+++ b/js/src/value-store.js
@@ -90,8 +90,8 @@ export default class ValueStore {
     return this._bs.flush();
   }
 
-  close() {
-    this._bs.close();
+  close(): Promise<void> {
+    return this._bs.close();
   }
 }
 

--- a/js/src/walk-test.js
+++ b/js/src/walk-test.js
@@ -16,13 +16,18 @@ import {newMap} from './map.js';
 import {newSet} from './set.js';
 import walk from './walk.js';
 
-import {suite, test} from 'mocha';
+import {suite, suiteSetup, suiteTeardown, test} from 'mocha';
 import {assert} from 'chai';
 
 import type {valueOrPrimitive} from './value.js';
 
 suite('walk', () => {
-  const ds = new Database(new BatchStoreAdaptor(new MemoryStore()));
+  let ds;
+  suiteSetup(() => {
+    ds = new Database(new BatchStoreAdaptor(new MemoryStore()));
+  });
+
+  suiteTeardown((): Promise<void> => ds.close());
 
   test('primitives', async () => {
     await Promise.all([true, false, 42, 88.8, 'hello!', ''].map(async v => {

--- a/js/src/xp-test.js
+++ b/js/src/xp-test.js
@@ -29,6 +29,7 @@ suite('cross platform test', () => {
     assert.strictEqual(v2, t._value, t._description);
     assert.strictEqual(t._value, v2, t._description);
     assert.strictEqual(t._expectedRef, r.targetRef.toString(), t._description);
+    return db.close();
   }
 
   async function testTypes(testValues: Array<TestValue>): Promise<void> {


### PR DESCRIPTION
Other than DatasetSpec::value(), this should close all Database
instances that we create. I'm not sure how to deal with that one
case, though.
