### PR TITLE
Restrict dataset ID names

### DIFF
--- a/clients/go/flags/dataspec.go
+++ b/clients/go/flags/dataspec.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	storeRegex = regexp.MustCompile("^([^:]+):?(.+)?$")
-	pathRegex  = regexp.MustCompile("^(.+):(.+)$")
+	pathRegex  = regexp.MustCompile(`^(.+):([a-zA-Z0-9\-_/]+)$`)
 )
 
 type DatabaseSpec struct {

--- a/clients/go/flags/dataspec_test.go
+++ b/clients/go/flags/dataspec_test.go
@@ -287,6 +287,18 @@ func TestDatasetSpecs(t *testing.T) {
 		assert.Error(err)
 	}
 
+	invalidDatasetNames := []string{" ", "", "$", "#", ":", "\n", "💩"}
+	for _, s := range invalidDatasetNames {
+		_, err := ParseDatasetSpec("mem:" + s)
+		assert.Error(err)
+	}
+
+	validDatasetNames := []string{"a", "Z", "0", "/", "-", "_"}
+	for _, s := range validDatasetNames {
+		_, err := ParseDatasetSpec("mem:" + s)
+		assert.NoError(err)
+	}
+
 	setSpec, err := ParseDatasetSpec("http://localhost:8000:dsname")
 	assert.NoError(err)
 	assert.Equal(DatasetSpec{StoreSpec: DatabaseSpec{Protocol: "http", Path: "//localhost:8000"}, DatasetName: "dsname"}, setSpec)

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -1,19 +1,23 @@
 package dataset
 
 import (
+	"regexp"
+
 	"github.com/attic-labs/noms/d"
 	"github.com/attic-labs/noms/datas"
 	"github.com/attic-labs/noms/types"
 )
+
+var idRe = regexp.MustCompile(`^[a-zA-Z0-9\-_/]+$`)
 
 type Dataset struct {
 	store datas.Database
 	id    string
 }
 
-func NewDataset(store datas.Database, datasetID string) Dataset {
-	d.Exp.NotEmpty(datasetID, "Cannot create an unnamed Dataset.")
-	return Dataset{store, datasetID}
+func NewDataset(db datas.Database, datasetID string) Dataset {
+	d.Exp.True(idRe.MatchString(datasetID), "Invalid dataset ID: %s", datasetID)
+	return Dataset{db, datasetID}
 }
 
 func (ds *Dataset) Store() datas.Database {

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -148,3 +148,15 @@ func TestTwoClientsWithNonEmptyDataset(t *testing.T) {
 	assert.NoError(err)
 	assert.True(dsy.Head().Get(datas.ValueField).Equals(c))
 }
+
+func TestIdValidation(t *testing.T) {
+	assert := assert.New(t)
+	store := datas.NewDatabase(chunks.NewMemoryStore())
+
+	invalidDatasetNames := []string{" ", "", "a ", " a", "$", "#", ":", "\n", "💩"}
+	for _, id := range invalidDatasetNames {
+		assert.Panics(func() {
+			NewDataset(store, id)
+		})
+	}
+}

--- a/js/src/dataset-test.js
+++ b/js/src/dataset-test.js
@@ -10,8 +10,8 @@ import {invariant, notNull} from './assert.js';
 suite('Dataset', () => {
   test('commit', async () => {
     const bs = makeTestingBatchStore();
-    const store = new Database(bs);
-    let ds = new Dataset(store, 'ds1');
+    const db = new Database(bs);
+    let ds = new Dataset(db, 'ds1');
 
     // |a|
     const ds2 = await ds.commit('a');
@@ -49,7 +49,7 @@ suite('Dataset', () => {
 
 
     // Add a commit to a different datasetId
-    ds = new Dataset(store, 'otherDs');
+    ds = new Dataset(db, 'otherDs');
     ds = await ds.commit('a');
     assert.strictEqual('a', notNull(await ds.head('otherDs')).value);
 
@@ -58,5 +58,14 @@ suite('Dataset', () => {
     assert.strictEqual('d', notNull(await newStore.head('ds1')).value);
     assert.strictEqual('a', notNull(await newStore.head('otherDs')).value);
     await newStore.close();
+  });
+
+  test('id validation', () => {
+    const db = new Database(makeTestingBatchStore());
+
+    const invalidDatasetNames = [' ', '', 'a ', ' a', '$', '#', ':', '\n', '💩'];
+    for (const s of invalidDatasetNames) {
+      assert.throws(() => { new Dataset(db, s); });
+    }
   });
 });

--- a/js/src/dataset.js
+++ b/js/src/dataset.js
@@ -6,11 +6,16 @@ import type Database from './database.js';
 import Ref from './ref.js';
 import Set from './set.js';
 
+const idRe = /^[a-zA-Z0-9\-_/]+$/;
+
 export default class Dataset {
   _store: Database;
   _id: string;
 
   constructor(store: Database, id: string) {
+    if (!idRe.test(id)) {
+      throw new TypeError(`Invalid dataset ID: ${id}`);
+    }
     this._store = store;
     this._id = id;
   }

--- a/js/src/specs-test.js
+++ b/js/src/specs-test.js
@@ -41,9 +41,20 @@ suite('Specs', () => {
     assert.equal(spec.path, '//foo');
   });
 
-  test('DataSetSpec', async () => {
-    const invalid = ['mem', 'mem:', 'http', 'http:', 'http://foo', 'monkey', 'monkey:balls'];
+  test('DatasetSpec', async () => {
+    const invalid = ['mem', 'mem:', 'http', 'http:', 'http://foo', 'monkey', 'monkey:balls',
+        'http::dsname', 'mem:/a/bogus/path:dsname'];
     invalid.forEach(s => assert.isNull(DatasetSpec.parse(s)));
+
+    const invalidDatasetNames = [' ', '', '$', '#', ':', '\n', '💩'];
+    for (const s of invalidDatasetNames) {
+      assert.isNull(DatasetSpec.parse(`mem:${s}`));
+    }
+
+    const validDatasetNames = ['a', 'Z', '0','/', '-', '_'];
+    for (const s of validDatasetNames) {
+      assert.isNotNull(DatasetSpec.parse(`mem:${s}`));
+    }
 
     let spec = DatasetSpec.parse('mem:ds');
     invariant(spec);

--- a/js/src/specs.js
+++ b/js/src/specs.js
@@ -69,7 +69,7 @@ export class DatasetSpec {
 
   // Returns a parsed spec, or null if the spec was invalid.
   static parse(spec: string): ?DatasetSpec {
-    const match = spec.match(/^(.+)\:(.+)$/);
+    const match = spec.match(/^(.+)\:([a-zA-Z0-9\-_/]+)$/);
     if (!match) {
       return null;
     }


### PR DESCRIPTION
A dataset id must be of the form `^[a-zA-Z0-9\-_/]+$`

Towards #1402
