### PR TITLE
Go: Simplify enabling profiling

### DIFF
--- a/cmd/noms-serve/noms_serve.go
+++ b/cmd/noms-serve/noms_serve.go
@@ -25,8 +25,8 @@ var (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Serves a Noms database over HTTP\n")
-		fmt.Fprintln(os.Stderr, "Usage: noms serve <database>")
+		fmt.Fprintf(os.Stderr, "Serves a Noms database over HTTP\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: noms serve <database>\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nFor detailed information on spelling databases, see: at https://github.com/attic-labs/noms/blob/master/doc/spelling.md.\n\n")
 	}
@@ -60,9 +60,7 @@ func main() {
 	}()
 
 	d.Try(func() {
-		if profile.MaybeStartCPUProfile() {
-			defer profile.StopCPUProfile()
-		}
+		defer profile.MaybeStartProfile().Stop()
 		server.Run()
 	})
 }

--- a/cmd/noms-sync/noms_sync.go
+++ b/cmd/noms-sync/noms_sync.go
@@ -28,8 +28,8 @@ func main() {
 	runtime.GOMAXPROCS(cpuCount)
 
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Moves datasets between or within databases")
-		fmt.Fprintln(os.Stderr, "noms sync [options] <source-object> <dest-dataset>")
+		fmt.Fprintf(os.Stderr, "Moves datasets between or within databases\n\n")
+		fmt.Fprintf(os.Stderr, "noms sync [options] <source-object> <dest-dataset>\n\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nFor detailed information on spelling objects and datasets, see: at https://github.com/attic-labs/noms/blob/master/doc/spelling.md.\n\n")
 	}
@@ -55,14 +55,10 @@ func main() {
 	defer sinkDataset.Database().Close()
 
 	err = d.Try(func() {
-		if profile.MaybeStartCPUProfile() {
-			defer profile.StopCPUProfile()
-		}
+		defer profile.MaybeStartProfile().Stop()
 
 		var err error
 		sinkDataset, err = sinkDataset.Pull(sourceStore, types.NewRef(sourceObj), int(*p))
-
-		profile.MaybeWriteMemProfile()
 		d.Exp.NoError(err)
 	})
 

--- a/samples/go/codec-perf-rig/main.go
+++ b/samples/go/codec-perf-rig/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	buildCount := *count
 	insertCount := buildCount / 50
-	profiling := profile.MaybeStartCPUProfile()
+	defer profile.MaybeStartProfile().Stop()
 
 	collectionTypes := []string{"List", "Set", "Map"}
 	buildFns := []buildCollectionFn{buildList, buildSet, buildMap}
@@ -104,10 +104,6 @@ func main() {
 	readDuration := time.Since(t1)
 	d.Chk.True(bytes.Compare(blobBytes, outBytes) == 0)
 	fmt.Printf("\t\t\t%s\t\t%s\n\n", rate(buildDuration, *blobSize), rate(readDuration, *blobSize))
-
-	if profiling {
-		profile.StopCPUProfile()
-	}
 }
 
 func rate(d time.Duration, size uint64) string {
@@ -144,7 +140,7 @@ var structType = types.MakeStructType("S1", map[string]*types.Type{
 
 func createStruct(i uint64) types.Value {
 	return types.NewStructWithType(structType, map[string]types.Value{
-		"str":  types.NewString(fmt.Sprintf("i am a 55 bytes............................%12d", strPrefix, i)),
+		"str":  types.NewString(fmt.Sprintf("i am a 55 bytes............................%12d", i)),
 		"num":  types.Number(i),
 		"bool": types.Bool(i%2 == 0),
 	})

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/go/util/progressreader"
 	"github.com/attic-labs/noms/go/util/status"
 	"github.com/attic-labs/noms/samples/go/csv"
@@ -49,7 +50,7 @@ func main() {
 	runtime.GOMAXPROCS(cpuCount)
 
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage: csv-import [options] <dataset> <csvfile>\n")
+		fmt.Fprintf(os.Stderr, "Usage: csv-import [options] <dataset> <csvfile>\n\n")
 		flag.PrintDefaults()
 	}
 
@@ -61,6 +62,8 @@ func main() {
 	}
 
 	path := flag.Arg(1)
+
+	defer profile.MaybeStartProfile().Stop()
 
 	res, err := os.Open(path)
 	d.Exp.NoError(err)

--- a/samples/go/xml-import/xml_importer.go
+++ b/samples/go/xml-import/xml_importer.go
@@ -64,9 +64,7 @@ func main() {
 		ds, err := spec.Dataset()
 		util.CheckError(err)
 
-		if profile.MaybeStartCPUProfile() {
-			defer profile.StopCPUProfile()
-		}
+		defer profile.MaybeStartProfile().Stop()
 
 		cpuCount := runtime.NumCPU()
 		runtime.GOMAXPROCS(cpuCount)
@@ -90,7 +88,7 @@ func main() {
 		}
 
 		wg := sync.WaitGroup{}
-		importXml := func() {
+		importXML := func() {
 			expectedType := types.NewMap()
 			for f := range filesChan {
 				file, err := os.Open(f.path)
@@ -118,7 +116,7 @@ func main() {
 		go getFilePaths()
 		for i := 0; i < cpuCount*8; i++ {
 			wg.Add(1)
-			go importXml()
+			go importXML()
 		}
 		go func() {
 			wg.Wait()
@@ -142,8 +140,6 @@ func main() {
 			_, err := ds.Commit(rl)
 			d.Exp.NoError(err)
 		}
-
-		profile.MaybeWriteMemProfile()
 	})
 
 	if err != nil {


### PR DESCRIPTION
One side effect of the way that Go's flag library works is that any
flag that's defined at the global scope by any library that's built
into your binary shows up in your help -- whether you honor it or
not. Arguably, including the library and calling its entry points
should be tantamount to honoring the flags. This change makes the
profiling flags behave that way -- there's one function that you call
to turn on whichever kinds of profiling the user specifies on the
command line. It returns an object with a Stop() method that you call
to shut down profiling and flush data, like so:

defer profile.MaybeStartProfile().Stop()
