### PR TITLE
Rename metaSequenceObject::ChildHash back to ChildRef

### DIFF
--- a/types/collection_test.go
+++ b/types/collection_test.go
@@ -67,7 +67,7 @@ func (suite *collectionTestSuite) TestAppendChunkDiff() {
 }
 
 func deriveCollectionHeight(c Collection) uint64 {
-	// Note: not using mt.childRef.Height() because the purpose of this method is to be redundant.
+	// Note: not using mt.ref.Height() because the purpose of this method is to be redundant.
 	seq := c.sequence()
 	if seq.seqLen() == 0 {
 		return 0
@@ -81,5 +81,5 @@ func deriveCollectionHeight(c Collection) uint64 {
 }
 
 func getRefHeightOfCollection(c Collection) uint64 {
-	return c.sequence().getItem(0).(metaTuple).childRef.Height()
+	return c.sequence().getItem(0).(metaTuple).ref.Height()
 }

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -115,7 +115,7 @@ func (w *jsonArrayWriter) maybeWriteMetaSequence(seq sequence, tr *Type) bool {
 			// Write unwritten chunked sequences. Chunks are lazily written so that intermediate chunked structures like NewList().Append(x).Append(y) don't cause unnecessary churn.
 			w.vw.WriteValue(tuple.child)
 		}
-		w2.writeValue(tuple.ChildRef())
+		w2.writeValue(tuple.ref)
 		w2.writeValue(tuple.value)
 		w2.writeUint(tuple.numLeaves)
 	}

--- a/types/encode_noms_value.go
+++ b/types/encode_noms_value.go
@@ -115,7 +115,7 @@ func (w *jsonArrayWriter) maybeWriteMetaSequence(seq sequence, tr *Type) bool {
 			// Write unwritten chunked sequences. Chunks are lazily written so that intermediate chunked structures like NewList().Append(x).Append(y) don't cause unnecessary churn.
 			w.vw.WriteValue(tuple.child)
 		}
-		w2.writeValue(tuple.ChildHash())
+		w2.writeValue(tuple.ChildRef())
 		w2.writeValue(tuple.value)
 		w2.writeUint(tuple.numLeaves)
 	}

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -21,7 +21,7 @@ func newListMetaSequence(tuples metaSequenceData, vr ValueReader) indexedMetaSeq
 	ts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<List<T>>
-		ts[i] = mt.ChildHash().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
+		ts[i] = mt.ChildRef().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
 	}
 	t := MakeListType(MakeUnionType(ts...))
 	return newIndexedMetaSequence(tuples, t, vr)
@@ -94,7 +94,7 @@ func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 
 func newIndexedMetaSequenceBoundaryChecker() boundaryChecker {
 	return newBuzHashBoundaryChecker(objectWindowSize, sha1.Size, objectPattern, func(item sequenceItem) []byte {
-		digest := item.(metaTuple).ChildHash().TargetHash().Digest()
+		digest := item.(metaTuple).ChildRef().TargetHash().Digest()
 		return digest[:]
 	})
 }

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -21,7 +21,7 @@ func newListMetaSequence(tuples metaSequenceData, vr ValueReader) indexedMetaSeq
 	ts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<List<T>>
-		ts[i] = mt.ChildRef().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
+		ts[i] = mt.ref.Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
 	}
 	t := MakeListType(MakeUnionType(ts...))
 	return newIndexedMetaSequence(tuples, t, vr)
@@ -94,7 +94,7 @@ func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 
 func newIndexedMetaSequenceBoundaryChecker() boundaryChecker {
 	return newBuzHashBoundaryChecker(objectWindowSize, sha1.Size, objectPattern, func(item sequenceItem) []byte {
-		digest := item.(metaTuple).ChildRef().TargetHash().Digest()
+		digest := item.(metaTuple).ref.TargetHash().Digest()
 		return digest[:]
 	})
 }

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -27,7 +27,7 @@ type metaTuple struct {
 	numLeaves uint64
 }
 
-func (mt metaTuple) ChildHash() Ref {
+func (mt metaTuple) ChildRef() Ref {
 	return mt.childRef
 }
 
@@ -78,24 +78,16 @@ func (ms metaSequenceObject) valueReader() ValueReader {
 	return ms.vr
 }
 
-func (ms metaSequenceObject) Chunks() (chunks []Ref) {
-	for _, tuple := range ms.tuples {
-		chunks = append(chunks, tuple.ChildHash())
+func (ms metaSequenceObject) Chunks() []Ref {
+	chunks := make([]Ref, len(ms.tuples))
+	for i, tuple := range ms.tuples {
+		chunks[i] = tuple.ChildRef()
 	}
-	return
+	return chunks
 }
 
 func (ms metaSequenceObject) Type() *Type {
 	return ms.t
-}
-
-// Value interface
-func (ms metaSequenceObject) ChildValues() []Value {
-	vals := make([]Value, len(ms.tuples))
-	for i, mt := range ms.tuples {
-		vals[i] = mt.childRef
-	}
-	return vals
 }
 
 // metaSequence interface

--- a/types/meta_sequence.go
+++ b/types/meta_sequence.go
@@ -22,13 +22,9 @@ func newMetaTuple(value Value, child Collection, childRef Ref, numLeaves uint64)
 // metaTuple is a node in a Prolly Tree, consisting of data in the node (either tree leaves or other metaSequences), and a Value annotation for exploring the tree (e.g. the largest item if this an ordered sequence).
 type metaTuple struct {
 	child     Collection // may be nil
-	childRef  Ref
+	ref       Ref
 	value     Value
 	numLeaves uint64
-}
-
-func (mt metaTuple) ChildRef() Ref {
-	return mt.childRef
 }
 
 func (mt metaTuple) uint64Value() uint64 {
@@ -81,7 +77,7 @@ func (ms metaSequenceObject) valueReader() ValueReader {
 func (ms metaSequenceObject) Chunks() []Ref {
 	chunks := make([]Ref, len(ms.tuples))
 	for i, tuple := range ms.tuples {
-		chunks[i] = tuple.ChildRef()
+		chunks[i] = tuple.ref
 	}
 	return chunks
 }
@@ -97,7 +93,7 @@ func (ms metaSequenceObject) getChildSequence(idx int) sequence {
 		return mt.child.sequence()
 	}
 
-	return mt.childRef.TargetValue(ms.vr).(Collection).sequence()
+	return mt.ref.TargetValue(ms.vr).(Collection).sequence()
 }
 
 // Creates a sequenceCursor pointing to the first metaTuple in a metaSequence, and returns that cursor plus the leaf Value referenced from that metaTuple.
@@ -122,7 +118,7 @@ func readMetaTupleValue(item sequenceItem, vr ValueReader) Value {
 		return mt.child
 	}
 
-	r := mt.childRef.TargetHash()
+	r := mt.ref.TargetHash()
 	d.Chk.False(r.IsEmpty())
 	return vr.ReadValue(r)
 }

--- a/types/ordered_sequences.go
+++ b/types/ordered_sequences.go
@@ -23,7 +23,7 @@ func newSetMetaSequence(tuples metaSequenceData, vr ValueReader) orderedMetaSequ
 	ts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<Set<T>>
-		ts[i] = mt.ChildHash().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
+		ts[i] = mt.ChildRef().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
 	}
 	t := MakeSetType(MakeUnionType(ts...))
 	return newOrderedMetaSequence(tuples, t, vr)
@@ -34,7 +34,7 @@ func newMapMetaSequence(tuples metaSequenceData, vr ValueReader) orderedMetaSequ
 	vts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<Map<K, V>>
-		ets := mt.ChildHash().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes
+		ets := mt.ChildRef().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes
 		kts[i] = ets[0]
 		vts[i] = ets[1]
 	}
@@ -140,7 +140,7 @@ func getCurrentKey(cur *sequenceCursor) Value {
 
 func newOrderedMetaSequenceBoundaryChecker() boundaryChecker {
 	return newBuzHashBoundaryChecker(orderedSequenceWindowSize, sha1.Size, objectPattern, func(item sequenceItem) []byte {
-		digest := item.(metaTuple).ChildHash().TargetHash().Digest()
+		digest := item.(metaTuple).ChildRef().TargetHash().Digest()
 		return digest[:]
 	})
 }

--- a/types/ordered_sequences.go
+++ b/types/ordered_sequences.go
@@ -23,7 +23,7 @@ func newSetMetaSequence(tuples metaSequenceData, vr ValueReader) orderedMetaSequ
 	ts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<Set<T>>
-		ts[i] = mt.ChildRef().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
+		ts[i] = mt.ref.Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
 	}
 	t := MakeSetType(MakeUnionType(ts...))
 	return newOrderedMetaSequence(tuples, t, vr)
@@ -34,7 +34,7 @@ func newMapMetaSequence(tuples metaSequenceData, vr ValueReader) orderedMetaSequ
 	vts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<Map<K, V>>
-		ets := mt.ChildRef().Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes
+		ets := mt.ref.Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes
 		kts[i] = ets[0]
 		vts[i] = ets[1]
 	}
@@ -63,7 +63,7 @@ func (oms orderedMetaSequence) getKey(idx int) Value {
 }
 
 func (oms orderedMetaSequence) equalsAt(idx int, other interface{}) bool {
-	return oms.tuples[idx].childRef.Equals(other.(metaTuple).childRef)
+	return oms.tuples[idx].ref.Equals(other.(metaTuple).ref)
 }
 
 func newCursorAtKey(seq orderedSequence, key Value, forInsertion bool, last bool) *sequenceCursor {
@@ -140,7 +140,7 @@ func getCurrentKey(cur *sequenceCursor) Value {
 
 func newOrderedMetaSequenceBoundaryChecker() boundaryChecker {
 	return newBuzHashBoundaryChecker(orderedSequenceWindowSize, sha1.Size, objectPattern, func(item sequenceItem) []byte {
-		digest := item.(metaTuple).ChildRef().TargetHash().Digest()
+		digest := item.(metaTuple).ref.TargetHash().Digest()
 		return digest[:]
 	})
 }


### PR DESCRIPTION
This method returns a types.Ref, so ChildRef is the right name.
Also, delete metaSequenceObject::ChildValues, since it isn't and
shouldn't ever be called.
