### PR TITLE
Disallow nil in Value Equals

### DIFF
--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -53,7 +53,7 @@ func (b Blob) hashPointer() *hash.Hash {
 
 // Value interface
 func (b Blob) Equals(other Value) bool {
-	return other != nil && b.Hash() == other.Hash()
+	return b.Hash() == other.Hash()
 }
 
 func (b Blob) Less(other Value) bool {

--- a/go/types/equals_test.go
+++ b/go/types/equals_test.go
@@ -15,7 +15,6 @@ func TestValueEquals(t *testing.T) {
 	assert := assert.New(t)
 
 	values := []func() Value{
-		func() Value { return nil },
 		func() Value { return Bool(false) },
 		func() Value { return Bool(true) },
 		func() Value { return Number(0) },
@@ -69,9 +68,6 @@ func TestValueEquals(t *testing.T) {
 
 	for i, f1 := range values {
 		for j, f2 := range values {
-			if f1() == nil {
-				continue
-			}
 			if i == j {
 				assert.True(f1().Equals(f2()))
 			} else {

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -60,7 +60,7 @@ func (l List) hashPointer() *hash.Hash {
 
 // Value interface
 func (l List) Equals(other Value) bool {
-	return other != nil && l.Hash() == other.Hash()
+	return l.Hash() == other.Hash()
 }
 
 func (l List) Less(other Value) bool {

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -82,7 +82,7 @@ func (m Map) hashPointer() *hash.Hash {
 
 // Value interface
 func (m Map) Equals(other Value) bool {
-	return other != nil && m.Hash() == other.Hash()
+	return m.Hash() == other.Hash()
 }
 
 func (m Map) Less(other Value) bool {

--- a/go/types/ref.go
+++ b/go/types/ref.go
@@ -52,7 +52,7 @@ func (r Ref) TargetValue(vr ValueReader) Value {
 
 // Value interface
 func (r Ref) Equals(other Value) bool {
-	return other != nil && r.Hash() == other.Hash()
+	return r.Hash() == other.Hash()
 }
 
 func (r Ref) Less(other Value) bool {

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -53,7 +53,7 @@ func (s Set) hashPointer() *hash.Hash {
 
 // Value interface
 func (s Set) Equals(other Value) bool {
-	return other != nil && s.Hash() == other.Hash()
+	return s.Hash() == other.Hash()
 }
 
 func (s Set) Less(other Value) bool {

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -60,7 +60,7 @@ func (s Struct) hashPointer() *hash.Hash {
 
 // Value interface
 func (s Struct) Equals(other Value) bool {
-	return other != nil && s.Hash() == other.Hash()
+	return s.Hash() == other.Hash()
 }
 
 func (s Struct) Less(other Value) bool {

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -73,7 +73,7 @@ func (t *Type) HasUnresolvedCycle() bool {
 
 // Value interface
 func (t *Type) Equals(other Value) (res bool) {
-	return other != nil && t.Hash() == other.Hash()
+	return t == other || t.Hash() == other.Hash()
 }
 
 func (t *Type) Less(other Value) (res bool) {


### PR DESCRIPTION
We do not allow nil in any other places as a Vale so there is
little reason to allow it Equals

Fixes #2155
