### PR TITLE
JS: Fix http batch store

### DIFF
--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -29,7 +29,7 @@ type URLParams interface {
 type Handler func(w http.ResponseWriter, req *http.Request, ps URLParams, cs chunks.ChunkStore)
 
 // NomsVersionHeader is the name of the header that Noms clients and servers must set in every request/response.
-const NomsVersionHeader = "X-Noms-Vers"
+const NomsVersionHeader = "x-noms-vers"
 
 var (
 	// HandleWriteValue is meant to handle HTTP POST requests to the writeValue/ server endpoint. The payload should be an appropriately-ordered sequence of Chunks to be validated and stored on the server.

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "47.0.0",
+  "version": "48.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/version.js
+++ b/js/src/version.js
@@ -4,4 +4,4 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
-export const NomsVersion = '1';
+export default '1';

--- a/samples/js/counter/package.json
+++ b/samples/js/counter/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "version": "1.0.1",
   "dependencies": {
-    "@attic/noms": "^42.0.0",
+    "@attic/noms": "file:../../../js/",
     "babel-regenerator-runtime": "6.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There were a few issues here:
1. The version header was not always passed to fetch
2. HTTP headers are case insensitive and Node an Fetch uses lower case.
3. The old code used a Map instead of an object as map. Node and Fetch
   uses an object as map. Now we just pass along the response headers.

Fixes #1881
Closes #1880 (which this is partially based in)
