### PR TITLE
Sort field names when created

### DIFF
--- a/js/src/encoding-test.js
+++ b/js/src/encoding-test.js
@@ -503,5 +503,3 @@ suite('Encoding', () => {
     new List());
   });
 });
-
-

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -65,10 +65,10 @@ export class StructDesc {
   fields: {[key: string]: Type};
   fieldCount: number;
 
-  constructor(name: string, fields: {[key: string]: Type}) {
+  constructor(name: string, fields: {[key: string]: Type}, fieldCount: number) {
     this.name = name;
     this.fields = fields;
-    this.fieldCount = Object.keys(fields).length;
+    this.fieldCount = fieldCount;
   }
 
   get kind(): NomsKind {
@@ -108,11 +108,9 @@ export class StructDesc {
 
   forEachField(cb: (name: string, type: Type) => void) {
     const {fields} = this;
-    const names = Object.keys(fields);
-    names.sort();
-    names.forEach(n => {
+    for (const n in fields) {
       cb(n, fields[n]);
-    });
+    }
   }
 }
 
@@ -181,8 +179,16 @@ export function makeRefType(elemType: Type): Type<CompoundDesc> {
 
 export function makeStructType(name: string, fields: {[key: string]: Type}): Type<StructDesc> {
   verifyStructName(name);
-  Object.keys(fields).forEach(verifyFieldName);
-  return buildType(new StructDesc(name, fields));
+  const newFields = Object.create(null);
+  const keys = Object.keys(fields);
+  keys.sort();
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i];
+    verifyFieldName(k);
+    newFields[k] = fields[k];
+  }
+
+  return buildType(new StructDesc(name, newFields, keys.length));
 }
 
 /**

--- a/types/type.go
+++ b/types/type.go
@@ -126,10 +126,15 @@ func MakePrimitiveTypeByString(p string) *Type {
 
 func MakeStructType(name string, fields map[string]*Type) *Type {
 	verifyStructName(name)
+	names := make([]string, len(fields))
+	i := 0
 	for fn := range fields {
 		verifyFieldName(fn)
+		names[i] = fn
+		i++
 	}
-	return buildType(StructDesc{name, fields})
+	sort.Strings(names)
+	return buildType(StructDesc{name, fields, names})
 }
 
 var fieldNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)

--- a/types/type_desc.go
+++ b/types/type_desc.go
@@ -4,8 +4,6 @@
 
 package types
 
-import "sort"
-
 // TypeDesc describes a type of the kind returned by Kind(), e.g. Map, Number, or a custom type.
 type TypeDesc interface {
 	Kind() NomsKind
@@ -73,8 +71,9 @@ type TypeMap map[string]*Type
 // StructDesc describes a custom Noms Struct.
 // Structs can contain at most one anonymous union, so Union may be nil.
 type StructDesc struct {
-	Name   string
-	Fields TypeMap
+	Name        string
+	Fields      TypeMap
+	sortedNames []string
 }
 
 func (s StructDesc) Kind() NomsKind {
@@ -94,12 +93,7 @@ func (s StructDesc) Equals(other TypeDesc) bool {
 }
 
 func (s StructDesc) IterFields(cb func(name string, t *Type)) {
-	names := make([]string, 0, len(s.Fields))
-	for name := range s.Fields {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
+	for _, name := range s.sortedNames {
 		cb(name, s.Fields[name])
 	}
 }

--- a/types/value_decoder.go
+++ b/types/value_decoder.go
@@ -186,17 +186,20 @@ func (r *valueDecoder) readStructType(parentStructTypes []*Type) *Type {
 	name := r.readString()
 
 	fields := map[string]*Type{}
-	st := MakeStructType(name, fields)
+	fieldNames := []string{}
+	desc := StructDesc{name, fields, fieldNames}
+	st := buildType(desc)
 	parentStructTypes = append(parentStructTypes, st)
-	desc := st.Desc.(StructDesc)
 
 	count := r.readUint32()
 	for i := uint32(0); i < count; i++ {
 		fieldName := r.readString()
 		fieldType := r.readType(parentStructTypes)
 		fields[fieldName] = fieldType
+		fieldNames = append(fieldNames, fieldName)
 	}
 	desc.Fields = fields
+	desc.sortedNames = fieldNames
 	st.Desc = desc
 	return st
 }


### PR DESCRIPTION
This also skips the sorting of the field names when the StructDesc
is created by the decoder.

Fixes #1687
