### PR TITLE
Work around null pointer exception in ValueDecoder

### DIFF
--- a/go/types/value_decoder.go
+++ b/go/types/value_decoder.go
@@ -192,6 +192,11 @@ func (r *valueDecoder) readStructType(parentStructTypes []*Type) *Type {
 	st := buildType(desc)
 	parentStructTypes = append(parentStructTypes, st)
 
+	// HACK: If readType ends up referring to this type it is possible that we still have a null pointer for the type. Initialize all of the types to a valid (dummy) type.
+	for i := uint32(0); i < count; i++ {
+		fields[i].t = ValueType
+	}
+
 	for i := uint32(0); i < count; i++ {
 		fields[i] = field{name: r.readString(), t: r.readType(parentStructTypes)}
 	}


### PR DESCRIPTION
Go creates the slice with nil for the type of the field. nil is
never a valid type and when there are recursive types we may end
up calling Hash() on the field type which panics.

Towards #1881
