### PR TITLE
Fix crash in hr when dataset spec invalid

### DIFF
--- a/samples/go/counter/counter.go
+++ b/samples/go/counter/counter.go
@@ -5,15 +5,12 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
 
-	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/types"
-	"github.com/attic-labs/noms/samples/go/util"
 )
 
 func main() {
@@ -21,25 +18,30 @@ func main() {
 		fmt.Fprintf(os.Stderr, "usage: %s [options] <dataset>\n", os.Args[0])
 		flag.PrintDefaults()
 	}
-
-	spec.RegisterDatabaseFlags()
 	flag.Parse()
 
 	if flag.NArg() != 1 {
-		util.CheckError(errors.New("expected dataset arg"))
+		fmt.Fprintln(os.Stderr, "Missing required dataset argument")
+		return
 	}
 
 	ds, err := spec.GetDataset(flag.Arg(0))
-	util.CheckError(err)
-
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not create dataset: %s\n", err)
+		return
+	}
 	defer ds.Database().Close()
 
 	newVal := uint64(1)
 	if lastVal, ok := ds.MaybeHeadValue(); ok {
 		newVal = uint64(lastVal.(types.Number)) + 1
 	}
+
 	_, err = ds.Commit(types.Number(newVal))
-	d.PanicIfError(err)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error committing: %s\n", err)
+		return
+	}
 
 	fmt.Println(newVal)
 }

--- a/samples/go/hr/main.go
+++ b/samples/go/hr/main.go
@@ -40,11 +40,11 @@ func main() {
 	}
 
 	ds, err := spec.GetDataset(*dsStr)
-	defer ds.Database().Close()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not create dataset: %s\n", err)
 		return
 	}
+	defer ds.Database().Close()
 
 	switch flag.Arg(0) {
 	case "add-person":
@@ -74,7 +74,11 @@ func addPerson(ds dataset.Dataset) {
 		"title": types.String(flag.Arg(3)),
 	})
 
-	ds.Commit(getPersons(ds).Set(types.Number(id), np))
+	_, err = ds.Commit(getPersons(ds).Set(types.Number(id), np))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error committing: %s\n", err)
+		return
+	}
 }
 
 func listPersons(ds dataset.Dataset) {

--- a/samples/go/hr/main_test.go
+++ b/samples/go/hr/main_test.go
@@ -54,3 +54,8 @@ func (s *testSuite) TestReadCanned() {
 Samuel Boodman (id: 13, title: VP, Culture)
 `, out)
 }
+
+func (s *testSuite) TestInvalidDatasetSpec() {
+	// Should not crash
+	_ = s.Run(main, []string{"-ds", "invalid-dataset", "list-persons"})
+}


### PR DESCRIPTION
Also remove test util code from the two simpler Go samples. I think we will want to distinguish between "samples" and "utilities". The former should be as easy to understand and lightweight as possible, while the latter will tend to be more a real part of the project that is maintained, tuned, relied upon, etc.

The former should only rely on the Noms SDK and the Go stdlib. The latter should follow normal Noms internal coding conventions.
