### PR TITLE
Fix a typo in DynamoStore that caused panic on getting Version

### DIFF
--- a/go/chunks/dynamo_store.go
+++ b/go/chunks/dynamo_store.go
@@ -407,7 +407,7 @@ func (s *DynamoStore) Version() string {
 	d.Chk.True(itemLen == 2, "Version should have 2 attributes on it: %+v", result.Item)
 	d.Chk.True(result.Item[numAttr] != nil)
 	d.Chk.True(result.Item[numAttr].S != nil)
-	return aws.StringValue(result.Item[chunkAttr].S)
+	return aws.StringValue(result.Item[numAttr].S)
 }
 
 func (s *DynamoStore) setVersIfUnset() {


### PR DESCRIPTION
Unit test to follow in subsequent patch.

Toward #1872
