### PR TITLE
Make go test ./... and go build ./... work with integration tests

### DIFF
--- a/samples/js/counter/dummy.go
+++ b/samples/js/counter/dummy.go
@@ -1,0 +1,3 @@
+package counter
+
+// go build fails if there are _test.go but no other go files in a directory.

--- a/samples/js/counter/package.json
+++ b/samples/js/counter/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "version": "1.0.1",
   "scripts": {
-    "preinstall": "rm -rf node_modules && ln -sf ../node_modules/",
+    "preinstall": "pushd .. && npm install && popd && rm -rf node_modules && ln -sf ../node_modules/",
     "prepublish": "npm run build",
     "start": "babel -d dist -w src",
     "build": "BABEL_ENV=production ../node_modules/.bin/babel -d dist src",

--- a/samples/js/fs/dummy.go
+++ b/samples/js/fs/dummy.go
@@ -1,0 +1,3 @@
+package fs
+
+// go build fails if there are _test.go but no other go files in a directory.

--- a/samples/js/fs/package.json
+++ b/samples/js/fs/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "main": "dist/main.js",
   "scripts": {
-    "preinstall": "rm -rf node_modules && ln -sf ../node_modules/",
+    "preinstall": "pushd .. && npm install && popd && rm -rf node_modules && ln -sf ../node_modules/",
     "prepublish": "npm run build",
     "start": "babel -d dist -w src",
     "build": "BABEL_ENV=production babel -d dist src",


### PR DESCRIPTION
For go build we need a dummy go file or go build fails

For go test we now make sure we run npm install so that the test
passes
