### PR TITLE
Add back pprof.StopCPUProfile() in profile.go

### DIFF
--- a/go/util/profile/profile.go
+++ b/go/util/profile/profile.go
@@ -58,6 +58,7 @@ func (p *prof) Stop() {
 		runtime.SetBlockProfileRate(0)
 	}
 	if p.cpu != nil {
+		pprof.StopCPUProfile()
 		p.cpu.Close()
 	}
 	if p.mem != nil {


### PR DESCRIPTION
TBR

I dropped this in an earlier CL by accident.
