### PR TITLE
Add concurrency to noms-sync

### DIFF
--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -108,7 +108,7 @@ func (suite *PullSuite) TestPullEverything() {
 	l := buildListOfHeight(2, suite.source)
 	sourceRef := suite.commitToSource(l, types.NewSet())
 
-	Pull(suite.source, suite.sink, sourceRef, types.Ref{})
+	Pull(suite.source, suite.sink, sourceRef, types.Ref{}, 2)
 	suite.Equal(0, suite.sinkCS.Reads)
 
 	suite.sink.batchStore().Flush()
@@ -148,7 +148,7 @@ func (suite *PullSuite) TestPullMultiGeneration() {
 	srcL = buildListOfHeight(5, suite.source)
 	sourceRef = suite.commitToSource(srcL, types.NewSet(sourceRef))
 
-	Pull(suite.source, suite.sink, sourceRef, sinkRef)
+	Pull(suite.source, suite.sink, sourceRef, sinkRef, 2)
 	if suite.sinkIsLocal() {
 		// C1 gets read from most-local DB
 		expectedReads++
@@ -195,7 +195,7 @@ func (suite *PullSuite) TestPullDivergentHistory() {
 	sourceRef = suite.commitToSource(srcL, types.NewSet(sourceRef))
 	preReads := suite.sinkCS.Reads
 
-	Pull(suite.source, suite.sink, sourceRef, sinkRef)
+	Pull(suite.source, suite.sink, sourceRef, sinkRef, 2)
 
 	// No objects read from sink, since sink Head is not an ancestor of source HEAD.
 	suite.Equal(preReads, suite.sinkCS.Reads)
@@ -236,7 +236,7 @@ func (suite *PullSuite) TestPullUpdates() {
 	srcL = srcL.Set(1, suite.source.WriteValue(L3))
 	sourceRef = suite.commitToSource(srcL, types.NewSet(sourceRef))
 
-	Pull(suite.source, suite.sink, sourceRef, sinkRef)
+	Pull(suite.source, suite.sink, sourceRef, sinkRef, 2)
 
 	if suite.sinkIsLocal() {
 		// 3 objects read from sink: L3, L2 and C1 (when considering the shared commit).

--- a/go/datas/put_cache.go
+++ b/go/datas/put_cache.go
@@ -58,6 +58,10 @@ func (hs hashSet) Has(hash hash.Hash) (has bool) {
 	return
 }
 
+func (hs hashSet) Remove(hash hash.Hash) {
+	delete(hs, hash)
+}
+
 // Insert can be called from any goroutine to store c in the cache. If c is successfully added to the cache, Insert returns true. If c was already in the cache, Insert returns false.
 func (p *orderedChunkCache) Insert(c chunks.Chunk, refHeight uint64) bool {
 	hash := c.Hash()

--- a/go/dataset/dataset.go
+++ b/go/dataset/dataset.go
@@ -89,7 +89,7 @@ func (ds *Dataset) pull(source datas.Database, sourceRef types.Ref, concurrency 
 		return sink, nil
 	}
 
-	datas.Pull(source, sink.Database(), sourceRef, sinkHeadRef)
+	datas.Pull(source, sink.Database(), sourceRef, sinkHeadRef, concurrency)
 	err := datas.ErrOptimisticLockFailed
 	for ; err == datas.ErrOptimisticLockFailed; sink, err = sink.setNewHead(sourceRef) {
 	}

--- a/go/types/ref_heap.go
+++ b/go/types/ref_heap.go
@@ -12,7 +12,7 @@ func (h RefHeap) Len() int {
 }
 
 func (h RefHeap) Less(i, j int) bool {
-	return HigherThan(h[i], h[j])
+	return HeapOrder(h[i], h[j])
 }
 
 func (h RefHeap) Swap(i, j int) {
@@ -31,12 +31,12 @@ func (h *RefHeap) Pop() interface{} {
 	return x
 }
 
-func (h *RefHeap) Empty() bool {
-	return len(*h) == 0
+func (h RefHeap) Empty() bool {
+	return len(h) == 0
 }
 
-// HigherThan returns true if a is 'higher than' b, generally if its ref-height is greater. If the two are of the same height, fall back to sorting by TargetHash.
-func HigherThan(a, b Ref) bool {
+// HeapOrder returns true if a is 'higher than' b, generally if its ref-height is greater. If the two are of the same height, fall back to sorting by TargetHash.
+func HeapOrder(a, b Ref) bool {
 	if a.Height() == b.Height() {
 		return a.TargetHash().Less(b.TargetHash())
 	}


### PR DESCRIPTION
The basic approach here is to take the max of the heights of the
source and sink queues, then grab all the refs of that height from
both and sort them into three sets: refs in the source, refs in the
sink, and refs in both. These are then processed in parallel and the
reachable refs are all added to the appropriate queue. Repeat as long
as stuff still shows up in the source queue.

Fixes #1564
