### PR TITLE
fixing bug #1723, diff being slow 

### DIFF
--- a/cmd/noms-diff/noms_diff.go
+++ b/cmd/noms-diff/noms_diff.go
@@ -118,7 +118,7 @@ func diff(w io.Writer) {
 
 func diffLists(w io.Writer, p types.Path, v1, v2 types.List) {
 	wroteHeader := false
-	splices, _ := v2.Diff(v1)
+	splices, _, _ := v2.Diff(v1)
 	for _, splice := range splices {
 		if splice.SpRemoved == splice.SpAdded {
 			for i := uint64(0); i < splice.SpRemoved; i++ {

--- a/cmd/noms-diff/noms_diff.go
+++ b/cmd/noms-diff/noms_diff.go
@@ -118,7 +118,7 @@ func diff(w io.Writer) {
 
 func diffLists(w io.Writer, p types.Path, v1, v2 types.List) {
 	wroteHeader := false
-	splices, _, _ := v2.Diff(v1)
+	splices, _ := v2.Diff(v1)
 	for _, splice := range splices {
 		if splice.SpRemoved == splice.SpAdded {
 			for i := uint64(0); i < splice.SpRemoved; i++ {

--- a/go/types/indexed_sequence_diff.go
+++ b/go/types/indexed_sequence_diff.go
@@ -26,14 +26,12 @@ func maybeLoadCompositeSequence(ms indexedMetaSequence, idx uint64, length uint6
 
 func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64,
 	current indexedSequence, currentHeight int, currentOffset uint64, loadLimit uint64) ([]Splice, error) {
-
 	if lastHeight > currentHeight {
 		lastChild, newLoadLimit, err := maybeLoadCompositeSequence(last.(indexedMetaSequence), 0, uint64(last.seqLen()), loadLimit)
 		if err != nil {
 			return nil, err
 		}
-		splices, err := indexedSequenceDiff(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, newLoadLimit)
-		return splices, err
+		return indexedSequenceDiff(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, newLoadLimit)
 	}
 
 	if currentHeight > lastHeight {
@@ -41,14 +39,12 @@ func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64
 		if err != nil {
 			return nil, err
 		}
-		splices, err := indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, newLoadLimit)
-		return splices, err
+		return indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, newLoadLimit)
 	}
 
-	initialSplices := calcSplices(uint64(last.seqLen()), uint64(current.seqLen()),
-		func(i uint64, j uint64) bool {
-			return last.equalsAt(int(i), current.getItem(int(j)))
-		})
+	initialSplices := calcSplices(uint64(last.seqLen()), uint64(current.seqLen()), func(i uint64, j uint64) bool {
+		return last.equalsAt(int(i), current.getItem(int(j)))
+	})
 
 	finalSplices := []Splice{}
 	newLoadLimit := loadLimit

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -66,7 +66,7 @@ func (ims indexedMetaSequence) getOffset(idx int) uint64 {
 }
 
 func (ims indexedMetaSequence) equalsAt(idx int, other interface{}) bool {
-	return ims.getItem(idx).(metaTuple).ref == other.(metaTuple).ref
+	return ims.getItem(idx).(metaTuple).ref.Equals(other.(metaTuple).ref)
 }
 
 func newCursorAtIndex(seq indexedSequence, idx uint64) *sequenceCursor {

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -188,20 +188,20 @@ func (l List) IterAll(f listIterAllFunc) {
 	})
 }
 
-func (l List) Diff(last List) (splices []Splice, numSequencesLoaded uint64, err error) {
+func (l List) Diff(last List) ([]Splice, error) {
 	return l.DiffWithLoadLimit(last, DIFF_WITHOUT_LIMIT)
 }
 
-func (l List) DiffWithLoadLimit(last List, loadLimit uint64) (splices []Splice, numSequencesLoaded uint64, err error) {
+func (l List) DiffWithLoadLimit(last List, loadLimit uint64) ([]Splice, error) {
 	if l.Equals(last) {
-		return []Splice{}, uint64(0), nil // nothing changed
+		return []Splice{}, nil // nothing changed
 	}
 	lLen, lastLen := l.Len(), last.Len()
 	if lLen == 0 {
-		return []Splice{Splice{0, lastLen, 0, 0}}, uint64(0), nil // everything removed
+		return []Splice{Splice{0, lastLen, 0, 0}}, nil // everything removed
 	}
 	if lastLen == 0 {
-		return []Splice{Splice{0, 0, lLen, 0}}, uint64(0), nil // everything added
+		return []Splice{Splice{0, 0, lLen, 0}}, nil // everything added
 	}
 	lastCur := newCursorAtIndex(last.seq, 0)
 	lCur := newCursorAtIndex(l.seq, 0)

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -6,7 +6,6 @@ package types
 
 import (
 	"crypto/sha1"
-	"math"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
@@ -189,20 +188,20 @@ func (l List) IterAll(f listIterAllFunc) {
 	})
 }
 
-func (l List) Diff(last List) ([]Splice, error) {
-	return l.DiffWithLoadLimit(last, math.MaxUint64)
+func (l List) Diff(last List) (splices []Splice, numSequencesLoaded uint64, err error) {
+	return l.DiffWithLoadLimit(last, DIFF_WITHOUT_LIMIT)
 }
 
-func (l List) DiffWithLoadLimit(last List, loadLimit uint64) ([]Splice, error) {
+func (l List) DiffWithLoadLimit(last List, loadLimit uint64) (splices []Splice, numSequencesLoaded uint64, err error) {
 	if l.Equals(last) {
-		return []Splice{}, nil // nothing changed
+		return []Splice{}, uint64(0), nil // nothing changed
 	}
 	lLen, lastLen := l.Len(), last.Len()
 	if lLen == 0 {
-		return []Splice{Splice{0, lastLen, 0, 0}}, nil // everything removed
+		return []Splice{Splice{0, lastLen, 0, 0}}, uint64(0), nil // everything removed
 	}
 	if lastLen == 0 {
-		return []Splice{Splice{0, 0, lLen, 0}}, nil // everything added
+		return []Splice{Splice{0, 0, lLen, 0}}, uint64(0), nil // everything added
 	}
 	lastCur := newCursorAtIndex(last.seq, 0)
 	lCur := newCursorAtIndex(l.seq, 0)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/testify/assert"
 	"github.com/attic-labs/testify/suite"
 )
@@ -610,14 +611,12 @@ func TestListDiffIdentical(t *testing.T) {
 	nums := generateNumbersAsValues(5)
 	l1 := NewList(nums...)
 	l2 := NewList(nums...)
-	diff1, nSeqLoaded1, err1 := l1.Diff(l2)
-	diff2, nSeqLoaded2, err2 := l2.Diff(l1)
+	diff1, err1 := l1.Diff(l2)
+	diff2, err2 := l2.Diff(l1)
 	assert.NoError(err1)
 	assert.NoError(err2)
 	assert.Equal(0, len(diff1))
 	assert.Equal(0, len(diff2))
-	assert.Equal(uint64(0), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
 }
 
 func TestListDiffVersusEmpty(t *testing.T) {
@@ -625,14 +624,12 @@ func TestListDiffVersusEmpty(t *testing.T) {
 	nums1 := generateNumbersAsValues(5)
 	l1 := NewList(nums1...)
 	l2 := NewList()
-	diff1, nSeqLoaded1, err1 := l1.Diff(l2)
-	diff2, nSeqLoaded2, err2 := l2.Diff(l1)
+	diff1, err1 := l1.Diff(l2)
+	diff2, err2 := l2.Diff(l1)
 	assert.NoError(err1)
 	assert.NoError(err2)
 	assert.Equal(1, len(diff1))
 	assert.Equal(len(diff2), len(diff1))
-	assert.Equal(uint64(0), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
 }
 
 func TestListDiffReverse(t *testing.T) {
@@ -644,14 +641,12 @@ func TestListDiffReverse(t *testing.T) {
 	nums2 := reverseValues(nums1)
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff1, nSeqLoaded1, err1 := l1.Diff(l2)
-	diff2, nSeqLoaded2, err2 := l2.Diff(l1)
+	diff1, err1 := l1.Diff(l2)
+	diff2, err2 := l2.Diff(l1)
 	assert.NoError(err1)
 	assert.NoError(err2)
 	assert.Equal(2, len(diff1))
 	assert.Equal(len(diff2), len(diff1))
-	assert.Equal(uint64(175), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
 }
 
 func TestListDiffRemove5x100(t *testing.T) {
@@ -666,14 +661,12 @@ func TestListDiffRemove5x100(t *testing.T) {
 	}
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff1, nSeqLoaded1, err1 := l1.Diff(l2)
-	diff2, nSeqLoaded2, err2 := l2.Diff(l1)
+	diff1, err1 := l1.Diff(l2)
+	diff2, err2 := l2.Diff(l1)
 	assert.NoError(err1)
 	assert.NoError(err2)
 	assert.Equal(5, len(diff2))
 	assert.Equal(len(diff1), len(diff2))
-	assert.Equal(uint64(36), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
 
 	diff2Expected := []Splice{
 		Splice{0, 100, 0, 0},
@@ -697,14 +690,12 @@ func TestListDiffAdd5x5(t *testing.T) {
 	}
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff1, nSeqLoaded1, err1 := l1.Diff(l2)
-	diff2, nSeqLoaded2, err2 := l2.Diff(l1)
+	diff1, err1 := l1.Diff(l2)
+	diff2, err2 := l2.Diff(l1)
 	assert.NoError(err1)
 	assert.NoError(err2)
 	assert.Equal(5, len(diff2))
 	assert.Equal(len(diff1), len(diff2))
-	assert.Equal(uint64(29), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
 
 	diff2Expected := []Splice{
 		Splice{5, 0, 5, 5},
@@ -729,10 +720,9 @@ func TestListDiffReplaceReverse5x100(t *testing.T) {
 	}
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff, nSeqLoaded, err := l2.Diff(l1)
+	diff, err := l2.Diff(l1)
 	assert.NoError(err)
 	assert.Equal(10, len(diff))
-	assert.Equal(uint64(47), nSeqLoaded)
 
 	diffExpected := []Splice{
 		Splice{0, 49, 50, 0},
@@ -755,12 +745,10 @@ func TestListDiffLoadLimit(t *testing.T) {
 	nums2 := generateNumbersAsValues(5000)
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff1, nSeqLoaded1, err1 := l2.DiffWithLoadLimit(l1, 50)
-	diff2, nSeqLoaded2, err2 := l1.DiffWithLoadLimit(l2, 50)
+	diff1, err1 := l2.DiffWithLoadLimit(l1, 50)
+	diff2, err2 := l1.DiffWithLoadLimit(l2, 50)
 	assert.Nil(diff1)
 	assert.Nil(diff2)
-	assert.Equal(uint64(4), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
 	assert.Equal("load limit exceeded", err1.Error())
 	assert.Equal("load limit exceeded", err2.Error())
 }
@@ -771,10 +759,9 @@ func TestListDiffString1(t *testing.T) {
 	nums2 := []Value{NewString("one"), NewString("two"), NewString("three")}
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff, nSeqLoaded, err := l2.Diff(l1)
+	diff, err := l2.Diff(l1)
 	assert.NoError(err)
 	assert.Equal(0, len(diff))
-	assert.Equal(uint64(0), nSeqLoaded)
 
 	diffExpected := []Splice{}
 	assert.Equal(diffExpected, diff, "expected diff is wrong")
@@ -786,10 +773,9 @@ func TestListDiffString2(t *testing.T) {
 	nums2 := []Value{NewString("one"), NewString("two"), NewString("three"), NewString("four")}
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff, nSeqLoaded, err := l2.Diff(l1)
+	diff, err := l2.Diff(l1)
 	assert.NoError(err)
 	assert.Equal(1, len(diff))
-	assert.Equal(uint64(0), nSeqLoaded)
 
 	diffExpected := []Splice{
 		Splice{3, 0, 1, 3},
@@ -803,10 +789,9 @@ func TestListDiffString3(t *testing.T) {
 	nums2 := []Value{NewString("one"), NewString("two"), NewString("four")}
 	l1 := NewList(nums1...)
 	l2 := NewList(nums2...)
-	diff, nSeqLoaded, err := l2.Diff(l1)
+	diff, err := l2.Diff(l1)
 	assert.NoError(err)
 	assert.Equal(1, len(diff))
-	assert.Equal(uint64(0), nSeqLoaded)
 
 	diffExpected := []Splice{
 		Splice{2, 1, 1, 2},
@@ -819,16 +804,37 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 	assert := assert.New(t)
+
+	cs1 := chunks.NewTestStore()
+	vs1 := newLocalValueStore(cs1)
 	nums1 := generateNumbersAsValues(5000)
-	nums2 := generateNumbersAsValuesFromToBy(5, 4550, 1)
 	l1 := NewList(nums1...)
+	ref1 := vs1.WriteValue(l1).TargetHash()
+	refList1 := vs1.ReadValue(ref1).(List)
+
+	cs2 := chunks.NewTestStore()
+	vs2 := newLocalValueStore(cs2)
+	nums2 := generateNumbersAsValuesFromToBy(5, 4550, 1)
 	l2 := NewList(nums2...)
-	diff1, nSeqLoaded1, err1 := l1.Diff(l2)
-	diff2, nSeqLoaded2, err2 := l2.Diff(l1)
+	ref2 := vs2.WriteValue(l2).TargetHash()
+	refList2 := vs2.ReadValue(ref2).(List)
+
+	// diff lists without value store
+	diff1, err1 := l2.Diff(l1)
 	assert.NoError(err1)
-	assert.NoError(err2)
 	assert.Equal(2, len(diff1))
+
+	// diff lists from value stores
+	diff2, err2 := refList2.Diff(refList1)
+	assert.NoError(err2)
 	assert.Equal(2, len(diff2))
-	assert.Equal(uint64(20), nSeqLoaded1)
-	assert.Equal(nSeqLoaded1, nSeqLoaded2)
+
+	// diff without and with value store should be same
+	assert.Equal(diff1, diff2)
+
+	// should only read/write a "small & reasonably sized portion of the total"
+	assert.Equal(95, cs1.Writes)
+	assert.Equal(18, cs1.Reads)
+	assert.Equal(85, cs2.Writes)
+	assert.Equal(8, cs2.Reads)
 }


### PR DESCRIPTION
diff was slow because of an incorrect comparison of metaTuple values that then ended up having us load a lot more sequences into memory than needed, so the fix was simple but much of this pull request is around keeping metrics on the number of sequences loaded to perform the diff and using this metric in tests to double check we aren't regressing as we attempt to continue to improve diff
