### PR TITLE
Arg enhancements to noms-log.

### DIFF
--- a/clients/go/flags/dataspec.go
+++ b/clients/go/flags/dataspec.go
@@ -159,6 +159,7 @@ func (spec DatasetSpec) Value() (datas.Database, types.Value, error) {
 
 	commit, ok := dataset.MaybeHead()
 	if !ok {
+		dataset.Database().Close()
 		return nil, nil, fmt.Errorf("No head value for dataset: %s", spec.DatasetName)
 	}
 

--- a/clients/go/util/check_error.go
+++ b/clients/go/util/check_error.go
@@ -5,15 +5,34 @@
 package util
 
 import (
-    "flag"
-    "fmt"
-    "os"
+	"flag"
+	"fmt"
+	"os"
 )
 
+type Exiter interface {
+	Exit(code int)
+}
+
+type nomsExiter struct{}
+
+func (e nomsExiter) Exit(code int) {
+	os.Exit(code)
+}
+
+var UtilExiter Exiter = nomsExiter{}
+
 func CheckError(err error) {
-    if err != nil {
-        fmt.Fprintf(os.Stderr, "error: %s\n", err)
-        flag.Usage()
-        os.Exit(-1)
-    }
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		flag.Usage()
+		UtilExiter.Exit(-1)
+	}
+}
+
+func CheckErrorNoUsage(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		UtilExiter.Exit(-1)
+	}
 }

--- a/datas/commit.go
+++ b/datas/commit.go
@@ -49,3 +49,7 @@ func NewMapOfStringToRefOfCommit() types.Map {
 func typeForSetOfRefOfCommit() *types.Type {
 	return types.MakeSetType(types.MakeRefType(commitType))
 }
+
+func CommitType() *types.Type {
+	return commitType
+}


### PR DESCRIPTION
Added -n arg to limit number of commits that are displayed.
Changed dataspec arg to valuespec arg so that sha1's can be used as starting commit.
