### PR TITLE
Go: Fix race condition in httpBatchStore

### DIFF
--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -235,6 +235,18 @@ func (suite *HTTPBatchStoreSuite) TestGet() {
 	suite.Equal(chnx[1].Hash(), got.Hash())
 }
 
+func (suite *HTTPBatchStoreSuite) TestGetSame() {
+	chnx := []chunks.Chunk{
+		chunks.NewChunk([]byte("def")),
+		chunks.NewChunk([]byte("def")),
+	}
+	suite.NoError(suite.cs.PutMany(chnx))
+	got := suite.store.Get(chnx[0].Hash())
+	suite.Equal(chnx[0].Hash(), got.Hash())
+	got = suite.store.Get(chnx[1].Hash())
+	suite.Equal(chnx[1].Hash(), got.Hash())
+}
+
 func (suite *HTTPBatchStoreSuite) TestHas() {
 	chnx := []chunks.Chunk{
 		chunks.NewChunk([]byte("abc")),


### PR DESCRIPTION
In httpBatchStore.Get() and Has(), I add 1 to a WaitGroup, so that
Flush() and Close() can wait for all outstanding requests to complete.

As each Get or Has is processed, it's added to a ReadBatch. Once the
batch is processed, the WaitGroup count is decreased by the size of
the ReadBatch...  but ReadBatch is a map! So if the same object is
passed to Get or Has twice, it will (by design) only show up in the
ReadBatch once. That means that we'd add 2 to the WaitGroup, but only
remove 1!

This will lead to waiting forever on Flush() or Close(), and is no
good.
