### PR TITLE
Rename valueOrPrimite to Value

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "33.0.0",
+  "version": "34.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/assert-type.js
+++ b/js/src/assert-type.js
@@ -5,7 +5,7 @@ import {CompoundDesc, getTypeOfValue} from './type.js';
 import type {Type} from './type.js';
 import {invariant} from './assert.js';
 import {equals} from './compare.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 
 /**
  * Ensures that the Noms value is a subtype of the Noms type. Throws a `TypeError` if not.
@@ -31,7 +31,7 @@ import type {valueOrPrimitive} from './value.js';
  * newStruct("S", {x: 42, y: true}) < struct S {x: Number}, extra fields OK.
  * ```
  */
-export default function assertSubtype(requiredType: Type, v: valueOrPrimitive): void {
+export default function assertSubtype(requiredType: Type, v: Value): void {
   assert(isSubtype(requiredType, getTypeOfValue(v)), v, requiredType);
 }
 

--- a/js/src/assert-type.js
+++ b/js/src/assert-type.js
@@ -5,7 +5,7 @@ import {CompoundDesc, getTypeOfValue} from './type.js';
 import type {Type} from './type.js';
 import {invariant} from './assert.js';
 import {equals} from './compare.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 
 /**
  * Ensures that the Noms value is a subtype of the Noms type. Throws a `TypeError` if not.

--- a/js/src/collection.js
+++ b/js/src/collection.js
@@ -3,9 +3,9 @@
 import RefValue from './ref-value.js';
 import type Sequence from './sequence.js'; // eslint-disable-line no-unused-vars
 import type {Type} from './type.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 
-export class Collection<S: Sequence> extends Value {
+export class Collection<S: Sequence> extends ValueBase {
   sequence: S;
 
   constructor(sequence: S) {

--- a/js/src/commit.js
+++ b/js/src/commit.js
@@ -3,12 +3,12 @@
 import {invariant} from './assert.js';
 import {getDatasTypes} from './database.js';
 import Struct from './struct.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import type RefValue from './ref-value.js';
 import Set from './set.js';
 
 
-export default class Commit<T: valueOrPrimitive> extends Struct {
+export default class Commit<T: Value> extends Struct {
   constructor(value: T, parents: Set<RefValue<Commit>> = new Set()) {
     const {commitType} = getDatasTypes();
     super(commitType, {value, parents});
@@ -20,7 +20,7 @@ export default class Commit<T: valueOrPrimitive> extends Struct {
     return value;
   }
 
-  setValue<U: valueOrPrimitive>(value: U): Commit<U> {
+  setValue<U: Value>(value: U): Commit<U> {
     return new Commit(value, this.parents);
   }
 

--- a/js/src/commit.js
+++ b/js/src/commit.js
@@ -3,7 +3,7 @@
 import {invariant} from './assert.js';
 import {getDatasTypes} from './database.js';
 import Struct from './struct.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import type RefValue from './ref-value.js';
 import Set from './set.js';
 

--- a/js/src/compare.js
+++ b/js/src/compare.js
@@ -1,11 +1,11 @@
 // @flow
 
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 
 // All Noms values are ordered. The ordering is booleans, numbers, strings and then Values.
 // All Value objects are ordered by their hash.
 
-export function compare(v1: valueOrPrimitive, v2: valueOrPrimitive): number {
+export function compare(v1: Value, v2: Value): number {
   const t1 = typeof v1;
   const t2 = typeof v2;
 
@@ -53,10 +53,10 @@ export function compare(v1: valueOrPrimitive, v2: valueOrPrimitive): number {
   }
 }
 
-export function less(v1: valueOrPrimitive, v2: valueOrPrimitive): boolean {
+export function less(v1: Value, v2: Value): boolean {
   return compare(v1, v2) < 0;
 }
 
-export function equals(v1: valueOrPrimitive, v2: valueOrPrimitive): boolean {
+export function equals(v1: Value, v2: Value): boolean {
   return compare(v1, v2) === 0;
 }

--- a/js/src/compare.js
+++ b/js/src/compare.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Value} from './value.js';
+import type Value from './value.js';
 
 // All Noms values are ordered. The ordering is booleans, numbers, strings and then Values.
 // All Value objects are ordered by their hash.

--- a/js/src/database.js
+++ b/js/src/database.js
@@ -4,7 +4,7 @@ import Ref from './ref.js';
 import RefValue from './ref-value.js';
 import Map from './map.js';
 import Set from './set.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import type {RootTracker} from './chunk-store.js';
 import ValueStore from './value-store.js';
 import BatchStore from './batch-store.js';

--- a/js/src/database.js
+++ b/js/src/database.js
@@ -4,7 +4,7 @@ import Ref from './ref.js';
 import RefValue from './ref-value.js';
 import Map from './map.js';
 import Set from './set.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import type {RootTracker} from './chunk-store.js';
 import ValueStore from './value-store.js';
 import BatchStore from './batch-store.js';
@@ -94,13 +94,13 @@ export default class Database {
     return this._datasets;
   }
 
-  // TODO: This should return Promise<?valueOrPrimitive>
+  // TODO: This should return Promise<?Value>
   async readValue(ref: Ref): Promise<any> {
     return this._vs.readValue(ref);
   }
 
 
-  writeValue<T: valueOrPrimitive>(v: T): RefValue<T> {
+  writeValue<T: Value>(v: T): RefValue<T> {
     return this._vs.writeValue(v);
   }
 

--- a/js/src/dataset.js
+++ b/js/src/dataset.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Commit from './commit.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import type Database from './database.js';
 import RefValue from './ref-value.js';
 import Set from './set.js';

--- a/js/src/dataset.js
+++ b/js/src/dataset.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Commit from './commit.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import type Database from './database.js';
 import RefValue from './ref-value.js';
 import Set from './set.js';
@@ -33,7 +33,7 @@ export default class Dataset {
 
   // Commit updates the commit that a dataset points at. If parents is provided then an the promise
   // is rejected if the commit does not descend from the parents.
-  async commit(v: valueOrPrimitive,
+  async commit(v: Value,
                parents: ?Array<RefValue<Commit>> = undefined): Promise<Dataset> {
     if (!parents) {
       const headRef = await this.headRef();

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -6,7 +6,7 @@ import {makeTestingBatchStore} from './batch-store-adaptor.js';
 import type RefValue from './ref-value.js';
 import Struct, {StructMirror} from './struct.js';
 import type {TypeDesc} from './type.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {assert} from 'chai';
 import {decodeNomsValue, JsonArrayReader} from './decode.js';
 import {

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -6,7 +6,7 @@ import {makeTestingBatchStore} from './batch-store-adaptor.js';
 import type RefValue from './ref-value.js';
 import Struct, {StructMirror} from './struct.js';
 import type {TypeDesc} from './type.js';
-import type {Value} from './value.js';
+import type {valueOrPrimitive} from './value.js';
 import {assert} from 'chai';
 import {decodeNomsValue, JsonArrayReader} from './decode.js';
 import {
@@ -124,7 +124,7 @@ suite('Decode', () => {
     const a = [Kind.List, Kind.Union, 3, Kind.Bool, Kind.Number, Kind.String, false,
       [Kind.Number, '1', Kind.String, 'hi', Kind.Bool, true]];
     const r = new JsonArrayReader(a, db);
-    const v: List<Value> = r.readValue();
+    const v: List<valueOrPrimitive> = r.readValue();
     invariant(v instanceof List);
 
     const tr = makeListType(makeUnionType([boolType, numberType, stringType]));
@@ -225,7 +225,7 @@ suite('Decode', () => {
       ],
     ];
     const r = new JsonArrayReader(a, db);
-    const v: Map<RefValue<Value>, number> = r.readValue();
+    const v: Map<RefValue<valueOrPrimitive>, number> = r.readValue();
     invariant(v instanceof Map);
 
     const m = new Map([[rv1, 2], [rv2, 4]]);

--- a/js/src/decode-test.js
+++ b/js/src/decode-test.js
@@ -6,7 +6,7 @@ import {makeTestingBatchStore} from './batch-store-adaptor.js';
 import type RefValue from './ref-value.js';
 import Struct, {StructMirror} from './struct.js';
 import type {TypeDesc} from './type.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {assert} from 'chai';
 import {decodeNomsValue, JsonArrayReader} from './decode.js';
 import {
@@ -124,7 +124,7 @@ suite('Decode', () => {
     const a = [Kind.List, Kind.Union, 3, Kind.Bool, Kind.Number, Kind.String, false,
       [Kind.Number, '1', Kind.String, 'hi', Kind.Bool, true]];
     const r = new JsonArrayReader(a, db);
-    const v: List<valueOrPrimitive> = r.readValue();
+    const v: List<Value> = r.readValue();
     invariant(v instanceof List);
 
     const tr = makeListType(makeUnionType([boolType, numberType, stringType]));
@@ -225,7 +225,7 @@ suite('Decode', () => {
       ],
     ];
     const r = new JsonArrayReader(a, db);
-    const v: Map<RefValue<valueOrPrimitive>, number> = r.readValue();
+    const v: Map<RefValue<Value>, number> = r.readValue();
     invariant(v instanceof Map);
 
     const m = new Map([[rv1, 2], [rv2, 4]]);

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -27,7 +27,7 @@ import {ListLeafSequence, newListFromSequence} from './list.js';
 import {MapLeafSequence, newMapFromSequence} from './map.js';
 import {SetLeafSequence, newSetFromSequence} from './set.js';
 import {IndexedMetaSequence, OrderedMetaSequence} from './meta-sequence.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import type {ValueReader} from './value-store.js';
 
 const typedTag = 't ';

--- a/js/src/decode.js
+++ b/js/src/decode.js
@@ -27,7 +27,7 @@ import {ListLeafSequence, newListFromSequence} from './list.js';
 import {MapLeafSequence, newMapFromSequence} from './map.js';
 import {SetLeafSequence, newSetFromSequence} from './set.js';
 import {IndexedMetaSequence, OrderedMetaSequence} from './meta-sequence.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import type {ValueReader} from './value-store.js';
 
 const typedTag = 't ';
@@ -268,7 +268,7 @@ export class JsonArrayReader {
     const {desc} = type;
     invariant(desc instanceof StructDesc);
 
-    const data: {[key: string]: valueOrPrimitive} = Object.create(null);
+    const data: {[key: string]: Value} = Object.create(null);
 
     desc.forEachField((name: string) => {
       const v = this.readValue();
@@ -300,7 +300,7 @@ export class JsonArrayReader {
   }
 }
 
-export function decodeNomsValue(chunk: Chunk, vr: ValueReader): valueOrPrimitive {
+export function decodeNomsValue(chunk: Chunk, vr: ValueReader): Value {
   const tag = new Chunk(new Uint8Array(chunk.data.buffer, 0, 2)).toString();
 
   switch (tag) {

--- a/js/src/encode-human-readable.js
+++ b/js/src/encode-human-readable.js
@@ -5,7 +5,7 @@ import type {Type} from './type.js';
 import {Kind, kindToString} from './noms-kind.js';
 import type {NomsKind} from './noms-kind.js';
 import {invariant} from './assert.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 
 export interface StringWriter {
   write(s: string): void;

--- a/js/src/encode-human-readable.js
+++ b/js/src/encode-human-readable.js
@@ -5,7 +5,7 @@ import type {Type} from './type.js';
 import {Kind, kindToString} from './noms-kind.js';
 import type {NomsKind} from './noms-kind.js';
 import {invariant} from './assert.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 
 export interface StringWriter {
   write(s: string): void;
@@ -157,7 +157,7 @@ export function describeType(t: Type): string {
   return s;
 }
 
-export function describeTypeOfValue(v: valueOrPrimitive): string {
+export function describeTypeOfValue(v: Value): string {
   if (v === null) {
     return 'null';
   }

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -29,7 +29,7 @@ import {newMapFromSequence, newMapLeafSequence} from './map.js';
 import {newSetFromSequence, newSetLeafSequence} from './set.js';
 import Blob from './blob.js';
 import Database from './database.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 
 suite('Encode', () => {
   let db;
@@ -41,7 +41,7 @@ suite('Encode', () => {
   teardown((): Promise<void> => db.close());
 
   test('write primitives', () => {
-    function f(k: NomsKind, v: valueOrPrimitive, ex: valueOrPrimitive) {
+    function f(k: NomsKind, v: Value, ex: Value) {
       const w = new JsonArrayWriter(db);
       w.writeValue(v);
       assert.deepEqual([k, ex], w.array);

--- a/js/src/encode-test.js
+++ b/js/src/encode-test.js
@@ -29,7 +29,7 @@ import {newMapFromSequence, newMapLeafSequence} from './map.js';
 import {newSetFromSequence, newSetLeafSequence} from './set.js';
 import Blob from './blob.js';
 import Database from './database.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 
 suite('Encode', () => {
   let db;

--- a/js/src/encode.js
+++ b/js/src/encode.js
@@ -17,7 +17,7 @@ import {setEncodeNomsValue} from './get-ref.js';
 import Blob, {BlobLeafSequence} from './blob.js';
 import {describeTypeOfValue} from './encode-human-readable.js';
 import type {primitive} from './primitives.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import type {ValueWriter} from './value-store.js';
 
 const typedTag = 't ';

--- a/js/src/encode.js
+++ b/js/src/encode.js
@@ -17,7 +17,7 @@ import {setEncodeNomsValue} from './get-ref.js';
 import Blob, {BlobLeafSequence} from './blob.js';
 import {describeTypeOfValue} from './encode-human-readable.js';
 import type {primitive} from './primitives.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import type {ValueWriter} from './value-store.js';
 
 const typedTag = 't ';
@@ -117,7 +117,7 @@ export class JsonArrayWriter {
     return true;
   }
 
-  writeValue(v: valueOrPrimitive) {
+  writeValue(v: Value) {
     const t = getTypeOfValue(v);
     this.writeType(t, []);
     switch (t.kind) {
@@ -260,7 +260,7 @@ export class JsonArrayWriter {
   }
 }
 
-function encodeEmbeddedNomsValue(v: valueOrPrimitive, vw: ?ValueWriter): Chunk {
+function encodeEmbeddedNomsValue(v: Value, vw: ?ValueWriter): Chunk {
   const w = new JsonArrayWriter(vw);
   w.writeValue(v);
   return Chunk.fromString(typedTag + JSON.stringify(w.array));
@@ -279,7 +279,7 @@ function encodeTopLevelBlob(sequence: BlobLeafSequence): Chunk {
   return new Chunk(data);
 }
 
-export function encodeNomsValue(v: valueOrPrimitive, vw: ?ValueWriter): Chunk {
+export function encodeNomsValue(v: Value, vw: ?ValueWriter): Chunk {
   const t = getTypeOfValue(v);
   if (t.kind === Kind.Blob) {
     invariant(v instanceof Blob);

--- a/js/src/get-ref.js
+++ b/js/src/get-ref.js
@@ -6,13 +6,13 @@ import type {ValueWriter} from './value-store.js';
 import {notNull} from './assert.js';
 import type {valueOrPrimitive} from './value.js';
 import {getTypeOfValue} from './type.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 
 type encodeFn = (v: valueOrPrimitive, vw: ?ValueWriter) => Chunk;
 let encodeNomsValue: ?encodeFn = null;
 
 export function getRefOfValue(v: valueOrPrimitive): Ref {
-  if (v instanceof Value) {
+  if (v instanceof ValueBase) {
     return v.ref;
   }
 

--- a/js/src/get-ref.js
+++ b/js/src/get-ref.js
@@ -4,14 +4,14 @@ import type Chunk from './chunk.js';
 import type Ref from './ref.js';
 import type {ValueWriter} from './value-store.js';
 import {notNull} from './assert.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {getTypeOfValue} from './type.js';
 import {ValueBase} from './value.js';
 
-type encodeFn = (v: valueOrPrimitive, vw: ?ValueWriter) => Chunk;
+type encodeFn = (v: Value, vw: ?ValueWriter) => Chunk;
 let encodeNomsValue: ?encodeFn = null;
 
-export function getRefOfValue(v: valueOrPrimitive): Ref {
+export function getRefOfValue(v: Value): Ref {
   if (v instanceof ValueBase) {
     return v.ref;
   }
@@ -19,11 +19,11 @@ export function getRefOfValue(v: valueOrPrimitive): Ref {
   return getRef(v, getTypeOfValue(v));
 }
 
-export function getRef(v: valueOrPrimitive): Ref {
+export function getRef(v: Value): Ref {
   return notNull(encodeNomsValue)(v, null).ref;
 }
 
-export function ensureRef(r: ?Ref, v: valueOrPrimitive): Ref {
+export function ensureRef(r: ?Ref, v: Value): Ref {
   if (r !== null && r !== undefined && !r.isEmpty()) {
     return r;
   }

--- a/js/src/get-ref.js
+++ b/js/src/get-ref.js
@@ -4,7 +4,7 @@ import type Chunk from './chunk.js';
 import type Ref from './ref.js';
 import type {ValueWriter} from './value-store.js';
 import {notNull} from './assert.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {getTypeOfValue} from './type.js';
 import {ValueBase} from './value.js';
 

--- a/js/src/list.js
+++ b/js/src/list.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type {ValueReader} from './value-store.js';
 import type {Splice} from './edit-distance.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import type {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import {Collection} from './collection.js';

--- a/js/src/list.js
+++ b/js/src/list.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type {ValueReader} from './value-store.js';
 import type {Splice} from './edit-distance.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 import type {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import {Collection} from './collection.js';
@@ -24,7 +24,7 @@ import {Kind} from './noms-kind.js';
 const listWindowSize = 64;
 const listPattern = ((1 << 6) | 0) - 1;
 
-function newListLeafChunkFn<T: valueOrPrimitive>(vr: ?ValueReader): makeChunkFn {
+function newListLeafChunkFn<T: Value>(vr: ?ValueReader): makeChunkFn {
   return (items: Array<T>) => {
     const list = newListFromSequence(newListLeafSequence(vr, items));
     const mt = new MetaTuple(new RefValue(list), items.length, items.length, list);
@@ -32,13 +32,13 @@ function newListLeafChunkFn<T: valueOrPrimitive>(vr: ?ValueReader): makeChunkFn 
   };
 }
 
-function newListLeafBoundaryChecker<T: valueOrPrimitive>(): BoundaryChecker<T> {
+function newListLeafBoundaryChecker<T: Value>(): BoundaryChecker<T> {
   return new BuzHashBoundaryChecker(listWindowSize, sha1Size, listPattern,
     (v: T) => getRefOfValue(v).digest
   );
 }
 
-export default class List<T: valueOrPrimitive> extends Collection<IndexedSequence> {
+export default class List<T: Value> extends Collection<IndexedSequence> {
   constructor(values: Array<T> = []) {
     const self = chunkSequenceSync(
         values,
@@ -125,14 +125,14 @@ export default class List<T: valueOrPrimitive> extends Collection<IndexedSequenc
   }
 }
 
-export function newListFromSequence<T: valueOrPrimitive>(sequence: IndexedSequence): List<T> {
+export function newListFromSequence<T: Value>(sequence: IndexedSequence): List<T> {
   const list = Object.create(List.prototype);
   list._ref = null; // Value
   list.sequence = sequence;
   return list;
 }
 
-export class ListLeafSequence<T: valueOrPrimitive> extends IndexedSequence<T> {
+export class ListLeafSequence<T: Value> extends IndexedSequence<T> {
   get chunks(): Array<RefValue> {
     return getValueChunks(this.items);
   }
@@ -147,7 +147,7 @@ export class ListLeafSequence<T: valueOrPrimitive> extends IndexedSequence<T> {
   }
 }
 
-export function newListLeafSequence<T: valueOrPrimitive>(vr: ?ValueReader, items: T[]):
+export function newListLeafSequence<T: Value>(vr: ?ValueReader, items: T[]):
     ListLeafSequence<T> {
   const t = makeListType(makeUnionType(items.map(getTypeOfValue)));
   return new ListLeafSequence(vr, t, items);

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import RefValue from './ref-value.js';
 import type {ValueReader} from './value-store.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import type {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import {Collection} from './collection.js';

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -17,7 +17,7 @@ import {MetaTuple, newOrderedMetaSequenceBoundaryChecker, newOrderedMetaSequence
 import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator,} from
   './ordered-sequence.js';
 import diff from './ordered-sequence-diff.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 import {Kind} from './noms-kind.js';
 
 export type MapEntry<K: valueOrPrimitive, V: valueOrPrimitive> = [K, V];
@@ -34,7 +34,7 @@ function newMapLeafChunkFn<K: valueOrPrimitive, V: valueOrPrimitive>(vr: ?ValueR
     let indexValue: ?valueOrPrimitive = null;
     if (items.length > 0) {
       indexValue = items[items.length - 1][KEY];
-      if (indexValue instanceof Value) {
+      if (indexValue instanceof ValueBase) {
         indexValue = new RefValue(indexValue);
       }
     }
@@ -207,10 +207,10 @@ export class MapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive> extends
   get chunks(): Array<RefValue> {
     const chunks = [];
     for (const entry of this.items) {
-      if (entry[KEY] instanceof Value) {
+      if (entry[KEY] instanceof ValueBase) {
         chunks.push(...entry[KEY].chunks);
       }
-      if (entry[VALUE] instanceof Value) {
+      if (entry[VALUE] instanceof ValueBase) {
         chunks.push(...entry[VALUE].chunks);
       }
     }

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import RefValue from './ref-value.js';
 import type {ValueReader} from './value-store.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 import type {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import {Collection} from './collection.js';
@@ -20,7 +20,7 @@ import diff from './ordered-sequence-diff.js';
 import {ValueBase} from './value.js';
 import {Kind} from './noms-kind.js';
 
-export type MapEntry<K: valueOrPrimitive, V: valueOrPrimitive> = [K, V];
+export type MapEntry<K: Value, V: Value> = [K, V];
 
 const KEY = 0;
 const VALUE = 1;
@@ -28,10 +28,10 @@ const VALUE = 1;
 const mapWindowSize = 1;
 const mapPattern = ((1 << 6) | 0) - 1;
 
-function newMapLeafChunkFn<K: valueOrPrimitive, V: valueOrPrimitive>(vr: ?ValueReader):
+function newMapLeafChunkFn<K: Value, V: Value>(vr: ?ValueReader):
     makeChunkFn {
   return (items: Array<MapEntry<K, V>>) => {
-    let indexValue: ?valueOrPrimitive = null;
+    let indexValue: ?Value = null;
     if (items.length > 0) {
       indexValue = items[items.length - 1][KEY];
       if (indexValue instanceof ValueBase) {
@@ -45,7 +45,7 @@ function newMapLeafChunkFn<K: valueOrPrimitive, V: valueOrPrimitive>(vr: ?ValueR
   };
 }
 
-function newMapLeafBoundaryChecker<K: valueOrPrimitive, V: valueOrPrimitive>():
+function newMapLeafBoundaryChecker<K: Value, V: Value>():
     BoundaryChecker<MapEntry<K, V>> {
   return new BuzHashBoundaryChecker(mapWindowSize, sha1Size, mapPattern,
     (entry: MapEntry<K, V>) => getRefOfValue(entry[KEY]).digest);
@@ -72,7 +72,7 @@ function compareKeys(v1, v2) {
   return compare(v1[KEY], v2[KEY]);
 }
 
-function buildMapData<K: valueOrPrimitive, V: valueOrPrimitive>(
+function buildMapData<K: Value, V: Value>(
     kvs: Array<MapEntry<K, V>>): Array<MapEntry<K, V>> {
   // TODO: Assert k & v are of correct type
   const entries = kvs.slice();
@@ -80,7 +80,7 @@ function buildMapData<K: valueOrPrimitive, V: valueOrPrimitive>(
   return removeDuplicateFromOrdered(entries, compareKeys);
 }
 
-export default class Map<K: valueOrPrimitive, V: valueOrPrimitive> extends
+export default class Map<K: Value, V: Value> extends
     Collection<OrderedSequence> {
   constructor(kvs: Array<MapEntry<K, V>> = []) {
     const self = chunkSequenceSync(
@@ -185,7 +185,7 @@ export default class Map<K: valueOrPrimitive, V: valueOrPrimitive> extends
   }
 }
 
-export function newMapFromSequence<K: valueOrPrimitive, V: valueOrPrimitive>(
+export function newMapFromSequence<K: Value, V: Value>(
     sequence: OrderedSequence): Map<K, V> {
   const map = Object.create(Map.prototype);
   map._ref = null; // Value
@@ -193,7 +193,7 @@ export function newMapFromSequence<K: valueOrPrimitive, V: valueOrPrimitive>(
   return map;
 }
 
-export class MapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive> extends
+export class MapLeafSequence<K: Value, V: Value> extends
     OrderedSequence<K, MapEntry<K, V>> {
   getKey(idx: number): K {
     return this.items[idx][KEY];
@@ -218,7 +218,7 @@ export class MapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive> extends
   }
 }
 
-export function newMapLeafSequence<K: valueOrPrimitive, V: valueOrPrimitive>(vr: ?ValueReader,
+export function newMapLeafSequence<K: Value, V: Value>(vr: ?ValueReader,
     items: Array<MapEntry<K, V>>): MapLeafSequence<K, V> {
   const kt = [];
   const vt = [];

--- a/js/src/meta-sequence.js
+++ b/js/src/meta-sequence.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import {sha1Size} from './ref.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type {ValueReader} from './value-store.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import type {Collection} from './collection.js';
 import type {Type} from './type.js';
 import {makeListType, makeUnionType, blobType, makeSetType, makeMapType} from './type.js';

--- a/js/src/meta-sequence.js
+++ b/js/src/meta-sequence.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import {sha1Size} from './ref.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type {ValueReader} from './value-store.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 import type {Collection} from './collection.js';
 import type {Type} from './type.js';
 import {makeListType, makeUnionType, blobType, makeSetType, makeMapType} from './type.js';
@@ -143,7 +143,7 @@ export class IndexedMetaSequence extends IndexedSequence<MetaTuple<number>> {
   }
 }
 
-export function newMapMetaSequence<K: valueOrPrimitive>(vr: ?ValueReader,
+export function newMapMetaSequence<K: Value>(vr: ?ValueReader,
     tuples: Array<MetaTuple<K>>): OrderedMetaSequence<K> {
   const kt = makeUnionType(tuples.map(mt => getCollectionTypes(mt)[0]));
   const vt = makeUnionType(tuples.map(mt => getCollectionTypes(mt)[1]));
@@ -151,13 +151,13 @@ export function newMapMetaSequence<K: valueOrPrimitive>(vr: ?ValueReader,
   return new OrderedMetaSequence(vr, t, tuples);
 }
 
-export function newSetMetaSequence<K: valueOrPrimitive>(vr: ?ValueReader,
+export function newSetMetaSequence<K: Value>(vr: ?ValueReader,
     tuples: Array<MetaTuple<K>>): OrderedMetaSequence<K> {
   const t = makeSetType(makeUnionType(tuples.map(mt => getCollectionTypes(mt)[0])));
   return new OrderedMetaSequence(vr, t, tuples);
 }
 
-export class OrderedMetaSequence<K: valueOrPrimitive> extends OrderedSequence<K, MetaTuple<K>> {
+export class OrderedMetaSequence<K: Value> extends OrderedSequence<K, MetaTuple<K>> {
   _numLeaves: number;
 
   constructor(vr: ?ValueReader, t: Type, items: Array<MetaTuple<K>>) {

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -54,6 +54,6 @@ export type {AsyncIteratorResult} from './async-iterator.js';
 export type {ChunkStore} from './chunk-store.js';
 export type {MapEntry} from './map.js';
 export type {Splice} from './edit-distance.js';
-export type {Value, ValueBase} from './value.js';
+export type {default as Value, ValueBase} from './value.js';
 export type {NomsKind} from './noms-kind.js';
 export type {primitive} from './primitives.js';

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -54,6 +54,6 @@ export type {AsyncIteratorResult} from './async-iterator.js';
 export type {ChunkStore} from './chunk-store.js';
 export type {MapEntry} from './map.js';
 export type {Splice} from './edit-distance.js';
-export type {valueOrPrimitive, Value} from './value.js';
+export type {valueOrPrimitive, ValueBase} from './value.js';
 export type {NomsKind} from './noms-kind.js';
 export type {primitive} from './primitives.js';

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -54,6 +54,6 @@ export type {AsyncIteratorResult} from './async-iterator.js';
 export type {ChunkStore} from './chunk-store.js';
 export type {MapEntry} from './map.js';
 export type {Splice} from './edit-distance.js';
-export type {valueOrPrimitive, ValueBase} from './value.js';
+export type {Value, ValueBase} from './value.js';
 export type {NomsKind} from './noms-kind.js';
 export type {primitive} from './primitives.js';

--- a/js/src/ordered-sequence-diff.js
+++ b/js/src/ordered-sequence-diff.js
@@ -4,7 +4,7 @@ import {invariant} from './assert.js';
 import {equals, less} from './compare.js';
 import {OrderedSequence, OrderedSequenceCursor} from './ordered-sequence.js';
 import {SequenceCursor} from './sequence.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 
 // TODO: Expose an iteration API.
 

--- a/js/src/ordered-sequence-diff.js
+++ b/js/src/ordered-sequence-diff.js
@@ -4,14 +4,14 @@ import {invariant} from './assert.js';
 import {equals, less} from './compare.js';
 import {OrderedSequence, OrderedSequenceCursor} from './ordered-sequence.js';
 import {SequenceCursor} from './sequence.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 
 // TODO: Expose an iteration API.
 
 /**
  * Returns a 3-tuple [added, removed, modified] sorted keys.
  */
-export default async function diff<K: valueOrPrimitive, T>(
+export default async function diff<K: Value, T>(
     last: OrderedSequence<K, T>, current: OrderedSequence<K, T>):
     Promise<[Array<K>, Array<K>, Array<K>]> {
   // TODO: Construct the cursor at exactly the right position. There is no point reading in the

--- a/js/src/ordered-sequence.js
+++ b/js/src/ordered-sequence.js
@@ -6,7 +6,7 @@ import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unus
 import {invariant, notNull} from './assert.js';
 import {compare} from './compare.js';
 import Sequence, {search, SequenceCursor} from './sequence.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 
 export class OrderedSequence<K: valueOrPrimitive, T> extends Sequence<T> {
   // Returns:
@@ -124,10 +124,10 @@ export class OrderedSequenceIterator<T, K: valueOrPrimitive> extends AsyncIterat
 function getSearchFunction(sequence: OrderedSequence, key: valueOrPrimitive):
     (i: number) => number {
   if (sequence.isMeta) {
-    const keyRef = key instanceof Value ? key.ref : null;
+    const keyRef = key instanceof ValueBase ? key.ref : null;
     return i => {
       const sk = sequence.getKey(i);
-      if (sk instanceof Value) {
+      if (sk instanceof ValueBase) {
         if (keyRef) {
           return sk.targetRef.compare(keyRef);
         }

--- a/js/src/ordered-sequence.js
+++ b/js/src/ordered-sequence.js
@@ -2,7 +2,7 @@
 
 import {AsyncIterator} from './async-iterator.js';
 import type {AsyncIteratorResult} from './async-iterator.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import {invariant, notNull} from './assert.js';
 import {compare} from './compare.js';
 import Sequence, {search, SequenceCursor} from './sequence.js';

--- a/js/src/ordered-sequence.js
+++ b/js/src/ordered-sequence.js
@@ -2,13 +2,13 @@
 
 import {AsyncIterator} from './async-iterator.js';
 import type {AsyncIteratorResult} from './async-iterator.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 import {invariant, notNull} from './assert.js';
 import {compare} from './compare.js';
 import Sequence, {search, SequenceCursor} from './sequence.js';
 import {ValueBase} from './value.js';
 
-export class OrderedSequence<K: valueOrPrimitive, T> extends Sequence<T> {
+export class OrderedSequence<K: Value, T> extends Sequence<T> {
   // Returns:
   //   -null, if sequence is empty.
   //   -null, if all values in sequence are < key.
@@ -50,7 +50,7 @@ export class OrderedSequence<K: valueOrPrimitive, T> extends Sequence<T> {
   }
 }
 
-export class OrderedSequenceCursor<T, K: valueOrPrimitive> extends
+export class OrderedSequenceCursor<T, K: Value> extends
     SequenceCursor<T, OrderedSequence> {
   getCurrentKey(): K {
     invariant(this.idx >= 0 && this.idx < this.length);
@@ -104,7 +104,7 @@ export class OrderedSequenceCursor<T, K: valueOrPrimitive> extends
   }
 }
 
-export class OrderedSequenceIterator<T, K: valueOrPrimitive> extends AsyncIterator<T> {
+export class OrderedSequenceIterator<T, K: Value> extends AsyncIterator<T> {
   _iterator: Promise<AsyncIterator<T>>;
 
   constructor(cursorP: Promise<OrderedSequenceCursor<T, K>>) {
@@ -121,7 +121,7 @@ export class OrderedSequenceIterator<T, K: valueOrPrimitive> extends AsyncIterat
   }
 }
 
-function getSearchFunction(sequence: OrderedSequence, key: valueOrPrimitive):
+function getSearchFunction(sequence: OrderedSequence, key: Value):
     (i: number) => number {
   if (sequence.isMeta) {
     const keyRef = key instanceof ValueBase ? key.ref : null;

--- a/js/src/path-test.js
+++ b/js/src/path-test.js
@@ -5,14 +5,14 @@ import {suite, test} from 'mocha';
 import {equals} from './compare.js';
 
 import Path from './path.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import List from './list.js';
 import Map from './map.js';
 import {newStruct} from './struct.js';
 
 suite('Path', () => {
 
-  async function assertPathEqual(expect: any, ref: valueOrPrimitive, path: Path):
+  async function assertPathEqual(expect: any, ref: Value, path: Path):
       Promise<void> {
     // $FlowIssue: need to be able to pass in null for ref
     const actual = await path.resolve(ref);

--- a/js/src/path-test.js
+++ b/js/src/path-test.js
@@ -5,7 +5,7 @@ import {suite, test} from 'mocha';
 import {equals} from './compare.js';
 
 import Path from './path.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import List from './list.js';
 import Map from './map.js';
 import {newStruct} from './struct.js';

--- a/js/src/path.js
+++ b/js/src/path.js
@@ -1,12 +1,12 @@
 // @flow
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {Kind} from './noms-kind.js';
 import List from './list.js';
 import Map from './map.js';
 import {getTypeOfValue, StructDesc} from './type.js';
 
 interface Part {
-  resolve(v: Promise<?valueOrPrimitive>): Promise<?valueOrPrimitive>;
+  resolve(v: Promise<?Value>): Promise<?Value>;
   toString(): string;
 }
 
@@ -17,7 +17,7 @@ class FieldPart {
     this.name = name;
   }
 
-  resolve(v: Promise<?valueOrPrimitive>): Promise<?valueOrPrimitive> {
+  resolve(v: Promise<?Value>): Promise<?Value> {
     return v.then(value => {
       if (value === null || value === undefined) {
         return;
@@ -62,7 +62,7 @@ class IndexPart {
     }
   }
 
-  resolve(v: Promise<?valueOrPrimitive>): Promise<?valueOrPrimitive> {
+  resolve(v: Promise<?Value>): Promise<?Value> {
     return v.then(value => {
       if (value === null || value === undefined) {
         return;
@@ -121,7 +121,7 @@ export default class Path {
     return this._addPart(new IndexPart(idx));
   }
 
-  resolve(v: valueOrPrimitive): Promise<?valueOrPrimitive> {
+  resolve(v: Value): Promise<?Value> {
     return this._parts.reduce((v, p) => p.resolve(v), Promise.resolve(v));
   }
 

--- a/js/src/path.js
+++ b/js/src/path.js
@@ -1,5 +1,5 @@
 // @flow
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {Kind} from './noms-kind.js';
 import List from './list.js';
 import Map from './map.js';

--- a/js/src/ref-value.js
+++ b/js/src/ref-value.js
@@ -6,7 +6,7 @@ import {getRefOfValue} from './get-ref.js';
 import {Kind} from './noms-kind.js';
 import type Ref from './ref.js';
 import type {Type} from './type.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 import {invariant} from './assert.js';
 import {getTypeOfValue, makeRefType} from './type.js';
 import {ValueBase, getChunksOfValue} from './value.js';
@@ -22,7 +22,7 @@ export function constructRefValue(t: Type, targetRef: Ref, height: number): RefV
   return rv;
 }
 
-export default class RefValue<T: valueOrPrimitive> extends ValueBase {
+export default class RefValue<T: Value> extends ValueBase {
   _type: Type;
   // Ref of the value this points to.
   targetRef: Ref;

--- a/js/src/ref-value.js
+++ b/js/src/ref-value.js
@@ -9,7 +9,7 @@ import type {Type} from './type.js';
 import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
 import {invariant} from './assert.js';
 import {getTypeOfValue, makeRefType} from './type.js';
-import {Value, getChunksOfValue} from './value.js';
+import {ValueBase, getChunksOfValue} from './value.js';
 
 export function constructRefValue(t: Type, targetRef: Ref, height: number): RefValue {
   invariant(t.kind === Kind.Ref, () => `Not a Ref type: ${describeType(t)}`);
@@ -22,7 +22,7 @@ export function constructRefValue(t: Type, targetRef: Ref, height: number): RefV
   return rv;
 }
 
-export default class RefValue<T: valueOrPrimitive> extends Value {
+export default class RefValue<T: valueOrPrimitive> extends ValueBase {
   _type: Type;
   // Ref of the value this points to.
   targetRef: Ref;

--- a/js/src/ref-value.js
+++ b/js/src/ref-value.js
@@ -6,7 +6,7 @@ import {getRefOfValue} from './get-ref.js';
 import {Kind} from './noms-kind.js';
 import type Ref from './ref.js';
 import type {Type} from './type.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import {invariant} from './assert.js';
 import {getTypeOfValue, makeRefType} from './type.js';
 import {ValueBase, getChunksOfValue} from './value.js';

--- a/js/src/sequence.js
+++ b/js/src/sequence.js
@@ -6,7 +6,7 @@ import {AsyncIterator} from './async-iterator.js';
 import type {AsyncIteratorResult} from './async-iterator.js';
 import RefValue from './ref-value.js';
 import type {Type} from './type.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 
 export default class Sequence<T> {
   vr: ?ValueReader;
@@ -296,7 +296,7 @@ export function search(length: number, compare: (i: number) => number): number {
 export function getValueChunks<T>(items: Array<T>): Array<RefValue> {
   const chunks = [];
   for (const item of items) {
-    if (item instanceof Value) {
+    if (item instanceof ValueBase) {
       chunks.push(...item.chunks);
     }
   }

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import RefValue from './ref-value.js';
 import type {ValueReader} from './value-store.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
-import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import {ValueBase} from './value.js';
 import {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -4,7 +4,7 @@ import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import RefValue from './ref-value.js';
 import type {ValueReader} from './value-store.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
-import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
+import type {Value} from './value.js'; // eslint-disable-line no-unused-vars
 import {ValueBase} from './value.js';
 import {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
@@ -26,7 +26,7 @@ import {Kind} from './noms-kind.js';
 const setWindowSize = 1;
 const setPattern = ((1 << 6) | 0) - 1;
 
-function newSetLeafChunkFn<T:valueOrPrimitive>(vr: ?ValueReader): makeChunkFn {
+function newSetLeafChunkFn<T:Value>(vr: ?ValueReader): makeChunkFn {
   return (items: Array<T>) => {
     let indexValue: ?(T | RefValue) = null;
     if (items.length > 0) {
@@ -42,26 +42,26 @@ function newSetLeafChunkFn<T:valueOrPrimitive>(vr: ?ValueReader): makeChunkFn {
   };
 }
 
-function newSetLeafBoundaryChecker<T:valueOrPrimitive>(): BoundaryChecker<T> {
+function newSetLeafBoundaryChecker<T:Value>(): BoundaryChecker<T> {
   return new BuzHashBoundaryChecker(setWindowSize, sha1Size, setPattern, (v: T) => {
     const ref = getRefOfValue(v);
     return ref.digest;
   });
 }
 
-function buildSetData<T: valueOrPrimitive>(values: Array<any>): Array<T> {
+function buildSetData<T: Value>(values: Array<any>): Array<T> {
   values = values.slice();
   values.sort(compare);
   return removeDuplicateFromOrdered(values, compare);
 }
 
-export function newSetLeafSequence<K: valueOrPrimitive>(
+export function newSetLeafSequence<K: Value>(
     vr: ?ValueReader, items: K[]): SetLeafSequence {
   const t = makeSetType(makeUnionType(items.map(getTypeOfValue)));
   return new SetLeafSequence(vr, t, items);
 }
 
-export default class Set<T: valueOrPrimitive> extends Collection<OrderedSequence> {
+export default class Set<T: Value> extends Collection<OrderedSequence> {
   constructor(values: Array<T> = []) {
     const self = chunkSequenceSync(
         buildSetData(values),
@@ -196,14 +196,14 @@ export default class Set<T: valueOrPrimitive> extends Collection<OrderedSequence
   }
 }
 
-export function newSetFromSequence<T: valueOrPrimitive>(sequence: OrderedSequence): Set<T> {
+export function newSetFromSequence<T: Value>(sequence: OrderedSequence): Set<T> {
   const set = Object.create(Set.prototype);
   set._ref = null; // Value
   set.sequence = sequence;
   return set;
 }
 
-export class SetLeafSequence<K: valueOrPrimitive> extends OrderedSequence<K, K> {
+export class SetLeafSequence<K: Value> extends OrderedSequence<K, K> {
   getKey(idx: number): K {
     return this.items[idx];
   }
@@ -217,14 +217,14 @@ export class SetLeafSequence<K: valueOrPrimitive> extends OrderedSequence<K, K> 
   }
 }
 
-type OrderedCursor<K: valueOrPrimitive> = {
+type OrderedCursor<K: Value> = {
   valid: boolean;
   getCurrent(): K;
   advanceTo(key: K): Promise<boolean>;
   advance(): Promise<boolean>;
 }
 
-class SetIntersectionCursor<K: valueOrPrimitive> {
+class SetIntersectionCursor<K: Value> {
   s1: OrderedCursor<K>;
   s2: OrderedCursor<K>;
   valid: boolean;

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -5,7 +5,7 @@ import RefValue from './ref-value.js';
 import type {ValueReader} from './value-store.js';
 import type {BoundaryChecker, makeChunkFn} from './sequence-chunker.js';
 import type {valueOrPrimitive} from './value.js'; // eslint-disable-line no-unused-vars
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 import {AsyncIterator} from './async-iterator.js';
 import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import {Collection} from './collection.js';
@@ -31,7 +31,7 @@ function newSetLeafChunkFn<T:valueOrPrimitive>(vr: ?ValueReader): makeChunkFn {
     let indexValue: ?(T | RefValue) = null;
     if (items.length > 0) {
       indexValue = items[items.length - 1];
-      if (indexValue instanceof Value) {
+      if (indexValue instanceof ValueBase) {
         indexValue = new RefValue(indexValue);
       }
     }

--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -3,7 +3,7 @@
 import assertSubtype from './assert-type.js';
 import type RefValue from './ref-value.js';
 import type {Type, StructDesc} from './type.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {Kind} from './noms-kind.js';
 import {ValueBase} from './value.js';
 import {equals} from './compare.js';
@@ -11,7 +11,7 @@ import {getTypeOfValue, makeStructType} from './type.js';
 import {invariant} from './assert.js';
 import {isPrimitive} from './primitives.js';
 
-type StructData = {[key: string]: valueOrPrimitive};
+type StructData = {[key: string]: Value};
 
 /**
  * Base class for all Noms structs. The decoder creates sub classes of this for Noms struct.
@@ -76,7 +76,7 @@ function validate(type: Type, data: StructData): void {
 }
 
 export class StructFieldMirror {
-  value: valueOrPrimitive;
+  value: Value;
   name: string;
   type: Type;
 
@@ -112,7 +112,7 @@ export class StructMirror<T: Struct> {
     return this.type.name;
   }
 
-  get(name: string): ?valueOrPrimitive {
+  get(name: string): ?Value {
     return this._data[name];
   }
 
@@ -120,7 +120,7 @@ export class StructMirror<T: Struct> {
     return this.get(name) !== undefined;
   }
 
-  set(name: string, value: ?valueOrPrimitive): T {
+  set(name: string, value: ?Value): T {
     const data = addProperty(this, name, value);
     return newStruct(this.name, data);
   }
@@ -171,7 +171,7 @@ function getSetter(name: string) {
   };
 }
 
-function addProperty(mirror: StructMirror, name: string, value: ?valueOrPrimitive): StructData {
+function addProperty(mirror: StructMirror, name: string, value: ?Value): StructData {
   const data = Object.create(null);
   let found = false;
   mirror.forEachField(f => {

--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -5,7 +5,7 @@ import type RefValue from './ref-value.js';
 import type {Type, StructDesc} from './type.js';
 import type {valueOrPrimitive} from './value.js';
 import {Kind} from './noms-kind.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 import {equals} from './compare.js';
 import {getTypeOfValue, makeStructType} from './type.js';
 import {invariant} from './assert.js';
@@ -34,7 +34,7 @@ type StructData = {[key: string]: valueOrPrimitive};
  *
  * To reflect over structs you can create a new StructMirror.
  */
-export default class Struct extends Value {
+export default class Struct extends ValueBase {
   _data: StructData;
   _type: Type;
 
@@ -58,7 +58,7 @@ export default class Struct extends Value {
     const add = field => {
       const {value} = field;
       if (!isPrimitive(value)) {
-        invariant(value instanceof Value);
+        invariant(value instanceof ValueBase);
         chunks.push(...value.chunks);
       }
     };

--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -3,7 +3,7 @@
 import assertSubtype from './assert-type.js';
 import type RefValue from './ref-value.js';
 import type {Type, StructDesc} from './type.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {Kind} from './noms-kind.js';
 import {ValueBase} from './value.js';
 import {equals} from './compare.js';

--- a/js/src/test-util.js
+++ b/js/src/test-util.js
@@ -2,7 +2,7 @@
 
 import Database from './database.js';
 import type {Collection} from './collection.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {assert} from 'chai';
 import {notNull} from './assert.js';
 import {AsyncIterator} from './async-iterator.js';
@@ -29,11 +29,11 @@ export async function flattenParallel<T>(iter: AsyncIterator<T>, count: number):
   return results.map(res => notNull(res.value));
 }
 
-export function assertValueRef(expectRefStr: string, v: valueOrPrimitive) {
+export function assertValueRef(expectRefStr: string, v: Value) {
   assert.strictEqual(expectRefStr, getRefOfValue(v).toString());
 }
 
-export function assertValueType(expectType: Type, v: valueOrPrimitive) {
+export function assertValueType(expectType: Type, v: Value) {
   assert.isTrue(equals(expectType, getTypeOfValue(v)));
 }
 
@@ -44,7 +44,7 @@ export function assertChunkCountAndType(expectCount: number, expectType: Type,
   v.chunks.forEach(r => assert.isTrue(equals(expectType, r.type)));
 }
 
-export async function testRoundTripAndValidate<T: valueOrPrimitive>(v: T,
+export async function testRoundTripAndValidate<T: Value>(v: T,
       validateFn: (v2: T) => Promise<void>): Promise<void> {
   const bs = makeTestingBatchStore();
   const ds = new Database(bs);
@@ -63,7 +63,7 @@ export async function testRoundTripAndValidate<T: valueOrPrimitive>(v: T,
   await ds2.close();
 }
 
-export function chunkDiffCount(v1: valueOrPrimitive, v2: valueOrPrimitive): number {
+export function chunkDiffCount(v1: Value, v2: Value): number {
   const c1 = getChunksOfValue(v1);
   const c2 = getChunksOfValue(v2);
 

--- a/js/src/test-util.js
+++ b/js/src/test-util.js
@@ -6,7 +6,7 @@ import type {valueOrPrimitive} from './value.js';
 import {assert} from 'chai';
 import {notNull} from './assert.js';
 import {AsyncIterator} from './async-iterator.js';
-import {getChunksOfValue, Value} from './value.js';
+import {getChunksOfValue, ValueBase} from './value.js';
 import {getRefOfValue} from './get-ref.js';
 import {getTypeOfValue, Type} from './type.js';
 import {makeTestingBatchStore} from './batch-store-adaptor.js';
@@ -53,7 +53,7 @@ export async function testRoundTripAndValidate<T: valueOrPrimitive>(v: T,
   const ds2 = new Database(bs);
 
   const v2 = await ds2.readValue(r1);
-  if (v instanceof Value) {
+  if (v instanceof ValueBase) {
     assert.isTrue(equals(v, v2));
     assert.isTrue(equals(v2, v));
   } else {

--- a/js/src/test-util.js
+++ b/js/src/test-util.js
@@ -2,7 +2,7 @@
 
 import Database from './database.js';
 import type {Collection} from './collection.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {assert} from 'chai';
 import {notNull} from './assert.js';
 import {AsyncIterator} from './async-iterator.js';

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -6,7 +6,7 @@ import type {NomsKind} from './noms-kind.js';
 import {invariant} from './assert.js';
 import {isPrimitiveKind, Kind} from './noms-kind.js';
 import {ValueBase} from './value.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {compare, equals} from './compare.js';
 
 export interface TypeDesc {

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -6,7 +6,7 @@ import type {NomsKind} from './noms-kind.js';
 import {invariant} from './assert.js';
 import {isPrimitiveKind, Kind} from './noms-kind.js';
 import {ValueBase} from './value.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {compare, equals} from './compare.js';
 
 export interface TypeDesc {
@@ -243,7 +243,7 @@ export function getPrimitiveType(k: NomsKind): Type {
 
 // Returns the Noms type of any value. This will throw if you pass in an object that cannot be
 // represented by noms.
-export function getTypeOfValue(v: valueOrPrimitive): Type {
+export function getTypeOfValue(v: Value): Type {
   if (v instanceof ValueBase) {
     return v.type;
   }

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -5,7 +5,7 @@ import RefValue from './ref-value.js';
 import type {NomsKind} from './noms-kind.js';
 import {invariant} from './assert.js';
 import {isPrimitiveKind, Kind} from './noms-kind.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 import type {valueOrPrimitive} from './value.js';
 import {compare, equals} from './compare.js';
 
@@ -109,7 +109,7 @@ export class StructDesc {
   }
 }
 
-export class Type<T: TypeDesc> extends Value {
+export class Type<T: TypeDesc> extends ValueBase {
   _desc: T;
   _ref: ?Ref;
 
@@ -244,7 +244,7 @@ export function getPrimitiveType(k: NomsKind): Type {
 // Returns the Noms type of any value. This will throw if you pass in an object that cannot be
 // represented by noms.
 export function getTypeOfValue(v: valueOrPrimitive): Type {
-  if (v instanceof Value) {
+  if (v instanceof ValueBase) {
     return v.type;
   }
 

--- a/js/src/value-store.js
+++ b/js/src/value-store.js
@@ -4,7 +4,7 @@ import Chunk from './chunk.js';
 import Ref, {emptyRef} from './ref.js';
 import RefValue from './ref-value.js';
 import type BatchStore from './batch-store.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import {
   getTypeOfValue,
   Type,
@@ -19,24 +19,24 @@ import {describeType, describeTypeOfValue} from './encode-human-readable.js';
 import {equals} from './compare.js';
 
 export interface ValueWriter {
-  writeValue<T: valueOrPrimitive>(v: T, t: ?Type): RefValue<T>
+  writeValue<T: Value>(v: T, t: ?Type): RefValue<T>
 }
 
 export interface ValueReader {
-  // TODO: This should return Promise<?valueOrPrimitive>
+  // TODO: This should return Promise<?Value>
   readValue(ref: Ref): Promise<any>
 }
 
 export interface ValueReadWriter {
-  // TODO: This should return Promise<?valueOrPrimitive>
+  // TODO: This should return Promise<?Value>
   readValue(ref: Ref): Promise<any>;
-  writeValue<T: valueOrPrimitive>(v: T): RefValue<T>;
+  writeValue<T: Value>(v: T): RefValue<T>;
 }
 
 export default class ValueStore {
   _bs: BatchStore;
   _knownRefs: RefCache;
-  _valueCache: Cache<?valueOrPrimitive>;
+  _valueCache: Cache<?Value>;
 
   constructor(bs: BatchStore, cacheSize: number = 0) {
     this._bs = bs;
@@ -44,7 +44,7 @@ export default class ValueStore {
     this._valueCache = cacheSize > 0 ? new SizeCache(cacheSize) : new NoopCache();
   }
 
-  // TODO: This should return Promise<?valueOrPrimitive>
+  // TODO: This should return Promise<?Value>
   async readValue(ref: Ref): Promise<any> {
     const entry = this._valueCache.entry(ref);
     if (entry) {
@@ -70,7 +70,7 @@ export default class ValueStore {
     return v;
   }
 
-  writeValue<T: valueOrPrimitive>(v: T): RefValue<T> {
+  writeValue<T: Value>(v: T): RefValue<T> {
     const t = getTypeOfValue(v);
     const chunk = encodeNomsValue(v, this);
     invariant(!chunk.isEmpty());
@@ -213,7 +213,7 @@ class RefCache {
     }
   }
 
-  cacheChunks(v: valueOrPrimitive, ref: Ref) {
+  cacheChunks(v: Value, ref: Ref) {
     if (v instanceof ValueBase) {
       v.chunks.forEach(reachable => {
         const hash = reachable.targetRef;
@@ -225,7 +225,7 @@ class RefCache {
     }
   }
 
-  checkChunksInCache(v: valueOrPrimitive): Set<Ref> {
+  checkChunksInCache(v: Value): Set<Ref> {
     const hints = new Set();
     if (v instanceof ValueBase) {
       const chunks = v.chunks;

--- a/js/src/value-store.js
+++ b/js/src/value-store.js
@@ -4,7 +4,7 @@ import Chunk from './chunk.js';
 import Ref, {emptyRef} from './ref.js';
 import RefValue from './ref-value.js';
 import type BatchStore from './batch-store.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import {
   getTypeOfValue,
   Type,

--- a/js/src/value-store.js
+++ b/js/src/value-store.js
@@ -11,7 +11,7 @@ import {
   valueType,
 } from './type.js';
 import {Kind} from './noms-kind.js';
-import {Value} from './value.js';
+import {ValueBase} from './value.js';
 import {decodeNomsValue} from './decode.js';
 import {invariant, notNull} from './assert.js';
 import {encodeNomsValue} from './encode.js';
@@ -214,7 +214,7 @@ class RefCache {
   }
 
   cacheChunks(v: valueOrPrimitive, ref: Ref) {
-    if (v instanceof Value) {
+    if (v instanceof ValueBase) {
       v.chunks.forEach(reachable => {
         const hash = reachable.targetRef;
         const cur = this.get(hash);
@@ -227,7 +227,7 @@ class RefCache {
 
   checkChunksInCache(v: valueOrPrimitive): Set<Ref> {
     const hints = new Set();
-    if (v instanceof Value) {
+    if (v instanceof ValueBase) {
       const chunks = v.chunks;
       for (let i = 0; i < chunks.length; i++) {
         const reachable = chunks[i];

--- a/js/src/value.js
+++ b/js/src/value.js
@@ -6,7 +6,7 @@ import {ensureRef} from './get-ref.js';
 import type {Type} from './type.js';
 import type RefValue from './ref-value.js';
 
-export class Value {
+export class ValueBase {
   _ref: ?Ref;
 
   constructor() {
@@ -26,10 +26,10 @@ export class Value {
   }
 }
 
-export type valueOrPrimitive = primitive | Value;
+export type valueOrPrimitive = primitive | ValueBase;
 
 export function getChunksOfValue(v: valueOrPrimitive): Array<RefValue> {
-  if (v instanceof Value) {
+  if (v instanceof ValueBase) {
     return v.chunks;
   }
 

--- a/js/src/value.js
+++ b/js/src/value.js
@@ -26,9 +26,9 @@ export class ValueBase {
   }
 }
 
-export type valueOrPrimitive = primitive | ValueBase;
+export type Value = primitive | ValueBase;
 
-export function getChunksOfValue(v: valueOrPrimitive): Array<RefValue> {
+export function getChunksOfValue(v: Value): Array<RefValue> {
   if (v instanceof ValueBase) {
     return v.chunks;
   }

--- a/js/src/value.js
+++ b/js/src/value.js
@@ -26,7 +26,8 @@ export class ValueBase {
   }
 }
 
-export type Value = primitive | ValueBase;
+type Value = primitive | ValueBase;
+export type {Value as default};
 
 export function getChunksOfValue(v: Value): Array<RefValue> {
   if (v instanceof ValueBase) {

--- a/js/src/walk-test.js
+++ b/js/src/walk-test.js
@@ -19,7 +19,7 @@ import walk from './walk.js';
 import {suite, suiteSetup, suiteTeardown, test} from 'mocha';
 import {assert} from 'chai';
 
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 
 suite('walk', () => {
   let ds;
@@ -160,7 +160,7 @@ suite('walk', () => {
   });
 });
 
-async function callbackHappensOnce(v: valueOrPrimitive, ds: Database,
+async function callbackHappensOnce(v: Value, ds: Database,
                                    recurse: bool = false) : Promise<void> {
   // Test that our callback only gets called once.
   let count = 0;

--- a/js/src/walk-test.js
+++ b/js/src/walk-test.js
@@ -19,7 +19,7 @@ import walk from './walk.js';
 import {suite, suiteSetup, suiteTeardown, test} from 'mocha';
 import {assert} from 'chai';
 
-import type {Value} from './value.js';
+import type Value from './value.js';
 
 suite('walk', () => {
   let ds;

--- a/js/src/walk.js
+++ b/js/src/walk.js
@@ -8,9 +8,9 @@ import RefValue from './ref-value.js';
 import Struct, {StructMirror} from './struct.js';
 
 import type Database from './database.js';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 
-type walkCb = (v: valueOrPrimitive) => ?bool | Promise<?bool>;
+type walkCb = (v: Value) => ?bool | Promise<?bool>;
 
 // Invokes |cb| once for |v| and each of its descendants. The returned promise is resolved when all
 // invocations to |cb| have been resolved.
@@ -19,7 +19,7 @@ type walkCb = (v: valueOrPrimitive) => ?bool | Promise<?bool>;
 // Promise which resolves to |false| to skip a node's children.
 //
 // For convenience, if |cb| returns |undefined| or a Promise to |undefined|, the default is |true|.
-export default async function walk(v: valueOrPrimitive, ds: Database, cb: walkCb): Promise<void> {
+export default async function walk(v: Value, ds: Database, cb: walkCb): Promise<void> {
   let cont = cb(v);
   if (cont instanceof Promise) {
     cont = await cont;

--- a/js/src/walk.js
+++ b/js/src/walk.js
@@ -8,7 +8,7 @@ import RefValue from './ref-value.js';
 import Struct, {StructMirror} from './struct.js';
 
 import type Database from './database.js';
-import type {Value} from './value.js';
+import type Value from './value.js';
 
 type walkCb = (v: Value) => ?bool | Promise<?bool>;
 

--- a/js/src/xp-test.js
+++ b/js/src/xp-test.js
@@ -2,7 +2,7 @@
 
 import {assert} from 'chai';
 import {suite, test} from 'mocha';
-import type {Value} from './value.js';
+import type Value from './value.js';
 import Database from './database.js';
 import {makeTestingBatchStore} from './batch-store-adaptor.js';
 

--- a/js/src/xp-test.js
+++ b/js/src/xp-test.js
@@ -2,16 +2,16 @@
 
 import {assert} from 'chai';
 import {suite, test} from 'mocha';
-import type {valueOrPrimitive} from './value.js';
+import type {Value} from './value.js';
 import Database from './database.js';
 import {makeTestingBatchStore} from './batch-store-adaptor.js';
 
 export class TestValue {
-  _value: valueOrPrimitive;
+  _value: Value;
   _expectedRef: string;
   _description: string;
 
-  constructor(value: valueOrPrimitive, expectedRef: string, description: string) {
+  constructor(value: Value, expectedRef: string, description: string) {
     this._value = value;
     this._expectedRef = expectedRef;
     this._description = description;


### PR DESCRIPTION
This renames Value to ValueBase, valueOrPrimite to Value and make Value the default export.

Fixes #1528
