### PR TITLE
Move Go profiling helpers out of samples/

### DIFF
--- a/cmd/noms-serve/noms_serve.go
+++ b/cmd/noms-serve/noms_serve.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/samples/go/flags"
 	"github.com/attic-labs/noms/samples/go/util"
 )
@@ -59,8 +60,8 @@ func main() {
 	}()
 
 	d.Try(func() {
-		if util.MaybeStartCPUProfile() {
-			defer util.StopCPUProfile()
+		if profile.MaybeStartCPUProfile() {
+			defer profile.StopCPUProfile()
 		}
 		server.Run()
 	})

--- a/cmd/noms-sync/noms_sync.go
+++ b/cmd/noms-sync/noms_sync.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/samples/go/flags"
 	"github.com/attic-labs/noms/samples/go/util"
 )
@@ -27,8 +28,8 @@ func main() {
 	runtime.GOMAXPROCS(cpuCount)
 
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Moves datasets between or within databases\n")
-		fmt.Fprintln(os.Stderr, "noms sync [options] <source-object> <dest-dataset>\n")
+		fmt.Fprintln(os.Stderr, "Moves datasets between or within databases")
+		fmt.Fprintln(os.Stderr, "noms sync [options] <source-object> <dest-dataset>")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nFor detailed information on spelling objects and datasets, see: at https://github.com/attic-labs/noms/blob/master/doc/spelling.md.\n\n")
 	}
@@ -54,14 +55,14 @@ func main() {
 	defer sinkDataset.Database().Close()
 
 	err = d.Try(func() {
-		if util.MaybeStartCPUProfile() {
-			defer util.StopCPUProfile()
+		if profile.MaybeStartCPUProfile() {
+			defer profile.StopCPUProfile()
 		}
 
 		var err error
 		sinkDataset, err = sinkDataset.Pull(sourceStore, types.NewRef(sourceObj), int(*p))
 
-		util.MaybeWriteMemProfile()
+		profile.MaybeWriteMemProfile()
 		d.Exp.NoError(err)
 	})
 

--- a/go/util/profile/profile.go
+++ b/go/util/profile/profile.go
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package util
+package profile
 
 import (
 	"flag"

--- a/samples/go/xml-import/xml_importer.go
+++ b/samples/go/xml-import/xml_importer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/samples/go/flags"
 	"github.com/attic-labs/noms/samples/go/util"
 	"github.com/clbanning/mxj"
@@ -63,8 +64,8 @@ func main() {
 		ds, err := spec.Dataset()
 		util.CheckError(err)
 
-		if util.MaybeStartCPUProfile() {
-			defer util.StopCPUProfile()
+		if profile.MaybeStartCPUProfile() {
+			defer profile.StopCPUProfile()
 		}
 
 		cpuCount := runtime.NumCPU()
@@ -142,7 +143,7 @@ func main() {
 			d.Exp.NoError(err)
 		}
 
-		util.MaybeWriteMemProfile()
+		profile.MaybeWriteMemProfile()
 	})
 
 	if err != nil {


### PR DESCRIPTION
These are used in cmd as well, so it seemed weird to have
them over in samples/util
