### PR TITLE
Report progress during commit in CSV importer

### DIFF
--- a/go/datas/commit_progress.go
+++ b/go/datas/commit_progress.go
@@ -1,0 +1,13 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package datas
+
+// CommitProgress provides information about the progress of the commit method.
+type CommitProgress struct {
+	// DoneBytes is the number of bytes that have been sent so far.
+	DoneBytes uint64
+	// KnownBytes is the total number of bytes that commit needs to send.
+	KnownBytes uint64
+}

--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -35,7 +35,7 @@ type Database interface {
 	Datasets() types.Map
 
 	// Commit updates the Commit that datasetID in this database points at. All Values that have been written to this Database are guaranteed to be persistent after Commit(). If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the database is always returned.
-	Commit(datasetID string, commit types.Struct) (Database, error)
+	Commit(datasetID string, commit types.Struct, progressChan chan CommitProgress) (Database, error)
 
 	// Delete removes the Dataset named datasetID from the map at the root of the Database. The Dataset data is not necessarily cleaned up at this time, but may be garbage collected in the future. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the database is always returned.
 	Delete(datasetID string) (Database, error)

--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -14,11 +14,12 @@ import (
 )
 
 type databaseCommon struct {
-	cch      *cachingChunkHaver
-	vs       *types.ValueStore
-	rt       chunks.RootTracker
-	rootRef  hash.Hash
-	datasets *types.Map
+	cch          *cachingChunkHaver
+	vs           *types.ValueStore
+	rt           chunks.RootTracker
+	rootRef      hash.Hash
+	datasets     *types.Map
+	progressChan chan CommitProgress
 }
 
 var (

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -27,8 +27,9 @@ func TestRemoteDatabase(t *testing.T) {
 type DatabaseSuite struct {
 	suite.Suite
 	cs     *chunks.TestStore
-	ds     Database
+	db     Database
 	makeDs func(chunks.ChunkStore) Database
+	remote bool
 }
 
 type LocalDatabaseSuite struct {
@@ -38,7 +39,7 @@ type LocalDatabaseSuite struct {
 func (suite *LocalDatabaseSuite) SetupTest() {
 	suite.cs = chunks.NewTestStore()
 	suite.makeDs = NewDatabase
-	suite.ds = suite.makeDs(suite.cs)
+	suite.db = suite.makeDs(suite.cs)
 }
 
 type RemoteDatabaseSuite struct {
@@ -49,22 +50,26 @@ func (suite *RemoteDatabaseSuite) SetupTest() {
 	suite.cs = chunks.NewTestStore()
 	suite.makeDs = func(cs chunks.ChunkStore) Database {
 		hbs := newHTTPBatchStoreForTest(cs)
-		return &RemoteDatabaseClient{newDatabaseCommon(newCachingChunkHaver(hbs), types.NewValueStore(hbs), hbs)}
+		return &RemoteDatabaseClient{
+			databaseCommon: newDatabaseCommon(newCachingChunkHaver(hbs), types.NewValueStore(hbs), hbs),
+			httpBS:         hbs,
+		}
 	}
-	suite.ds = suite.makeDs(suite.cs)
+	suite.db = suite.makeDs(suite.cs)
+	suite.remote = true
 }
 
 func (suite *DatabaseSuite) TearDownTest() {
-	suite.ds.Close()
+	suite.db.Close()
 	suite.cs.Close()
 }
 
 func (suite *DatabaseSuite) TestReadWriteCache() {
 	var v types.Value = types.Bool(true)
-	suite.NotEqual(hash.Hash{}, suite.ds.WriteValue(v))
-	r := suite.ds.WriteValue(v).TargetHash()
+	suite.NotEqual(hash.Hash{}, suite.db.WriteValue(v))
+	r := suite.db.WriteValue(v).TargetHash()
 	commit := NewCommit(v, types.NewSet())
-	newDs, err := suite.ds.Commit("foo", commit)
+	newDs, err := suite.db.Commit("foo", commit, nil)
 	suite.NoError(err)
 	suite.Equal(1, suite.cs.Writes-writesOnCommit)
 
@@ -75,41 +80,41 @@ func (suite *DatabaseSuite) TestReadWriteCache() {
 func (suite *DatabaseSuite) TestReadWriteCachePersists() {
 	var err error
 	var v types.Value = types.Bool(true)
-	suite.NotEqual(hash.Hash{}, suite.ds.WriteValue(v))
-	r := suite.ds.WriteValue(v)
+	suite.NotEqual(hash.Hash{}, suite.db.WriteValue(v))
+	r := suite.db.WriteValue(v)
 	commit := NewCommit(v, types.NewSet())
-	suite.ds, err = suite.ds.Commit("foo", commit)
+	suite.db, err = suite.db.Commit("foo", commit, nil)
 	suite.NoError(err)
 	suite.Equal(1, suite.cs.Writes-writesOnCommit)
 
 	newCommit := NewCommit(r, types.NewSet(types.NewRef(commit)))
-	suite.ds, err = suite.ds.Commit("foo", newCommit)
+	suite.db, err = suite.db.Commit("foo", newCommit, nil)
 	suite.NoError(err)
 }
 
 func (suite *DatabaseSuite) TestWriteRefToNonexistentValue() {
-	suite.Panics(func() { suite.ds.WriteValue(types.NewRef(types.Bool(true))) })
+	suite.Panics(func() { suite.db.WriteValue(types.NewRef(types.Bool(true))) })
 }
 
 func (suite *DatabaseSuite) TestTolerateUngettableRefs() {
-	suite.Nil(suite.ds.ReadValue(hash.Hash{}))
+	suite.Nil(suite.db.ReadValue(hash.Hash{}))
 }
 
 func (suite *DatabaseSuite) TestDatabaseCommit() {
 	datasetID := "ds1"
-	datasets := suite.ds.Datasets()
+	datasets := suite.db.Datasets()
 	suite.Zero(datasets.Len())
 
 	// |a|
 	a := types.String("a")
 	aCommit := NewCommit(a, types.NewSet())
-	ds2, err := suite.ds.Commit(datasetID, aCommit)
+	ds2, err := suite.db.Commit(datasetID, aCommit, nil)
 	suite.NoError(err)
 
 	// The old database still has no head.
-	_, ok := suite.ds.MaybeHead(datasetID)
+	_, ok := suite.db.MaybeHead(datasetID)
 	suite.False(ok)
-	_, ok = suite.ds.MaybeHeadRef(datasetID)
+	_, ok = suite.db.MaybeHeadRef(datasetID)
 	suite.False(ok)
 
 	// The new database has |a|.
@@ -118,41 +123,41 @@ func (suite *DatabaseSuite) TestDatabaseCommit() {
 	aRef1 := ds2.HeadRef(datasetID)
 	suite.Equal(aCommit1.Hash(), aRef1.TargetHash())
 	suite.Equal(uint64(1), aRef1.Height())
-	suite.ds = ds2
+	suite.db = ds2
 
 	// |a| <- |b|
 	b := types.String("b")
 	bCommit := NewCommit(b, types.NewSet(types.NewRef(aCommit)))
-	suite.ds, err = suite.ds.Commit(datasetID, bCommit)
+	suite.db, err = suite.db.Commit(datasetID, bCommit, nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(b))
-	suite.Equal(uint64(2), suite.ds.HeadRef(datasetID).Height())
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(b))
+	suite.Equal(uint64(2), suite.db.HeadRef(datasetID).Height())
 
 	// |a| <- |b|
 	//   \----|c|
 	// Should be disallowed.
 	c := types.String("c")
 	cCommit := NewCommit(c, types.NewSet(types.NewRef(aCommit)))
-	suite.ds, err = suite.ds.Commit(datasetID, cCommit)
+	suite.db, err = suite.db.Commit(datasetID, cCommit, nil)
 	suite.Error(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(b))
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(b))
 
 	// |a| <- |b| <- |d|
 	d := types.String("d")
 	dCommit := NewCommit(d, types.NewSet(types.NewRef(bCommit)))
-	suite.ds, err = suite.ds.Commit(datasetID, dCommit)
+	suite.db, err = suite.db.Commit(datasetID, dCommit, nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(d))
-	suite.Equal(uint64(3), suite.ds.HeadRef(datasetID).Height())
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(d))
+	suite.Equal(uint64(3), suite.db.HeadRef(datasetID).Height())
 
 	// Attempt to recommit |b| with |a| as parent.
 	// Should be disallowed.
-	suite.ds, err = suite.ds.Commit(datasetID, bCommit)
+	suite.db, err = suite.db.Commit(datasetID, bCommit, nil)
 	suite.Error(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(d))
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(d))
 
 	// Add a commit to a different datasetId
-	_, err = suite.ds.Commit("otherDs", aCommit)
+	_, err = suite.db.Commit("otherDs", aCommit, nil)
 	suite.NoError(err)
 
 	// Get a fresh database, and verify that both datasets are present
@@ -164,59 +169,59 @@ func (suite *DatabaseSuite) TestDatabaseCommit() {
 
 func (suite *DatabaseSuite) TestDatabaseDelete() {
 	datasetID1, datasetID2 := "ds1", "ds2"
-	datasets := suite.ds.Datasets()
+	datasets := suite.db.Datasets()
 	suite.Zero(datasets.Len())
 
 	// |a|
 	var err error
 	a := types.String("a")
-	suite.ds, err = suite.ds.Commit(datasetID1, NewCommit(a, types.NewSet()))
+	suite.db, err = suite.db.Commit(datasetID1, NewCommit(a, types.NewSet()), nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID1).Get(ValueField).Equals(a))
+	suite.True(suite.db.Head(datasetID1).Get(ValueField).Equals(a))
 
 	// ds1; |a|, ds2: |b|
 	b := types.String("b")
-	suite.ds, err = suite.ds.Commit(datasetID2, NewCommit(b, types.NewSet()))
+	suite.db, err = suite.db.Commit(datasetID2, NewCommit(b, types.NewSet()), nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID2).Get(ValueField).Equals(b))
+	suite.True(suite.db.Head(datasetID2).Get(ValueField).Equals(b))
 
-	suite.ds, err = suite.ds.Delete(datasetID1)
+	suite.db, err = suite.db.Delete(datasetID1)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID2).Get(ValueField).Equals(b))
-	_, present := suite.ds.MaybeHead(datasetID1)
+	suite.True(suite.db.Head(datasetID2).Get(ValueField).Equals(b))
+	_, present := suite.db.MaybeHead(datasetID1)
 	suite.False(present, "Dataset %s should not be present", datasetID1)
 
 	// Get a fresh database, and verify that only ds1 is present
 	newDs := suite.makeDs(suite.cs)
 	datasets = newDs.Datasets()
 	suite.Equal(uint64(1), datasets.Len())
-	_, present = suite.ds.MaybeHead(datasetID2)
+	_, present = suite.db.MaybeHead(datasetID2)
 	suite.True(present, "Dataset %s should be present", datasetID2)
 	newDs.Close()
 }
 
 func (suite *DatabaseSuite) TestDatabaseDeleteConcurrent() {
 	datasetID := "ds1"
-	suite.Zero(suite.ds.Datasets().Len())
+	suite.Zero(suite.db.Datasets().Len())
 	var err error
 
 	// |a|
 	a := types.String("a")
 	aCommit := NewCommit(a, types.NewSet())
-	suite.ds, err = suite.ds.Commit(datasetID, aCommit)
+	suite.db, err = suite.db.Commit(datasetID, aCommit, nil)
 	suite.NoError(err)
 
 	// |a| <- |b|
 	b := types.String("b")
 	bCommit := NewCommit(b, types.NewSet(types.NewRef(aCommit)))
-	ds2, err := suite.ds.Commit(datasetID, bCommit)
+	ds2, err := suite.db.Commit(datasetID, bCommit, nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(a))
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(a))
 	suite.True(ds2.Head(datasetID).Get(ValueField).Equals(b))
 
-	suite.ds, err = suite.ds.Delete(datasetID)
+	suite.db, err = suite.db.Delete(datasetID)
 	suite.NoError(err)
-	_, present := suite.ds.MaybeHead(datasetID)
+	_, present := suite.db.MaybeHead(datasetID)
 	suite.False(present, "Dataset %s should not be present", datasetID)
 	_, present = ds2.MaybeHead(datasetID)
 	suite.True(present, "Dataset %s should be present", datasetID)
@@ -235,12 +240,12 @@ func (suite *DatabaseSuite) TestDatabaseConcurrency() {
 	// |a| <- |b|
 	a := types.String("a")
 	aCommit := NewCommit(a, types.NewSet())
-	suite.ds, err = suite.ds.Commit(datasetID, aCommit)
+	suite.db, err = suite.db.Commit(datasetID, aCommit, nil)
 	b := types.String("b")
 	bCommit := NewCommit(b, types.NewSet(types.NewRef(aCommit)))
-	suite.ds, err = suite.ds.Commit(datasetID, bCommit)
+	suite.db, err = suite.db.Commit(datasetID, bCommit, nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(b))
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(b))
 
 	// Important to create this here.
 	ds2 := suite.makeDs(suite.cs)
@@ -249,27 +254,27 @@ func (suite *DatabaseSuite) TestDatabaseConcurrency() {
 	// |a| <- |b| <- |c|
 	c := types.String("c")
 	cCommit := NewCommit(c, types.NewSet(types.NewRef(bCommit)))
-	suite.ds, err = suite.ds.Commit(datasetID, cCommit)
+	suite.db, err = suite.db.Commit(datasetID, cCommit, nil)
 	suite.NoError(err)
-	suite.True(suite.ds.Head(datasetID).Get(ValueField).Equals(c))
+	suite.True(suite.db.Head(datasetID).Get(ValueField).Equals(c))
 
 	// Change 2:
 	// |a| <- |b| <- |e|
 	// Should be disallowed, Database returned by Commit() should have |c| as Head.
 	e := types.String("e")
 	eCommit := NewCommit(e, types.NewSet(types.NewRef(bCommit)))
-	ds2, err = ds2.Commit(datasetID, eCommit)
+	ds2, err = ds2.Commit(datasetID, eCommit, nil)
 	suite.Error(err)
 	suite.True(ds2.Head(datasetID).Get(ValueField).Equals(c))
 }
 
 func (suite *DatabaseSuite) TestDatabaseHeightOfRefs() {
-	r1 := suite.ds.WriteValue(types.String("hello"))
+	r1 := suite.db.WriteValue(types.String("hello"))
 	suite.Equal(uint64(1), r1.Height())
 
-	r2 := suite.ds.WriteValue(r1)
+	r2 := suite.db.WriteValue(r1)
 	suite.Equal(uint64(2), r2.Height())
-	suite.Equal(uint64(3), suite.ds.WriteValue(r2).Height())
+	suite.Equal(uint64(3), suite.db.WriteValue(r2).Height())
 }
 
 func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
@@ -280,33 +285,62 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
 	v1 := types.String("hello")
 	v2 := types.String("world")
 	s1 := types.NewSet(v1, v2)
-	suite.Equal(uint64(1), suite.ds.WriteValue(s1).Height())
+	suite.Equal(uint64(1), suite.db.WriteValue(s1).Height())
 
 	// Set<Ref<String>>
-	s2 := types.NewSet(suite.ds.WriteValue(v1), suite.ds.WriteValue(v2))
-	suite.Equal(uint64(2), suite.ds.WriteValue(s2).Height())
+	s2 := types.NewSet(suite.db.WriteValue(v1), suite.db.WriteValue(v2))
+	suite.Equal(uint64(2), suite.db.WriteValue(s2).Height())
 
 	// List<Set<String>>
 	v3 := types.String("foo")
 	v4 := types.String("bar")
 	s3 := types.NewSet(v3, v4)
 	l1 := types.NewList(s1, s3)
-	suite.Equal(uint64(1), suite.ds.WriteValue(l1).Height())
+	suite.Equal(uint64(1), suite.db.WriteValue(l1).Height())
 
 	// List<Ref<Set<String>>
 	l2 := types.NewList(types.MakeListType(types.MakeRefType(setOfStringType)),
-		suite.ds.WriteValue(s1), suite.ds.WriteValue(s3))
-	suite.Equal(uint64(2), suite.ds.WriteValue(l2).Height())
+		suite.db.WriteValue(s1), suite.db.WriteValue(s3))
+	suite.Equal(uint64(2), suite.db.WriteValue(l2).Height())
 
 	// List<Ref<Set<Ref<String>>>
-	s4 := types.NewSet(suite.ds.WriteValue(v3), suite.ds.WriteValue(v4))
+	s4 := types.NewSet(suite.db.WriteValue(v3), suite.db.WriteValue(v4))
 	l3 := types.NewList(types.MakeListType(types.MakeRefType(setOfRefOfStringType)),
-		suite.ds.WriteValue(s4))
-	suite.Equal(uint64(3), suite.ds.WriteValue(l3).Height())
+		suite.db.WriteValue(s4))
+	suite.Equal(uint64(3), suite.db.WriteValue(l3).Height())
 
 	// List<Set<String> | RefValue<Set<String>>>.
-	l4 := types.NewList(s1, suite.ds.WriteValue(s3))
-	suite.Equal(uint64(2), suite.ds.WriteValue(l4).Height())
-	l5 := types.NewList(suite.ds.WriteValue(s1), s3)
-	suite.Equal(uint64(2), suite.ds.WriteValue(l5).Height())
+	l4 := types.NewList(s1, suite.db.WriteValue(s3))
+	suite.Equal(uint64(2), suite.db.WriteValue(l4).Height())
+	l5 := types.NewList(suite.db.WriteValue(s1), s3)
+	suite.Equal(uint64(2), suite.db.WriteValue(l5).Height())
+}
+
+func (suite *DatabaseSuite) TestDatabaseCommitProgress() {
+	var waitChan chan struct{}
+	var progressChan chan CommitProgress
+	progressReported := false
+	if suite.remote {
+		progressChan = make(chan CommitProgress)
+		waitChan = make(chan struct{})
+		go func() {
+			for range progressChan {
+				progressReported = true
+				break
+			}
+			waitChan <- struct{}{}
+
+		}()
+	}
+
+	a := types.String("a")
+	c := NewCommit(a, types.NewSet())
+	_, err := suite.db.Commit("dsid", c, progressChan)
+	suite.NoError(err)
+
+	if suite.remote {
+		<-waitChan
+	}
+
+	suite.Equal(suite.remote, progressReported)
 }

--- a/go/datas/local_database.go
+++ b/go/datas/local_database.go
@@ -24,22 +24,22 @@ func newLocalDatabase(cs chunks.ChunkStore) *LocalDatabase {
 	}
 }
 
-func (lds *LocalDatabase) Commit(datasetID string, commit types.Struct) (Database, error) {
-	err := lds.commit(datasetID, commit)
-	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
+func (ldb *LocalDatabase) Commit(datasetID string, commit types.Struct, progressCh chan CommitProgress) (Database, error) {
+	err := ldb.commit(datasetID, commit)
+	return &LocalDatabase{newDatabaseCommon(ldb.cch, ldb.vs, ldb.rt), ldb.cs}, err
 }
 
-func (lds *LocalDatabase) Delete(datasetID string) (Database, error) {
-	err := lds.doDelete(datasetID)
-	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
+func (ldb *LocalDatabase) Delete(datasetID string) (Database, error) {
+	err := ldb.doDelete(datasetID)
+	return &LocalDatabase{newDatabaseCommon(ldb.cch, ldb.vs, ldb.rt), ldb.cs}, err
 }
 
-func (lds *LocalDatabase) validatingBatchStore() (bs types.BatchStore) {
-	bs = lds.vs.BatchStore()
+func (ldb *LocalDatabase) validatingBatchStore() (bs types.BatchStore) {
+	bs = ldb.vs.BatchStore()
 	if !bs.IsValidating() {
-		bs = newLocalBatchStore(lds.cs)
-		lds.vs = types.NewValueStore(bs)
-		lds.rt = bs
+		bs = newLocalBatchStore(ldb.cs)
+		ldb.vs = types.NewValueStore(bs)
+		ldb.rt = bs
 	}
 	d.Chk.True(bs.IsValidating())
 	return bs

--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -86,7 +86,10 @@ func (suite *RemoteToRemoteSuite) SetupTest() {
 
 func makeRemoteDb(cs chunks.ChunkStore) Database {
 	hbs := newHTTPBatchStoreForTest(cs)
-	return &RemoteDatabaseClient{newDatabaseCommon(newCachingChunkHaver(hbs), types.NewValueStore(hbs), hbs)}
+	return &RemoteDatabaseClient{
+		newDatabaseCommon(newCachingChunkHaver(hbs), types.NewValueStore(hbs), hbs),
+		hbs,
+	}
 }
 
 func (suite *PullSuite) sinkIsLocal() bool {
@@ -310,14 +313,14 @@ func (suite *PullSuite) TestPullUpdates() {
 
 func (suite *PullSuite) commitToSource(v types.Value, p types.Set) types.Ref {
 	var err error
-	suite.source, err = suite.source.Commit(dsID, NewCommit(v, p))
+	suite.source, err = suite.source.Commit(dsID, NewCommit(v, p), nil)
 	suite.NoError(err)
 	return suite.source.HeadRef(dsID)
 }
 
 func (suite *PullSuite) commitToSink(v types.Value, p types.Set) types.Ref {
 	var err error
-	suite.sink, err = suite.sink.Commit(dsID, NewCommit(v, p))
+	suite.sink, err = suite.sink.Commit(dsID, NewCommit(v, p), nil)
 	suite.NoError(err)
 	return suite.sink.HeadRef(dsID)
 }

--- a/go/dataset/commit_options.go
+++ b/go/dataset/commit_options.go
@@ -4,10 +4,15 @@
 
 package dataset
 
-import "github.com/attic-labs/noms/go/types"
+import (
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/types"
+)
 
 // CommitOptions is used to pass options into Commit.
 type CommitOptions struct {
 	// Parents, if provided is the parent commits of the commit we are creating.
 	Parents types.Set
+	// Progress gets sent progress data as the commit progresses.
+	Progress chan datas.CommitProgress
 }

--- a/go/dataset/dataset.go
+++ b/go/dataset/dataset.go
@@ -91,7 +91,7 @@ func (ds *Dataset) Commit(v types.Value, opts CommitOptions) (Dataset, error) {
 		}
 	}
 	newCommit := datas.NewCommit(v, parents)
-	store, err := ds.Database().Commit(ds.id, newCommit)
+	store, err := ds.Database().Commit(ds.id, newCommit, opts.Progress)
 	return Dataset{store, ds.id}, err
 }
 

--- a/go/spec/absolute_path_test.go
+++ b/go/spec/absolute_path_test.go
@@ -44,7 +44,7 @@ func TestAbsolutePaths(t *testing.T) {
 	db.WriteValue(emptySet)
 
 	var err error
-	db, err = db.Commit("ds", datas.NewCommit(list, types.NewSet()))
+	db, err = db.Commit("ds", datas.NewCommit(list, types.NewSet()), nil)
 	assert.NoError(err)
 	head := db.Head("ds")
 

--- a/go/spec/dataspec_test.go
+++ b/go/spec/dataspec_test.go
@@ -32,7 +32,7 @@ func TestLDBDatabase(t *testing.T) {
 
 	s1 := types.String("A String")
 	s1Hash := ds.WriteValue(s1)
-	ds.Commit("testDs", datas.NewCommit(s1Hash, types.NewSet()))
+	ds.Commit("testDs", datas.NewCommit(s1Hash, types.NewSet()), nil)
 	ds.Close()
 
 	sp, errRead := parseDatabaseSpec(spec)

--- a/go/util/progressreader/reader.go
+++ b/go/util/progressreader/reader.go
@@ -5,9 +5,7 @@
 // Package progressreader provides an io.Reader that reports progress to a callback
 package progressreader
 
-import (
-	"io"
-)
+import "io"
 
 type Callback func(seen uint64)
 
@@ -17,6 +15,7 @@ func New(inner io.Reader, cb Callback) io.Reader {
 		uint64(0),
 		uint64(0),
 		cb,
+		true,
 	}
 }
 
@@ -25,13 +24,15 @@ type reader struct {
 	seen     uint64
 	lastMult uint64
 	cb       Callback
+	first    bool
 }
 
 const reportFreq = 2 << 19 // 1 MB
 
 func (r *reader) Read(p []byte) (n int, err error) {
 	mult := uint64(r.seen / reportFreq)
-	if mult > r.lastMult {
+	if r.first || mult > r.lastMult {
+		r.first = false
 		r.cb(r.seen)
 		r.lastMult = mult
 	}


### PR DESCRIPTION
This is done by setting a channel on the database. The API for this is
to pass in a channel to the Commit method and we then post progress to
this channel.

At this point only progress on Commit for RemoteDatabaseClient is
reported.

Towards #2037