### PR TITLE
increasing the mocha timeout so travis builds fail less

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "pretest": "eslint src/ && flow src/",
     "ts": "mocha --ui tdd --timeout=4000 --reporter spec --slow=50 --invert --grep='LONG:' --compilers js:babel-core/register src/*-test.js",
-    "test": "mocha --ui tdd --timeout=3000 --reporter dot --compilers js:babel-core/register src/*-test.js",
+    "test": "mocha --ui tdd --timeout=6000 --reporter dot --compilers js:babel-core/register src/*-test.js",
     "prepublish": "rm -rf dist/ && npm run compile && npm run copy-flow-files",
     "compile": "npm run compile-to-commonjs && npm run compile-to-es6",
     "compile-to-commonjs": "BABEL_ENV=production babel -d dist/commonjs src/",


### PR DESCRIPTION
@cmasone-attic @aboodman i think it is not travis timeouts when the build fails, but instead is mocha timeouts, at least those are the ones I am seeing.
