### PR TITLE
Fix 2 deadlocks in orderedSequenceDiffBest causing noms log to hang

### DIFF
--- a/go/types/map.go
+++ b/go/types/map.go
@@ -60,7 +60,7 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 }
 
 func (m Map) Diff(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
-	orderedSequenceDiffBest(last.sequence().(orderedSequence), m.sequence().(orderedSequence), changes, closeChan)
+	orderedSequenceDiffBest(last.seq, m.seq, changes, closeChan)
 }
 
 // Collection interface

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -151,3 +151,27 @@ func TestOrderedSequencesDisjoint(t *testing.T) {
 	ts1.Equal(ts1.added, ts2.removed, "added and removed in disjoint diff")
 	ts1.Equal(ts1.removed, ts2.added, "removed and added in disjoint diff")
 }
+
+func TestOrderedSequencesDiffCloseWithoutReading(t *testing.T) {
+	runTest := func(df diffFn) {
+		s1 := NewSet().seq
+		// A single item should be enough, but generate lots anyway.
+		s2 := NewSet(generateNumbersAsValuesFromToBy(0, 1000, 1)...).seq
+
+		changeChan := make(chan ValueChanged)
+		closeChan := make(chan struct{})
+		stopChan := make(chan struct{})
+
+		go func() {
+			df(s1, s2, changeChan, closeChan)
+			stopChan <- struct{}{}
+		}()
+
+		closeChan <- struct{}{}
+		<-stopChan
+	}
+
+	runTest(orderedSequenceDiffBest)
+	runTest(orderedSequenceDiffLeftRight)
+	runTest(orderedSequenceDiffTopDown)
+}

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -31,7 +31,7 @@ func NewSet(v ...Value) Set {
 }
 
 func (s Set) Diff(last Set, changes chan<- ValueChanged, closeChan <-chan struct{}) {
-	orderedSequenceDiffBest(last.sequence().(orderedSequence), s.sequence().(orderedSequence), changes, closeChan)
+	orderedSequenceDiffBest(last.seq, s.seq, changes, closeChan)
 }
 
 // Collection interface


### PR DESCRIPTION
First: diff wasn't checking whether it had stopped before sending the
final set of changes. If the caller had stopped - and therefore no
longer reading from the changes channel - diff would hang.

Second: the same close channel was being used on 2 threads and it was
possible for both to read the close signal - causing the other to hang.
