### PR TITLE
Move paging functionality into specific noms sub commands.

### DIFF
--- a/cmd/noms-ds/noms_ds.go
+++ b/cmd/noms-ds/noms_ds.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	toDelete    = flag.String("d", "", "dataset to delete")
-	stdoutIsTty = flag.Int("stdout-is-tty", -1, "value of 1 forces tty ouput, 0 forces non-tty output (provided for use by other programs)")
+	toDelete = flag.String("d", "", "dataset to delete")
 )
 
 func main() {

--- a/cmd/noms-serve/noms_serve.go
+++ b/cmd/noms-serve/noms_serve.go
@@ -19,8 +19,7 @@ import (
 )
 
 var (
-	port        = flag.Int("port", 8000, "")
-	stdoutIsTty = flag.Int("stdout-is-tty", -1, "value of 1 forces tty ouput, 0 forces non-tty output (provided for use by other programs)")
+	port = flag.Int("port", 8000, "")
 )
 
 func main() {

--- a/cmd/noms-show/noms_show.go
+++ b/cmd/noms-show/noms_show.go
@@ -13,11 +13,11 @@ import (
 	"github.com/attic-labs/noms/clients/go/flags"
 	"github.com/attic-labs/noms/clients/go/util"
 	"github.com/attic-labs/noms/types"
+	"github.com/attic-labs/noms/util/outputpager"
 )
 
 var (
-	showHelp    = flag.Bool("help", false, "show help text")
-	stdoutIsTty = flag.Int("stdout-is-tty", -1, "value of 1 forces tty ouput, 0 forces non-tty output (provided for use by other programs)")
+	showHelp = flag.Bool("help", false, "show help text")
 )
 
 func main() {
@@ -43,7 +43,14 @@ func main() {
 	database, value, err := spec.Value()
 	util.CheckError(err)
 
+	waitChan := outputpager.PageOutput(!*outputpager.NoPager)
+
 	types.WriteEncodedValueWithTags(os.Stdout, value)
 	fmt.Fprintf(os.Stdout, "\n")
 	database.Close()
+
+	if waitChan != nil {
+		os.Stdout.Close()
+		<-waitChan
+	}
 }

--- a/cmd/noms-sync/noms_sync.go
+++ b/cmd/noms-sync/noms_sync.go
@@ -19,8 +19,7 @@ import (
 )
 
 var (
-	p           = flag.Uint("p", 512, "parallelism")
-	stdoutIsTty = flag.Int("stdout-is-tty", -1, "value of 1 forces tty ouput, 0 forces non-tty output (provided for use by other programs)")
+	p = flag.Uint("p", 512, "parallelism")
 )
 
 func main() {

--- a/cmd/noms-ui/noms_ui.go
+++ b/cmd/noms-ui/noms_ui.go
@@ -28,8 +28,7 @@ const (
 )
 
 var (
-	portFlag    = flag.Int("port", 0, "Port to listen on")
-	stdoutIsTty = flag.Int("stdout-is-tty", -1, "value of 1 forces tty ouput, 0 forces non-tty output (provided for use by other programs)")
+	portFlag = flag.Int("port", 0, "Port to listen on")
 )
 
 type chunkStoreRecord struct {

--- a/util/outputpager/page_output.go
+++ b/util/outputpager/page_output.go
@@ -1,0 +1,53 @@
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package outputpager
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+
+	"github.com/attic-labs/noms/d"
+	goisatty "github.com/mattn/go-isatty"
+)
+
+var (
+	NoPager = flag.Bool("no-pager", false, "suppress paging functionality")
+)
+
+func PageOutput(usePager bool) <-chan struct{} {
+	if !usePager || !IsStdoutTty() {
+		return nil
+	}
+
+	lessExecutable, err := exec.LookPath("less")
+	d.Chk.NoError(err, "unable to find 'less' utility: %s", err)
+
+	lessStdin, newStdout, err := os.Pipe()
+	d.Chk.NoError(err, "os.Pipe() failed: %s\n", err)
+
+	cmd := exec.Command(lessExecutable, []string{"-FSRX"}...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	os.Stdout = newStdout
+	cmd.Stdin = lessStdin
+
+	err = cmd.Start()
+	d.Chk.NoError(err, "cmd execution failed: %s\n", err)
+
+	ch := make(chan struct{})
+	go func() {
+		err := cmd.Wait()
+		d.Chk.NoError(err, "pager exited with error: %s\n", err)
+		os.Stdout.Close()
+		ch <- struct{}{}
+	}()
+
+	return ch
+}
+
+func IsStdoutTty() bool {
+	return goisatty.IsTerminal(os.Stdout.Fd())
+}


### PR DESCRIPTION
This also fixes some edge cases where paging wasn't terminating properly
and eliminates the dreaded -stdout-is-tty argument.
