### PR TITLE
Re-add hasRefs to DatabaseServer

### DIFF
--- a/chunks/remote_requests.go
+++ b/chunks/remote_requests.go
@@ -76,10 +76,6 @@ func (h OutstandingHas) Fail() {
 // ReadBatch represents a set of queued Get/Has requests, each of which are blocking on a receive channel for a response.
 type ReadBatch map[hash.Hash][]OutstandingRequest
 
-// GetBatch represents a set of queued Get requests, each of which are blocking on a receive channel for a response.
-type GetBatch map[hash.Hash][]chan Chunk
-type HasBatch map[hash.Hash][]chan bool
-
 // Close ensures that callers to Get() and Has() are failed correctly if the corresponding chunk wasn't in the response from the server (i.e. it wasn't found).
 func (rb *ReadBatch) Close() error {
 	for _, reqs := range *rb {
@@ -103,33 +99,6 @@ func (rb *ReadBatch) Put(c Chunk) {
 func (rb *ReadBatch) PutMany(chunks []Chunk) (e BackpressureError) {
 	for _, c := range chunks {
 		rb.Put(c)
-	}
-	return
-}
-
-// Close ensures that callers to Get() must receive nil if the corresponding chunk wasn't in the response from the server (i.e. it wasn't found).
-func (gb *GetBatch) Close() error {
-	for _, chs := range *gb {
-		for _, ch := range chs {
-			ch <- EmptyChunk
-		}
-	}
-	return nil
-}
-
-// Put is implemented so that GetBatch implements the ChunkSink interface.
-func (gb *GetBatch) Put(c Chunk) {
-	for _, ch := range (*gb)[c.Hash()] {
-		ch <- c
-	}
-
-	delete(*gb, c.Hash())
-}
-
-// PutMany is implemented so that GetBatch implements the ChunkSink interface.
-func (gb *GetBatch) PutMany(chunks []Chunk) (e BackpressureError) {
-	for _, c := range chunks {
-		gb.Put(c)
 	}
 	return
 }

--- a/constants/http.go
+++ b/constants/http.go
@@ -7,6 +7,7 @@ package constants
 const (
 	RootPath       = "/root/"
 	GetRefsPath    = "/getRefs/"
+	HasRefsPath    = "/hasRefs/"
 	PostRefsPath   = "/postRefs/"
 	WriteValuePath = "/writeValue/"
 )

--- a/datas/database_server.go
+++ b/datas/database_server.go
@@ -44,6 +44,7 @@ func (s *remoteDatabaseServer) Run() {
 	router := httprouter.New()
 
 	router.POST(constants.GetRefsPath, s.makeHandle(HandleGetRefs))
+	router.POST(constants.HasRefsPath, s.makeHandle(HandleHasRefs))
 	router.GET(constants.RootPath, s.makeHandle(HandleRootGet))
 	router.POST(constants.RootPath, s.makeHandle(HandleRootPost))
 	router.POST(constants.PostRefsPath, s.makeHandle(HandlePostRefs))


### PR DESCRIPTION
In order to simplify our pull/push code, we need to allow our httpBatchStore
implementations to perform batched remote 'has' checks again.

Towards #1568
