### PR TITLE
Go: Make StructDesc use slices for names and types instead of a map

### DIFF
--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -26,7 +26,7 @@ func init() {
 		ValueField:   types.ValueType,
 	}
 	commitType = types.MakeStructType(structName, fieldTypes)
-	commitType.Desc.(types.StructDesc).Fields[ParentsField] = types.MakeSetType(types.MakeRefType(commitType))
+	commitType.Desc.(types.StructDesc).SetField(ParentsField, types.MakeSetType(types.MakeRefType(commitType)))
 }
 
 func NewCommit() types.Struct {

--- a/go/types/assert_type.go
+++ b/go/types/assert_type.go
@@ -46,21 +46,21 @@ func isSubtype(requiredType, concreteType *Type) bool {
 		if requiredDesc.Name != "" && requiredDesc.Name != concreteDesc.Name {
 			return false
 		}
-		type Entry struct {
-			name string
-			t    *Type
-		}
-		entries := make([]Entry, 0, len(requiredDesc.Fields))
-		requiredDesc.IterFields(func(name string, t *Type) {
-			entries = append(entries, Entry{name, t})
-		})
-		for _, entry := range entries {
-			at, ok := concreteDesc.Fields[entry.name]
-			if !ok || !isSubtype(entry.t, at) {
+		j := 0
+		for _, field := range requiredDesc.fields {
+			for ; j < concreteDesc.Len() && concreteDesc.fields[j].name != field.name; j++ {
+			}
+			if j == concreteDesc.Len() {
+				return false
+			}
+
+			f := concreteDesc.fields[j]
+			if !isSubtype(field.t, f.t) {
 				return false
 			}
 		}
 		return true
+
 	}
 
 	panic("unreachable")

--- a/go/types/assert_type_test.go
+++ b/go/types/assert_type_test.go
@@ -205,9 +205,9 @@ func TestAssertTypeStructSubtype(tt *testing.T) {
 
 	t11 := MakeStructType("Commit", TypeMap{
 		"value":   NumberType,
-		"parents": MakeSetType(MakeRefType(NumberType /* placeholder */)),
+		"parents": NumberType, // placeholder MakeSetType(MakeRefType(NumberType /* placeholder */)),
 	})
-	t11.Desc.(StructDesc).Fields["parents"].Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0] = t11
+	t11.Desc.(StructDesc).SetField("parents", MakeSetType(MakeRefType(t1)))
 	assertSubtype(t11, c1)
 
 	c2 := NewStruct("Commit", structData{

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -279,10 +279,10 @@ func TestRecursiveStruct(t *testing.T) {
 		"e": nil,
 		"f": a,
 	})
-	a.Desc.(StructDesc).Fields["b"] = a
-	a.Desc.(StructDesc).Fields["c"] = MakeListType(a)
-	a.Desc.(StructDesc).Fields["d"] = d
-	d.Desc.(StructDesc).Fields["e"] = d
+	a.Desc.(StructDesc).SetField("b", a)
+	a.Desc.(StructDesc).SetField("c", MakeListType(a))
+	a.Desc.(StructDesc).SetField("d", d)
+	d.Desc.(StructDesc).SetField("e", d)
 	assertWriteHRSEqual(t, `struct A {
   b: Cycle<0>
   c: List<Cycle<0>>

--- a/go/types/encoding_test.go
+++ b/go/types/encoding_test.go
@@ -462,7 +462,7 @@ func nomsTestWriteRecursiveStruct(t *testing.T) {
 	listType := MakeListType(structType)
 	// Mutate...
 
-	structType.Desc.(StructDesc).Fields["cs"] = listType
+	structType.Desc.(StructDesc).SetField("cs", listType)
 
 	assertEncoding(t,
 		[]interface{}{

--- a/go/types/path.go
+++ b/go/types/path.go
@@ -66,7 +66,7 @@ func newFieldPart(name string) fieldPart {
 
 func (fp fieldPart) Resolve(v Value) Value {
 	if s, ok := v.(Struct); ok {
-		if fv, ok := s.data[fp.name]; ok {
+		if fv, ok := s.MaybeGet(fp.name); ok {
 			return fv
 		}
 	}

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -126,15 +126,16 @@ func MakePrimitiveTypeByString(p string) *Type {
 
 func MakeStructType(name string, fields map[string]*Type) *Type {
 	verifyStructName(name)
-	names := make([]string, len(fields))
+	fs := make(fieldSlice, len(fields))
 	i := 0
-	for fn := range fields {
+	for fn, t := range fields {
 		verifyFieldName(fn)
-		names[i] = fn
+		fs[i] = field{fn, t}
 		i++
 	}
-	sort.Strings(names)
-	return buildType(StructDesc{name, fields, names})
+
+	sort.Sort(fs)
+	return buildType(StructDesc{name, fs})
 }
 
 var fieldNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -23,7 +23,7 @@ func TestTypes(t *testing.T) {
 	recType := MakeStructType("RecursiveStruct", TypeMap{
 		"self": nil,
 	})
-	recType.Desc.(StructDesc).Fields["self"] = recType
+	recType.Desc.(StructDesc).SetField("self", recType)
 
 	mRef := vs.WriteValue(mapType).TargetHash()
 	setRef := vs.WriteValue(setType).TargetHash()

--- a/go/types/value_encoder.go
+++ b/go/types/value_encoder.go
@@ -171,7 +171,7 @@ func indexOfType(t *Type, ts []*Type) int {
 }
 
 func (w *valueEncoder) writeStruct(v Value, t *Type) {
-	for _, v := range structReader(v.(Struct), t) {
+	for _, v := range v.(Struct).values {
 		w.writeValue(v)
 	}
 }
@@ -193,11 +193,12 @@ func (w *valueEncoder) writeStructType(t *Type, parentStructTypes []*Type) {
 	w.writeKind(StructKind)
 	w.writeString(t.Name())
 
-	count := len(t.Desc.(StructDesc).Fields)
+	count := t.Desc.(StructDesc).Len()
 	w.writeUint32(uint32(count))
 
-	t.Desc.(StructDesc).IterFields(func(name string, t *Type) {
-		w.writeString(name)
-		w.writeType(t, parentStructTypes)
-	})
+	fields := t.Desc.(StructDesc).fields
+	for _, field := range fields {
+		w.writeString(field.name)
+		w.writeType(field.t, parentStructTypes)
+	}
 }

--- a/samples/go/csv/read.go
+++ b/samples/go/csv/read.go
@@ -103,7 +103,10 @@ func Read(r *csv.Reader, structName string, headers_raw []string, kinds KindSlic
 	valueChan := make(chan types.Value, 128) // TODO: Make this a function param?
 	listChan := types.NewStreamingList(vrw, valueChan)
 
-	structFields := t.Desc.(types.StructDesc).Fields
+	kindMap := make(map[string]types.NomsKind, len(headers))
+	t.Desc.(types.StructDesc).IterFields(func(name string, t *types.Type) {
+		kindMap[name] = t.Kind()
+	})
 
 	for {
 		row, err := r.Read()
@@ -118,7 +121,7 @@ func Read(r *csv.Reader, structName string, headers_raw []string, kinds KindSlic
 		for i, v := range row {
 			if i < len(headers) {
 				name := headers[i]
-				fields[name] = StringToType(v, structFields[name].Kind())
+				fields[name] = StringToType(v, kindMap[name])
 			}
 		}
 		valueChan <- types.NewStructWithType(t, fields)

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -34,10 +34,10 @@ b,2,false
 
 	desc, ok := typ.Desc.(types.StructDesc)
 	assert.True(ok)
-	assert.Len(desc.Fields, 3)
-	assert.Equal(types.StringKind, desc.Fields["A"].Kind())
-	assert.Equal(types.NumberKind, desc.Fields["B"].Kind())
-	assert.Equal(types.BoolKind, desc.Fields["C"].Kind())
+	assert.Equal(desc.Len(), 3)
+	assert.Equal(types.StringKind, desc.Field("A").Kind())
+	assert.Equal(types.NumberKind, desc.Field("B").Kind())
+	assert.Equal(types.BoolKind, desc.Field("C").Kind())
 
 	assert.True(l.Get(0).(types.Struct).Get("A").Equals(types.NewString("a")))
 	assert.True(l.Get(1).(types.Struct).Get("A").Equals(types.NewString("b")))
@@ -65,9 +65,9 @@ func testTrailingHelper(t *testing.T, dataString string) {
 
 	desc, ok := typ.Desc.(types.StructDesc)
 	assert.True(ok)
-	assert.Len(desc.Fields, 2)
-	assert.Equal(types.StringKind, desc.Fields["A"].Kind())
-	assert.Equal(types.StringKind, desc.Fields["B"].Kind())
+	assert.Equal(desc.Len(), 2)
+	assert.Equal(types.StringKind, desc.Field("A").Kind())
+	assert.Equal(types.StringKind, desc.Field("B").Kind())
 }
 
 func TestReadTrailingHole(t *testing.T) {


### PR DESCRIPTION
The map showed up in benchmarks...

Fixes #1716
