### PR TITLE
Small tweaks to speed HandleWriteValue a bit

### DIFF
--- a/go/chunks/chunk_serializer.go
+++ b/go/chunks/chunk_serializer.go
@@ -115,13 +115,13 @@ func Deserialize(reader io.Reader, cs ChunkSink, rateLimit chan struct{}) {
 }
 
 // DeserializeToChan reads off of |reader| until EOF, sending chunks to chunkChan in the order they are read.
-func DeserializeToChan(reader io.Reader, chunkChan chan<- Chunk) {
+func DeserializeToChan(reader io.Reader, chunkChan chan<- *Chunk) {
 	for {
 		c, success := deserializeChunk(reader)
 		if !success {
 			break
 		}
-		chunkChan <- c
+		chunkChan <- &c
 	}
 	close(chunkChan)
 }

--- a/go/datas/put_cache.go
+++ b/go/datas/put_cache.go
@@ -102,9 +102,9 @@ func (p *orderedChunkCache) Get(hash hash.Hash) chunks.Chunk {
 	data, err := p.orderedChunks.Get(dbKey, nil)
 	d.Chk.NoError(err)
 	reader := snappy.NewReader(bytes.NewReader(data))
-	chunkChan := make(chan chunks.Chunk)
+	chunkChan := make(chan *chunks.Chunk)
 	go chunks.DeserializeToChan(reader, chunkChan)
-	return <-chunkChan
+	return *(<-chunkChan)
 }
 
 // Clear can be called from any goroutine to remove chunks referenced by the given hashes from the cache.

--- a/go/datas/put_cache_test.go
+++ b/go/datas/put_cache_test.go
@@ -180,12 +180,12 @@ func (suite *LevelDBPutCacheSuite) TestExtractChunksOrder() {
 	suite.Len(orderedHashes, 0)
 }
 
-func (suite *LevelDBPutCacheSuite) extractChunks(hashes hashSet) <-chan chunks.Chunk {
+func (suite *LevelDBPutCacheSuite) extractChunks(hashes hashSet) <-chan *chunks.Chunk {
 	buf := &bytes.Buffer{}
 	err := suite.cache.ExtractChunks(hashes, buf)
 	suite.NoError(err)
 
-	chunkChan := make(chan chunks.Chunk)
+	chunkChan := make(chan *chunks.Chunk)
 	go chunks.DeserializeToChan(snappy.NewReader(buf), chunkChan)
 	return chunkChan
 }

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -41,12 +41,12 @@ func HandleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs
 		vbs := types.NewValidatingBatchingSink(cs)
 		vbs.Prepare(deserializeHints(reader))
 
-		chunkChan := make(chan chunks.Chunk, 16)
+		chunkChan := make(chan *chunks.Chunk, 16)
 		go chunks.DeserializeToChan(reader, chunkChan)
 		var bpe chunks.BackpressureError
 		for c := range chunkChan {
 			if bpe == nil {
-				bpe = vbs.Enqueue(c)
+				bpe = vbs.Enqueue(*c)
 			} else {
 				bpe = append(bpe, c.Hash())
 			}

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -116,7 +116,7 @@ func TestBuildWriteValueRequest(t *testing.T) {
 	}
 	assert.Equal(len(hints), count)
 
-	chunkChan := make(chan chunks.Chunk, 16)
+	chunkChan := make(chan *chunks.Chunk, 16)
 	go chunks.DeserializeToChan(gr, chunkChan)
 	for c := range chunkChan {
 		assert.Equal(chnx[0].Hash(), c.Hash())
@@ -180,7 +180,7 @@ func TestHandleGetRefs(t *testing.T) {
 	)
 
 	if assert.Equal(http.StatusOK, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
-		chunkChan := make(chan chunks.Chunk)
+		chunkChan := make(chan *chunks.Chunk)
 		go chunks.DeserializeToChan(w.Body, chunkChan)
 		for c := range chunkChan {
 			assert.Equal(chnx[0].Hash(), c.Hash())

--- a/go/types/validating_batching_sink.go
+++ b/go/types/validating_batching_sink.go
@@ -10,7 +10,7 @@ import (
 	"github.com/attic-labs/noms/go/hash"
 )
 
-const batchSize = 16
+const batchSize = 100
 
 type ValidatingBatchingSink struct {
 	vs    *ValueStore
@@ -37,7 +37,7 @@ func (vbs *ValidatingBatchingSink) Enqueue(c chunks.Chunk) chunks.BackpressureEr
 		return nil
 	}
 	v := DecodeValue(c, vbs.vs)
-	d.Exp.Equal(EnsureHash(&hash.Hash{}, v), h)
+	d.Exp.True(EnsureHash(&hash.Hash{}, v) == h)
 	vbs.vs.ensureChunksInCache(v)
 	vbs.vs.set(h, hintedChunk{v.Type(), h})
 


### PR DESCRIPTION
The bigger change here is having chunks.DeserializeToChan take a
channel of *Chunk, instead of Chunk. It saves a couple of seconds
when committing the sfcrime dataset.

Also, get rid of a d.Chk.Equal in favor of a d.Chk.True and increase
the batch size that ValidatingBatchSink uses to reduce stalls due to
putting into a ChunkStore.

Tiny amount toward #1706
