### PR TITLE
Go: Allow serialization of a single Chunk without a Chunk serializer

### DIFF
--- a/go/datas/put_cache.go
+++ b/go/datas/put_cache.go
@@ -74,9 +74,7 @@ func (p *orderedChunkCache) Insert(c chunks.Chunk, refHeight uint64) bool {
 	if !present {
 		buf := &bytes.Buffer{}
 		gw := snappy.NewBufferedWriter(buf)
-		sz := chunks.NewSerializer(gw)
-		sz.Put(c)
-		sz.Close()
+		chunks.Serialize(c, gw)
 		gw.Close()
 		d.Chk.NoError(p.orderedChunks.Put(dbKey, buf.Bytes(), nil))
 		return true


### PR DESCRIPTION
In datas/put_cache.go, we need to serialize one chunk at a time. With
the old API, this entailed creating a serializer (which creates some
channels and a goroutine) only to use it for one Chunk.

Instead, just expose Serialize() and use it directly.

A smidge toward #1706
