### PR TITLE
Update clients to use latest eslint

### DIFF
--- a/clients/js/aggregate/package.json
+++ b/clients/js/aggregate/package.json
@@ -7,7 +7,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/bar-chart/package.json
+++ b/clients/js/bar-chart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noms-bar-chart",
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "@attic/noms": "^37.0.0",
     "@attic/webpack-config": "^2.1.0",
     "babel-cli": "6.6.5",

--- a/clients/js/counter/package.json
+++ b/clients/js/counter/package.json
@@ -8,7 +8,7 @@
     "babel-regenerator-runtime": "6.5.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/csv/package.json
+++ b/clients/js/csv/package.json
@@ -10,7 +10,7 @@
     "request": "^2.72.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^2.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/csv/src/main.js
+++ b/clients/js/csv/src/main.js
@@ -7,7 +7,7 @@
 import argv from 'yargs';
 import request from 'request';
 import parse from 'csv-parse';
-import {DatasetSpec, List, ListWriter, Struct, newStruct, escapeStructField} from '@attic/noms';
+import {DatasetSpec, ListWriter, Struct, newStruct, escapeStructField} from '@attic/noms';
 
 const args = argv
   .usage('Usage: $0 <url> <dataset>')

--- a/clients/js/fb/find-photos/package.json
+++ b/clients/js/fb/find-photos/package.json
@@ -8,7 +8,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/fb/slurp/package.json
+++ b/clients/js/fb/slurp/package.json
@@ -9,7 +9,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/flickr/find-photos/package.json
+++ b/clients/js/flickr/find-photos/package.json
@@ -10,7 +10,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/fs/package.json
+++ b/clients/js/fs/package.json
@@ -10,7 +10,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/hash-perf-rig/package.json
+++ b/clients/js/hash-perf-rig/package.json
@@ -10,7 +10,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/pitch-index/package.json
+++ b/clients/js/pitch-index/package.json
@@ -8,7 +8,7 @@
     "babel-regenerator-runtime": "6.5.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/clients/js/pitch-index/src/main.js
+++ b/clients/js/pitch-index/src/main.js
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
   const input = inSpec.dataset();
   const commit = await input.head();
   const head = commit && commit.value;
-  invariant(head, quit(`{args._[0]} does not exist}`));
+  invariant(head, quit(`${args._[0]} does not exist}`));
 
   const pitchers = new Map();
   const inningPs = [];

--- a/clients/js/splore/package.json
+++ b/clients/js/splore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noms-splore",
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "@attic/noms": "^37.0.0",
     "@attic/webpack-config": "^2.1.0",
     "babel-cli": "6.6.5",

--- a/clients/js/splore/src/main.js
+++ b/clients/js/splore/src/main.js
@@ -218,11 +218,11 @@ function handleNodeClick(e: MouseEvent, id: string) {
 
   if (id.indexOf('/') > -1) {
     if (data.links[id] && data.links[id].length > 0) {
-      data.nodes[id].isOpen = !Boolean(data.nodes[id].isOpen);
+      data.nodes[id].isOpen = !data.nodes[id].isOpen;
       render();
     }
   } else {
-    data.nodes[id].isOpen = !Boolean(data.nodes[id].isOpen);
+    data.nodes[id].isOpen = !data.nodes[id].isOpen;
     if (data.links[id] || !data.nodes[id].isOpen) {
       render();
     } else {

--- a/clients/js/url_fetch/package.json
+++ b/clients/js/url_fetch/package.json
@@ -8,7 +8,7 @@
     "yargs": "4.4.0"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^1.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/js/package.json
+++ b/js/package.json
@@ -16,7 +16,7 @@
     "tingodb": "^0.4.2"
   },
   "devDependencies": {
-    "@attic/eslintrc": "^2.0.0",
+    "@attic/eslintrc": "^3.1.0",
     "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-generator": "6.7.2",

--- a/js/src/blob.js
+++ b/js/src/blob.js
@@ -10,7 +10,7 @@ import {SequenceCursor} from './sequence.js';
 import {invariant} from './assert.js';
 import type {ValueReader, ValueWriter, ValueReadWriter} from './value-store.js';
 import {blobType} from './type.js';
-import {MetaTuple, newIndexedMetaSequenceChunkFn, newIndexedMetaSequenceBoundaryChecker,} from
+import {MetaTuple, newIndexedMetaSequenceChunkFn, newIndexedMetaSequenceBoundaryChecker} from
   './meta-sequence.js';
 import BuzHashBoundaryChecker from './buzhash-boundary-checker.js';
 import Ref from './ref.js';

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -16,9 +16,9 @@ import {compare, equals} from './compare.js';
 import {sha1Size} from './hash.js';
 import {getHashOfValue} from './get-hash.js';
 import {getTypeOfValue, makeMapType, makeUnionType} from './type.js';
-import {MetaTuple, newOrderedMetaSequenceBoundaryChecker, newOrderedMetaSequenceChunkFn,} from
+import {MetaTuple, newOrderedMetaSequenceBoundaryChecker, newOrderedMetaSequenceChunkFn} from
   './meta-sequence.js';
-import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator,} from
+import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator} from
   './ordered-sequence.js';
 import diff from './ordered-sequence-diff.js';
 import {ValueBase} from './value.js';

--- a/js/src/meta-sequence-test.js
+++ b/js/src/meta-sequence-test.js
@@ -8,7 +8,7 @@ import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
 import List from './list.js';
-import {MetaTuple, newOrderedMetaSequenceChunkFn, newIndexedMetaSequenceChunkFn,} from
+import {MetaTuple, newOrderedMetaSequenceChunkFn, newIndexedMetaSequenceChunkFn} from
   './meta-sequence.js';
 import Ref from './ref.js';
 import Set from './set.js';

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -16,9 +16,9 @@ import Collection from './collection.js';
 import {compare, equals} from './compare.js';
 import {getHashOfValue} from './get-hash.js';
 import {invariant} from './assert.js';
-import {MetaTuple, newOrderedMetaSequenceBoundaryChecker, newOrderedMetaSequenceChunkFn,} from
+import {MetaTuple, newOrderedMetaSequenceBoundaryChecker, newOrderedMetaSequenceChunkFn} from
   './meta-sequence.js';
-import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator,} from
+import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator} from
   './ordered-sequence.js';
 import diff from './ordered-sequence-diff.js';
 import {makeSetType, makeUnionType, getTypeOfValue} from './type.js';

--- a/jsmodules/eslintrc/package.json
+++ b/jsmodules/eslintrc/package.json
@@ -8,5 +8,8 @@
     "eslint": "^2.11.1",
     "eslint-plugin-flow-vars": "^0.4.0",
     "eslint-plugin-react": "^5.1.1"
+  },
+  "scripts": {
+    "test": "exit 0"
   }
 }

--- a/jsmodules/webpack-config/package.json
+++ b/jsmodules/webpack-config/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "babel-loader": "^6.2.1",
     "webpack": "^1.12.11"
+  },
+  "scripts": {
+    "test": "exit 0"
   }
 }

--- a/tools/run-all-js-tests.py
+++ b/tools/run-all-js-tests.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+# Copyright 2016 The Noms Authors. All rights reserved.
+# Licensed under the Apache License, version 2.0:
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# This tool finds all package.json files and runs npm install and npm test in those directories.
+
+import os
+import subprocess
+from contextlib import contextmanager
+
+@contextmanager
+def pushd(path):
+  currentDir = os.getcwd()
+  os.chdir(path)
+  yield
+  os.chdir(currentDir)
+
+def main():
+  lsfiles = subprocess.check_output(['git', 'ls-files']).split('\n')
+  for f in lsfiles:
+    path, name = os.path.split(f)
+    if name == 'package.json':
+      with pushd(path):
+        subprocess.check_call(['npm', 'install'])
+        subprocess.check_call(['npm', 'test'])
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
And fix new errors that were found.

This also adds tools/run-all-js-tests.py which runs `npm install`
and `npm test` in all directories containing a package.json file.
