### PR TITLE
JS: Split BinaryNomsWriter into Node+Browser

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -56,6 +56,8 @@
     "./src/utf8.js": "./src/browser/utf8.js",
     "./dist/commonjs/utf8.js": "./dist/commonjs/browser/utf8.js",
     "./src/put-cache.js": "./src/browser/put-cache.js",
-    "./dist/commonjs/put-cache.js": "./dist/commonjs/browser/put-cache.js"
+    "./dist/commonjs/put-cache.js": "./dist/commonjs/browser/put-cache.js",
+    "./src/binary-noms-writer.js": "./src/browser/binary-noms-writer.js",
+    "./dist/commonjs/binary-noms-writer.js": "./dist/commonjs/browser/binary-noms-writer.js"
   }
 }

--- a/js/src/binary-noms-reader.js
+++ b/js/src/binary-noms-reader.js
@@ -1,0 +1,84 @@
+// @flow
+
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+import Hash, {sha1Size} from './hash.js';
+import {decode} from './utf8.js';
+import {invariant} from './assert.js';
+
+const maxUInt32 = Math.pow(2, 32);
+const littleEndian = true;
+
+export default class BinaryNomsReader {
+  buf: ArrayBuffer;
+  dv: DataView;
+  byteOffset: number;
+  offset: number;
+  length: number;
+
+  constructor(data: Uint8Array) {
+    this.buf = data.buffer;
+    this.byteOffset = data.byteOffset;
+    this.offset = 0;
+    this.length = data.length;
+    this.dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  }
+
+  readBytes(): Uint8Array {
+    const size = this.readUint32();
+    return this._copyBytes(size);
+  }
+
+  readUint8(): number {
+    const v = this.dv.getUint8(this.offset);
+    this.offset++;
+    return v;
+  }
+
+  readUint32(): number {
+    const v = this.dv.getUint32(this.offset, littleEndian);
+    this.offset += 4;
+    return v;
+  }
+
+  readUint64(): number {
+    const lsi = this.readUint32();
+    const msi = this.readUint32();
+    const v = msi * maxUInt32 + lsi;
+    invariant(v <= Number.MAX_SAFE_INTEGER);
+    return v;
+  }
+
+  readFloat64(): number {
+    const v = this.dv.getFloat64(this.offset, littleEndian);
+    this.offset += 8;
+    return v;
+  }
+
+  readBool(): boolean {
+    const v = this.readUint8();
+    invariant(v === 0 || v === 1);
+    return v === 1;
+  }
+
+  readString(): string {
+    const size = this.readUint32();
+    // No copy here.
+    const v = new Uint8Array(this.buf, this.byteOffset + this.offset, size);
+    this.offset += size;
+    return decode(v);
+  }
+
+  readHash(): Hash {
+    return new Hash(this._copyBytes(sha1Size));
+  }
+
+  _copyBytes(size: number): Uint8Array {
+    const start = this.byteOffset + this.offset;
+    const v = new Uint8Array(this.buf.slice(start, start + size));
+    this.offset += size;
+    return v;
+  }
+}

--- a/js/src/binary-noms-writer.js
+++ b/js/src/binary-noms-writer.js
@@ -16,7 +16,8 @@ export default class BinaryNomsWriter {
   length: number;
 
   constructor() {
-    this.buf = new Buffer(initialBufferSize);
+    // $FlowIssue: Flow does not know about allocUnsafe
+    this.buf = Buffer.allocUnsafe(initialBufferSize);
     this.offset = 0;
     this.length = initialBufferSize;
   }
@@ -40,7 +41,8 @@ export default class BinaryNomsWriter {
     while (this.offset + n > this.length) {
       this.length *= 2;
     }
-    this.buf = new Buffer(this.length);
+    // $FlowIssue: Flow does not know about allocUnsafe
+    this.buf = Buffer.allocUnsafe(this.length);
     oldBuf.copy(this.buf);
   }
 
@@ -78,14 +80,14 @@ export default class BinaryNomsWriter {
   }
 
   writeString(v: string): void {
-    const byteLength = Buffer.byteLength(v, 'utf8');
+    const byteLength = Buffer.byteLength(v);
     this.writeUint32(byteLength);
 
     this.ensureCapacity(byteLength);
 
     // Unlike other write methods write returns the number of bytes written and does not include
     // the offset
-    this.buf.write(v, this.offset, byteLength, 'utf8');
+    this.buf.write(v, this.offset, byteLength);
     this.offset += byteLength;
   }
 

--- a/js/src/binary-noms-writer.js
+++ b/js/src/binary-noms-writer.js
@@ -1,0 +1,110 @@
+// @flow
+
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+import Hash, {sha1Size} from './hash.js';
+import {invariant} from './assert.js';
+
+const maxUInt32 = Math.pow(2, 32);
+const initialBufferSize = 2 * 1024;
+
+export default class BinaryNomsWriter {
+  buf: Buffer;
+  offset: number;
+  length: number;
+
+  constructor() {
+    this.buf = new Buffer(initialBufferSize);
+    this.offset = 0;
+    this.length = initialBufferSize;
+  }
+
+  /**
+   * Returns a view of the underlying buffer data. The underlying ArrayBuffer might be larger than
+   * the returned Uint8Array.
+   */
+  get data(): Uint8Array {
+    // $FlowIssue: Flow does not know Buffer extends Uint8Array.
+    return this.buf.slice(0, this.offset);
+  }
+
+  ensureCapacity(n: number): void {
+    if (this.offset + n <= this.length) {
+      return;
+    }
+
+    const oldBuf = this.buf;
+
+    while (this.offset + n > this.length) {
+      this.length *= 2;
+    }
+    this.buf = new Buffer(this.length);
+    oldBuf.copy(this.buf);
+  }
+
+  writeBytes(v: Uint8Array): void {
+    const size = v.byteLength;
+    this.writeUint32(size);
+    this.writeBytesWithoutPrefix(v, size);
+  }
+
+  writeUint8(v: number): void {
+    this.ensureCapacity(1);
+    this.offset = this.buf.writeUInt8(v, this.offset);
+  }
+
+  writeUint32(v: number): void {
+    this.ensureCapacity(4);
+    this.offset = this.buf.writeUInt32LE(v, this.offset);
+  }
+
+  writeUint64(v: number): void {
+    invariant(v <= Number.MAX_SAFE_INTEGER);
+    const v2 = (v / maxUInt32) | 0;
+    const v1 = v % maxUInt32;
+    this.writeUint32(v1);
+    this.writeUint32(v2);
+  }
+
+  writeFloat64(v: number): void {
+    this.ensureCapacity(8);
+    this.offset = this.buf.writeDoubleLE(v, this.offset);
+  }
+
+  writeBool(v:boolean): void {
+    this.writeUint8(v ? 1 : 0);
+  }
+
+  writeString(v: string): void {
+    const byteLength = Buffer.byteLength(v, 'utf8');
+    this.writeUint32(byteLength);
+
+    this.ensureCapacity(byteLength);
+
+    // Unlike other write methods write returns the number of bytes written and does not include
+    // the offset
+    this.buf.write(v, this.offset, byteLength, 'utf8');
+    this.offset += byteLength;
+  }
+
+  writeHash(h: Hash): void {
+    this.writeBytesWithoutPrefix(h.digest, sha1Size);
+  }
+
+  writeBytesWithoutPrefix(v: Uint8Array, size: number) {
+    this.ensureCapacity(size);
+    copy(this.buf, v, this.offset);
+    this.offset += size;
+  }
+}
+
+function copy(dst: Buffer, src: Buffer | Uint8Array, offset: number) {
+  if (src instanceof Buffer) {
+    src.copy(dst, offset);
+  } else {
+    // $FlowIssue: Flow does not know Buffer extends Uint8Array.
+    dst.set(src, offset);
+  }
+}

--- a/js/src/browser/binary-noms-writer.js
+++ b/js/src/browser/binary-noms-writer.js
@@ -1,0 +1,106 @@
+// @flow
+
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// This is the browser version. The Node.js version is in ../binary-noms-writer.js.
+
+import Hash, {sha1Size} from '../hash.js';
+import {encode} from '../utf8.js';
+import {invariant} from '../assert.js';
+
+const maxUInt32 = Math.pow(2, 32);
+const littleEndian = true;
+const initialBufferSize = 2 * 1024;
+
+export default class BinaryNomsWriter {
+  buf: ArrayBuffer;
+  dv: DataView;
+  offset: number;
+  length: number;
+
+  constructor() {
+    this.buf = new ArrayBuffer(initialBufferSize);
+    this.dv = new DataView(this.buf, 0);
+    this.offset = 0;
+    this.length = initialBufferSize;
+  }
+
+  /**
+   * Returns a view of the underlying buffer data. The underlying ArrayBuffer might be larger than
+   * the returned Uint8Array.
+   */
+  get data(): Uint8Array {
+    // Callers now owns the copied data.
+    return new Uint8Array(this.buf.slice(0, this.offset));
+  }
+
+  ensureCapacity(n: number): void {
+    if (this.offset + n <= this.length) {
+      return;
+    }
+
+    const oldData = new Uint8Array(this.buf);
+
+    while (this.offset + n > this.length) {
+      this.length *= 2;
+    }
+    this.buf = new ArrayBuffer(this.length);
+    this.dv = new DataView(this.buf, 0);
+
+    const a = new Uint8Array(this.buf);
+    a.set(oldData);
+  }
+
+  writeBytes(v: Uint8Array): void {
+    const size = v.byteLength;
+    this.writeUint32(size);
+    this.writeBytesWithoutPrefix(v, size);
+  }
+
+  writeUint8(v: number): void {
+    this.ensureCapacity(1);
+    this.dv.setUint8(this.offset, v);
+    this.offset++;
+  }
+
+  writeUint32(v: number): void {
+    this.ensureCapacity(4);
+    this.dv.setUint32(this.offset, v, littleEndian);
+    this.offset += 4;
+  }
+
+  writeUint64(v: number): void {
+    invariant(v <= Number.MAX_SAFE_INTEGER);
+    const v2 = (v / maxUInt32) | 0;
+    const v1 = v % maxUInt32;
+    this.writeUint32(v1);
+    this.writeUint32(v2);
+  }
+
+  writeFloat64(v: number): void {
+    this.ensureCapacity(8);
+    this.dv.setFloat64(this.offset, v, littleEndian);
+    this.offset += 8;
+  }
+
+  writeBool(v:boolean): void {
+    this.writeUint8(v ? 1 : 0);
+  }
+
+  writeString(v: string): void {
+    this.writeBytes(encode(v));
+  }
+
+  writeHash(h: Hash): void {
+    this.writeBytesWithoutPrefix(h.digest, sha1Size);
+  }
+
+  writeBytesWithoutPrefix(v: Uint8Array, size: number) {
+    this.ensureCapacity(size);
+    const a = new Uint8Array(this.buf, this.offset, size);
+    a.set(v);
+    this.offset += size;
+  }
+}

--- a/js/src/chunk-test.js
+++ b/js/src/chunk-test.js
@@ -34,7 +34,7 @@ suite('Chunk', () => {
       assert.isTrue(c.isEmpty());
     }
 
-    assertChunkIsEmpty(new Chunk());
+    assertChunkIsEmpty(new Chunk(new Uint8Array(0)));
     assertChunkIsEmpty(Chunk.fromString(''));
   });
 });

--- a/js/src/chunk.js
+++ b/js/src/chunk.js
@@ -11,7 +11,7 @@ export default class Chunk {
   data: Uint8Array;
   _hash: ?Hash;
 
-  constructor(data: Uint8Array = new Uint8Array(0), hash: ?Hash) {
+  constructor(data: Uint8Array, hash: ?Hash) {
     this.data = data;
     this._hash = hash;
   }
@@ -35,4 +35,4 @@ export default class Chunk {
   }
 }
 
-export const emptyChunk = new Chunk();
+export const emptyChunk = new Chunk(new Uint8Array(0));

--- a/js/src/codec.js
+++ b/js/src/codec.js
@@ -5,15 +5,15 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 import Chunk from './chunk.js';
-import Hash, {sha1Size} from './hash.js';
+import Hash from './hash.js';
 import ValueDecoder from './value-decoder.js';
 import ValueEncoder from './value-encoder.js';
-import {encode, decode} from './utf8.js';
-import {invariant} from './assert.js';
 import {setEncodeValue} from './get-hash.js';
 import {setHash, ValueBase} from './value.js';
 import type Value from './value.js';
 import type {ValueReader, ValueWriter} from './value-store.js';
+import BinaryNomsReader from './binary-noms-reader.js';
+import BinaryNomsWriter from './binary-noms-writer.js';
 
 export function encodeValue(v: Value, vw: ?ValueWriter): Chunk {
   const w = new BinaryNomsWriter();
@@ -41,10 +41,6 @@ export function decodeValue(chunk: Chunk, vr: ValueReader): Value {
   return v;
 }
 
-
-const maxUInt32 = Math.pow(2, 32);
-const littleEndian = true;
-
 export interface NomsReader {
   readBytes(): Uint8Array;
   readUint8(): number;
@@ -65,161 +61,4 @@ export interface NomsWriter {
   writeBool(v:boolean): void;
   writeString(v: string): void;
   writeHash(h: Hash): void;
-}
-
-export class BinaryNomsReader {
-  buff: ArrayBuffer;
-  dv: DataView;
-  offset: number;
-  length: number;
-
-  constructor(data: Uint8Array) {
-    this.buff = data.buffer;
-    this.offset = data.byteOffset;
-    this.length = data.byteLength;
-    this.dv = new DataView(this.buff, this.offset, this.length);
-  }
-
-  readBytes(): Uint8Array {
-    const size = this.readUint32();
-    // Make a copy of the buffer to return
-    const v = new Uint8Array(new Uint8Array(this.buff, this.offset, size));
-    this.offset += size;
-    return v;
-  }
-
-  readUint8(): number {
-    const v = this.dv.getUint8(this.offset);
-    this.offset++;
-    return v;
-  }
-
-  readUint32(): number {
-    const v = this.dv.getUint32(this.offset, littleEndian);
-    this.offset += 4;
-    return v;
-  }
-
-  readUint64(): number {
-    const lsi = this.readUint32();
-    const msi = this.readUint32();
-    const v = msi * maxUInt32 + lsi;
-    invariant(v <= Number.MAX_SAFE_INTEGER);
-    return v;
-  }
-
-  readFloat64(): number {
-    const v = this.dv.getFloat64(this.offset, littleEndian);
-    this.offset += 8;
-    return v;
-  }
-
-  readBool(): boolean {
-    const v = this.readUint8();
-    invariant(v === 0 || v === 1);
-    return v === 1;
-  }
-
-  readString(): string {
-    const size = this.readUint32();
-    const v = new Uint8Array(this.buff, this.offset, size);
-    this.offset += size;
-    return decode(v);
-  }
-
-  readHash(): Hash {
-    // Make a copy of the data.
-    const digest = new Uint8Array(this.buff.slice(this.offset, this.offset + sha1Size));
-    this.offset += sha1Size;
-    return new Hash(digest);
-  }
-}
-
-const initialBufferSize = 2048;
-
-export class BinaryNomsWriter {
-  buff: ArrayBuffer;
-  dv: DataView;
-  offset: number;
-  length: number;
-
-  constructor() {
-    this.buff = new ArrayBuffer(initialBufferSize);
-    this.dv = new DataView(this.buff, 0);
-    this.offset = 0;
-    this.length = this.buff.byteLength;
-  }
-
-  get data(): Uint8Array {
-    // Callers now owns the copied data.
-    return new Uint8Array(new Uint8Array(this.buff, 0, this.offset));
-  }
-
-  ensureCapacity(n: number): void {
-    if (this.offset + n <= this.length) {
-      return;
-    }
-
-    const oldData = new Uint8Array(this.buff);
-
-    while (this.offset + n > this.length) {
-      this.length *= 2;
-    }
-    this.buff = new ArrayBuffer(this.length);
-    this.dv = new DataView(this.buff, 0);
-
-    const a = new Uint8Array(this.buff);
-    a.set(oldData);
-  }
-
-  writeBytes(v: Uint8Array): void {
-    const size = v.byteLength;
-    this.writeUint32(size);
-
-    this.ensureCapacity(size);
-    const a = new Uint8Array(this.buff, this.offset, size);
-    a.set(v);
-    this.offset += size;
-  }
-
-  writeUint8(v: number): void {
-    this.ensureCapacity(1);
-    this.dv.setUint8(this.offset, v);
-    this.offset++;
-  }
-
-  writeUint32(v: number): void {
-    this.ensureCapacity(4);
-    this.dv.setUint32(this.offset, v, littleEndian);
-    this.offset += 4;
-  }
-
-  writeUint64(v: number): void {
-    invariant(v <= Number.MAX_SAFE_INTEGER);
-    const v2 = (v / maxUInt32) | 0;
-    const v1 = v % maxUInt32;
-    this.writeUint32(v1);
-    this.writeUint32(v2);
-  }
-
-  writeFloat64(v: number): void {
-    this.ensureCapacity(8);
-    this.dv.setFloat64(this.offset, v, littleEndian);
-    this.offset += 8;
-  }
-
-  writeBool(v:boolean): void {
-    this.writeUint8(v ? 1 : 0);
-  }
-
-  writeString(v: string): void {
-    this.writeBytes(encode(v));
-  }
-
-  writeHash(h: Hash): void {
-    this.ensureCapacity(sha1Size);
-    const a = new Uint8Array(this.buff, this.offset, sha1Size);
-    a.set(h.digest);
-    this.offset += sha1Size;
-  }
 }

--- a/js/src/hash.js
+++ b/js/src/hash.js
@@ -47,6 +47,7 @@ export default class Hash {
   }
 
   isEmpty(): boolean {
+    // TODO: Use Buffer equals with empty hash.
     for (let i = 0; i < sha1Size; i++) {
       if (this._digest[i]) {
         return false;
@@ -56,6 +57,7 @@ export default class Hash {
   }
 
   equals(other: Hash): boolean {
+    // TODO: Use Buffer equals
     for (let i = 0; i < sha1Size; i++) {
       if (this._digest[i] !== other._digest[i]) {
         return false;
@@ -65,6 +67,7 @@ export default class Hash {
   }
 
   compare(other: Hash): number {
+    // TODO: Use Buffer.compare
     for (let i = 0; i < sha1Size; i++) {
       const d = this._digest[i] - other._digest[i];
       if (d) {
@@ -75,6 +78,7 @@ export default class Hash {
   }
 
   toString(): string {
+    // TODO: Use Buffer toString('hex')?
     return uint8ArrayToSha1(this._digest);
   }
 

--- a/js/src/put-cache.js
+++ b/js/src/put-cache.js
@@ -42,9 +42,7 @@ export default class OrderedPutCache {
   }
 
   _init(): Promise<DbCollection> {
-    // invariant(false === true);
     return makeTempDir().then((dir): Promise<DbCollection> => {
-      // console.log('creating', dir);
       this._folder = dir;
       const coll = new DbCollection(dir);
       return coll.ensureIndex({hash: 1}, {unique: true}).then(() => coll);
@@ -158,9 +156,13 @@ class DbCollection {
   insert(item: ChunkItem, options: Object = {}): Promise<number> {
     return new Promise((resolve, reject) => {
       options.w = 1;
-      //$FlowIssue
-      const data = new Binary(new Buffer(item.data.buffer));
-      this._coll.insert({hash: item.hash, data: data}, options, (err, result) => {
+      const {buffer, byteOffset, byteLength} = item.data;
+      const ua = new Uint8Array(buffer.slice(byteOffset, byteOffset + byteLength));
+      // $FlowIssue
+      const buf = new Buffer(ua);
+      const data = new Binary(buf);
+
+      this._coll.insert({hash: item.hash, data}, options, (err, result) => {
         if (err) {
           reject(err);
         } else {

--- a/js/src/put-cache.js
+++ b/js/src/put-cache.js
@@ -156,11 +156,19 @@ class DbCollection {
   insert(item: ChunkItem, options: Object = {}): Promise<number> {
     return new Promise((resolve, reject) => {
       options.w = 1;
-      const {buffer, byteOffset, byteLength} = item.data;
-      const ua = new Uint8Array(buffer.slice(byteOffset, byteOffset + byteLength));
-      // $FlowIssue
-      const buf = new Buffer(ua);
-      const data = new Binary(buf);
+
+      // TODO(arv): TingoDB is broken for Uint8Array
+      let data;
+      if (item.data instanceof Buffer) {
+        data = new Binary(item.data);
+      } else {
+        invariant(item.data instanceof Uint8Array);
+        const {buffer, byteOffset, byteLength} = item.data;
+        const ua = new Uint8Array(buffer.slice(byteOffset, byteOffset + byteLength));
+        // $FlowIssue
+        const buf = new Buffer(ua);
+        data = new Binary(buf);
+      }
 
       this._coll.insert({hash: item.hash, data}, options, (err, result) => {
         if (err) {


### PR DESCRIPTION
This is because on Node we can write UTF8 directly to a buffer
