### PR TITLE
Go: Stop treating a chunk's hash as a hint for itself

### DIFF
--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -98,7 +98,7 @@ func (lvs *ValueStore) WriteValue(v Value) Ref {
 	}
 	hints := lvs.chunkHintsFromCache(v)
 	lvs.bs.SchedulePut(c, height, hints)
-	lvs.set(hash, hintedChunk{v.Type(), hash})
+	lvs.set(hash, (*presentChunk)(v.Type()))
 	return r
 }
 
@@ -166,6 +166,7 @@ func (lvs *ValueStore) checkChunksInCache(v Value, readValues bool) Hints {
 		if entry == nil || !entry.Present() {
 			var reachableV Value
 			if readValues {
+				// TODO: log or report that we needed to ReadValue here BUG 1762
 				reachableV = lvs.ReadValue(targetHash)
 				entry = lvs.check(targetHash)
 			}
@@ -204,6 +205,20 @@ func (h hintedChunk) Hint() (r hash.Hash) {
 
 func (h hintedChunk) Type() *Type {
 	return h.t
+}
+
+type presentChunk Type
+
+func (p *presentChunk) Present() bool {
+	return true
+}
+
+func (p *presentChunk) Hint() (h hash.Hash) {
+	return
+}
+
+func (p *presentChunk) Type() *Type {
+	return (*Type)(p)
 }
 
 type absentChunk struct{}

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -114,8 +114,8 @@ func TestHintsOnCache(t *testing.T) {
 		})
 
 		hints := cvs.chunkHintsFromCache(s2)
-		if assert.Len(hints, 2) {
-			for _, hash := range []hash.Hash{r.TargetHash(), cr3.TargetHash()} {
+		if assert.Len(hints, 1) {
+			for _, hash := range []hash.Hash{r.TargetHash()} {
 				_, present := hints[hash]
 				assert.True(present)
 			}


### PR DESCRIPTION
At some point, the Go ValueStore code started caching the hash of a
Chunk as a validation 'hint' for the Chunk itself.  JS never did
this. This must have addressed some edge case back when it was fatal
for validation code to run across a Chunk it hadn't seen and didn't
have a hint for. The downside is that doing this can cause us to send
a hint for every novel Chunk present in a writeValue payload in the
worst case.

Since I can't remember the edge case, and that edge case will no
longer be fatal anyway, removing this to avoid the (potentially
terrible) downside makes sense.
