### PR TITLE
Add commas to HRS of struct type

### DIFF
--- a/cmd/noms-show/noms_show_test.go
+++ b/cmd/noms-show/noms_show_test.go
@@ -24,11 +24,11 @@ type nomsShowTestSuite struct {
 }
 
 const (
-	res1 = "struct Commit {\n  parents: Set<Ref<Cycle<0>>>\n  value: Value\n}({\n  parents: {},\n  value: sha1-0ddf89c44a4ce4075714a4fc51d31a76e38f84ce,\n})\n"
+	res1 = "struct Commit {\n  parents: Set<Ref<Cycle<0>>>,\n  value: Value,\n}({\n  parents: {},\n  value: sha1-0ddf89c44a4ce4075714a4fc51d31a76e38f84ce,\n})\n"
 	res2 = "\"test string\"\n"
-	res3 = "struct Commit {\n  parents: Set<Ref<Cycle<0>>>\n  value: Value\n}({\n  parents: {\n    sha1-46506c93810ce363c04c4bcf945797e4843a2a50,\n  },\n  value: sha1-dc6f386ab57b4ca62f54f7b63e5fe21a787f761e,\n})\n"
+	res3 = "struct Commit {\n  parents: Set<Ref<Cycle<0>>>,\n  value: Value,\n}({\n  parents: {\n    sha1-46506c93810ce363c04c4bcf945797e4843a2a50,\n  },\n  value: sha1-dc6f386ab57b4ca62f54f7b63e5fe21a787f761e,\n})\n"
 	res4 = "List<String | Number>([\n  \"elem1\",\n  2,\n  \"elem3\",\n])\n"
-	res5 = "struct Commit {\n  parents: Set<Ref<Cycle<0>>>\n  value: Value\n}({\n  parents: {\n    sha1-88ccdecaa410c101bfac396ed6a451aa14b5043b,\n  },\n  value: sha1-0ddf89c44a4ce4075714a4fc51d31a76e38f84ce,\n})\n"
+	res5 = "struct Commit {\n  parents: Set<Ref<Cycle<0>>>,\n  value: Value,\n}({\n  parents: {\n    sha1-88ccdecaa410c101bfac396ed6a451aa14b5043b,\n  },\n  value: sha1-0ddf89c44a4ce4075714a4fc51d31a76e38f84ce,\n})\n"
 )
 
 func writeTestData(ds dataset.Dataset, value types.Value) types.Ref {

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -244,6 +244,7 @@ func (w *hrsWriter) writeStructType(t *Type, parentStructTypes []*Type) {
 		w.write(name)
 		w.write(": ")
 		w.writeType(t, parentStructTypes)
+		w.write(",")
 		w.newLine()
 	})
 	w.outdent()

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -128,7 +128,7 @@ func TestWriteHumanReadableStruct(t *testing.T) {
 		"y": Number(2),
 	})
 	assertWriteHRSEqual(t, "S1 {\n  x: 1,\n  y: 2,\n}", str)
-	assertWriteTaggedHRSEqual(t, "struct S1 {\n  x: Number\n  y: Number\n}({\n  x: 1,\n  y: 2,\n})", str)
+	assertWriteTaggedHRSEqual(t, "struct S1 {\n  x: Number,\n  y: Number,\n}({\n  x: 1,\n  y: 2,\n})", str)
 }
 
 func TestWriteHumanReadableListOfStruct(t *testing.T) {
@@ -154,7 +154,7 @@ func TestWriteHumanReadableListOfStruct(t *testing.T) {
   },
 ]`, l)
 	assertWriteTaggedHRSEqual(t, `List<struct S3 {
-  x: Number
+  x: Number,
 }>([
   S3 {
     x: 1,
@@ -284,37 +284,37 @@ func TestRecursiveStruct(t *testing.T) {
 	a.Desc.(StructDesc).SetField("d", d)
 	d.Desc.(StructDesc).SetField("e", d)
 	assertWriteHRSEqual(t, `struct A {
-  b: Cycle<0>
-  c: List<Cycle<0>>
+  b: Cycle<0>,
+  c: List<Cycle<0>>,
   d: struct D {
-    e: Cycle<0>
-    f: Cycle<1>
-  }
+    e: Cycle<0>,
+    f: Cycle<1>,
+  },
 }`, a)
 	assertWriteTaggedHRSEqual(t, `Type(struct A {
-  b: Cycle<0>
-  c: List<Cycle<0>>
+  b: Cycle<0>,
+  c: List<Cycle<0>>,
   d: struct D {
-    e: Cycle<0>
-    f: Cycle<1>
-  }
+    e: Cycle<0>,
+    f: Cycle<1>,
+  },
 })`, a)
 
 	assertWriteHRSEqual(t, `struct D {
-  e: Cycle<0>
+  e: Cycle<0>,
   f: struct A {
-    b: Cycle<0>
-    c: List<Cycle<0>>
-    d: Cycle<1>
-  }
+    b: Cycle<0>,
+    c: List<Cycle<0>>,
+    d: Cycle<1>,
+  },
 }`, d)
 	assertWriteTaggedHRSEqual(t, `Type(struct D {
-  e: Cycle<0>
+  e: Cycle<0>,
   f: struct A {
-    b: Cycle<0>
-    c: List<Cycle<0>>
-    d: Cycle<1>
-  }
+    b: Cycle<0>,
+    c: List<Cycle<0>>,
+    d: Cycle<1>,
+  },
 })`, d)
 }
 

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -55,7 +55,7 @@ func TestTypeRefDescribe(t *testing.T) {
 		"Field1": StringType,
 		"Field2": BoolType,
 	})
-	assert.Equal("struct MahStruct {\n  Field1: String\n  Field2: Bool\n}", mahType.Describe())
+	assert.Equal("struct MahStruct {\n  Field1: String,\n  Field2: Bool,\n}", mahType.Describe())
 }
 
 func TestTypeOrdered(t *testing.T) {

--- a/js/src/encode-human-readable-test.js
+++ b/js/src/encode-human-readable-test.js
@@ -61,7 +61,7 @@ suite('Encode human readable types', () => {
       'x': numberType,
       'y': stringType,
     });
-    assertWriteType('struct S1 {\n  x: Number\n  y: String\n}', type);
+    assertWriteType('struct S1 {\n  x: Number,\n  y: String,\n}', type);
   });
 
 
@@ -69,7 +69,7 @@ suite('Encode human readable types', () => {
     const type = makeStructType('S3', {
       'x': numberType,
     });
-    assertWriteType('List<struct S3 {\n  x: Number\n}>', makeListType(type));
+    assertWriteType('List<struct S3 {\n  x: Number,\n}>', makeListType(type));
   });
 
   test('recursive struct', () => {
@@ -98,21 +98,21 @@ suite('Encode human readable types', () => {
     a.desc.setField('c', makeListType(a));
 
     assertWriteType(`struct A {
-  b: Cycle<0>
-  c: List<Cycle<0>>
+  b: Cycle<0>,
+  c: List<Cycle<0>>,
   d: struct D {
-    e: Cycle<0>
-    f: Cycle<1>
-  }
+    e: Cycle<0>,
+    f: Cycle<1>,
+  },
 }`, a);
 
     assertWriteType(`struct D {
-  e: Cycle<0>
+  e: Cycle<0>,
   f: struct A {
-    b: Cycle<0>
-    c: List<Cycle<0>>
-    d: Cycle<1>
-  }
+    b: Cycle<0>,
+    c: List<Cycle<0>>,
+    d: Cycle<1>,
+  },
 }`, d);
   });
 });

--- a/js/src/encode-human-readable.js
+++ b/js/src/encode-human-readable.js
@@ -141,6 +141,7 @@ export class TypeWriter {
       this._w.write(name);
       this._w.write(': ');
       this._writeType(type, parentStructTypes);
+      this._w.write(',');
       this._w.newLine();
     });
 


### PR DESCRIPTION
This makes the struct more consistent with the rest.
