### PR TITLE
Re-land "tweak ldb settings for put cache (#1806)"

### DIFF
--- a/go/datas/put_cache.go
+++ b/go/datas/put_cache.go
@@ -28,7 +28,8 @@ func newOrderedChunkCache() *orderedChunkCache {
 		Compression:            opt.NoCompression,
 		Filter:                 filter.NewBloomFilter(10), // 10 bits/key
 		OpenFilesCacheCapacity: 24,
-		WriteBuffer:            1 << 24, // 16MiB,
+		NoSync:                 true,    // We dont need this data to be durable. LDB is acting as sorting temporary storage that can be larger than main memory.
+		WriteBuffer:            1 << 28, // 256MiB
 	})
 	d.Chk.NoError(err, "opening put cache in %s", dir)
 	return &orderedChunkCache{


### PR DESCRIPTION
This reverts commit ba909929c2b0e84572dc50d7ca48a9a449ec54c2, but
tweaks the size of the memory cache so that, hopefully, Travis
doesn't barf. Maybe once travis is dead we can size up.

Fixes #1817
