### PR TITLE
noms (diff|log|show): gracefully handle user specifying non-existent spec

### DIFF
--- a/cmd/noms-diff/noms_diff.go
+++ b/cmd/noms-diff/noms_diff.go
@@ -40,15 +40,21 @@ func main() {
 	}
 
 	if len(flag.Args()) != 2 {
-		util.CheckError(errors.New("expected exactly two arguments"))
+		util.CheckErrorNoUsage(errors.New("Expected exactly two arguments"))
 	}
 
 	db1, value1, err := spec.GetPath(flag.Arg(0))
-	util.CheckError(err)
+	util.CheckErrorNoUsage(err)
+	if value1 == nil {
+		util.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", flag.Arg(0)))
+	}
 	defer db1.Close()
 
 	db2, value2, err := spec.GetPath(flag.Arg(1))
-	util.CheckError(err)
+	util.CheckErrorNoUsage(err)
+	if value2 == nil {
+		util.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", flag.Arg(1)))
+	}
 	defer db2.Close()
 
 	waitChan := outputpager.PageOutput(!*outputpager.NoPager)

--- a/cmd/noms-log/noms_log.go
+++ b/cmd/noms-log/noms_log.go
@@ -62,6 +62,10 @@ func main() {
 	}
 	defer database.Close()
 
+	if value == nil {
+		util.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", flag.Arg(0)))
+	}
+
 	waitChan := outputpager.PageOutput(!*outputpager.NoPager)
 
 	origCommit, ok := value.(types.Struct)

--- a/cmd/noms-show/noms_show.go
+++ b/cmd/noms-show/noms_show.go
@@ -35,11 +35,16 @@ func main() {
 	}
 
 	if len(flag.Args()) != 1 {
-		util.CheckError(errors.New("expected exactly one argument"))
+		util.CheckErrorNoUsage(errors.New("expected exactly one argument"))
 	}
 
 	database, value, err := spec.GetPath(flag.Arg(0))
-	util.CheckError(err)
+	util.CheckErrorNoUsage(err)
+
+	if value == nil {
+		fmt.Fprintf(os.Stderr, "Object not found: %s\n", flag.Arg(0))
+		return
+	}
 
 	waitChan := outputpager.PageOutput(!*outputpager.NoPager)
 


### PR DESCRIPTION
Fixes #1847 
