### PR TITLE
orderedSequenceDiff more like indexedSequenceDiff - parallel

### DIFF
--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -33,37 +33,38 @@ func Diff(w io.Writer, v1, v2 types.Value) (err error) {
 
 	err = d.Try(func() {
 		for di, ok := dq.PopFront(); ok; di, ok = dq.PopFront() {
-			p, key, v1, v2 := di.path, di.key, di.v1, di.v2
-
-			v1.Type().Kind()
-			if v1 == nil && v2 != nil {
-				line(w, addPrefix, key, v2)
-			}
-			if v1 != nil && v2 == nil {
-				line(w, subPrefix, key, v1)
-			}
-			if !v1.Equals(v2) {
-				if !canCompare(v1, v2) {
-					line(w, subPrefix, key, v1)
-					line(w, addPrefix, key, v2)
-				} else {
-					switch v1.Type().Kind() {
-					case types.ListKind:
-						diffLists(dq, w, p, v1.(types.List), v2.(types.List))
-					case types.MapKind:
-						diffMaps(dq, w, p, v1.(types.Map), v2.(types.Map))
-					case types.SetKind:
-						diffSets(dq, w, p, v1.(types.Set), v2.(types.Set))
-					case types.StructKind:
-						diffStructs(dq, w, p, v1.(types.Struct), v2.(types.Struct))
-					default:
-						panic("Unrecognized type in diff function")
-					}
-				}
-			}
+			performDiff(dq, w, di.path, di.key, di.v1, di.v2)
 		}
 	})
 	return
+}
+
+func performDiff(dq *diffQueue, w io.Writer, p types.Path, key, v1, v2 types.Value) {
+	if v1 == nil && v2 != nil {
+		line(w, addPrefix, key, v2)
+	}
+	if v1 != nil && v2 == nil {
+		line(w, subPrefix, key, v1)
+	}
+	if !v1.Equals(v2) {
+		if !canCompare(v1, v2) {
+			line(w, subPrefix, key, v1)
+			line(w, addPrefix, key, v2)
+		} else {
+			switch v1.Type().Kind() {
+			case types.ListKind:
+				diffLists(dq, w, p, v1.(types.List), v2.(types.List))
+			case types.MapKind:
+				diffMaps(dq, w, p, v1.(types.Map), v2.(types.Map))
+			case types.SetKind:
+				diffSets(dq, w, p, v1.(types.Set), v2.(types.Set))
+			case types.StructKind:
+				diffStructs(dq, w, p, v1.(types.Struct), v2.(types.Struct))
+			default:
+				panic("Unrecognized type in diff function")
+			}
+		}
+	}
 }
 
 func diffLists(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.List) {
@@ -130,10 +131,11 @@ func diffMaps(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.Map) {
 					d.PanicIfError(types.WriteEncodedValueWithTags(buf, change.V))
 					p1 := p.AddField(buf.String())
 					dq.PushBack(diffInfo{path: p1, key: change.V, v1: c1, v2: c2})
+					//performDiff(dq, buf, p1, change.V, c1, c2)
 				} else {
 					wroteHeader = writeHeader(w, wroteHeader, p)
-					line(w, subPrefix, change.V, v1.Get(change.V))
-					line(w, addPrefix, change.V, v2.Get(change.V))
+					line(w, subPrefix, change.V, c1)
+					line(w, addPrefix, change.V, c2)
 				}
 			default:
 				panic("unknown change type")

--- a/go/types/indexed_sequence_diff.go
+++ b/go/types/indexed_sequence_diff.go
@@ -16,12 +16,12 @@ func (e ChangeChannelClosedError) Error() string { return e.msg }
 
 func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64, current indexedSequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) error {
 	if lastHeight > currentHeight {
-		lastChild := last.(indexedMetaSequence).getCompositeChildSequence(0, uint64(last.seqLen()))
+		lastChild := last.(indexedMetaSequence).getCompositeChildIndexedSequence(0, uint64(last.seqLen()))
 		return indexedSequenceDiff(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
 	if currentHeight > lastHeight {
-		currentChild := current.(indexedMetaSequence).getCompositeChildSequence(0, uint64(current.seqLen()))
+		currentChild := current.(indexedMetaSequence).getCompositeChildIndexedSequence(0, uint64(current.seqLen()))
 		return indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
@@ -43,8 +43,8 @@ func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64
 			}
 
 		} else {
-			lastChild := last.(indexedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved)
-			currentChild := current.(indexedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded)
+			lastChild := last.(indexedMetaSequence).getCompositeChildIndexedSequence(splice.SpAt, splice.SpRemoved)
+			currentChild := current.(indexedMetaSequence).getCompositeChildIndexedSequence(splice.SpFrom, splice.SpAdded)
 			lastChildOffset := lastOffset
 			if splice.SpAt > 0 {
 				lastChildOffset += last.getOffset(int(splice.SpAt)-1) + 1

--- a/go/types/indexed_sequence_diff.go
+++ b/go/types/indexed_sequence_diff.go
@@ -16,12 +16,12 @@ func (e ChangeChannelClosedError) Error() string { return e.msg }
 
 func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64, current indexedSequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) error {
 	if lastHeight > currentHeight {
-		lastChild := last.(indexedMetaSequence).getCompositeChildIndexedSequence(0, uint64(last.seqLen()))
+		lastChild := last.(indexedMetaSequence).getCompositeChildSequence(0, uint64(last.seqLen())).(indexedSequence)
 		return indexedSequenceDiff(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
 	if currentHeight > lastHeight {
-		currentChild := current.(indexedMetaSequence).getCompositeChildIndexedSequence(0, uint64(current.seqLen()))
+		currentChild := current.(indexedMetaSequence).getCompositeChildSequence(0, uint64(current.seqLen())).(indexedSequence)
 		return indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
@@ -43,8 +43,8 @@ func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64
 			}
 
 		} else {
-			lastChild := last.(indexedMetaSequence).getCompositeChildIndexedSequence(splice.SpAt, splice.SpRemoved)
-			currentChild := current.(indexedMetaSequence).getCompositeChildIndexedSequence(splice.SpFrom, splice.SpAdded)
+			lastChild := last.(indexedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(indexedSequence)
+			currentChild := current.(indexedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(indexedSequence)
 			lastChildOffset := lastOffset
 			if splice.SpAt > 0 {
 				lastChildOffset += last.getOffset(int(splice.SpAt)-1) + 1

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -61,7 +61,10 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 
 func (m Map) Diff(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	go func() {
-		orderedSequenceDiff(last.sequence().(orderedSequence), m.sequence().(orderedSequence), changes, closeChan)
+		err := orderedSequenceDiff(last.sequence().(orderedSequence), m.sequence().(orderedSequence), changes, closeChan)
+		if err == nil {
+			close(changes)
+		}
 	}()
 }
 

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -138,7 +138,7 @@ func (ms metaSequenceObject) getChildSequence(idx int) sequence {
 	return mt.ref.TargetValue(ms.vr).(Collection).sequence()
 }
 
-func (ms metaSequenceObject) startGetCompositeChildSequence(start, length uint64) chan interface{} {
+func (ms metaSequenceObject) beginFetchingChildSequences(start, length uint64) chan interface{} {
 	input := make(chan interface{})
 	output := orderedparallel.New(input, func(item interface{}) interface{} {
 		i := item.(int)
@@ -157,75 +157,54 @@ func (ms metaSequenceObject) startGetCompositeChildSequence(start, length uint64
 
 // Returns the sequences pointed to by all items[i], s.t. start <= i < end, and returns the
 // concatentation as one long composite sequence
-func (ms metaSequenceObject) getCompositeChildIndexedSequence(start uint64, length uint64) indexedSequence {
-	childIsMeta := false
-	metaItems := []metaTuple{}
-	valueItems := []Value{}
-
-	output := ms.startGetCompositeChildSequence(start, length)
-	i := uint64(start)
-	for item := range output {
-		seq := item.(sequence)
-		if i == start {
-			if idxSeq, ok := seq.(indexedSequence); ok {
-				childIsMeta = isMetaSequence(idxSeq)
-			}
-		}
-		if childIsMeta {
-			childMs, _ := seq.(indexedMetaSequence)
-			metaItems = append(metaItems, childMs.metaSequenceObject.tuples...)
-			continue
-		}
-
-		if ll, ok := seq.(listLeafSequence); ok {
-			valueItems = append(valueItems, ll.values...)
-		}
-
-		i++
-	}
-
-	if childIsMeta {
-		return newIndexedMetaSequence(metaItems, ms.Type(), ms.vr)
-	} else {
-		return newListLeafSequence(ms.vr, valueItems...)
-	}
-}
-
-func (ms metaSequenceObject) getCompositeChildOrderedSequence(start uint64, length uint64) orderedSequence {
-	childIsMeta := false
+func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint64) sequence {
 	metaItems := []metaTuple{}
 	mapItems := []mapEntry{}
-	setItems := []Value{}
+	valueItems := []Value{}
 
-	output := ms.startGetCompositeChildSequence(start, length)
-	i := uint64(start)
-	for item := range output {
-		seq := item.(sequence)
-		if i == start {
-			if oSeq, ok := seq.(orderedSequence); ok {
-				childIsMeta = isMetaSequence(oSeq)
-			}
-		}
-		if childIsMeta {
-			childMs, _ := seq.(orderedMetaSequence)
-			metaItems = append(metaItems, childMs.metaSequenceObject.tuples...)
-			continue
-		} else if ml, ok := seq.(mapLeafSequence); ok {
-			mapItems = append(mapItems, ml.data...)
-		} else if sl, ok := seq.(setLeafSequence); ok {
-			setItems = append(setItems, sl.data...)
-		}
-
-		i++
+	childIsMeta := false
+	isIndexedSequence := false
+	if ListKind == ms.Type().Kind() {
+		isIndexedSequence = true
 	}
 
-	if childIsMeta {
-		return newOrderedMetaSequence(metaItems, ms.Type(), ms.vr)
-	} else {
-		if len(mapItems) > 0 {
-			return newMapLeafSequence(ms.vr, mapItems...)
+	output := ms.beginFetchingChildSequences(start, length)
+	for item := range output {
+		seq := item.(sequence)
+
+		switch t := seq.(type) {
+		case indexedMetaSequence:
+			childIsMeta = true
+			metaItems = append(metaItems, t.metaSequenceObject.tuples...)
+		case orderedMetaSequence:
+			childIsMeta = true
+			metaItems = append(metaItems, t.metaSequenceObject.tuples...)
+		case mapLeafSequence:
+			mapItems = append(mapItems, t.data...)
+		case setLeafSequence:
+			valueItems = append(valueItems, t.data...)
+		case listLeafSequence:
+			valueItems = append(valueItems, t.values...)
+		default:
+			panic("no!")
+		}
+	}
+
+	if isIndexedSequence {
+		if childIsMeta {
+			return newIndexedMetaSequence(metaItems, ms.Type(), ms.vr)
 		} else {
-			return newSetLeafSequence(ms.vr, setItems...)
+			return newListLeafSequence(ms.vr, valueItems...)
+		}
+	} else {
+		if childIsMeta {
+			return newOrderedMetaSequence(metaItems, ms.Type(), ms.vr)
+		} else {
+			if MapKind == ms.Type().Kind() {
+				return newMapLeafSequence(ms.vr, mapItems...)
+			} else {
+				return newSetLeafSequence(ms.vr, valueItems...)
+			}
 		}
 	}
 }

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -186,7 +186,7 @@ func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint
 		case listLeafSequence:
 			valueItems = append(valueItems, t.values...)
 		default:
-			panic("no!")
+			panic("unreachable")
 		}
 	}
 

--- a/go/types/ordered_sequences_diff.go
+++ b/go/types/ordered_sequences_diff.go
@@ -31,8 +31,7 @@ func sendChange(changes chan<- ValueChanged, closeChan <-chan struct{}, change V
 	return nil
 }
 
-// TODO - something other than the literal edit-distance, which is way too much cpu work for this case
-// https://github.com/attic-labs/noms/issues/2027
+// TODO - something other than the literal edit-distance, which is way too much cpu work for this case - https://github.com/attic-labs/noms/issues/2027
 func orderedSequenceDiff(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) error {
 	lastCur := newCursorAt(last, emptyKey, false, false)
 	currentCur := newCursorAt(current, emptyKey, false, false)

--- a/go/types/ordered_sequences_diff.go
+++ b/go/types/ordered_sequences_diff.go
@@ -34,6 +34,42 @@ func sendChange(changes chan<- ValueChanged, closeChan <-chan struct{}, change V
 func orderedSequenceDiff(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) error {
 	lastCur := newCursorAt(last, emptyKey, false, false)
 	currentCur := newCursorAt(current, emptyKey, false, false)
+	lastHeight := lastCur.depth()
+	currentHeight := currentCur.depth()
+
+	if lastHeight > currentHeight {
+		lastChild := last.(orderedMetaSequence).getCompositeChildOrderedSequence(0, uint64(last.seqLen()))
+		return orderedSequenceDiff(lastChild, current, changes, closeChan)
+	}
+
+	if currentHeight > lastHeight {
+		currentChild := current.(orderedMetaSequence).getCompositeChildOrderedSequence(0, uint64(current.seqLen()))
+		return orderedSequenceDiff(last, currentChild, changes, closeChan)
+	}
+
+	if !isMetaSequence(last) && !isMetaSequence(current) {
+		return orderedSequenceDiffOld(last, current, changes, closeChan)
+	} else {
+		compareFn := last.getCompareFn(current)
+		initialSplices := calcSplices(uint64(last.seqLen()), uint64(current.seqLen()), DEFAULT_MAX_SPLICE_MATRIX_SIZE,
+			func(i uint64, j uint64) bool { return compareFn(int(i), int(j)) })
+
+		for _, splice := range initialSplices {
+			lastChild := last.(orderedMetaSequence).getCompositeChildOrderedSequence(splice.SpAt, splice.SpRemoved)
+			currentChild := current.(orderedMetaSequence).getCompositeChildOrderedSequence(splice.SpFrom, splice.SpAdded)
+			err := orderedSequenceDiff(lastChild, currentChild, changes, closeChan)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func orderedSequenceDiffOld(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) error {
+	lastCur := newCursorAt(last, emptyKey, false, false)
+	currentCur := newCursorAt(current, emptyKey, false, false)
 
 	for lastCur.valid() && currentCur.valid() {
 		fastForward(lastCur, currentCur)
@@ -74,7 +110,6 @@ func orderedSequenceDiff(last orderedSequence, current orderedSequence, changes 
 		}
 		currentCur.advance()
 	}
-	close(changes)
 	return nil
 }
 

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -40,7 +40,10 @@ func accumulateOrderedSequenceDiffChanges(o1, o2 orderedSequence) (added []Value
 	changes := make(chan ValueChanged)
 	closeChan := make(chan struct{})
 
-	go orderedSequenceDiff(o1, o2, changes, closeChan)
+	go func() {
+		orderedSequenceDiffOld(o1, o2, changes, closeChan)
+		close(changes)
+	}()
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -41,8 +41,10 @@ func accumulateOrderedSequenceDiffChanges(o1, o2 orderedSequence) (added []Value
 	closeChan := make(chan struct{})
 
 	go func() {
-		orderedSequenceDiffOld(o1, o2, changes, closeChan)
-		close(changes)
+		err := orderedSequenceDiffLeafItems(o1, o2, changes, closeChan)
+		if err == nil {
+			close(changes)
+		}
 	}()
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -39,7 +39,7 @@ func NewSet(v ...Value) Set {
 
 func (s Set) Diff(last Set, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	go func() {
-		err := orderedSequenceDiffOld(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
+		err := orderedSequenceDiff(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
 		if err == nil {
 			close(changes)
 		}

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -39,7 +39,10 @@ func NewSet(v ...Value) Set {
 
 func (s Set) Diff(last Set, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	go func() {
-		orderedSequenceDiff(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
+		err := orderedSequenceDiffOld(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
+		if err == nil {
+			close(changes)
+		}
 	}()
 }
 


### PR DESCRIPTION
@rafael-atticlabs PTAL, not complete but it gets to the problem of diff calling diffQueue.PushBack to put more detailed diff work on to the back of the diff queue but those are items we want to diff and have in the output now; also uses orderedParallel to move the map.Get() calls off the main diff thread to enable diff to keep moving forward if the map.Get calls take a while

@aboodman feel free to pull and give it a try, output is probably different though

@willhite FYI for when you return from vacay
