### PR TITLE
Go: Add Mx() for Noms Maps

### DIFF
--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -13,7 +13,7 @@ import (
 	"github.com/attic-labs/noms/go/hash"
 )
 
-var initialBufferSize = 2048
+const initialBufferSize = 2048
 
 func EncodeValue(v Value, vw ValueWriter) chunks.Chunk {
 	w := &binaryNomsWriter{make([]byte, initialBufferSize, initialBufferSize), 0}

--- a/go/types/compare.go
+++ b/go/types/compare.go
@@ -1,0 +1,86 @@
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"crypto/sha1"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/hash"
+)
+
+type nomsComparer struct{}
+
+func (nomsComparer) Compare(a, b []byte) int {
+	if compared, res := compareEmpties(a, b); compared {
+		return res
+	}
+	aKind, bKind := NomsKind(a[0]), NomsKind(b[0])
+	switch aKind {
+	default:
+		if bKind <= StringKind {
+			return 1
+		}
+		a, b = a[1:], b[1:]
+		d.Chk.True(len(a) == sha1.Size && len(b) == sha1.Size, "Compared objects should be %d bytes long, not %d and %d", sha1.Size, len(a), len(b))
+		aHash, bHash := hash.FromSlice(a), hash.FromSlice(b)
+		if aHash == bHash {
+			d.Chk.True(aKind == bKind, "%d != %d, but Values with the same hash MUST be the same Kind", aKind, bKind)
+			return 0
+		}
+		if aHash.Less(bHash) {
+			return -1
+		}
+		return 1
+	case BoolKind, NumberKind, StringKind:
+		if res := compareKinds(aKind, bKind); res != 0 {
+			return res
+		}
+		vA := newValueDecoder(&binaryNomsReader{a, 0}, nil).readValue()
+		vB := newValueDecoder(&binaryNomsReader{b, 0}, nil).readValue()
+		if vA.Equals(vB) {
+			return 0
+		}
+		if vA.Less(vB) {
+			return -1
+		}
+		return 1
+	}
+}
+
+func compareEmpties(a, b []byte) (bool, int) {
+	aLen, bLen := len(a), len(b)
+	if aLen > 0 && bLen > 0 {
+		return false, 0
+	}
+	if aLen == 0 {
+		if bLen == 0 {
+			return true, 0
+		}
+		return true, -1
+	}
+	return true, 1
+}
+
+func compareKinds(aKind, bKind NomsKind) (res int) {
+	if aKind < bKind {
+		res = -1
+	} else if aKind > bKind {
+		res = 1
+	}
+	return
+}
+
+func (nomsComparer) Name() string {
+	return "noms.ValueComparator"
+}
+
+func (nomsComparer) Successor(dst, b []byte) []byte {
+	return nil
+}
+
+func (nomsComparer) Separator(dst, a, b []byte) []byte {
+	return nil
+}

--- a/go/types/compare_test.go
+++ b/go/types/compare_test.go
@@ -47,7 +47,7 @@ func TestTotalOrdering(t *testing.T) {
 
 func TestCompareEmpties(t *testing.T) {
 	assert := assert.New(t)
-	comp := nomsComparer{}
+	comp := opCacheComparer{}
 	assert.Equal(-1, comp.Compare(nil, []byte{0xff}))
 	assert.Equal(-1, comp.Compare([]byte{}, []byte{0xff}))
 
@@ -62,7 +62,7 @@ func TestCompareEmpties(t *testing.T) {
 
 func TestCompareDifferentPrimitiveTypes(t *testing.T) {
 	assert := assert.New(t)
-	comp := nomsComparer{}
+	comp := opCacheComparer{}
 
 	b := []byte{byte(BoolKind), 0x00}
 	n := []byte{byte(NumberKind), 0x00}
@@ -79,7 +79,7 @@ func TestCompareDifferentPrimitiveTypes(t *testing.T) {
 
 func TestComparePrimitives(t *testing.T) {
 	assert := assert.New(t)
-	comp := nomsComparer{}
+	comp := opCacheComparer{}
 
 	tru := encode(Bool(true))
 	fls := encode(Bool(false))
@@ -103,7 +103,7 @@ func TestComparePrimitives(t *testing.T) {
 
 func TestCompareHashes(t *testing.T) {
 	assert := assert.New(t)
-	comp := nomsComparer{}
+	comp := opCacheComparer{}
 
 	tru := encode(Bool(true))
 	one := encode(Number(1))

--- a/go/types/compare_test.go
+++ b/go/types/compare_test.go
@@ -5,6 +5,8 @@
 package types
 
 import (
+	"bytes"
+	"crypto/sha1"
 	"testing"
 
 	"github.com/attic-labs/testify/assert"
@@ -41,4 +43,105 @@ func TestTotalOrdering(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestCompareEmpties(t *testing.T) {
+	assert := assert.New(t)
+	comp := nomsComparer{}
+	assert.Equal(-1, comp.Compare(nil, []byte{0xff}))
+	assert.Equal(-1, comp.Compare([]byte{}, []byte{0xff}))
+
+	assert.Equal(0, comp.Compare(nil, nil))
+	assert.Equal(0, comp.Compare(nil, []byte{}))
+	assert.Equal(0, comp.Compare([]byte{}, []byte{}))
+	assert.Equal(0, comp.Compare([]byte{}, nil))
+
+	assert.Equal(1, comp.Compare([]byte{0xff}, nil))
+	assert.Equal(1, comp.Compare([]byte{0xff}, []byte{}))
+}
+
+func TestCompareDifferentPrimitiveTypes(t *testing.T) {
+	assert := assert.New(t)
+	comp := nomsComparer{}
+
+	b := []byte{byte(BoolKind), 0x00}
+	n := []byte{byte(NumberKind), 0x00}
+	s := []byte{byte(StringKind), 'a'}
+
+	assert.Equal(-1, comp.Compare(b, n))
+	assert.Equal(-1, comp.Compare(b, s))
+	assert.Equal(-1, comp.Compare(n, s))
+
+	assert.Equal(1, comp.Compare(s, n))
+	assert.Equal(1, comp.Compare(s, b))
+	assert.Equal(1, comp.Compare(n, b))
+}
+
+func TestComparePrimitives(t *testing.T) {
+	assert := assert.New(t)
+	comp := nomsComparer{}
+
+	tru := encode(Bool(true))
+	fls := encode(Bool(false))
+	one := encode(Number(1))
+	fortytwo := encode(Number(42))
+	hey := encode(String("hey"))
+	ya := encode(String("ya"))
+
+	assert.Equal(-1, comp.Compare(fls, tru))
+	assert.Equal(-1, comp.Compare(one, fortytwo))
+	assert.Equal(-1, comp.Compare(hey, ya))
+
+	assert.Equal(0, comp.Compare(tru, tru))
+	assert.Equal(0, comp.Compare(one, one))
+	assert.Equal(0, comp.Compare(hey, hey))
+
+	assert.Equal(1, comp.Compare(tru, fls))
+	assert.Equal(1, comp.Compare(fortytwo, one))
+	assert.Equal(1, comp.Compare(ya, hey))
+}
+
+func TestCompareHashes(t *testing.T) {
+	assert := assert.New(t)
+	comp := nomsComparer{}
+
+	tru := encode(Bool(true))
+	one := encode(Number(1))
+	hey := encode(String("hey"))
+
+	minHash := append([]byte{byte(BlobKind)}, bytes.Repeat([]byte{0}, sha1.Size)...)
+	maxHash := append([]byte{byte(BlobKind)}, bytes.Repeat([]byte{0xff}, sha1.Size)...)
+	almostMaxHash := append([]byte{byte(BlobKind)}, append(bytes.Repeat([]byte{0xff}, sha1.Size-1), 0xfe)...)
+
+	assert.Equal(-1, comp.Compare(tru, minHash))
+	assert.Equal(-1, comp.Compare(one, minHash))
+	assert.Equal(-1, comp.Compare(hey, minHash))
+	assert.Equal(-1, comp.Compare(minHash, almostMaxHash))
+	assert.Equal(-1, comp.Compare(almostMaxHash, maxHash))
+
+	assert.Equal(0, comp.Compare(minHash, minHash))
+	assert.Equal(0, comp.Compare(almostMaxHash, almostMaxHash))
+	assert.Equal(0, comp.Compare(maxHash, maxHash))
+
+	assert.Equal(1, comp.Compare(minHash, tru))
+	assert.Equal(1, comp.Compare(minHash, one))
+	assert.Equal(1, comp.Compare(minHash, hey))
+	assert.Equal(1, comp.Compare(almostMaxHash, tru))
+	assert.Equal(1, comp.Compare(almostMaxHash, one))
+	assert.Equal(1, comp.Compare(almostMaxHash, hey))
+	assert.Equal(1, comp.Compare(maxHash, tru))
+	assert.Equal(1, comp.Compare(maxHash, one))
+	assert.Equal(1, comp.Compare(maxHash, hey))
+	assert.Equal(1, comp.Compare(maxHash, almostMaxHash))
+	assert.Equal(1, comp.Compare(almostMaxHash, minHash))
+
+	almostMaxHash[0]++
+	assert.Equal(1, comp.Compare(maxHash, almostMaxHash))
+
+}
+
+func encode(v Value) []byte {
+	w := &binaryNomsWriter{make([]byte, 128, 128), 0}
+	newValueEncoder(w, nil).writeValue(v)
+	return w.data()
 }

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -112,6 +112,11 @@ func (m Map) MaybeGet(key Value) (v Value, ok bool) {
 	return entry.value, true
 }
 
+func (m Map) Mx(vrw ValueReadWriter) *MapMutator {
+	d.Chk.True(m.Empty(), "Mx() currently only works on empty Maps")
+	return newMutator(vrw)
+}
+
 func (m Map) Set(key Value, val Value) Map {
 	return m.SetM(key, val)
 }

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -28,7 +28,7 @@ func newMap(seq orderedSequence) Map {
 
 func NewMap(kv ...Value) Map {
 	entries := buildMapData(kv)
-	seq := newEmptySequenceChunker(makeMapLeafChunkFn(nil), newOrderedMetaSequenceChunkFn(MapKind, nil), newMapLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
+	seq := newEmptySequenceChunker(makeMapLeafChunkFn(nil, nil), newOrderedMetaSequenceChunkFn(MapKind, nil, nil), newMapLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
 
 	for _, entry := range entries {
 		seq.Append(entry)
@@ -145,7 +145,7 @@ func (m Map) Remove(k Value) Map {
 }
 
 func (m Map) splice(cur *sequenceCursor, deleteCount uint64, vs ...mapEntry) Map {
-	ch := newSequenceChunker(cur, makeMapLeafChunkFn(m.seq.valueReader()), newOrderedMetaSequenceChunkFn(MapKind, m.seq.valueReader()), newMapLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
+	ch := newSequenceChunker(cur, makeMapLeafChunkFn(m.seq.valueReader(), nil), newOrderedMetaSequenceChunkFn(MapKind, m.seq.valueReader(), nil), newMapLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
 	for deleteCount > 0 {
 		ch.Skip()
 		deleteCount--
@@ -238,7 +238,9 @@ func newMapLeafBoundaryChecker() boundaryChecker {
 	})
 }
 
-func makeMapLeafChunkFn(vr ValueReader) makeChunkFn {
+// If |vw| is not nil, chunks will be eagerly written as they're created. Otherwise they are
+// written when the root is written.
+func makeMapLeafChunkFn(vr ValueReader, vw ValueWriter) makeChunkFn {
 	return func(items []sequenceItem) (metaTuple, sequence) {
 		mapData := make([]mapEntry, len(items), len(items))
 
@@ -250,10 +252,20 @@ func makeMapLeafChunkFn(vr ValueReader) makeChunkFn {
 		m := newMap(seq)
 
 		var key orderedKey
+		var ref Ref
+		var child Collection
+		if vw != nil {
+			// Eagerly write chunks
+			ref = vw.WriteValue(m)
+			child = nil
+		} else {
+			ref = NewRef(m)
+			child = m
+		}
 		if len(mapData) > 0 {
 			key = newOrderedKey(mapData[len(mapData)-1].key)
 		}
 
-		return newMetaTuple(NewRef(m), key, uint64(len(items)), m), seq
+		return newMetaTuple(ref, key, uint64(len(items)), child), seq
 	}
 }

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -465,6 +465,21 @@ func TestMapSetGet(t *testing.T) {
 	assert.Nil(m4.Get(String("foo")))
 }
 
+func TestMapMx(t *testing.T) {
+	assert := assert.New(t)
+	vs := NewTestValueStore()
+
+	mx := NewMap().Mx(vs)
+	m := mx.Set(String("foo"), Number(42)).Set(String("foo"), Number(43)).Set(Number(1), NewList(Number(2))).Finish()
+
+	assert.False(Number(42).Equals(m.Get(String("foo"))))
+	assert.True(Number(43).Equals(m.Get(String("foo"))))
+
+	l := m.Get(Number(1))
+	assert.NotNil(l)
+	assert.True(Number(2).Equals(l.(List).Get(0)))
+}
+
 func validateMapInsertion(t *testing.T, tm testMap) {
 	m := NewMap()
 	for i, entry := range tm.entries {

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -216,8 +216,18 @@ func newMapTestSuite(size uint, expectRefStr string, expectChunkCount int, expec
 	}
 }
 
-func newNumberStruct(i int) Value {
-	return NewStruct("", structData{"n": Number(i)})
+func (suite *mapTestSuite) TestMapMx() {
+	randomized := make(mapEntrySlice, len(suite.elems.entries))
+	for i, j := range rand.Perm(len(randomized)) {
+		randomized[j] = suite.elems.entries[i]
+	}
+	vs := NewTestValueStore()
+
+	mx := NewMap().Mx(vs)
+	for _, entry := range randomized {
+		mx = mx.Set(entry.key, entry.value)
+	}
+	suite.validate(mx.Finish())
 }
 
 func TestMapSuite1K(t *testing.T) {
@@ -237,6 +247,10 @@ func TestMapSuite4KStructs(t *testing.T) {
 
 func newNumber(i int) Value {
 	return Number(i)
+}
+
+func newNumberStruct(i int) Value {
+	return NewStruct("", structData{"n": Number(i)})
 }
 
 func getTestNativeOrderMap(scale int) testMap {
@@ -463,21 +477,6 @@ func TestMapSetGet(t *testing.T) {
 	assert.True(Number(42).Equals(m2.Get(String("foo"))))
 	assert.True(Number(43).Equals(m3.Get(String("foo"))))
 	assert.Nil(m4.Get(String("foo")))
-}
-
-func TestMapMx(t *testing.T) {
-	assert := assert.New(t)
-	vs := NewTestValueStore()
-
-	mx := NewMap().Mx(vs)
-	m := mx.Set(String("foo"), Number(42)).Set(String("foo"), Number(43)).Set(Number(1), NewList(Number(2))).Finish()
-
-	assert.False(Number(42).Equals(m.Get(String("foo"))))
-	assert.True(Number(43).Equals(m.Get(String("foo"))))
-
-	l := m.Get(Number(1))
-	assert.NotNil(l)
-	assert.True(Number(2).Equals(l.(List).Get(0)))
 }
 
 func validateMapInsertion(t *testing.T, tm testMap) {

--- a/go/types/mutator.go
+++ b/go/types/mutator.go
@@ -1,0 +1,38 @@
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import "github.com/attic-labs/noms/go/d"
+
+type MapMutator struct {
+	oc *opCache
+}
+
+func newMutator(vrw ValueReadWriter) *MapMutator {
+	return &MapMutator{newOpCache(vrw)}
+}
+
+func (mx *MapMutator) Set(key Value, val Value) *MapMutator {
+	d.Chk.True(mx.oc != nil, "Can't call Set() again after Finish()")
+	mx.oc.Set(key, val)
+	return mx
+}
+
+func (mx *MapMutator) Finish() Map {
+	d.Chk.True(mx.oc != nil, "Can only call Finish() once")
+	defer func() {
+		mx.oc.Destroy()
+		mx.oc = nil
+	}()
+
+	seq := newEmptySequenceChunker(makeMapLeafChunkFn(nil), newOrderedMetaSequenceChunkFn(MapKind, nil), newMapLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
+
+	iter := mx.oc.NewIterator()
+	defer iter.Release()
+	for iter.Next() {
+		seq.Append(iter.Op())
+	}
+	return newMap(seq.Done().(orderedSequence))
+}

--- a/go/types/number.go
+++ b/go/types/number.go
@@ -17,7 +17,7 @@ func (v Number) Equals(other Value) bool {
 
 func (v Number) Less(other Value) bool {
 	if v2, ok := other.(Number); ok {
-		return float64(v) < float64(v2)
+		return v < v2
 	}
 	return NumberKind < other.Type().Kind()
 }

--- a/go/types/opcache.go
+++ b/go/types/opcache.go
@@ -1,0 +1,130 @@
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"io/ioutil"
+	"os"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/filter"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+func newOpCache(vrw ValueReadWriter) *opCache {
+	dir, err := ioutil.TempDir("", "")
+	d.Chk.NoError(err)
+	db, err := leveldb.OpenFile(dir, &opt.Options{
+		Compression:            opt.NoCompression,
+		Comparer:               nomsComparer{},
+		Filter:                 filter.NewBloomFilter(10), // 10 bits/key
+		OpenFilesCacheCapacity: 24,
+		NoSync:                 true,    // We don't need this data to be durable. LDB is acting as temporary storage that can be larger than main memory.
+		WriteBuffer:            1 << 28, // 256MiB
+	})
+	d.Chk.NoError(err, "opening put cache in %s", dir)
+	return &opCache{ops: db, dbDir: dir, vrw: vrw}
+}
+
+type opCache struct {
+	ops           *leveldb.DB
+	dbDir         string
+	vrw           ValueReadWriter
+	ldbKeyScratch [1 + sha1.Size]byte
+	keyScratch    [initialBufferSize]byte
+	valScratch    [initialBufferSize]byte
+}
+
+type opCacheIterator struct {
+	iter iterator.Iterator
+	vr   ValueReader
+}
+
+var uint32Size = binary.Size(uint32(0))
+
+// Set can be called from any goroutine
+func (p *opCache) Set(mapKey Value, mapVal Value) {
+	switch mapKey.Type().Kind() {
+	default:
+		// This is the complicated case. For non-primitives, we want the ldb key to be the hash of mapKey, but we obviously need to get both mapKey and mapVal into ldb somehow. The simplest thing is just to do this:
+		//
+		//     uint32 (4 bytes)             bytes                 bytes
+		// +-----------------------+---------------------+----------------------+
+		// | key serialization len |    serialized key   |   serialized value   |
+		// +-----------------------+---------------------+----------------------+
+
+		// Note that, if mapKey and/or mapVal are prolly trees, any in-memory child chunks will be written to vrw at this time.
+		p.ldbKeyScratch[0] = byte(mapKey.Type().Kind())
+		copy(p.ldbKeyScratch[1:], mapKey.Hash().DigestSlice())
+		mapKeyData := encToSlice(mapKey, p.keyScratch[:], p.vrw)
+		mapValData := encToSlice(mapVal, p.valScratch[:], p.vrw)
+
+		mapKeyByteLen := len(mapKeyData)
+		data := make([]byte, uint32Size+mapKeyByteLen+len(mapValData))
+		binary.LittleEndian.PutUint32(data, uint32(mapKeyByteLen))
+		copy(data[uint32Size:], mapKeyData)
+		copy(data[uint32Size+mapKeyByteLen:], mapValData)
+
+		// TODO: Will manually batching these help?
+		err := p.ops.Put(p.ldbKeyScratch[:], data, nil)
+		d.Chk.NoError(err)
+
+	case BoolKind, NumberKind, StringKind:
+		// In this case, we can just serialize mapKey and use it as the ldb key, so we can also just serialize mapVal and dump that into the DB.
+		keyData := encToSlice(mapKey, p.keyScratch[:], p.vrw)
+		valData := encToSlice(mapVal, p.valScratch[:], p.vrw)
+		// TODO: Will manually batching these help?
+		err := p.ops.Put(keyData, valData, nil)
+		d.Chk.NoError(err)
+	}
+}
+
+func encToSlice(v Value, initBuf []byte, vw ValueWriter) []byte {
+	// TODO: Are there enough calls to this that it's worth re-using a nomsWriter and valueEncoder?
+	w := &binaryNomsWriter{initBuf, 0}
+	enc := newValueEncoder(w, vw)
+	enc.writeValue(v)
+	return w.data()
+}
+
+func (p *opCache) NewIterator() *opCacheIterator {
+	return &opCacheIterator{p.ops.NewIterator(nil, nil), p.vrw}
+}
+
+func (p *opCache) Destroy() error {
+	d.Chk.NoError(p.ops.Close())
+	return os.RemoveAll(p.dbDir)
+}
+
+func (i *opCacheIterator) Next() bool {
+	return i.iter.Next()
+}
+
+func (i *opCacheIterator) Op() sequenceItem {
+	entry := mapEntry{}
+	ldbKey := i.iter.Key()
+	data := i.iter.Value()
+	dataOffset := 0
+	switch NomsKind(ldbKey[0]) {
+	case BoolKind, NumberKind, StringKind:
+		entry.key = newValueDecoder(&binaryNomsReader{ldbKey, 0}, i.vr).readValue()
+	default:
+		keyBytesLen := int(binary.LittleEndian.Uint32(data))
+		entry.key = newValueDecoder(&binaryNomsReader{data[uint32Size : uint32Size+keyBytesLen], 0}, i.vr).readValue()
+		dataOffset = uint32Size + keyBytesLen
+	}
+
+	dec := newValueDecoder(&binaryNomsReader{data[dataOffset:], 0}, i.vr)
+	entry.value = dec.readValue()
+	return entry
+}
+
+func (i *opCacheIterator) Release() {
+	i.iter.Release()
+}

--- a/go/types/opcache.go
+++ b/go/types/opcache.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
@@ -22,8 +21,7 @@ func newOpCache(vrw ValueReadWriter) *opCache {
 	d.Chk.NoError(err)
 	db, err := leveldb.OpenFile(dir, &opt.Options{
 		Compression:            opt.NoCompression,
-		Comparer:               nomsComparer{},
-		Filter:                 filter.NewBloomFilter(10), // 10 bits/key
+		Comparer:               opCacheComparer{},
 		OpenFilesCacheCapacity: 24,
 		NoSync:                 true,    // We don't need this data to be durable. LDB is acting as temporary storage that can be larger than main memory.
 		WriteBuffer:            1 << 28, // 256MiB

--- a/go/types/opcache_test.go
+++ b/go/types/opcache_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The Noms Authors. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/attic-labs/testify/suite"
+)
+
+func TestOpCache(t *testing.T) {
+	suite.Run(t, &OpCacheSuite{})
+}
+
+type OpCacheSuite struct {
+	suite.Suite
+	vs *ValueStore
+	oc *opCache
+}
+
+func (suite *OpCacheSuite) SetupTest() {
+	suite.vs = NewTestValueStore()
+	suite.oc = newOpCache(suite.vs)
+}
+
+func (suite *OpCacheSuite) TearDownTest() {
+	suite.vs.Close()
+	suite.oc.Destroy()
+}
+
+func (suite *OpCacheSuite) TestSet() {
+	entries := mapEntrySlice{
+		{NewList(Number(8), Number(0)), String("ahoy")},
+		{String("A key"), NewBlob(bytes.NewBufferString("A value"))},
+		{Number(1), Bool(true)},
+		{Bool(false), Number(1)},
+		{NewBlob(bytes.NewBuffer([]byte{0xff, 0, 0})), NewMap()},
+		{Bool(true), Number(42)},
+		{Number(42), String("other")},
+	}
+	for _, entry := range entries {
+		suite.oc.Set(entry.key, entry.value)
+	}
+	sort.Sort(entries)
+
+	iterated := mapEntrySlice{}
+	iter := suite.oc.NewIterator()
+	defer iter.Release()
+	for iter.Next() {
+		iterated = append(iterated, iter.Op().(mapEntry))
+	}
+	suite.True(entries.Equals(iterated))
+}

--- a/go/types/opcache_test.go
+++ b/go/types/opcache_test.go
@@ -40,6 +40,8 @@ func (suite *OpCacheSuite) TestSet() {
 		{Bool(false), Number(1)},
 		{NewBlob(bytes.NewBuffer([]byte{0xff, 0, 0})), NewMap()},
 		{Bool(true), Number(42)},
+		{NewStruct("thing1", structData{"a": Number(7)}), Number(42)},
+		{String("struct"), NewStruct("thing2", nil)},
 		{Number(42), String("other")},
 	}
 	for _, entry := range entries {

--- a/go/types/ordered_sequences.go
+++ b/go/types/ordered_sequences.go
@@ -128,7 +128,9 @@ func newOrderedMetaSequenceBoundaryChecker() boundaryChecker {
 	})
 }
 
-func newOrderedMetaSequenceChunkFn(kind NomsKind, vr ValueReader) makeChunkFn {
+// If |vw| is not nil, chunks will be eagerly written as they're created. Otherwise they are
+// written when the root is written.
+func newOrderedMetaSequenceChunkFn(kind NomsKind, vr ValueReader, vw ValueWriter) makeChunkFn {
 	return func(items []sequenceItem) (metaTuple, sequence) {
 		tuples := make(metaSequenceData, len(items))
 		numLeaves := uint64(0)
@@ -150,6 +152,9 @@ func newOrderedMetaSequenceChunkFn(kind NomsKind, vr ValueReader) makeChunkFn {
 			col = newMap(metaSeq)
 		}
 
+		if vw != nil {
+			return newMetaTuple(vw.WriteValue(col), tuples.last().key, numLeaves, nil), metaSeq
+		}
 		return newMetaTuple(NewRef(col), tuples.last().key, numLeaves, col), metaSeq
 	}
 }

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -28,7 +28,7 @@ func newSet(seq orderedSequence) Set {
 
 func NewSet(v ...Value) Set {
 	data := buildSetData(v)
-	seq := newEmptySequenceChunker(makeSetLeafChunkFn(nil), newOrderedMetaSequenceChunkFn(SetKind, nil), newSetLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
+	seq := newEmptySequenceChunker(makeSetLeafChunkFn(nil), newOrderedMetaSequenceChunkFn(SetKind, nil, nil), newSetLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
 
 	for _, v := range data {
 		seq.Append(v)
@@ -136,7 +136,7 @@ func (s Set) Remove(values ...Value) Set {
 }
 
 func (s Set) splice(cur *sequenceCursor, deleteCount uint64, vs ...Value) Set {
-	ch := newSequenceChunker(cur, makeSetLeafChunkFn(s.seq.valueReader()), newOrderedMetaSequenceChunkFn(SetKind, s.seq.valueReader()), newSetLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
+	ch := newSequenceChunker(cur, makeSetLeafChunkFn(s.seq.valueReader()), newOrderedMetaSequenceChunkFn(SetKind, s.seq.valueReader(), nil), newSetLeafBoundaryChecker(), newOrderedMetaSequenceBoundaryChecker)
 	for deleteCount > 0 {
 		ch.Skip()
 		deleteCount--


### PR DESCRIPTION
As one step towards #1819, we've created MapMutator, which can take a
bunch of (what would normally be) Map.Set() calls and batch them up to
be applied all at once. The keys and values are held in a LevelDB cache
until everything's done. Usage looks like this:

 m := types.NewMap()
 mx := m.Mx()
 mx = mx.Set(String("foo"), String("bar")).Set(String("baz"), Number(42))
 m = mx.Finish()

We intend to make this the only way to modify collections, but at first
this will only work on an empty NomsMap.
