### PR TITLE
Add tests for type after mutations

### DIFF
--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -795,3 +795,29 @@ func TestListDiffString3(t *testing.T) {
 	}
 	assert.Equal(diff2Expected, diff2, "expected diff is wrong")
 }
+
+func TestListTypeAfterMutations(t *testing.T) {
+	assert := assert.New(t)
+
+	test := func(n int, c interface{}) {
+		values := generateNumbersAsValues(n)
+
+		l := NewList(values...)
+		assert.Equal(l.Len(), uint64(n))
+		assert.IsType(c, l.sequence())
+		assert.True(l.Type().Equals(MakeListType(NumberType)))
+
+		l = l.Append(NewString("a"))
+		assert.Equal(l.Len(), uint64(n+1))
+		assert.IsType(c, l.sequence())
+		assert.True(l.Type().Equals(MakeListType(MakeUnionType(NumberType, StringType))))
+
+		l = l.Splice(l.Len()-1, 1)
+		assert.Equal(l.Len(), uint64(n))
+		assert.IsType(c, l.sequence())
+		assert.True(l.Type().Equals(MakeListType(NumberType)))
+	}
+
+	test(10, listLeafSequence{})
+	test(100, indexedMetaSequence{})
+}

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -804,3 +804,29 @@ func TestSetModifyAfterRead(t *testing.T) {
 	set = set.Insert(fst)
 	assert.True(set.Has(fst))
 }
+
+func TestSetTypeAfterMutations(t *testing.T) {
+	assert := assert.New(t)
+
+	test := func(n int, c interface{}) {
+		values := generateNumbersAsValues(n)
+
+		s := NewSet(values...)
+		assert.Equal(s.Len(), uint64(n))
+		assert.IsType(c, s.sequence())
+		assert.True(s.Type().Equals(MakeSetType(NumberType)))
+
+		s = s.Insert(NewString("a"))
+		assert.Equal(s.Len(), uint64(n+1))
+		assert.IsType(c, s.sequence())
+		assert.True(s.Type().Equals(MakeSetType(MakeUnionType(NumberType, StringType))))
+
+		s = s.Remove(NewString("a"))
+		assert.Equal(s.Len(), uint64(n))
+		assert.IsType(c, s.sequence())
+		assert.True(s.Type().Equals(MakeSetType(NumberType)))
+	}
+
+	test(10, setLeafSequence{})
+	test(100, orderedMetaSequence{})
+}

--- a/js/src/set.js
+++ b/js/src/set.js
@@ -159,11 +159,6 @@ export default class Set<T: Value> extends Collection<OrderedSequence> {
       return this;
     }
 
-    // Can't intersect sets of different element type.
-    for (let i = 0; i < sets.length; i++) {
-      invariant(equals(sets[i].type, this.type));
-    }
-
     let cursor = await this.sequence.newCursorAt(null);
     if (!cursor.valid) {
       return this;


### PR DESCRIPTION
Also, remove invariant for set intersection. We can handle different
types now.

Fixes #1749
