### PR TITLE
Version Noms SDK and storage

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -39,6 +39,9 @@ type ChunkSource interface {
 
 	// Returns true iff the value at the address |h| is contained in the source
 	Has(h hash.Hash) bool
+
+	// Returns the NomsVersion with which this ChunkSource is compatible.
+	Version() string
 }
 
 // ChunkSink is a place to put chunks.

--- a/go/chunks/leveldb_store_test.go
+++ b/go/chunks/leveldb_store_test.go
@@ -53,5 +53,6 @@ func (suite *LevelDBStoreTestSuite) TestReservedKeys() {
 	// This was happening to us here, so ldb.chunkPrefix was "/chunk/" and ldb.rootKey was "/chun" instead of "/root"
 	ldb := suite.factory.CreateStore("").(*LevelDBStore)
 	suite.True(bytes.HasSuffix(ldb.rootKey, []byte(rootKeyConst)))
+	suite.True(bytes.HasSuffix(ldb.versionKey, []byte(versionKeyConst)))
 	suite.True(bytes.HasSuffix(ldb.chunkPrefix, []byte(chunkPrefixConst)))
 }

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -7,6 +7,7 @@ package chunks
 import (
 	"sync"
 
+	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 )
@@ -41,6 +42,10 @@ func (ms *MemoryStore) Has(r hash.Hash) bool {
 	}
 	_, ok := ms.data[r]
 	return ok
+}
+
+func (ms *MemoryStore) Version() string {
+	return constants.NomsVersion
 }
 
 func (ms *MemoryStore) Put(c Chunk) {

--- a/go/chunks/read_through_store.go
+++ b/go/chunks/read_through_store.go
@@ -74,3 +74,7 @@ func (rts ReadThroughStore) Root() hash.Hash {
 func (rts ReadThroughStore) UpdateRoot(current, last hash.Hash) bool {
 	return rts.backingStore.UpdateRoot(current, last)
 }
+
+func (rts ReadThroughStore) Version() string {
+	return rts.backingStore.Version()
+}

--- a/go/constants/version.go
+++ b/go/constants/version.go
@@ -1,0 +1,4 @@
+package constants
+
+// TODO: generate this from some central thing with go generate, so that JS and Go can be easily kept in sync
+const NomsVersion = "1"

--- a/go/datas/database_server.go
+++ b/go/datas/database_server.go
@@ -29,6 +29,8 @@ type remoteDatabaseServer struct {
 }
 
 func NewRemoteDatabaseServer(cs chunks.ChunkStore, port int) *remoteDatabaseServer {
+	dataVersion := cs.Version()
+	d.Exp.True(constants.NomsVersion == dataVersion, "SDK version %s is incompatible with data of version %s", constants.NomsVersion, dataVersion)
 	return &remoteDatabaseServer{
 		cs, port, nil, make(chan *connectionState, 16), false,
 	}

--- a/go/datas/http_batch_store.go
+++ b/go/datas/http_batch_store.go
@@ -469,6 +469,7 @@ func (bhcs *httpBatchStore) requestRoot(method string, current, last hash.Hash) 
 func newRequest(method, auth, url string, body io.Reader, header http.Header) *http.Request {
 	req, err := http.NewRequest(method, url, body)
 	d.Chk.NoError(err)
+	req.Header.Set(NomsVersionHeader, constants.NomsVersion)
 	for k, vals := range header {
 		for _, v := range vals {
 			req.Header.Add(k, v)
@@ -487,7 +488,7 @@ func formatErrorResponse(res *http.Response) string {
 }
 
 func expectVersion(res *http.Response) {
-	dataVersion := res.Header.Get(nomsVersionHeader)
+	dataVersion := res.Header.Get(NomsVersionHeader)
 	if constants.NomsVersion != dataVersion {
 		ioutil.ReadAll(res.Body)
 		res.Body.Close()

--- a/go/datas/http_batch_store.go
+++ b/go/datas/http_batch_store.go
@@ -214,6 +214,7 @@ func (bhcs *httpBatchStore) getRefs(hashes hashSet, batch chunks.ReadBatch) {
 
 	res, err := bhcs.httpClient.Do(req)
 	d.Chk.NoError(err)
+	expectVersion(res)
 	reader := resBodyReader(res)
 	defer closeResponse(reader)
 
@@ -265,6 +266,7 @@ func (bhcs *httpBatchStore) hasRefs(hashes hashSet, batch chunks.ReadBatch) {
 
 	res, err := bhcs.httpClient.Do(req)
 	d.Chk.NoError(err)
+	expectVersion(res)
 	reader := resBodyReader(res)
 	defer closeResponse(reader)
 
@@ -401,6 +403,7 @@ func (bhcs *httpBatchStore) sendWriteRequests(hashes hashSet, hints types.Hints)
 			res, err = bhcs.httpClient.Do(req)
 			d.Exp.NoError(err)
 			d.Exp.NoError(<-errChan)
+			expectVersion(res)
 			defer closeResponse(res.Body)
 
 			if tryAgain = res.StatusCode == httpStatusTooManyRequests; tryAgain {
@@ -423,6 +426,7 @@ func (bhcs *httpBatchStore) sendWriteRequests(hashes hashSet, hints types.Hints)
 func (bhcs *httpBatchStore) Root() hash.Hash {
 	// GET http://<host>/root. Response will be ref of root.
 	res := bhcs.requestRoot("GET", hash.Hash{}, hash.Hash{})
+	expectVersion(res)
 	defer closeResponse(res.Body)
 
 	d.Chk.True(http.StatusOK == res.StatusCode, "Unexpected response: %s", http.StatusText(res.StatusCode))
@@ -436,6 +440,7 @@ func (bhcs *httpBatchStore) UpdateRoot(current, last hash.Hash) bool {
 	bhcs.Flush()
 
 	res := bhcs.requestRoot("POST", current, last)
+	expectVersion(res)
 	defer closeResponse(res.Body)
 
 	d.Chk.True(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusConflict, "Unexpected response: %s", http.StatusText(res.StatusCode))
@@ -479,6 +484,15 @@ func formatErrorResponse(res *http.Response) string {
 	data, err := ioutil.ReadAll(res.Body)
 	d.Chk.NoError(err)
 	return fmt.Sprintf("%s:\n%s\n", res.Status, data)
+}
+
+func expectVersion(res *http.Response) {
+	dataVersion := res.Header.Get(nomsVersionHeader)
+	if constants.NomsVersion != dataVersion {
+		ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		d.Exp.Fail("Version mismatch", "SDK version %s is incompatible with data of version %s", constants.NomsVersion, dataVersion)
+	}
 }
 
 // In order for keep alive to work we must read to EOF on every response. We may want to add a timeout so that a server that left its connection open can't cause all of ports to be eaten up.

--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -113,7 +113,7 @@ func newBadVersionHTTPBatchStoreForTest(suite *HTTPBatchStoreSuite) *httpBatchSt
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 			HandleRootPost(w, req, ps, suite.cs)
-			w.Header().Set(nomsVersionHeader, "BAD")
+			w.Header().Set(NomsVersionHeader, "BAD")
 		},
 	)
 	hcs := newHTTPBatchStore("http://localhost", "")

--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -107,6 +107,20 @@ func newAuthenticatingHTTPBatchStoreForTest(suite *HTTPBatchStoreSuite, hostUrl 
 	return hcs
 }
 
+func newBadVersionHTTPBatchStoreForTest(suite *HTTPBatchStoreSuite) *httpBatchStore {
+	serv := inlineServer{httprouter.New()}
+	serv.POST(
+		constants.RootPath,
+		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			HandleRootPost(w, req, ps, suite.cs)
+			w.Header().Set(nomsVersionHeader, "BAD")
+		},
+	)
+	hcs := newHTTPBatchStore("http://localhost", "")
+	hcs.httpClient = serv
+	return hcs
+}
+
 func (suite *HTTPBatchStoreSuite) TearDownTest() {
 	suite.store.Close()
 	suite.cs.Close()
@@ -209,10 +223,16 @@ func (suite *HTTPBatchStoreSuite) TestRoot() {
 	suite.Equal(c.Hash(), suite.store.Root())
 }
 
+func (suite *HTTPBatchStoreSuite) TestVersionMismatch() {
+	store := newBadVersionHTTPBatchStoreForTest(suite)
+	c := chunks.NewChunk([]byte("abc"))
+	suite.Panics(func() { store.UpdateRoot(c.Hash(), hash.Hash{}) })
+}
+
 func (suite *HTTPBatchStoreSuite) TestUpdateRoot() {
 	c := chunks.NewChunk([]byte("abc"))
-	suite.True(suite.cs.UpdateRoot(c.Hash(), hash.Hash{}))
-	suite.Equal(c.Hash(), suite.store.Root())
+	suite.True(suite.store.UpdateRoot(c.Hash(), hash.Hash{}))
+	suite.Equal(c.Hash(), suite.cs.Root())
 }
 
 func (suite *HTTPBatchStoreSuite) TestUpdateRootWithParams() {

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
@@ -27,7 +28,10 @@ type URLParams interface {
 
 type Handler func(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore)
 
+const nomsVersionHeader = "X-Noms-Version"
+
 func HandleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
 	hashes := hash.HashSlice{}
 	err := d.Try(func() {
 		d.Exp.Equal("POST", req.Method)
@@ -119,6 +123,7 @@ func (wc wc) Close() error {
 }
 
 func HandleGetRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
 	err := d.Try(func() {
 		d.Exp.Equal("POST", req.Method)
 
@@ -166,6 +171,7 @@ func buildHashesRequest(hashes map[hash.Hash]struct{}) io.Reader {
 }
 
 func HandleHasRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
 	err := d.Try(func() {
 		d.Exp.Equal("POST", req.Method)
 
@@ -187,6 +193,7 @@ func HandleHasRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs ch
 }
 
 func HandleRootGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
+	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
 	err := d.Try(func() {
 		d.Exp.Equal("GET", req.Method)
 
@@ -202,6 +209,7 @@ func HandleRootGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt ch
 }
 
 func HandleRootPost(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
+	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
 	err := d.Try(func() {
 		d.Exp.Equal("POST", req.Method)
 

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -28,57 +28,90 @@ type URLParams interface {
 
 type Handler func(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore)
 
-const nomsVersionHeader = "X-Noms-Version"
+// NomsVersionHeader is the name of the header that Noms clients and servers must set in every request/response.
+const NomsVersionHeader = "X-Noms-Version"
 
-func HandleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
-	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
-	hashes := hash.HashSlice{}
-	err := d.Try(func() {
-		d.Exp.Equal("POST", req.Method)
+var (
+	// HandleWriteValue is meant to handle HTTP POST requests to the writeValue/ server endpoint. The payload should be an appropriately-ordered sequence of Chunks to be validated and stored on the server.
+	// TODO: Nice comment about what headers it expects/honors, payload format, and error responses.
+	HandleWriteValue = versionCheck(handleWriteValue)
 
-		reader := bodyReader(req)
-		defer func() {
-			// Ensure all data on reader is consumed
-			io.Copy(ioutil.Discard, reader)
-			reader.Close()
-		}()
-		vbs := types.NewValidatingBatchingSink(cs)
-		vbs.Prepare(deserializeHints(reader))
+	// HandleGetRefs is meant to handle HTTP POST requests to the getRefs/ server endpoint. Given a sequence of Chunk hashes, the server will fetch and return them.
+	// TODO: Nice comment about what headers it expects/honors, payload format, and responses.
+	HandleGetRefs = versionCheck(handleGetRefs)
 
-		chunkChan := make(chan *chunks.Chunk, 16)
-		go chunks.DeserializeToChan(reader, chunkChan)
-		var bpe chunks.BackpressureError
-		for c := range chunkChan {
-			if bpe == nil {
-				bpe = vbs.Enqueue(*c)
-			} else {
-				bpe = append(bpe, c.Hash())
-			}
-			// If a previous Enqueue() errored, we still need to drain chunkChan
-			// TODO: what about having DeserializeToChan take a 'done' channel to stop it?
-			hashes = append(hashes, c.Hash())
-		}
-		if bpe == nil {
-			bpe = vbs.Flush()
-		}
-		if bpe != nil {
-			w.WriteHeader(httpStatusTooManyRequests)
-			w.Header().Add("Content-Type", "application/octet-stream")
-			writer := respWriter(req, w)
-			defer writer.Close()
-			serializeHashes(writer, bpe.AsHashes())
+	// HandleWriteValue is meant to handle HTTP POST requests to the hasRefs/ server endpoint. Given a sequence of Chunk hashes, the server check for their presence and return a list of true/false responses.
+	// TODO: Nice comment about what headers it expects/honors, payload format, and responses.
+	HandleHasRefs = versionCheck(handleHasRefs)
+
+	// HandleRootGet is meant to handle HTTP GET requests to the root/ server endpoint. The server returns the hash of the Root as a string.
+	// TODO: Nice comment about what headers it expects/honors, payload format, and responses.
+	HandleRootGet = versionCheck(handleRootGet)
+
+	// HandleWriteValue is meant to handle HTTP POST requests to the root/ server endpoint. This is used to update the Root to point to a new Chunk.
+	// TODO: Nice comment about what headers it expects/honors, payload format, and error responses.
+	HandleRootPost = versionCheck(handleRootPost)
+)
+
+func versionCheck(hndlr Handler) Handler {
+	return func(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+		w.Header().Set(NomsVersionHeader, constants.NomsVersion)
+		if req.Header.Get(NomsVersionHeader) != constants.NomsVersion {
+			http.Error(
+				w,
+				fmt.Sprintf("Error: SDK version %s is incompatible with data of version %s", req.Header.Get(NomsVersionHeader), constants.NomsVersion),
+				http.StatusBadRequest,
+			)
 			return
 		}
-		w.WriteHeader(http.StatusCreated)
-	})
 
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Error: %v\nChunks in payload: %v", err, hashes), http.StatusBadRequest)
-		return
+		err := d.Try(func() { hndlr(w, req, ps, cs) })
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
+			return
+		}
 	}
 }
 
-// Contents of the returned io.Reader are gzipped.
+func handleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+	d.Exp.Equal("POST", req.Method)
+
+	reader := bodyReader(req)
+	defer func() {
+		// Ensure all data on reader is consumed
+		io.Copy(ioutil.Discard, reader)
+		reader.Close()
+	}()
+	vbs := types.NewValidatingBatchingSink(cs)
+	vbs.Prepare(deserializeHints(reader))
+
+	chunkChan := make(chan *chunks.Chunk, 16)
+	go chunks.DeserializeToChan(reader, chunkChan)
+	var bpe chunks.BackpressureError
+	for c := range chunkChan {
+		if bpe == nil {
+			bpe = vbs.Enqueue(*c)
+		} else {
+			bpe = append(bpe, c.Hash())
+		}
+		// If a previous Enqueue() errored, we still need to drain chunkChan
+		// TODO: what about having DeserializeToChan take a 'done' channel to stop it?
+	}
+	if bpe == nil {
+		bpe = vbs.Flush()
+	}
+	if bpe != nil {
+		w.WriteHeader(httpStatusTooManyRequests)
+		w.Header().Add("Content-Type", "application/octet-stream")
+		writer := respWriter(req, w)
+		defer writer.Close()
+		serializeHashes(writer, bpe.AsHashes())
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+// Contents of the returned io.Reader are snappy-compressed.
 func buildWriteValueRequest(serializedChunks io.Reader, hints map[hash.Hash]struct{}) io.Reader {
 	body := &bytes.Buffer{}
 	gw := snappy.NewBufferedWriter(body)
@@ -122,31 +155,23 @@ func (wc wc) Close() error {
 	return nil
 }
 
-func HandleGetRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
-	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
-	err := d.Try(func() {
-		d.Exp.Equal("POST", req.Method)
+func handleGetRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+	d.Exp.Equal("POST", req.Method)
 
-		hashes := extractHashes(req)
+	hashes := extractHashes(req)
 
-		w.Header().Add("Content-Type", "application/octet-stream")
-		writer := respWriter(req, w)
-		defer writer.Close()
+	w.Header().Add("Content-Type", "application/octet-stream")
+	writer := respWriter(req, w)
+	defer writer.Close()
 
-		sz := chunks.NewSerializer(writer)
-		for _, h := range hashes {
-			c := cs.Get(h)
-			if !c.IsEmpty() {
-				sz.Put(c)
-			}
+	sz := chunks.NewSerializer(writer)
+	for _, h := range hashes {
+		c := cs.Get(h)
+		if !c.IsEmpty() {
+			sz.Put(c)
 		}
-		sz.Close()
-	})
-
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
-		return
 	}
+	sz.Close()
 }
 
 func extractHashes(req *http.Request) hash.HashSlice {
@@ -170,65 +195,41 @@ func buildHashesRequest(hashes map[hash.Hash]struct{}) io.Reader {
 	return strings.NewReader(values.Encode())
 }
 
-func HandleHasRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
-	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
-	err := d.Try(func() {
-		d.Exp.Equal("POST", req.Method)
+func handleHasRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore) {
+	d.Exp.Equal("POST", req.Method)
 
-		hashes := extractHashes(req)
+	hashes := extractHashes(req)
 
-		w.Header().Add("Content-Type", "text/plain")
-		writer := respWriter(req, w)
-		defer writer.Close()
+	w.Header().Add("Content-Type", "text/plain")
+	writer := respWriter(req, w)
+	defer writer.Close()
 
-		for _, h := range hashes {
-			fmt.Fprintf(writer, "%s %t\n", h, cs.Has(h))
-		}
-	})
-
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
-		return
+	for _, h := range hashes {
+		fmt.Fprintf(writer, "%s %t\n", h, cs.Has(h))
 	}
 }
 
-func HandleRootGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
-	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
-	err := d.Try(func() {
-		d.Exp.Equal("GET", req.Method)
+func handleRootGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
+	d.Exp.Equal("GET", req.Method)
 
-		rootRef := rt.Root()
-		fmt.Fprintf(w, "%v", rootRef.String())
-		w.Header().Add("content-type", "text/plain")
-	})
-
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
-		return
-	}
+	rootRef := rt.Root()
+	fmt.Fprintf(w, "%v", rootRef.String())
+	w.Header().Add("content-type", "text/plain")
 }
 
-func HandleRootPost(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
-	w.Header().Set(nomsVersionHeader, constants.NomsVersion)
-	err := d.Try(func() {
-		d.Exp.Equal("POST", req.Method)
+func handleRootPost(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
+	d.Exp.Equal("POST", req.Method)
 
-		params := req.URL.Query()
-		tokens := params["last"]
-		d.Exp.Len(tokens, 1)
-		last := hash.Parse(tokens[0])
-		tokens = params["current"]
-		d.Exp.Len(tokens, 1)
-		current := hash.Parse(tokens[0])
+	params := req.URL.Query()
+	tokens := params["last"]
+	d.Exp.Len(tokens, 1)
+	last := hash.Parse(tokens[0])
+	tokens = params["current"]
+	d.Exp.Len(tokens, 1)
+	current := hash.Parse(tokens[0])
 
-		if !rt.UpdateRoot(current, last) {
-			w.WriteHeader(http.StatusConflict)
-			return
-		}
-	})
-
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
+	if !rt.UpdateRoot(current, last) {
+		w.WriteHeader(http.StatusConflict)
 		return
 	}
 }

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -29,7 +29,7 @@ type URLParams interface {
 type Handler func(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore)
 
 // NomsVersionHeader is the name of the header that Noms clients and servers must set in every request/response.
-const NomsVersionHeader = "X-Noms-Version"
+const NomsVersionHeader = "X-Noms-Vers"
 
 var (
 	// HandleWriteValue is meant to handle HTTP POST requests to the writeValue/ server endpoint. The payload should be an appropriately-ordered sequence of Chunks to be validated and stored on the server.

--- a/go/types/batch_store.go
+++ b/go/types/batch_store.go
@@ -6,8 +6,11 @@ package types
 
 import (
 	"io"
+	"sync"
 
 	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/constants"
+	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 )
 
@@ -33,22 +36,30 @@ type Hints map[hash.Hash]struct{}
 
 // BatchStoreAdaptor provides a naive implementation of BatchStore should only be used with ChunkStores that can Put relatively quickly. It provides no actual batching or validation. Its intended use is for adapting a ChunkStore for use in something that requires a BatchStore.
 type BatchStoreAdaptor struct {
-	cs chunks.ChunkStore
+	cs   chunks.ChunkStore
+	once sync.Once
 }
 
 // NewBatchStoreAdaptor returns a BatchStore instance backed by a ChunkStore. Takes ownership of cs and manages its lifetime; calling Close on the returned BatchStore will Close cs.
 func NewBatchStoreAdaptor(cs chunks.ChunkStore) BatchStore {
-	return &BatchStoreAdaptor{cs}
+	return &BatchStoreAdaptor{cs: cs}
 }
 
 // Get simply proxies to the backing ChunkStore
 func (bsa *BatchStoreAdaptor) Get(h hash.Hash) chunks.Chunk {
+	bsa.once.Do(bsa.expectVersion)
 	return bsa.cs.Get(h)
 }
 
 // SchedulePut simply calls Put on the underlying ChunkStore, and ignores hints.
 func (bsa *BatchStoreAdaptor) SchedulePut(c chunks.Chunk, refHeight uint64, hints Hints) {
+	bsa.once.Do(bsa.expectVersion)
 	bsa.cs.Put(c)
+}
+
+func (bsa *BatchStoreAdaptor) expectVersion() {
+	dataVersion := bsa.cs.Version()
+	d.Exp.True(constants.NomsVersion == dataVersion, "SDK version %s incompatible with data of version %s", constants.NomsVersion, dataVersion)
 }
 
 // AddHints is a noop.

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -122,3 +122,21 @@ func TestHintsOnCache(t *testing.T) {
 		}
 	}
 }
+
+func TestPanicOnReadBadVersion(t *testing.T) {
+	cvs := newLocalValueStore(&badVersionStore{chunks.NewTestStore()})
+	assert.Panics(t, func() { cvs.ReadValue(hash.Hash{}) })
+}
+
+func TestPanicOnWriteBadVersion(t *testing.T) {
+	cvs := newLocalValueStore(&badVersionStore{chunks.NewTestStore()})
+	assert.Panics(t, func() { cvs.WriteValue(NewEmptyBlob()) })
+}
+
+type badVersionStore struct {
+	*chunks.TestStore
+}
+
+func (b *badVersionStore) Version() string {
+	return "BAD"
+}

--- a/js/src/browser/fetch.js
+++ b/js/src/browser/fetch.js
@@ -4,6 +4,8 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
+import {NomsVersion} from '../version.js';
+
 export type FetchOptions = {
   method?: string,
   body?: any,
@@ -19,6 +21,11 @@ function fetch<T>(url: string, responseType: string, options: FetchOptions = {})
   const p = new Promise((res, rej) => {
     xhr.onloadend = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
+        const vers = xhr.getResponseHeader('x-noms-version');
+        if (vers !== NomsVersion) {
+          rej(new Error(
+            `SDK version ${NomsVersion} is not compatible with data of version ${vers}.`));
+        }
         res(xhr.response);
       } else {
         rej(xhr.status);

--- a/js/src/fetch.js
+++ b/js/src/fetch.js
@@ -7,6 +7,7 @@
 import {request} from 'http';
 import {parse} from 'url';
 import Bytes from './bytes.js';
+import {NomsVersion} from './version.js';
 
 export type FetchOptions = {
   method?: string,
@@ -50,6 +51,11 @@ function fetch(url: string, options: FetchOptions = {}): Promise<Uint8Array> {
         offset += size;
       });
       res.on('end', () => {
+        const vers = res.headers['x-noms-version'];
+        if (vers !== NomsVersion) {
+          reject(new Error(
+            `SDK version ${NomsVersion} is not compatible with data of version ${vers}.`));
+        }
         resolve(Bytes.subarray(buf, 0, offset));
       });
     });

--- a/js/src/fetch.js
+++ b/js/src/fetch.js
@@ -7,16 +7,19 @@
 import {request} from 'http';
 import {parse} from 'url';
 import Bytes from './bytes.js';
-import {NomsVersion} from './version.js';
 
 export type FetchOptions = {
   method?: string,
   body?: any,
   headers?: {[key: string]: string},
+  respHeaders?: string[],
   withCredentials? : boolean,
 };
 
-function fetch(url: string, options: FetchOptions = {}): Promise<Uint8Array> {
+type TextResponse = {headers: Map<string, string>, buf: string}
+type BufResponse = {headers: Map<string, string>, buf: Uint8Array}
+
+function fetch(url: string, options: FetchOptions = {}): Promise<BufResponse> {
   const opts: any = parse(url);
   opts.method = options.method || 'GET';
   if (options.headers) {
@@ -51,12 +54,13 @@ function fetch(url: string, options: FetchOptions = {}): Promise<Uint8Array> {
         offset += size;
       });
       res.on('end', () => {
-        const vers = res.headers['x-noms-version'];
-        if (vers !== NomsVersion) {
-          reject(new Error(
-            `SDK version ${NomsVersion} is not compatible with data of version ${vers}.`));
+        const headers = new Map();
+        if (opts.respHeaders) {
+          for (const header of opts.respHeaders) {
+            headers.set(header, res.headers[header]);
+          }
         }
-        resolve(Bytes.subarray(buf, 0, offset));
+        resolve({headers: headers, buf: Bytes.subarray(buf, 0, offset)});
       });
     });
     req.on('error', err => {
@@ -92,10 +96,11 @@ function normalizeBody(opts: FetchOptions): FetchOptions {
   return opts;
 }
 
-export function fetchText(url: string, options: FetchOptions = {}): Promise<string> {
-  return fetch(url, normalizeBody(options)).then(ar => bufferToString(ar));
+export function fetchText(url: string, options: FetchOptions = {}): Promise<TextResponse> {
+  return fetch(url, normalizeBody(options))
+    .then(({headers, buf}) => ({headers: headers, buf: bufferToString(buf)}));
 }
 
-export function fetchUint8Array(url: string, options: FetchOptions = {}): Promise<Uint8Array> {
+export function fetchUint8Array(url: string, options: FetchOptions = {}): Promise<BufResponse> {
   return fetch(url, options);
 }

--- a/js/src/http-batch-store.js
+++ b/js/src/http-batch-store.js
@@ -13,13 +13,22 @@ import {serialize, deserializeChunks} from './chunk-serializer.js';
 import {emptyChunk} from './chunk.js';
 import {fetchUint8Array, fetchText} from './fetch.js';
 import {notNull} from './assert.js';
+import {NomsVersion} from './version.js';
 
 const HTTP_STATUS_CONFLICT = 409;
+const VersionHeader = 'X-Noms-Vers';
 
 type RpcStrings = {
   getRefs: string,
   root: string,
   writeValue: string,
+};
+
+const versOptions = {
+  headers: {
+    VersionHeader: NomsVersion,
+  },
+  respHeaders: [VersionHeader],
 };
 
 const readBatchOptions = {
@@ -72,8 +81,8 @@ export class Delegate {
 
   constructor(rpc: RpcStrings, fetchOptions: FetchOptions) {
     this._rpc = rpc;
-    this._rootOptions = fetchOptions;
-    this._readBatchOptions = mergeOptions(readBatchOptions, fetchOptions);
+    this._rootOptions = mergeOptions(versOptions, fetchOptions);
+    this._readBatchOptions = mergeOptions(readBatchOptions, this._rootOptions);
     this._body = new ArrayBuffer(0);
   }
 
@@ -81,7 +90,12 @@ export class Delegate {
     const hashStrs = Object.keys(reqs);
     const body = hashStrs.map(r => 'ref=' + r).join('&');
     const opts = Object.assign(this._readBatchOptions, {body: body});
-    const buf = await fetchUint8Array(this._rpc.getRefs, opts);
+    const {headers, buf} = await fetchUint8Array(this._rpc.getRefs, opts);
+
+    const versionErr = CheckVersion(headers);
+    if (versionErr) {
+      return Promise.reject(versionErr);
+    }
 
     const chunks = deserializeChunks(buf, new DataView(buf.buffer, buf.byteOffset, buf.byteLength));
 
@@ -99,19 +113,32 @@ export class Delegate {
   writeBatch(hints: Set<Hash>, chunkStream: ChunkStream): Promise<void> {
     return serialize(hints, chunkStream)
       .then(body => fetchText(this._rpc.writeValue, {method: 'POST', body}))
-      .then(() => undefined);
+      .then(({headers}) => {
+        const versionErr = CheckVersion(headers);
+        if (versionErr) {
+          return Promise.reject(versionErr);
+        }
+      });
   }
 
   async getRoot(): Promise<Hash> {
-    const hashStr = await fetchText(this._rpc.root, this._rootOptions);
-    return notNull(Hash.parse(hashStr));
+    const {headers, buf} = await fetchText(this._rpc.root, this._rootOptions);
+    const versionErr = CheckVersion(headers);
+    if (versionErr) {
+      return Promise.reject(versionErr);
+    }
+    return notNull(Hash.parse(buf));
   }
 
   async updateRoot(current: Hash, last: Hash): Promise<boolean> {
     const ch = this._rpc.root.indexOf('?') >= 0 ? '&' : '?';
     const params = `${ch}current=${current}&last=${last}`;
     try {
-      await fetchText(this._rpc.root + params, {method: 'POST'});
+      const {headers} = await fetchText(this._rpc.root + params, {method: 'POST'});
+      const versionErr = CheckVersion(headers);
+      if (versionErr) {
+        return Promise.reject(versionErr);
+      }
       return true;
     } catch (ex) {
       if (ex === HTTP_STATUS_CONFLICT) {
@@ -120,4 +147,13 @@ export class Delegate {
       throw ex;
     }
   }
+}
+
+function CheckVersion(headers: {[key: string]: string}): ?Error {
+  const vers = headers[VersionHeader];
+  if (vers !== NomsVersion) {
+    return new Error(
+      `SDK version ${NomsVersion} is not compatible with data of version ${vers}.`);
+  }
+  return null;
 }

--- a/js/src/http-batch-store.js
+++ b/js/src/http-batch-store.js
@@ -92,7 +92,7 @@ export class Delegate {
     const opts = Object.assign(this._readBatchOptions, {body: body});
     const {headers, buf} = await fetchUint8Array(this._rpc.getRefs, opts);
 
-    const versionErr = CheckVersion(headers);
+    const versionErr = checkVersion(headers);
     if (versionErr) {
       return Promise.reject(versionErr);
     }
@@ -114,7 +114,7 @@ export class Delegate {
     return serialize(hints, chunkStream)
       .then(body => fetchText(this._rpc.writeValue, {method: 'POST', body}))
       .then(({headers}) => {
-        const versionErr = CheckVersion(headers);
+        const versionErr = checkVersion(headers);
         if (versionErr) {
           return Promise.reject(versionErr);
         }
@@ -123,7 +123,7 @@ export class Delegate {
 
   async getRoot(): Promise<Hash> {
     const {headers, buf} = await fetchText(this._rpc.root, this._rootOptions);
-    const versionErr = CheckVersion(headers);
+    const versionErr = checkVersion(headers);
     if (versionErr) {
       return Promise.reject(versionErr);
     }
@@ -135,7 +135,7 @@ export class Delegate {
     const params = `${ch}current=${current}&last=${last}`;
     try {
       const {headers} = await fetchText(this._rpc.root + params, {method: 'POST'});
-      const versionErr = CheckVersion(headers);
+      const versionErr = checkVersion(headers);
       if (versionErr) {
         return Promise.reject(versionErr);
       }
@@ -149,7 +149,7 @@ export class Delegate {
   }
 }
 
-function CheckVersion(headers: {[key: string]: string}): ?Error {
+function checkVersion(headers: {[key: string]: string}): ?Error {
   const vers = headers[VersionHeader];
   if (vers !== NomsVersion) {
     return new Error(

--- a/js/src/version.js
+++ b/js/src/version.js
@@ -1,0 +1,7 @@
+// @flow
+
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+export const NomsVersion = '1';


### PR DESCRIPTION
ChunkStores provide a Version() method so that anyone directly
using a ChunkStore (e.g. BatchStoreAdaptor) can retrieve and
check the version of the underlying store.

remoteDatabaseServer checks the version of the ChunkStore it's
backed by at startup, and then provides that version as an HTTP
header to all clients. In Go, httpBatchStore checks this header
anytime it gets a response from the server and bails if there's
version skew.

In Go, the responsibility for checking whether the running code and
the data being accessed lies with the BatchStore layer. In JS, there
is code in fetch.js that checks the header mentioned above.

Towards #1561
