### PR TITLE
use Value.Equals() for list leaf diff

### DIFF
--- a/js/src/list-test.js
+++ b/js/src/list-test.js
@@ -410,8 +410,8 @@ suite('Diff List', () => {
     assert.deepEqual(expectedDiff, directDiff);
   });
 
- test('String 1', async () => {
-    const nums1 = ["one", "two", "three"];
+  test('String 1', async () => {
+    const nums1 = ['one', 'two', 'three'];
     const nums2 = nums1.slice(0);
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => equals(nums1[i],nums2[j]));
@@ -425,9 +425,9 @@ suite('Diff List', () => {
     assert.deepEqual(expectedDiff, directDiff);
   });
 
- test('String 2', async () => {
-    const nums1 = ["one", "two", "three"];
-    const nums2 = ["one", "two", "three", "four"];
+  test('String 2', async () => {
+    const nums1 = ['one', 'two', 'three'];
+    const nums2 = ['one', 'two', 'three', 'four'];
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => equals(nums1[i],nums2[j]));
     const l1 = new List(nums1);
@@ -442,9 +442,9 @@ suite('Diff List', () => {
     assert.deepEqual(expectedDiff, directDiff);
   });
 
- test('String 3', async () => {
-    const nums1 = ["one", "two", "three"];
-    const nums2 = ["one", "two", "four"];
+  test('String 3', async () => {
+    const nums1 = ['one', 'two', 'three'];
+    const nums2 = ['one', 'two', 'four'];
 
     const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => equals(nums1[i],nums2[j]));
     const l1 = new List(nums1);

--- a/js/src/list-test.js
+++ b/js/src/list-test.js
@@ -27,6 +27,7 @@ import {
 import {MetaTuple, newListMetaSequence} from './meta-sequence.js';
 import {invariant} from './assert.js';
 import List from './list.js';
+import {equals} from './compare.js';
 
 const testListSize = 5000;
 const listOfNRef = 'sha1-aa1605484d993e89dbc0431acb9f2478282f9d94';
@@ -405,6 +406,55 @@ suite('Diff List', () => {
       [3050,50,49,3051],
       [4000,49,50,4000],
       [4050,50,49,4051],
+    ];
+    assert.deepEqual(expectedDiff, directDiff);
+  });
+
+ test('String 1', async () => {
+    const nums1 = ["one", "two", "three"];
+    const nums2 = nums1.slice(0);
+
+    const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => equals(nums1[i],nums2[j]));
+    const l1 = new List(nums1);
+    const l2 = new List(nums2);
+
+    const listDiff = await l2.diff(l1);
+    assert.deepEqual(directDiff, listDiff);
+
+    const expectedDiff = [];
+    assert.deepEqual(expectedDiff, directDiff);
+  });
+
+ test('String 2', async () => {
+    const nums1 = ["one", "two", "three"];
+    const nums2 = ["one", "two", "three", "four"];
+
+    const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => equals(nums1[i],nums2[j]));
+    const l1 = new List(nums1);
+    const l2 = new List(nums2);
+
+    const listDiff = await l2.diff(l1);
+    assert.deepEqual(directDiff, listDiff);
+
+    const expectedDiff = [
+      [3,0,1,3],
+    ];
+    assert.deepEqual(expectedDiff, directDiff);
+  });
+
+ test('String 3', async () => {
+    const nums1 = ["one", "two", "three"];
+    const nums2 = ["one", "two", "four"];
+
+    const directDiff = calcSplices(nums1.length, nums2.length, (i, j) => equals(nums1[i],nums2[j]));
+    const l1 = new List(nums1);
+    const l2 = new List(nums2);
+
+    const listDiff = await l2.diff(l1);
+    assert.deepEqual(directDiff, listDiff);
+
+    const expectedDiff = [
+      [2,1,1,2],
     ];
     assert.deepEqual(expectedDiff, directDiff);
   });

--- a/types/blob_leaf_sequence.go
+++ b/types/blob_leaf_sequence.go
@@ -14,6 +14,10 @@ func (bl blobLeafSequence) getOffset(idx int) uint64 {
 	return uint64(idx)
 }
 
+func (bl blobLeafSequence) equalsAt(idx int, other interface{}) bool {
+	return bl.data[idx] == other
+}
+
 // sequence interface
 func (bl blobLeafSequence) getItem(idx int) sequenceItem {
 	return bl.data[idx]

--- a/types/indexed_sequence_diff.go
+++ b/types/indexed_sequence_diff.go
@@ -34,18 +34,9 @@ func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64
 		return indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, newLoadLimit)
 	}
 
-	var edEqFn EditDistanceEqualsFn
-	if isMetaSequence(last) {
-		edEqFn = func(i uint64, j uint64) bool {
-			return last.getItem(int(i)).(metaTuple).ref == current.getItem(int(j)).(metaTuple).ref
-		}
-	} else {
-		edEqFn = func(i uint64, j uint64) bool {
-			return last.getItem(int(i)) == current.getItem(int(j))
-		}
-	}
-
-	initialSplices := calcSplices(uint64(last.seqLen()), uint64(current.seqLen()), edEqFn)
+	initialSplices := calcSplices(uint64(last.seqLen()), uint64(current.seqLen()), func(i uint64, j uint64) bool {
+		return last.equalsAt(int(i), current.getItem(int(j)))
+	})
 
 	finalSplices := []Splice{}
 	newLoadLimit := loadLimit

--- a/types/indexed_sequences.go
+++ b/types/indexed_sequences.go
@@ -10,6 +10,7 @@ import (
 type indexedSequence interface {
 	sequence
 	getOffset(idx int) uint64
+	equalsAt(idx int, other interface{}) bool
 }
 
 type indexedMetaSequence struct {
@@ -58,6 +59,10 @@ func (ims indexedMetaSequence) getOffset(idx int) uint64 {
 	}
 
 	return ims.offsets[idx] - 1
+}
+
+func (ims indexedMetaSequence) equalsAt(idx int, other interface{}) bool {
+	return ims.getItem(idx).(metaTuple).ref == other.(metaTuple).ref
 }
 
 func newCursorAtIndex(seq indexedSequence, idx uint64) *sequenceCursor {

--- a/types/list_leaf_sequence.go
+++ b/types/list_leaf_sequence.go
@@ -20,6 +20,10 @@ func (ll listLeafSequence) getOffset(idx int) uint64 {
 	return uint64(idx)
 }
 
+func (ll listLeafSequence) equalsAt(idx int, other interface{}) bool {
+	return ll.values[idx].Equals(other.(Value))
+}
+
 // sequence interface
 func (ll listLeafSequence) getItem(idx int) sequenceItem {
 	return ll.values[idx]

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -708,3 +708,49 @@ func TestListDiffLoadLimit(t *testing.T) {
 	assert.Nil(diff2)
 	assert.Equal("load limit exceeded", err2.Error())
 }
+
+func TestListDiffString1(t *testing.T) {
+	assert := assert.New(t)
+	nums1 := []Value{NewString("one"), NewString("two"), NewString("three")}
+	nums2 := []Value{NewString("one"), NewString("two"), NewString("three")}
+	l1 := NewList(nums1...)
+	l2 := NewList(nums2...)
+	diff2, err2 := l2.Diff(l1)
+	assert.NoError(err2)
+	assert.Equal(0, len(diff2))
+
+	diff2Expected := []Splice{}
+	assert.Equal(diff2Expected, diff2, "expected diff is wrong")
+}
+
+func TestListDiffString2(t *testing.T) {
+	assert := assert.New(t)
+	nums1 := []Value{NewString("one"), NewString("two"), NewString("three")}
+	nums2 := []Value{NewString("one"), NewString("two"), NewString("three"), NewString("four")}
+	l1 := NewList(nums1...)
+	l2 := NewList(nums2...)
+	diff2, err2 := l2.Diff(l1)
+	assert.NoError(err2)
+	assert.Equal(1, len(diff2))
+
+	diff2Expected := []Splice{
+		Splice{3, 0, 1, 3},
+	}
+	assert.Equal(diff2Expected, diff2, "expected diff is wrong")
+}
+
+func TestListDiffString3(t *testing.T) {
+	assert := assert.New(t)
+	nums1 := []Value{NewString("one"), NewString("two"), NewString("three")}
+	nums2 := []Value{NewString("one"), NewString("two"), NewString("four")}
+	l1 := NewList(nums1...)
+	l2 := NewList(nums2...)
+	diff2, err2 := l2.Diff(l1)
+	assert.NoError(err2)
+	assert.Equal(1, len(diff2))
+
+	diff2Expected := []Splice{
+		Splice{2, 1, 1, 2},
+	}
+	assert.Equal(diff2Expected, diff2, "expected diff is wrong")
+}


### PR DESCRIPTION
@willhite this is the issue with your string diff

@rafael-atticlabs really do not like having indexed_sequence_diff know about list vs. blob sequences, do you have a better idea? or have the caller of indexedSequenceDiff() pass in the EditDistanceEqualsFn and it is only used on leaf nodes?
