### PR TITLE
Support snappy compression in getRefs/ endpoint

### DIFF
--- a/go/chunks/remote_requests.go
+++ b/go/chunks/remote_requests.go
@@ -85,20 +85,3 @@ func (rb *ReadBatch) Close() error {
 	}
 	return nil
 }
-
-// Put is implemented so that ReadBatch implements the ChunkSink interface.
-func (rb *ReadBatch) Put(c Chunk) {
-	for _, or := range (*rb)[c.Hash()] {
-		or.Satisfy(c)
-	}
-
-	delete(*rb, c.Hash())
-}
-
-// PutMany is implemented so that ReadBatch implements the ChunkSink interface.
-func (rb *ReadBatch) PutMany(chunks []Chunk) (e BackpressureError) {
-	for _, c := range chunks {
-		rb.Put(c)
-	}
-	return
-}

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -102,6 +102,10 @@ func respWriter(req *http.Request, w http.ResponseWriter) (writer io.WriteCloser
 		w.Header().Add("Content-Encoding", "gzip")
 		gw := gzip.NewWriter(w)
 		writer = gw
+	} else if strings.Contains(req.Header.Get("Accept-Encoding"), "x-snappy-framed") {
+		w.Header().Add("Content-Encoding", "x-snappy-framed")
+		sw := snappy.NewBufferedWriter(w)
+		writer = sw
 	}
 	return
 }


### PR DESCRIPTION
gzip is such a processor hog that using it to compress responses
makes reading noms data from the server take almost 4 times as long.
snappy still has pretty good compression ratios and reduces the time
to export sfcrime from 140s to about 40s with the Go csv exporter.

Adding some parallelism when httpBatchStore.getRefs() is deserializing
chunks from the server's response gets us 4 or 5 more seconds, down to
about 36s on my machine.

Toward #1764
