### PR TITLE
fixing bug in max splice matrix size

### DIFF
--- a/go/types/list.go
+++ b/go/types/list.go
@@ -217,7 +217,7 @@ func (l List) DiffWithLimit(last List, changes chan<- Splice, maxSpliceMatrixSiz
 
 		lastCur := newCursorAtIndex(last.seq, 0)
 		lCur := newCursorAtIndex(l.seq, 0)
-		indexedSequenceDiff(last.seq, lastCur.depth(), 0, l.seq, lCur.depth(), 0, DEFAULT_MAX_SPLICE_MATRIX_SIZE*3000, changes)
+		indexedSequenceDiff(last.seq, lastCur.depth(), 0, l.seq, lCur.depth(), 0, maxSpliceMatrixSize, changes)
 		close(changes)
 	}()
 }

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -691,8 +691,7 @@ func TestListDiffReverse(t *testing.T) {
 	diff2 := accumulateDiffSplices(l2, l1)
 
 	diffExpected := []Splice{
-		Splice{0, 2499, 2500, 0},
-		Splice{2500, 2500, 2499, 2501},
+		Splice{0, 5000, 5000, 0},
 	}
 	assert.Equal(diffExpected, diff1, "expected diff is wrong")
 	assert.Equal(diffExpected, diff2, "expected diff is wrong")


### PR DESCRIPTION
fixing some code checked in as a change yesterday, now the test result change makes sense too
