### PR TITLE
WIP - empty length of getCompositeChildSequence causing hang

### DIFF
--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -82,6 +82,46 @@ func (key orderedKey) Less(mk2 orderedKey) bool {
 	}
 }
 
+type emptySequence struct{}
+
+func (es emptySequence) getItem(idx int) sequenceItem {
+	panic("not to be called")
+}
+
+func (es emptySequence) seqLen() int {
+	return 0
+}
+
+func (es emptySequence) numLeaves() uint64 {
+	return 0
+}
+
+func (es emptySequence) valueReader() ValueReader {
+	return nil
+}
+
+func (es emptySequence) Chunks() (chunks []Ref) {
+	return
+}
+
+func (es emptySequence) Type() *Type {
+	panic("not to be called")
+}
+
+func (es emptySequence) getCompareFn(other sequence) compareFn {
+	return func(idx, otherIdx int) bool {
+		return false
+	}
+}
+
+func (es emptySequence) getKey(idx int) orderedKey {
+	return emptyKey
+}
+
+func (es emptySequence) getOffset(idx int) uint64 {
+	panic("not to be called")
+}
+
 type metaSequenceData []metaTuple
 
 func (msd metaSequenceData) last() metaTuple {
@@ -161,6 +201,10 @@ func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint
 	metaItems := []metaTuple{}
 	mapItems := []mapEntry{}
 	valueItems := []Value{}
+
+	if length == 0 {
+		return emptySequence{}
+	}
 
 	childIsMeta := false
 	isIndexedSequence := false

--- a/go/types/ordered_sequences_diff.go
+++ b/go/types/ordered_sequences_diff.go
@@ -56,33 +56,11 @@ func orderedSequenceDiff(last orderedSequence, current orderedSequence, changes 
 			func(i uint64, j uint64) bool { return compareFn(int(i), int(j)) })
 
 		for _, splice := range initialSplices {
-			if splice.SpRemoved == 0 && splice.SpAdded == 0 {
-				panic("Unreachable")
-			} else if splice.SpRemoved == 0 { // nothing removed, send the added items
-				currentChild := current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
-				cur := newCursorAt(currentChild, emptyKey, false, false)
-				for cur.valid() {
-					if err := sendChange(changes, closeChan, ValueChanged{DiffChangeAdded, getCurrentKey(cur).v}); err != nil {
-						return err
-					}
-					cur.advance()
-				}
-			} else if splice.SpAdded == 0 { // nothing added, send the removed items
-				lastChild := last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
-				cur := newCursorAt(lastChild, emptyKey, false, false)
-				for cur.valid() {
-					if err := sendChange(changes, closeChan, ValueChanged{DiffChangeRemoved, getCurrentKey(cur).v}); err != nil {
-						return err
-					}
-					cur.advance()
-				}
-			} else {
-				lastChild := last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
-				currentChild := current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
-				err := orderedSequenceDiff(lastChild, currentChild, changes, closeChan)
-				if err != nil {
-					return err
-				}
+			lastChild := last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
+			currentChild := current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
+			err := orderedSequenceDiff(lastChild, currentChild, changes, closeChan)
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/go/types/ordered_sequences_diff.go
+++ b/go/types/ordered_sequences_diff.go
@@ -56,11 +56,33 @@ func orderedSequenceDiff(last orderedSequence, current orderedSequence, changes 
 			func(i uint64, j uint64) bool { return compareFn(int(i), int(j)) })
 
 		for _, splice := range initialSplices {
-			lastChild := last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
-			currentChild := current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
-			err := orderedSequenceDiff(lastChild, currentChild, changes, closeChan)
-			if err != nil {
-				return err
+			if splice.SpRemoved == 0 && splice.SpAdded == 0 {
+				panic("Unreachable")
+			} else if splice.SpRemoved == 0 { // nothing removed, send the added items
+				currentChild := current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
+				cur := newCursorAt(currentChild, emptyKey, false, false)
+				for cur.valid() {
+					if err := sendChange(changes, closeChan, ValueChanged{DiffChangeAdded, getCurrentKey(cur).v}); err != nil {
+						return err
+					}
+					cur.advance()
+				}
+			} else if splice.SpAdded == 0 { // nothing added, send the removed items
+				lastChild := last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
+				cur := newCursorAt(lastChild, emptyKey, false, false)
+				for cur.valid() {
+					if err := sendChange(changes, closeChan, ValueChanged{DiffChangeRemoved, getCurrentKey(cur).v}); err != nil {
+						return err
+					}
+					cur.advance()
+				}
+			} else {
+				lastChild := last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
+				currentChild := current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
+				err := orderedSequenceDiff(lastChild, currentChild, changes, closeChan)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -7,6 +7,7 @@ package types
 import (
 	"testing"
 
+	"github.com/attic-labs/testify/assert"
 	"github.com/attic-labs/testify/suite"
 )
 
@@ -144,4 +145,20 @@ func TestOrderedSequencesDisjoint(t *testing.T) {
 	suite.Run(t, ts2)
 	ts1.Equal(ts1.added, ts2.removed, "added and removed in disjoint diff")
 	ts1.Equal(ts1.removed, ts2.added, "removed and added in disjoint diff")
+}
+
+func TestOrderedSequencesDiffVsEmpty(t *testing.T) {
+	assert := assert.New(t)
+	m := NewMap(generateNumbersAsValuesFromToBy(0, lengthOfNumbersTest, 1)...)
+
+	added, removed, modified := accumulateOrderedSequenceDiffChanges(emptySequence{}, m.sequence().(orderedSequence))
+	assert.True(len(added) == lengthOfNumbersTest/2)
+	assert.True(len(removed) == 0)
+	assert.True(len(modified) == 0)
+
+	added, removed, modified = accumulateOrderedSequenceDiffChanges(m.sequence().(orderedSequence), emptySequence{})
+	assert.True(len(added) == 0)
+	assert.True(len(removed) == lengthOfNumbersTest/2)
+	assert.True(len(modified) == 0)
+
 }


### PR DESCRIPTION
This fixes the hanging I was seeing when trying to do performance investigation into the slow noms diff/log commands.
