### PR TITLE
Add validation to BatchStore used by LocalDatabase

### DIFF
--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -41,7 +41,7 @@ type Database interface {
 	Delete(datasetID string) (Database, error)
 
 	has(hash hash.Hash) bool
-	batchStore() types.BatchStore
+	validatingBatchStore() types.BatchStore
 }
 
 func NewDatabase(cs chunks.ChunkStore) Database {

--- a/go/datas/local_batch_store.go
+++ b/go/datas/local_batch_store.go
@@ -1,0 +1,140 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package datas
+
+import (
+	"io"
+	"sync"
+
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/constants"
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/hash"
+	"github.com/attic-labs/noms/go/types"
+	"github.com/golang/snappy"
+)
+
+type localBatchStore struct {
+	cs            chunks.ChunkStore
+	unwrittenPuts *orderedChunkCache
+	vbs           *types.ValidatingBatchingSink
+	hints         types.Hints
+	hashes        hash.HashSet
+	mu            *sync.Mutex
+	once          sync.Once
+}
+
+func newLocalBatchStore(cs chunks.ChunkStore) *localBatchStore {
+	return &localBatchStore{
+		cs:            cs,
+		unwrittenPuts: newOrderedChunkCache(),
+		vbs:           types.NewValidatingBatchingSink(cs, types.NewTypeCache()),
+		hints:         types.Hints{},
+		hashes:        hash.HashSet{},
+		mu:            &sync.Mutex{},
+	}
+}
+
+func (lbs *localBatchStore) IsValidating() bool {
+	return true
+}
+
+// Get checks the internal Chunk cache, proxying to the backing ChunkStore if not present.
+func (lbs *localBatchStore) Get(h hash.Hash) chunks.Chunk {
+	lbs.once.Do(lbs.expectVersion)
+	if pending := lbs.unwrittenPuts.Get(h); !pending.IsEmpty() {
+		return pending
+	}
+	return lbs.cs.Get(h)
+}
+
+// Has checks the internal Chunk cache, proxying to the backing ChunkStore if not present.
+func (lbs *localBatchStore) Has(h hash.Hash) bool {
+	lbs.once.Do(lbs.expectVersion)
+	if lbs.unwrittenPuts.has(h) {
+		return true
+	}
+	return lbs.cs.Has(h)
+}
+
+// SchedulePut simply calls Put on the underlying ChunkStore, and ignores hints.
+func (lbs *localBatchStore) SchedulePut(c chunks.Chunk, refHeight uint64, hints types.Hints) {
+	lbs.once.Do(lbs.expectVersion)
+
+	lbs.unwrittenPuts.Insert(c, refHeight)
+	lbs.mu.Lock()
+	defer lbs.mu.Unlock()
+	lbs.hashes.Insert(c.Hash())
+	lbs.AddHints(hints)
+}
+
+func (lbs *localBatchStore) expectVersion() {
+	dataVersion := lbs.cs.Version()
+	d.PanicIfTrue(constants.NomsVersion != dataVersion, "SDK version %s incompatible with data of version %s", constants.NomsVersion, dataVersion)
+}
+
+func (lbs *localBatchStore) Root() hash.Hash {
+	lbs.once.Do(lbs.expectVersion)
+	return lbs.cs.Root()
+}
+
+// UpdateRoot flushes outstanding writes to the backing ChunkStore before updating its Root, because it's almost certainly the case that the caller wants to point that root at some recently-Put Chunk.
+func (lbs *localBatchStore) UpdateRoot(current, last hash.Hash) bool {
+	lbs.once.Do(lbs.expectVersion)
+	lbs.Flush()
+	return lbs.cs.UpdateRoot(current, last)
+}
+
+func (lbs *localBatchStore) AddHints(hints types.Hints) {
+	for h := range hints {
+		lbs.hints[h] = struct{}{}
+	}
+}
+
+func (lbs *localBatchStore) Flush() {
+	lbs.once.Do(lbs.expectVersion)
+
+	serializedChunks, pw := io.Pipe()
+	errChan := make(chan error)
+	go func() {
+		err := lbs.unwrittenPuts.ExtractChunks(lbs.hashes, pw)
+		// The ordering of these is important. Close the pipe, and only THEN block on errChan.
+		pw.Close()
+		errChan <- err
+		close(errChan)
+	}()
+
+	lbs.vbs.Prepare(lbs.hints)
+	var bpe chunks.BackpressureError
+	chunkChan := make(chan *chunks.Chunk, 16)
+	go chunks.DeserializeToChan(snappy.NewReader(serializedChunks), chunkChan)
+	for c := range chunkChan {
+		if bpe == nil {
+			bpe = lbs.vbs.Enqueue(*c)
+		} else {
+			bpe = append(bpe, c.Hash())
+		}
+		// If a previous Enqueue() errored, we still need to drain chunkChan
+		// TODO: what about having DeserializeToChan take a 'done' channel to stop it?
+	}
+	d.PanicIfError(<-errChan)
+	if bpe == nil {
+		bpe = lbs.vbs.Flush()
+	}
+	// Should probably do a thing with bpe. Will need to keep track of chunk hashes that are SechedulePut'd in order to do this :-/
+	if bpe != nil {
+		d.PanicIfError(bpe) // guarded because if bpe == nil, this still fires for some reason. Maybe something to do with custom error type??
+	}
+	lbs.unwrittenPuts.Clear(lbs.hashes)
+	lbs.hashes = hash.HashSet{}
+	lbs.hints = types.Hints{}
+}
+
+// Close closes the underlying ChunkStore
+func (lbs *localBatchStore) Close() error {
+	lbs.Flush()
+	lbs.unwrittenPuts.Destroy()
+	return lbs.cs.Close()
+}

--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -160,7 +160,7 @@ func (suite *PullSuite) TestPullEverything() {
 	suite.Equal(0, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.batchStore().Flush()
+	suite.sink.validatingBatchStore().Flush()
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(l.Equals(v.Get(ValueField)))
@@ -207,7 +207,7 @@ func (suite *PullSuite) TestPullMultiGeneration() {
 	suite.Equal(expectedReads, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.batchStore().Flush()
+	suite.sink.validatingBatchStore().Flush()
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(srcL.Equals(v.Get(ValueField)))
@@ -255,7 +255,7 @@ func (suite *PullSuite) TestPullDivergentHistory() {
 	suite.Equal(preReads, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.batchStore().Flush()
+	suite.sink.validatingBatchStore().Flush()
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(srcL.Equals(v.Get(ValueField)))
@@ -302,7 +302,7 @@ func (suite *PullSuite) TestPullUpdates() {
 	suite.Equal(expectedReads, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.batchStore().Flush()
+	suite.sink.validatingBatchStore().Flush()
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(srcL.Equals(v.Get(ValueField)))

--- a/go/datas/put_cache_test.go
+++ b/go/datas/put_cache_test.go
@@ -93,7 +93,7 @@ func (suite *LevelDBPutCacheSuite) TestGetParallel() {
 
 func (suite *LevelDBPutCacheSuite) TestClearParallel() {
 	keepIdx := 2
-	toClear1, toClear2 := hashSet{}, hashSet{}
+	toClear1, toClear2 := hash.HashSet{}, hash.HashSet{}
 	for i, v := range suite.values {
 		suite.cache.Insert(types.EncodeValue(v, nil), 1)
 		if i < keepIdx {
@@ -105,7 +105,7 @@ func (suite *LevelDBPutCacheSuite) TestClearParallel() {
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
-	clear := func(hs hashSet) {
+	clear := func(hs hash.HashSet) {
 		suite.cache.Clear(hs)
 		wg.Done()
 	}
@@ -124,7 +124,7 @@ func (suite *LevelDBPutCacheSuite) TestClearParallel() {
 }
 
 func (suite *LevelDBPutCacheSuite) TestReaderSubset() {
-	toExtract := hashSet{}
+	toExtract := hash.HashSet{}
 	for hash, c := range suite.chnx {
 		if len(toExtract) < 2 {
 			toExtract.Insert(hash)
@@ -144,7 +144,7 @@ func (suite *LevelDBPutCacheSuite) TestReaderSubset() {
 }
 
 func (suite *LevelDBPutCacheSuite) TestReaderSnapshot() {
-	hashes := hashSet{}
+	hashes := hash.HashSet{}
 	for h, c := range suite.chnx {
 		hashes.Insert(h)
 		suite.cache.Insert(c, 1)
@@ -163,7 +163,7 @@ func (suite *LevelDBPutCacheSuite) TestReaderSnapshot() {
 func (suite *LevelDBPutCacheSuite) TestExtractChunksOrder() {
 	maxHeight := len(suite.chnx)
 	orderedHashes := make(hash.HashSlice, maxHeight)
-	toExtract := hashSet{}
+	toExtract := hash.HashSet{}
 	heights := rand.Perm(maxHeight)
 	for hash, c := range suite.chnx {
 		toExtract.Insert(hash)
@@ -180,7 +180,7 @@ func (suite *LevelDBPutCacheSuite) TestExtractChunksOrder() {
 	suite.Len(orderedHashes, 0)
 }
 
-func (suite *LevelDBPutCacheSuite) extractChunks(hashes hashSet) <-chan *chunks.Chunk {
+func (suite *LevelDBPutCacheSuite) extractChunks(hashes hash.HashSet) <-chan *chunks.Chunk {
 	buf := &bytes.Buffer{}
 	err := suite.cache.ExtractChunks(hashes, buf)
 	suite.NoError(err)

--- a/go/datas/remote_database_client.go
+++ b/go/datas/remote_database_client.go
@@ -5,6 +5,7 @@
 package datas
 
 import (
+	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/julienschmidt/httprouter"
 )
@@ -19,19 +20,19 @@ func NewRemoteDatabase(baseURL, auth string) *RemoteDatabaseClient {
 	return &RemoteDatabaseClient{newDatabaseCommon(newCachingChunkHaver(httpBS), types.NewValueStore(httpBS), httpBS)}
 }
 
-func (rds *RemoteDatabaseClient) batchStore() types.BatchStore {
-	return rds.vs.BatchStore()
+func (rds *RemoteDatabaseClient) validatingBatchStore() (bs types.BatchStore) {
+	bs = rds.vs.BatchStore()
+	d.Chk.True(bs.IsValidating())
+	return
 }
 
 func (rds *RemoteDatabaseClient) Commit(datasetID string, commit types.Struct) (Database, error) {
 	err := rds.commit(datasetID, commit)
-	rds.vs.Flush()
 	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
 }
 
 func (rds *RemoteDatabaseClient) Delete(datasetID string) (Database, error) {
 	err := rds.doDelete(datasetID)
-	rds.vs.Flush()
 	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
 }
 

--- a/go/hash/hash.go
+++ b/go/hash/hash.go
@@ -114,3 +114,18 @@ func (r Hash) Less(other Hash) bool {
 func (r Hash) Greater(other Hash) bool {
 	return bytes.Compare(r.digest[:], other.digest[:]) > 0
 }
+
+type HashSet map[Hash]struct{}
+
+func (hs HashSet) Insert(hash Hash) {
+	hs[hash] = struct{}{}
+}
+
+func (hs HashSet) Has(hash Hash) (has bool) {
+	_, has = hs[hash]
+	return
+}
+
+func (hs HashSet) Remove(hash Hash) {
+	delete(hs, hash)
+}

--- a/go/types/batch_store.go
+++ b/go/types/batch_store.go
@@ -16,8 +16,11 @@ import (
 
 // BatchStore provides an interface similar to chunks.ChunkStore, but batch-oriented. Instead of Put(), it provides SchedulePut(), which enqueues a Chunk to be sent at a possibly later time.
 type BatchStore interface {
+	// IsValidating indicates whether this implementation can internally enforce chunk validity & completeness. If a BatchStore supports this, it must also support "staging" of writes -- that is, allowing chunks to be written which reference chunks which have yet to be written.
+	IsValidating() bool
+
 	// Get returns from the store the Value Chunk by r. If r is absent from the store, chunks.EmptyChunk is returned.
-	Get(r hash.Hash) chunks.Chunk
+	Get(h hash.Hash) chunks.Chunk
 
 	// SchedulePut enqueues a write for the Chunk c with the given refHeight. Typically, the Value which was encoded to provide c can also be queried for its refHeight. The call may or may not block until c is persisted. The provided hints are used to assist in validation. Validation requires checking that all refs embedded in c are themselves valid, which could naively be done by resolving each one. Instead, hints provides a (smaller) set of refs that point to Chunks that themselves contain many of c's refs. Thus, by checking only the hinted Chunks, c can be validated with fewer read operations.
 	// c may or may not be persisted when Put() returns, but is guaranteed to be persistent after a call to Flush() or Close().
@@ -28,6 +31,7 @@ type BatchStore interface {
 
 	// Flush causes enqueued Puts to be persisted.
 	Flush()
+	chunks.RootTracker
 	io.Closer
 }
 
@@ -45,6 +49,10 @@ func NewBatchStoreAdaptor(cs chunks.ChunkStore) BatchStore {
 	return &BatchStoreAdaptor{cs: cs}
 }
 
+func (bsa *BatchStoreAdaptor) IsValidating() bool {
+	return false
+}
+
 // Get simply proxies to the backing ChunkStore
 func (bsa *BatchStoreAdaptor) Get(h hash.Hash) chunks.Chunk {
 	bsa.once.Do(bsa.expectVersion)
@@ -60,6 +68,15 @@ func (bsa *BatchStoreAdaptor) SchedulePut(c chunks.Chunk, refHeight uint64, hint
 func (bsa *BatchStoreAdaptor) expectVersion() {
 	dataVersion := bsa.cs.Version()
 	d.PanicIfTrue(constants.NomsVersion != dataVersion, "SDK version %s incompatible with data of version %s", constants.NomsVersion, dataVersion)
+}
+
+func (bsa *BatchStoreAdaptor) Root() hash.Hash {
+	return bsa.cs.Root()
+}
+
+func (bsa *BatchStoreAdaptor) UpdateRoot(current, last hash.Hash) bool {
+	bsa.once.Do(bsa.expectVersion)
+	return bsa.cs.UpdateRoot(current, last)
 }
 
 // AddHints is a noop.


### PR DESCRIPTION
Prior to this change, LocalDatabase used a BatchStore that was a kinda
dumb wrapper around ChunkStore. This meant that, as a pull progressed,
Chunks wound up getting Put in a top-down fashion, meaning that Chunks
wound up in the backing store _before_ other Chunks that they reference.
This means they were transiently invalid, and that cancelling an in-progress
pull could lead to an invalid DB.

Now, LocalDatabase uses the same strategy as RemoteDatabaseClient, caching
chunks as the come in and putting them into the backing store bottom-up when
Flush() is called.

Fixes #1915 
