### PR TITLE
JS: Fix isSubtype for unions with cycles

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "51.1.0",
+  "version": "51.1.1",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/value-decoder.js
+++ b/js/src/value-decoder.js
@@ -212,7 +212,7 @@ export default class ValueDecoder {
       trie = trie.traverse(this.readType().id);
     }
 
-    return trie.t;
+    return notNull(trie.t);
   }
 
   readStructType(): Type {


### PR DESCRIPTION
This is the JS part of #2007

This exposed bugs in resolve/unresolve types and these were fixed
by making the code more similar to go.

Fixes #2015
