### PR TITLE
Change sequence diff functions to be synchronous

### DIFF
--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -69,7 +69,7 @@ func diffLists(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.List) {
 
 	splices := make(chan types.Splice)
 	closeChan := make(chan struct{})
-	v2.Diff(v1, splices, closeChan)
+	go v2.Diff(v1, splices, closeChan)
 
 	err := d.Try(func() {
 		for splice := range splices {
@@ -110,7 +110,7 @@ func diffMaps(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.Map) {
 
 	changes := make(chan types.ValueChanged)
 	closeChan := make(chan struct{})
-	v2.Diff(v1, changes, closeChan)
+	go v2.Diff(v1, changes, closeChan)
 
 	err := d.Try(func() {
 		for change := range changes {
@@ -166,7 +166,7 @@ func diffSets(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.Set) {
 
 	changes := make(chan types.ValueChanged)
 	closeChan := make(chan struct{})
-	v2.Diff(v1, changes, closeChan)
+	go v2.Diff(v1, changes, closeChan)
 
 	err := d.Try(func() {
 		for change := range changes {

--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -69,7 +69,10 @@ func diffLists(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.List) {
 
 	splices := make(chan types.Splice)
 	closeChan := make(chan struct{})
-	go v2.Diff(v1, splices, closeChan)
+	go func() {
+		v2.Diff(v1, splices, closeChan)
+		close(splices)
+	}()
 
 	err := d.Try(func() {
 		for splice := range splices {
@@ -110,7 +113,10 @@ func diffMaps(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.Map) {
 
 	changes := make(chan types.ValueChanged)
 	closeChan := make(chan struct{})
-	go v2.Diff(v1, changes, closeChan)
+	go func() {
+		v2.Diff(v1, changes, closeChan)
+		close(changes)
+	}()
 
 	err := d.Try(func() {
 		for change := range changes {
@@ -166,7 +172,10 @@ func diffSets(dq *diffQueue, w io.Writer, p types.Path, v1, v2 types.Set) {
 
 	changes := make(chan types.ValueChanged)
 	closeChan := make(chan struct{})
-	go v2.Diff(v1, changes, closeChan)
+	go func() {
+		v2.Diff(v1, changes, closeChan)
+		close(changes)
+	}()
 
 	err := d.Try(func() {
 		for change := range changes {

--- a/go/types/indexed_sequence_diff.go
+++ b/go/types/indexed_sequence_diff.go
@@ -14,20 +14,15 @@ type ChangeChannelClosedError struct {
 
 func (e ChangeChannelClosedError) Error() string { return e.msg }
 
-func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64, current indexedSequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) {
-	indexedSequenceDiffWithErr(last, lastHeight, lastOffset, current, currentHeight, currentOffset, changes, closeChan, maxSpliceMatrixSize)
-	close(changes)
-}
-
-func indexedSequenceDiffWithErr(last indexedSequence, lastHeight int, lastOffset uint64, current indexedSequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) error {
+func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64, current indexedSequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) error {
 	if lastHeight > currentHeight {
 		lastChild := last.(indexedMetaSequence).getCompositeChildSequence(0, uint64(last.seqLen())).(indexedSequence)
-		return indexedSequenceDiffWithErr(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, changes, closeChan, maxSpliceMatrixSize)
+		return indexedSequenceDiff(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
 	if currentHeight > lastHeight {
 		currentChild := current.(indexedMetaSequence).getCompositeChildSequence(0, uint64(current.seqLen())).(indexedSequence)
-		return indexedSequenceDiffWithErr(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, changes, closeChan, maxSpliceMatrixSize)
+		return indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
 	compareFn := last.getCompareFn(current)
@@ -58,7 +53,7 @@ func indexedSequenceDiffWithErr(last indexedSequence, lastHeight int, lastOffset
 			if splice.SpFrom > 0 {
 				currentChildOffset += current.getOffset(int(splice.SpFrom)-1) + 1
 			}
-			err := indexedSequenceDiffWithErr(lastChild, lastHeight-1, lastChildOffset, currentChild, currentHeight-1, currentChildOffset, changes, closeChan, maxSpliceMatrixSize)
+			err := indexedSequenceDiff(lastChild, lastHeight-1, lastChildOffset, currentChild, currentHeight-1, currentChildOffset, changes, closeChan, maxSpliceMatrixSize)
 			if err != nil {
 				return err
 			}

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -196,28 +196,26 @@ func (l List) Diff(last List, changes chan<- Splice, closeChan <-chan struct{}) 
 }
 
 func (l List) DiffWithLimit(last List, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) {
-	go func() {
-		if l.Equals(last) {
-			close(changes) // nothing changed
-			return
-		}
-		lLen, lastLen := l.Len(), last.Len()
-		if lLen == 0 {
-			changes <- Splice{0, lastLen, 0, 0} // everything removed
-			close(changes)
-			return
-		}
-		if lastLen == 0 {
-			changes <- Splice{0, 0, lLen, 0} // everything added
-			close(changes)
-			return
-		}
-
-		lastCur := newCursorAtIndex(last.seq, 0)
-		lCur := newCursorAtIndex(l.seq, 0)
-		indexedSequenceDiff(last.seq, lastCur.depth(), 0, l.seq, lCur.depth(), 0, changes, closeChan, maxSpliceMatrixSize)
+	if l.Equals(last) {
+		close(changes) // nothing changed
+		return
+	}
+	lLen, lastLen := l.Len(), last.Len()
+	if lLen == 0 {
+		changes <- Splice{0, lastLen, 0, 0} // everything removed
 		close(changes)
-	}()
+		return
+	}
+	if lastLen == 0 {
+		changes <- Splice{0, 0, lLen, 0} // everything added
+		close(changes)
+		return
+	}
+
+	lastCur := newCursorAtIndex(last.seq, 0)
+	lCur := newCursorAtIndex(l.seq, 0)
+	indexedSequenceDiff(last.seq, lastCur.depth(), 0, l.seq, lCur.depth(), 0, changes, closeChan, maxSpliceMatrixSize)
+	// indexedSequenceDiff will close |changes|.
 }
 
 func newListLeafBoundaryChecker() boundaryChecker {

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -197,25 +197,21 @@ func (l List) Diff(last List, changes chan<- Splice, closeChan <-chan struct{}) 
 
 func (l List) DiffWithLimit(last List, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) {
 	if l.Equals(last) {
-		close(changes) // nothing changed
 		return
 	}
 	lLen, lastLen := l.Len(), last.Len()
 	if lLen == 0 {
 		changes <- Splice{0, lastLen, 0, 0} // everything removed
-		close(changes)
 		return
 	}
 	if lastLen == 0 {
 		changes <- Splice{0, 0, lLen, 0} // everything added
-		close(changes)
 		return
 	}
 
 	lastCur := newCursorAtIndex(last.seq, 0)
 	lCur := newCursorAtIndex(l.seq, 0)
 	indexedSequenceDiff(last.seq, lastCur.depth(), 0, l.seq, lCur.depth(), 0, changes, closeChan, maxSpliceMatrixSize)
-	// indexedSequenceDiff will close |changes|.
 }
 
 func newListLeafBoundaryChecker() boundaryChecker {

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -627,7 +627,7 @@ func TestListModifyAfterRead(t *testing.T) {
 
 func accumulateDiffSplices(l1, l2 List) (diff []Splice) {
 	diffChan := make(chan Splice)
-	l1.Diff(l2, diffChan, nil)
+	go l1.Diff(l2, diffChan, nil)
 	for splice := range diffChan {
 		diff = append(diff, splice)
 	}
@@ -636,7 +636,7 @@ func accumulateDiffSplices(l1, l2 List) (diff []Splice) {
 
 func accumulateDiffSplicesWithLimit(l1, l2 List, maxSpliceMatrixSize uint64) (diff []Splice) {
 	diffChan := make(chan Splice)
-	l1.DiffWithLimit(l2, diffChan, nil, maxSpliceMatrixSize)
+	go l1.DiffWithLimit(l2, diffChan, nil, maxSpliceMatrixSize)
 	for splice := range diffChan {
 		diff = append(diff, splice)
 	}

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -627,7 +627,10 @@ func TestListModifyAfterRead(t *testing.T) {
 
 func accumulateDiffSplices(l1, l2 List) (diff []Splice) {
 	diffChan := make(chan Splice)
-	go l1.Diff(l2, diffChan, nil)
+	go func() {
+		l1.Diff(l2, diffChan, nil)
+		close(diffChan)
+	}()
 	for splice := range diffChan {
 		diff = append(diff, splice)
 	}
@@ -636,7 +639,10 @@ func accumulateDiffSplices(l1, l2 List) (diff []Splice) {
 
 func accumulateDiffSplicesWithLimit(l1, l2 List, maxSpliceMatrixSize uint64) (diff []Splice) {
 	diffChan := make(chan Splice)
-	go l1.DiffWithLimit(l2, diffChan, nil, maxSpliceMatrixSize)
+	go func() {
+		l1.DiffWithLimit(l2, diffChan, nil, maxSpliceMatrixSize)
+		close(diffChan)
+	}()
 	for splice := range diffChan {
 		diff = append(diff, splice)
 	}

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -59,12 +59,7 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 }
 
 func (m Map) Diff(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
-	go func() {
-		err := orderedSequenceDiff(last.sequence().(orderedSequence), m.sequence().(orderedSequence), changes, closeChan)
-		if err == nil {
-			close(changes)
-		}
-	}()
+	orderedSequenceDiffTopDown(last.sequence().(orderedSequence), m.sequence().(orderedSequence), changes, closeChan)
 }
 
 // Collection interface

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -275,7 +275,10 @@ func getTestRefToValueOrderMap(scale int, vw ValueWriter) testMap {
 
 func accumulateMapDiffChanges(m1, m2 Map) (added []Value, removed []Value, modified []Value) {
 	changes := make(chan ValueChanged)
-	go m1.Diff(m2, changes, nil)
+	go func() {
+		m1.Diff(m2, changes, nil)
+		close(changes)
+	}()
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -275,7 +275,7 @@ func getTestRefToValueOrderMap(scale int, vw ValueWriter) testMap {
 
 func accumulateMapDiffChanges(m1, m2 Map) (added []Value, removed []Value, modified []Value) {
 	changes := make(chan ValueChanged)
-	m1.Diff(m2, changes, nil)
+	go m1.Diff(m2, changes, nil)
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -83,9 +83,8 @@ func (suite *diffTestSuite) TestDiff() {
 	}
 
 	runTest := func(name string, vf valFn, cf colFn) {
-		runTestDf(name, vf, cf, orderedSequenceDiff)
+		runTestDf(name, vf, cf, orderedSequenceDiffTopDown)
 		runTestDf(name, vf, cf, orderedSequenceDiffLeftRight)
-		//runTestDf(name, vf, cf, orderedSequenceDiffZ)
 	}
 
 	newSetAsCol := func(vs []Value) Collection { return NewSet(vs...) }

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -14,7 +14,7 @@ const (
 	lengthOfNumbersTest = 1000
 )
 
-type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) error
+type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{})
 
 type diffTestSuite struct {
 	suite.Suite
@@ -41,13 +41,7 @@ func newDiffTestSuite(from1, to1, by1, from2, to2, by2, numAddsExpected, numRemo
 func accumulateOrderedSequenceDiffChanges(o1, o2 orderedSequence, df diffFn) (added []Value, removed []Value, modified []Value) {
 	changes := make(chan ValueChanged)
 	closeChan := make(chan struct{})
-
-	go func() {
-		err := df(o1, o2, changes, closeChan)
-		if err == nil {
-			close(changes)
-		}
-	}()
+	go df(o1, o2, changes, closeChan)
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)
@@ -90,7 +84,8 @@ func (suite *diffTestSuite) TestDiff() {
 
 	runTest := func(name string, vf valFn, cf colFn) {
 		runTestDf(name, vf, cf, orderedSequenceDiff)
-		runTestDf(name, vf, cf, orderedSequenceDiffLeafItems)
+		runTestDf(name, vf, cf, orderedSequenceDiffLeftRight)
+		//runTestDf(name, vf, cf, orderedSequenceDiffZ)
 	}
 
 	newSetAsCol := func(vs []Value) Collection { return NewSet(vs...) }

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -14,7 +14,7 @@ const (
 	lengthOfNumbersTest = 1000
 )
 
-type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) error
+type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) bool
 
 type diffTestSuite struct {
 	suite.Suite

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -14,7 +14,7 @@ const (
 	lengthOfNumbersTest = 1000
 )
 
-type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{})
+type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) error
 
 type diffTestSuite struct {
 	suite.Suite
@@ -41,7 +41,10 @@ func newDiffTestSuite(from1, to1, by1, from2, to2, by2, numAddsExpected, numRemo
 func accumulateOrderedSequenceDiffChanges(o1, o2 orderedSequence, df diffFn) (added []Value, removed []Value, modified []Value) {
 	changes := make(chan ValueChanged)
 	closeChan := make(chan struct{})
-	go df(o1, o2, changes, closeChan)
+	go func() {
+		df(o1, o2, changes, closeChan)
+		close(changes)
+	}()
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -37,12 +37,7 @@ func NewSet(v ...Value) Set {
 }
 
 func (s Set) Diff(last Set, changes chan<- ValueChanged, closeChan <-chan struct{}) {
-	go func() {
-		err := orderedSequenceDiff(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
-		if err == nil {
-			close(changes)
-		}
-	}()
+	orderedSequenceDiffTopDown(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
 }
 
 // Collection interface

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -194,7 +194,10 @@ func getTestRefToValueOrderSet(scale int, vw ValueWriter) testSet {
 
 func accumulateSetDiffChanges(s1, s2 Set) (added []Value, removed []Value) {
 	changes := make(chan ValueChanged)
-	go s1.Diff(s2, changes, nil)
+	go func() {
+		s1.Diff(s2, changes, nil)
+		close(changes)
+	}()
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -194,7 +194,7 @@ func getTestRefToValueOrderSet(scale int, vw ValueWriter) testSet {
 
 func accumulateSetDiffChanges(s1, s2 Set) (added []Value, removed []Value) {
 	changes := make(chan ValueChanged)
-	s1.Diff(s2, changes, nil)
+	go s1.Diff(s2, changes, nil)
 	for change := range changes {
 		if change.ChangeType == DiffChangeAdded {
 			added = append(added, change.V)

--- a/go/util/functions/all.go
+++ b/go/util/functions/all.go
@@ -10,8 +10,8 @@ import "sync"
 func All(fs ...func()) {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(fs))
-	for _, f := range fs {
-		f := f
+	for _, f_ := range fs {
+		f := f_
 		go func() {
 			f()
 			wg.Done()

--- a/go/util/functions/all.go
+++ b/go/util/functions/all.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package functions
+
+import "sync"
+
+// Runs all functions in |fs| in parallel, and returns when all functions have returned.
+func All(fs ...func()) {
+	wg := &sync.WaitGroup{}
+	wg.Add(len(fs))
+	for _, f := range fs {
+		f := f
+		go func() {
+			f()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/go/util/functions/all_test.go
+++ b/go/util/functions/all_test.go
@@ -1,0 +1,22 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package functions
+
+import (
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestAll(t *testing.T) {
+	assert := assert.New(t)
+
+	// Set |res| via |ch| to test it's running in parallel - if not, they'll deadlock.
+	var res int
+	ch := make(chan int)
+	All(func() { ch <- 42 }, func() { res = <-ch })
+
+	assert.Equal(42, res)
+}


### PR DESCRIPTION
Currently they return immediately, but run internal goroutines which
stream results back on a channel. Now they must be run on their own
goroutine from outside the function.

This makes the code easier to reason about, and a future patch to write
a top-down and left-right multiplexing diff easier to write.
