### PR TITLE
adding t.Parallel() to some of the longer tests to run in parallel

### DIFF
--- a/go/types/edit_distance_test.go
+++ b/go/types/edit_distance_test.go
@@ -16,6 +16,7 @@ func assertDiff(assert *assert.Assertions, last []uint64, current []uint64, expe
 }
 
 func TestEditDistanceAppend(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2},
@@ -25,6 +26,7 @@ func TestEditDistanceAppend(t *testing.T) {
 }
 
 func TestEditDistancePrepend(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{3, 4, 5, 6},
@@ -34,6 +36,7 @@ func TestEditDistancePrepend(t *testing.T) {
 }
 
 func TestEditDistanceChopFromEnd(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5},
@@ -43,6 +46,7 @@ func TestEditDistanceChopFromEnd(t *testing.T) {
 }
 
 func TestEditDistanceChopFromStart(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5},
@@ -52,6 +56,7 @@ func TestEditDistanceChopFromStart(t *testing.T) {
 }
 
 func TestEditDistanceChopFromMiddle(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5},
@@ -61,6 +66,7 @@ func TestEditDistanceChopFromMiddle(t *testing.T) {
 }
 
 func TestEditDistanceA(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8},
@@ -73,6 +79,7 @@ func TestEditDistanceA(t *testing.T) {
 }
 
 func TestEditDistanceRemoveABunch(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -87,6 +94,7 @@ func TestEditDistanceRemoveABunch(t *testing.T) {
 }
 
 func TestEditDistanceAddABunch(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -102,6 +110,7 @@ func TestEditDistanceAddABunch(t *testing.T) {
 }
 
 func TestEditDistanceUpdateABunch(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -115,6 +124,7 @@ func TestEditDistanceUpdateABunch(t *testing.T) {
 }
 
 func TestEditDistanceLeftOverlap(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -126,6 +136,7 @@ func TestEditDistanceLeftOverlap(t *testing.T) {
 }
 
 func TestEditDistanceRightOverlap(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -137,6 +148,7 @@ func TestEditDistanceRightOverlap(t *testing.T) {
 }
 
 func TestEditDistanceWithin(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -148,6 +160,7 @@ func TestEditDistanceWithin(t *testing.T) {
 }
 
 func TestEditDistanceWithout(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -159,6 +172,7 @@ func TestEditDistanceWithout(t *testing.T) {
 }
 
 func TestEditDistanceMix1(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -174,6 +188,7 @@ func TestEditDistanceMix1(t *testing.T) {
 }
 
 func TestEditDistanceReverse(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	assertDiff(assert,
 		[]uint64{0, 1, 2, 3, 4, 5, 6, 7},

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -607,6 +607,7 @@ func TestListModifyAfterRead(t *testing.T) {
 }
 
 func TestListDiffIdentical(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	nums := generateNumbersAsValues(5)
 	l1 := NewList(nums...)
@@ -620,6 +621,7 @@ func TestListDiffIdentical(t *testing.T) {
 }
 
 func TestListDiffVersusEmpty(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := generateNumbersAsValues(5)
 	l1 := NewList(nums1...)
@@ -636,6 +638,7 @@ func TestListDiffReverse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := generateNumbersAsValues(5000)
 	nums2 := reverseValues(nums1)
@@ -653,6 +656,7 @@ func TestListDiffRemove5x100(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := generateNumbersAsValues(5000)
 	nums2 := generateNumbersAsValues(5000)
@@ -682,6 +686,7 @@ func TestListDiffAdd5x5(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := generateNumbersAsValues(5000)
 	nums2 := generateNumbersAsValues(5000)
@@ -708,6 +713,7 @@ func TestListDiffAdd5x5(t *testing.T) {
 }
 
 func TestListDiffReplaceReverse5x100(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
@@ -740,6 +746,7 @@ func TestListDiffReplaceReverse5x100(t *testing.T) {
 }
 
 func TestListDiffLoadLimit(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := generateNumbersAsValues(5)
 	nums2 := generateNumbersAsValues(5000)
@@ -754,6 +761,7 @@ func TestListDiffLoadLimit(t *testing.T) {
 }
 
 func TestListDiffString1(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := []Value{NewString("one"), NewString("two"), NewString("three")}
 	nums2 := []Value{NewString("one"), NewString("two"), NewString("three")}
@@ -768,6 +776,7 @@ func TestListDiffString1(t *testing.T) {
 }
 
 func TestListDiffString2(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := []Value{NewString("one"), NewString("two"), NewString("three")}
 	nums2 := []Value{NewString("one"), NewString("two"), NewString("three"), NewString("four")}
@@ -784,6 +793,7 @@ func TestListDiffString2(t *testing.T) {
 }
 
 func TestListDiffString3(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 	nums1 := []Value{NewString("one"), NewString("two"), NewString("three")}
 	nums2 := []Value{NewString("one"), NewString("two"), NewString("four")}
@@ -803,6 +813,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 
 	cs1 := chunks.NewTestStore()

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -263,6 +263,7 @@ func diffMapTest(assert *assert.Assertions, m1 Map, m2 Map, numAddsExpected int,
 }
 
 func TestMapDiff(t *testing.T) {
+	t.Parallel()
 	testMap1 := newTestMapWithGen(int(mapPattern)*2, func(v Number) Value {
 		return v
 	})
@@ -358,6 +359,7 @@ func TestMapRemove(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 
 	doTest := func(incr int, tm testMap) {
@@ -471,6 +473,7 @@ func TestMapSet(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 
 	doTest := func(incr, offset int, tm testMap) {

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -384,6 +384,7 @@ func TestSetInsert2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
+	t.Parallel()
 	assert := assert.New(t)
 
 	doTest := func(incr, offset int, ts testSet) {
@@ -444,7 +445,7 @@ func TestSetRemove2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
-
+	t.Parallel()
 	assert := assert.New(t)
 
 	doTest := func(incr, offset int, ts testSet) {


### PR DESCRIPTION
using 'go test -parallel 2' on my machine runs all of the tests in under 10 seconds now, whereas 'go test -parallel 1' is still around 13 seconds.  We can add other tests to the parallel queue over time as needed.
