### PR TITLE
Additional parallelism in pull.go

### DIFF
--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -136,22 +136,23 @@ type traverseResult struct {
 // - head of sinkQ is higher than head of srcQ
 // - both heads are at the same height
 //
-// As we build up lists of refs to be processed in parallel, we need to avoid blowing past potential common refs. This could happen if we're too aggressive about pulling refs off the 'lower' queue. For now, if one queue is higher than the other we'll run down it and stop once we hit a ref at the same height as the head of the lower queue. If the two queues are at the same height, then just process them in tandem, checking for any that might be in common.
+// As we build up lists of refs to be processed in parallel, we need to avoid blowing past potential common refs. When processing a given Ref, we enumerate Refs of all Chunks that are directly reachable, which must _by definition_ be shorter than the given Ref. This means that, for example, if the queues are the same height we know that nothing can happen that will put more Refs of that height on either queue. In general, if you look at the height of the Ref at the head of a queue, you know that all Refs of that height in the current graph under consideration are already in the queue. Conversely, for any height less than that of the head of the queue, it's possible that Refs of that height remain to be discovered. Given this, we can figure out which Refs are safe to pull off the 'taller' queue in the cases where the heights of the two queues are not equal.
+// If one queue is 'taller' than the other, it's clear that we can process all refs from the taller queue with height greater than the height of the 'shorter' queue. We should also be able to process refs from the taller queue that are of the same height as the shorter queue, as long as we also check to see if they're common to both queues. It is not safe, however, to pull unique items off the shorter queue at this point. It's possible that, in processing some of the Refs from the taller queue, that these Refs will be discovered to be common after all.
 func planWork(srcQ, sinkQ *types.RefHeap) (srcRefs, sinkRefs, comRefs types.RefSlice) {
 	srcHt, sinkHt := headHeight(srcQ), headHeight(sinkQ)
 	if srcHt > sinkHt {
-		srcRefs = burnDown(srcQ, srcHt, sinkHt)
+		srcRefs, comRefs = burnDown(srcQ, sinkQ, srcHt, sinkHt)
 		return
 	}
 	if sinkHt > srcHt {
-		sinkRefs = burnDown(sinkQ, sinkHt, srcHt)
+		sinkRefs, comRefs = burnDown(sinkQ, srcQ, sinkHt, srcHt)
 		return
 	}
 
 	d.Chk.True(srcHt == sinkHt, "%d != %d", srcHt, sinkHt)
 	stopHt := srcHt
 	for ; srcHt == stopHt || sinkHt == stopHt; srcHt, sinkHt = headHeight(srcQ), headHeight(sinkQ) {
-		srcPeek, sinkPeek := peek(srcQ), peek(sinkQ)
+		srcPeek, sinkPeek := srcQ.Peek(), sinkQ.Peek()
 		if types.HeapOrder(sinkPeek, srcPeek) {
 			sinkRefs = append(sinkRefs, heap.Pop(sinkQ).(types.Ref))
 			continue
@@ -168,25 +169,31 @@ func planWork(srcQ, sinkQ *types.RefHeap) (srcRefs, sinkRefs, comRefs types.RefS
 	return
 }
 
-func burnDown(q *types.RefHeap, start, stop uint64) (refs types.RefSlice) {
-	for ht := start; ht > stop; ht = headHeight(q) {
-		refs = append(refs, heap.Pop(q).(types.Ref))
+func burnDown(taller, shorter *types.RefHeap, tall, short uint64) (tallRefs, comRefs types.RefSlice) {
+	for ht := tall; ht > short; ht = headHeight(taller) {
+		tallRefs = append(tallRefs, heap.Pop(taller).(types.Ref))
+	}
+	for shortIdx := 0; !taller.Empty() && headHeight(taller) == short; {
+		tallRef := heap.Pop(taller).(types.Ref)
+		shortPeek := shorter.PeekAt(shortIdx)
+		if types.HeapOrder(tallRef, shortPeek) {
+			tallRefs = append(tallRefs, tallRef)
+			continue
+		}
+		// This clause is the reason this code is different than the body of planWork.
+		if types.HeapOrder(shortPeek, tallRef) {
+			shortIdx++
+			continue
+		}
+		d.Chk.True(tallRef.Equals(shortPeek), "Refs should be equal: %s != %s", tallRef.TargetHash(), shortPeek.TargetHash())
+		heap.Remove(shorter, shortIdx)
+		comRefs = append(comRefs, tallRef)
 	}
 	return
 }
 
-func headHeight(h *types.RefHeap) (height uint64) {
-	if !h.Empty() {
-		height = (*h)[0].Height()
-	}
-	return
-}
-
-func peek(h *types.RefHeap) (head types.Ref) {
-	if !h.Empty() {
-		head = (*h)[0]
-	}
-	return
+func headHeight(h *types.RefHeap) uint64 {
+	return h.Peek().Height()
 }
 
 func sendWork(ch chan<- types.Ref, refs types.RefSlice) {

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -148,24 +148,9 @@ func planWork(srcQ, sinkQ *types.RefHeap) (srcRefs, sinkRefs, comRefs types.RefS
 		sinkRefs, comRefs = burnDown(sinkQ, srcQ, sinkHt, srcHt)
 		return
 	}
-
 	d.Chk.True(srcHt == sinkHt, "%d != %d", srcHt, sinkHt)
-	stopHt := srcHt
-	for ; srcHt == stopHt || sinkHt == stopHt; srcHt, sinkHt = headHeight(srcQ), headHeight(sinkQ) {
-		srcPeek, sinkPeek := srcQ.Peek(), sinkQ.Peek()
-		if types.HeapOrder(sinkPeek, srcPeek) {
-			sinkRefs = append(sinkRefs, heap.Pop(sinkQ).(types.Ref))
-			continue
-		}
-		if types.HeapOrder(srcPeek, sinkPeek) {
-			srcRefs = append(srcRefs, heap.Pop(srcQ).(types.Ref))
-			continue
-		}
-		d.Chk.True(!sinkQ.Empty(), "The heads should be the same, but sinkQ is empty!")
-		d.Chk.True(srcPeek.Equals(sinkPeek), "Refs should be equal: %s != %s", srcPeek.TargetHash(), sinkPeek.TargetHash())
-		heap.Pop(sinkQ)
-		comRefs = append(comRefs, heap.Pop(srcQ).(types.Ref))
-	}
+	srcRefs, comRefs = burnDown(srcQ, sinkQ, srcHt, sinkHt)
+	sinkRefs, _ = burnDown(sinkQ, srcQ, sinkHt, srcHt)
 	return
 }
 
@@ -180,7 +165,6 @@ func burnDown(taller, shorter *types.RefHeap, tall, short uint64) (tallRefs, com
 			tallRefs = append(tallRefs, tallRef)
 			continue
 		}
-		// This clause is the reason this code is different than the body of planWork.
 		if types.HeapOrder(shortPeek, tallRef) {
 			shortIdx++
 			continue

--- a/go/types/ref_heap.go
+++ b/go/types/ref_heap.go
@@ -35,6 +35,17 @@ func (h RefHeap) Empty() bool {
 	return len(h) == 0
 }
 
+func (h RefHeap) Peek() (head Ref) {
+	return h.PeekAt(0)
+}
+
+func (h RefHeap) PeekAt(idx int) (peek Ref) {
+	if idx < len(h) {
+		peek = h[idx]
+	}
+	return
+}
+
 // HeapOrder returns true if a is 'higher than' b, generally if its ref-height is greater. If the two are of the same height, fall back to sorting by TargetHash.
 func HeapOrder(a, b Ref) bool {
 	if a.Height() == b.Height() {


### PR DESCRIPTION
In discussing the patch that added parallelism, raf and I realized
that it's possible to be a bit more aggressive in the cases where one
queue is 'taller' than the other. In the current code, in that case,
we will parallelize work on all the Refs from the taller queue that
have a strictly higher ref-height than the head of the shorter queue.
We realized that it's safe to also take Refs from the taller queue
that are the SAME height as those at the top of the shorter queue,
as long as you handle common Refs correctly.

Fixes #1818
