### PR TITLE
Fix LevelDBStore root key

### DIFF
--- a/go/chunks/leveldb_store.go
+++ b/go/chunks/leveldb_store.go
@@ -51,10 +51,15 @@ func NewLevelDBStore(dir, ns string, maxFileHandles int, dumpStats bool) *LevelD
 }
 
 func newLevelDBStore(store *internalLevelDBStore, ns []byte, closeBackingStore bool) *LevelDBStore {
+	copyNsAndAppend := func(suffix string) (out []byte) {
+		out = make([]byte, len(ns)+len(suffix))
+		copy(out[copy(out, ns):], []byte(suffix))
+		return
+	}
 	return &LevelDBStore{
 		internalLevelDBStore: store,
-		rootKey:              append(ns, []byte(rootKeyConst)...),
-		chunkPrefix:          append(ns, []byte(chunkPrefixConst)...),
+		rootKey:              copyNsAndAppend(rootKeyConst),
+		chunkPrefix:          copyNsAndAppend(chunkPrefixConst),
 		closeBackingStore:    closeBackingStore,
 	}
 }


### PR DESCRIPTION
Apparently, the following:
  s := []byte("")
  s = append(s, 1, 2, 3)
  f := append(s, 10, 20, 30)
  g := append(s, 4, 5, 6)

Results in both f and g being [1, 2, 3, 4, 5, 6]

This was happening to us in NewLevelDBStore, so ldb.chunkPrefix was
getting set to "/chunk/" and ldb.rootKey was "/chun" (the first 5
bytes of "/chunk/") instead of "/root". This patch fixes it, but
invalidates all existing LevelDBs.
