### PR TITLE
JS: Make Hash store the digest internally

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attic/noms",
-  "version": "43.0.0",
+  "version": "44.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/batch-store-adaptor.js
+++ b/js/src/batch-store-adaptor.js
@@ -11,6 +11,7 @@ import BatchStore from './batch-store.js';
 import type {ChunkStore} from './chunk-store.js';
 import type {UnsentReadMap} from './batch-store.js';
 import type {ChunkStream} from './chunk-serializer.js';
+import {notNull} from './assert.js';
 
 export function makeTestingBatchStore(): BatchStore {
   return new BatchStore(3, new BatchStoreAdaptorDelegate(new MemoryStore()));
@@ -31,7 +32,7 @@ export class BatchStoreAdaptorDelegate {
 
   async readBatch(reqs: UnsentReadMap): Promise<void> {
     Object.keys(reqs).forEach(hashStr => {
-      this._cs.get(Hash.parse(hashStr)).then(chunk => { reqs[hashStr](chunk); });
+      this._cs.get(notNull(Hash.parse(hashStr))).then(chunk => { reqs[hashStr](chunk); });
     });
   }
 

--- a/js/src/browser/sha1.js
+++ b/js/src/browser/sha1.js
@@ -10,6 +10,6 @@ import Rusha from 'rusha';
 
 const r = new Rusha();
 
-export function hex(data: Uint8Array): Uint8Array {
-  return new Uint8Array(r.rawDigest(data).buffer);
+export default function sha1(data: Uint8Array): Uint32Array {
+  return r.rawDigest(data);
 }

--- a/js/src/browser/sha1.js
+++ b/js/src/browser/sha1.js
@@ -10,6 +10,6 @@ import Rusha from 'rusha';
 
 const r = new Rusha();
 
-export function hex(data: Uint8Array): string {
-  return r.digest(data);
+export function hex(data: Uint8Array): Uint8Array {
+  return new Uint8Array(r.rawDigest(data).buffer);
 }

--- a/js/src/chunk-serializer.js
+++ b/js/src/chunk-serializer.js
@@ -102,7 +102,7 @@ function deserializeHints(buffer: ArrayBuffer): {hints: Array<Hash>, offset: num
     invariant(buffer.byteLength - offset >= sha1Size, 'Invalid hint buffer');
 
     const hashArray = new Uint8Array(buffer, offset, sha1Size);
-    const hash = new Hash(new Uint8Array(hashArray));
+    const hash = new Hash(hashArray);
     offset += sha1Size;
 
     hints.push(hash);
@@ -119,7 +119,7 @@ export function deserializeChunks(buffer: ArrayBuffer, offset: number = 0): Arra
     invariant(buffer.byteLength - offset >= chunkHeaderSize, 'Invalid chunk buffer');
 
     const hashArray = new Uint8Array(buffer, offset, sha1Size);
-    const hash = new Hash(new Uint8Array(hashArray));
+    const hash = new Hash(hashArray);
     offset += sha1Size;
 
     const view = new DataView(buffer, offset, chunkLengthSize);

--- a/js/src/chunk-serializer.js
+++ b/js/src/chunk-serializer.js
@@ -102,7 +102,7 @@ function deserializeHints(buffer: ArrayBuffer): {hints: Array<Hash>, offset: num
     invariant(buffer.byteLength - offset >= sha1Size, 'Invalid hint buffer');
 
     const hashArray = new Uint8Array(buffer, offset, sha1Size);
-    const hash = Hash.fromDigest(new Uint8Array(hashArray));
+    const hash = new Hash(new Uint8Array(hashArray));
     offset += sha1Size;
 
     hints.push(hash);
@@ -119,7 +119,7 @@ export function deserializeChunks(buffer: ArrayBuffer, offset: number = 0): Arra
     invariant(buffer.byteLength - offset >= chunkHeaderSize, 'Invalid chunk buffer');
 
     const hashArray = new Uint8Array(buffer, offset, sha1Size);
-    const hash = Hash.fromDigest(new Uint8Array(hashArray));
+    const hash = new Hash(new Uint8Array(hashArray));
     offset += sha1Size;
 
     const view = new DataView(buffer, offset, chunkLengthSize);

--- a/js/src/chunk-test.js
+++ b/js/src/chunk-test.js
@@ -8,20 +8,23 @@ import {suite, test} from 'mocha';
 import {assert} from 'chai';
 import Chunk from './chunk.js';
 import Hash from './hash.js';
+import {notNull} from './assert.js';
 
 suite('Chunk', () => {
   test('construct', () => {
     const c = Chunk.fromString('abc');
     assert.strictEqual(c.toString(), 'abc');
-    assert.isTrue(c.hash.equals(Hash.parse('sha1-a9993e364706816aba3e25717850c26c9cd0d89d')));
+    assert.isTrue(c.hash.equals(
+        notNull(Hash.parse('sha1-a9993e364706816aba3e25717850c26c9cd0d89d'))));
     assert.isFalse(c.isEmpty());
   });
 
   test('construct with hash', () => {
-    const hash = Hash.parse('sha1-0000000000000000000000000000000000000001');
+    const hash = notNull(Hash.parse('sha1-0000000000000000000000000000000000000001'));
     const c = Chunk.fromString('abc', hash);
     assert.strictEqual(c.toString(), 'abc');
-    assert.isTrue(c.hash.equals(Hash.parse('sha1-0000000000000000000000000000000000000001')));
+    assert.isTrue(c.hash.equals(
+        notNull(Hash.parse('sha1-0000000000000000000000000000000000000001'))));
     assert.isFalse(c.isEmpty());
   });
 

--- a/js/src/codec.js
+++ b/js/src/codec.js
@@ -130,7 +130,6 @@ export class BinaryNomsReader {
   readHash(): Hash {
     const digest = new Uint8Array(this.buff, this.offset, sha1Size);
     this.offset += sha1Size;
-    // new Hash doesn't take ownership of the memory, so it's safe to pass a view.
     return new Hash(digest);
   }
 }

--- a/js/src/codec.js
+++ b/js/src/codec.js
@@ -130,8 +130,8 @@ export class BinaryNomsReader {
   readHash(): Hash {
     const digest = new Uint8Array(this.buff, this.offset, sha1Size);
     this.offset += sha1Size;
-    // fromDigest doesn't take ownership of the memory, so it's safe to pass a view.
-    return Hash.fromDigest(digest);
+    // new Hash doesn't take ownership of the memory, so it's safe to pass a view.
+    return new Hash(digest);
   }
 }
 

--- a/js/src/encoding-test.js
+++ b/js/src/encoding-test.js
@@ -169,7 +169,7 @@ suite('Encoding', () => {
     }
 
     readHash(): Hash {
-      return new Hash(this.readString());
+      return Hash.parse(this.readString());
     }
   }
 

--- a/js/src/hash-test.js
+++ b/js/src/hash-test.js
@@ -8,14 +8,12 @@ import {assert} from 'chai';
 import {suite, test} from 'mocha';
 import Hash, {emptyHash} from './hash.js';
 import {encode} from './utf8.js';
+import {notNull} from './assert.js';
 
 suite('Hash', () => {
   test('parse', () => {
     function assertParseError(s) {
-      assert.throws(() => {
-        Hash.parse(s);
-      });
-      assert.equal(null, Hash.maybeParse(s));
+      assert.equal(null, Hash.parse(s));
     }
 
     assertParseError('foo');
@@ -33,13 +31,12 @@ suite('Hash', () => {
 
     const valid = 'sha1-0000000000000000000000000000000000000000';
     assert.isNotNull(Hash.parse(valid));
-    assert.isNotNull(Hash.maybeParse(valid));
   });
 
   test('equals', () => {
-    const r0 = Hash.parse('sha1-0000000000000000000000000000000000000000');
-    const r01 = Hash.parse('sha1-0000000000000000000000000000000000000000');
-    const r1 = Hash.parse('sha1-0000000000000000000000000000000000000001');
+    const r0 = notNull(Hash.parse('sha1-0000000000000000000000000000000000000000'));
+    const r01 = notNull(Hash.parse('sha1-0000000000000000000000000000000000000000'));
+    const r1 = notNull(Hash.parse('sha1-0000000000000000000000000000000000000001'));
 
     assert.isTrue(r0.equals(r01));
     assert.isTrue(r01.equals(r0));
@@ -49,7 +46,7 @@ suite('Hash', () => {
 
   test('toString', () => {
     const s = 'sha1-0123456789abcdef0123456789abcdef01234567';
-    const r = Hash.parse(s);
+    const r = notNull(Hash.parse(s));
     assert.strictEqual(s, r.toString());
   });
 

--- a/js/src/hash-test.js
+++ b/js/src/hash-test.js
@@ -61,11 +61,11 @@ suite('Hash', () => {
 
   test('isEmpty', () => {
     const digest = new Uint8Array(20);
-    let r = Hash.fromDigest(digest);
+    let r = new Hash(digest);
     assert.isTrue(r.isEmpty());
 
     digest[0] = 10;
-    r = Hash.fromDigest(digest);
+    r = new Hash(digest);
     assert.isFalse(r.isEmpty());
 
     r = emptyHash;

--- a/js/src/hash.js
+++ b/js/src/hash.js
@@ -4,7 +4,7 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
-import {hex} from './sha1.js';
+import sha1 from './sha1.js';
 
 export const sha1Size = 20;
 const pattern = /^sha1-[0-9a-f]{40}$/;
@@ -34,7 +34,7 @@ function sha1ToUint8Array(s: string): Uint8Array {
 export default class Hash {
   _digest: Uint8Array;
 
-  constructor(digest: TypedArray) {
+  constructor(digest: Uint8Array) {
     // Make a copy to prevent holding on to the data that was passed in.
     this._digest = new Uint8Array(digest);
   }
@@ -90,7 +90,7 @@ export default class Hash {
   }
 
   static fromData(data: Uint8Array): Hash {
-    return new Hash(hex(data));
+    return new Hash(sha1(data));
   }
 }
 

--- a/js/src/hash.js
+++ b/js/src/hash.js
@@ -75,14 +75,7 @@ export default class Hash {
     return uint8ArrayToSha1(this._digest);
   }
 
-  static parse(s: string): Hash {
-    if (!pattern.test(s)) {
-      throw new Error(`Could not parse hash: ${s}`);
-    }
-    return new Hash(sha1ToUint8Array(s));
-  }
-
-  static maybeParse(s: string): ?Hash {
+  static parse(s: string): ?Hash {
     if (pattern.test(s)) {
       return new Hash(sha1ToUint8Array(s));
     }

--- a/js/src/http-batch-store.js
+++ b/js/src/http-batch-store.js
@@ -12,6 +12,7 @@ import type {ChunkStream} from './chunk-serializer.js';
 import {serialize, deserializeChunks} from './chunk-serializer.js';
 import {emptyChunk} from './chunk.js';
 import {fetchArrayBuffer, fetchText} from './fetch.js';
+import {notNull} from './assert.js';
 
 const HTTP_STATUS_CONFLICT = 409;
 
@@ -103,7 +104,7 @@ export class Delegate {
 
   async getRoot(): Promise<Hash> {
     const hashStr = await fetchText(this._rpc.root, this._rootOptions);
-    return Hash.parse(hashStr);
+    return notNull(Hash.parse(hashStr));
   }
 
   async updateRoot(current: Hash, last: Hash): Promise<boolean> {

--- a/js/src/memory-store-test.js
+++ b/js/src/memory-store-test.js
@@ -9,6 +9,7 @@ import {suite, test} from 'mocha';
 import Chunk from './chunk.js';
 import MemoryStore from './memory-store.js';
 import Hash from './hash.js';
+import {notNull} from './assert.js';
 
 suite('MemoryStore', () => {
   async function assertInputInStore(input: string, hash: Hash, ms: MemoryStore) {
@@ -43,9 +44,9 @@ suite('MemoryStore', () => {
     assert.isTrue(oldRoot.isEmpty());
 
     // sha1('Bogus, Dude')
-    const bogusRoot = Hash.parse('sha1-81c870618113ba29b6f2b396ea3a69c6f1d626c5');
+    const bogusRoot = notNull(Hash.parse('sha1-81c870618113ba29b6f2b396ea3a69c6f1d626c5'));
      // sha1('Hello, World')
-    const newRoot = Hash.parse('sha1-907d14fb3af2b0d4f18c2d46abe8aedce17367bd');
+    const newRoot = notNull(Hash.parse('sha1-907d14fb3af2b0d4f18c2d46abe8aedce17367bd'));
 
     // Try to update root with bogus oldRoot
     let result = await ms.updateRoot(newRoot, bogusRoot);
@@ -58,7 +59,7 @@ suite('MemoryStore', () => {
 
   test('get non-existing', async () => {
     const ms = new MemoryStore();
-    const hash = Hash.parse('sha1-1111111111111111111111111111111111111111');
+    const hash = notNull(Hash.parse('sha1-1111111111111111111111111111111111111111'));
     const c = await ms.get(hash);
     assert.isTrue(c.isEmpty());
   });

--- a/js/src/sha1-test.js
+++ b/js/src/sha1-test.js
@@ -7,18 +7,20 @@
 import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
-import {hex as hexNode} from './sha1.js';
-import {hex as hexBrowser} from './browser/sha1.js';
+import sha1Node from './sha1.js';
+import sha1Browser from './browser/sha1.js';
 
 suite('Sha1', () => {
   test('hex', () => {
     function assertSame(arr: Uint8Array) {
       // Node uses a Buffer, browser uses a Uint8Array
-      const n = hexNode(arr);
-      const b = hexBrowser(arr);
-      assert.equal(n.length, b.length);
-      for (let i = 0; i < n.length; i++) {
-        assert.equal(n[i], b[i]);
+      const n = sha1Node(arr);
+      const b = sha1Browser(arr);
+      assert.equal(n.byteLength, b.byteLength);
+      const n2 = new Uint8Array(n.buffer, n.byteOffset, n.byteLength);
+      const b2 = new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+      for (let i = 0; i < n2.length; i++) {
+        assert.equal(n2[i], b2[i]);
       }
     }
 

--- a/js/src/sha1-test.js
+++ b/js/src/sha1-test.js
@@ -13,7 +13,13 @@ import {hex as hexBrowser} from './browser/sha1.js';
 suite('Sha1', () => {
   test('hex', () => {
     function assertSame(arr: Uint8Array) {
-      assert.strictEqual(hexNode(arr), hexBrowser(arr));
+      // Node uses a Buffer, browser uses a Uint8Array
+      const n = hexNode(arr);
+      const b = hexBrowser(arr);
+      assert.equal(n.length, b.length);
+      for (let i = 0; i < n.length; i++) {
+        assert.equal(n[i], b[i]);
+      }
     }
 
     assertSame(new Uint8Array(0));

--- a/js/src/sha1.js
+++ b/js/src/sha1.js
@@ -8,7 +8,7 @@
 
 import crypto from 'crypto';
 
-export default function sha1(data: Uint8Array): TypedArray {
+export default function sha1(data: Uint8Array): Uint8Array {
   const hash = crypto.createHash('sha1');
   hash.update(data);
   return hash.digest();

--- a/js/src/sha1.js
+++ b/js/src/sha1.js
@@ -8,7 +8,7 @@
 
 import crypto from 'crypto';
 
-export function hex(data: Uint8Array): Uint8Array {
+export default function sha1(data: Uint8Array): TypedArray {
   const hash = crypto.createHash('sha1');
   hash.update(data);
   return hash.digest();

--- a/js/src/sha1.js
+++ b/js/src/sha1.js
@@ -8,8 +8,8 @@
 
 import crypto from 'crypto';
 
-export function hex(data: Uint8Array): string {
+export function hex(data: Uint8Array): Uint8Array {
   const hash = crypto.createHash('sha1');
   hash.update(data);
-  return hash.digest('hex');
+  return hash.digest();
 }

--- a/js/src/specs-test.js
+++ b/js/src/specs-test.js
@@ -82,7 +82,7 @@ suite('Specs', () => {
   });
 
   test('HashSpec', async () => {
-    const testHash = new Hash('sha1-0000000000000000000000000000000000000000');
+    const testHash = Hash.parse('sha1-0000000000000000000000000000000000000000');
     const invalid = [
       'mem', 'mem:', 'http', 'http:', 'http://foo', 'monkey', 'monkey:balls',
       'mem:not-hash', 'mem:sha1-', 'mem:sha2-0000',
@@ -106,7 +106,7 @@ suite('Specs', () => {
     assert.equal(spec.database.scheme, 'http');
     assert.equal(spec.database.path, '//foo:8000/test');
 
-    const testHash = new Hash('sha1-0000000000000000000000000000000000000000');
+    const testHash = Hash.parse('sha1-0000000000000000000000000000000000000000');
     spec = parseObjectSpec(`http://foo:8000/test:${testHash}`);
     invariant(spec);
     assert.isNotNull(spec.value());

--- a/js/src/specs-test.js
+++ b/js/src/specs-test.js
@@ -83,6 +83,7 @@ suite('Specs', () => {
 
   test('HashSpec', async () => {
     const testHash = Hash.parse('sha1-0000000000000000000000000000000000000000');
+    invariant(testHash);
     const invalid = [
       'mem', 'mem:', 'http', 'http:', 'http://foo', 'monkey', 'monkey:balls',
       'mem:not-hash', 'mem:sha1-', 'mem:sha2-0000',
@@ -107,6 +108,7 @@ suite('Specs', () => {
     assert.equal(spec.database.path, '//foo:8000/test');
 
     const testHash = Hash.parse('sha1-0000000000000000000000000000000000000000');
+    invariant(testHash);
     spec = parseObjectSpec(`http://foo:8000/test:${testHash}`);
     invariant(spec);
     assert.isNotNull(spec.value());

--- a/js/src/specs.js
+++ b/js/src/specs.js
@@ -121,7 +121,7 @@ export class HashSpec {
       return null;
     }
 
-    const hash = Hash.maybeParse(match[2]);
+    const hash = Hash.parse(match[2]);
     if (!hash) {
       return null;
     }


### PR DESCRIPTION
Now that we are using a binary serialization it makes more sense to
have Hash work with the digest and only compute the sha1 string when
needed.

Fixes #1685
