### PR TITLE
Remove Type name property

### DIFF
--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -108,7 +108,7 @@ func getRefElementType(t *types.Type) *types.Type {
 }
 
 func valueTypeFromCommit(t *types.Type) *types.Type {
-	d.Chk.True(t.Kind() == types.StructKind && t.Name() == "Commit")
+	d.Chk.True(t.Kind() == types.StructKind && t.Desc.(types.StructDesc).Name == "Commit")
 	return t.Desc.(types.StructDesc).Field(ValueField)
 }
 

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -180,7 +180,7 @@ func (w *hrsWriter) writeStruct(v Struct, printStructName bool) {
 
 	desc := t.Desc.(StructDesc)
 	if printStructName {
-		w.write(t.Name())
+		w.write(desc.Name)
 		w.write(" ")
 	}
 	w.write("{")
@@ -288,15 +288,14 @@ func (w *hrsWriter) writeStructType(t *Type, parentStructTypes []*Type) {
 	}
 	parentStructTypes = append(parentStructTypes, t)
 
-	w.write("struct ")
-	w.write(t.Name())
-	openBrace := "{"
-	if t.Name() != "" {
-		openBrace = " {"
-	}
-	w.write(openBrace)
-	w.indent()
 	desc := t.Desc.(StructDesc)
+	w.write("struct ")
+	if desc.Name != "" {
+		w.write(desc.Name + " ")
+	}
+	w.write("{")
+	w.indent()
+
 	first := true
 	desc.IterFields(func(name string, t *Type) {
 		if first {

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -53,11 +53,6 @@ func (t *Type) Kind() NomsKind {
 	return t.Desc.Kind()
 }
 
-func (t *Type) Name() string {
-	// TODO: Remove from Type
-	return t.Desc.(StructDesc).Name
-}
-
 func (t *Type) hasUnresolvedCycle(visited []*Type) bool {
 	_, found := indexOfType(t, visited)
 	if found {

--- a/go/types/type_desc.go
+++ b/go/types/type_desc.go
@@ -96,7 +96,6 @@ func (s fieldSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s fieldSlice) Less(i, j int) bool { return s[i].name < s[j].name }
 
 // StructDesc describes a custom Noms Struct.
-// Structs can contain at most one anonymous union, so Union may be nil.
 type StructDesc struct {
 	Name   string
 	fields []field

--- a/go/types/value_encoder.go
+++ b/go/types/value_encoder.go
@@ -187,13 +187,12 @@ func (w *valueEncoder) writeStructType(t *Type, parentStructTypes []*Type) {
 	parentStructTypes = append(parentStructTypes, t)
 
 	w.writeKind(StructKind)
-	w.writeString(t.Name())
+	desc := t.Desc.(StructDesc)
+	w.writeString(desc.Name)
 
-	count := t.Desc.(StructDesc).Len()
-	w.writeUint32(uint32(count))
+	w.writeUint32(uint32(desc.Len()))
 
-	fields := t.Desc.(StructDesc).fields
-	for _, field := range fields {
+	for _, field := range desc.fields {
 		w.writeString(field.name)
 		w.writeType(field.t, parentStructTypes)
 	}

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "54.0.0",
+  "version": "55.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/commit.js
+++ b/js/src/commit.js
@@ -119,7 +119,7 @@ function getRefElementType(t: Type<CompoundDesc>): Type<*> {
 }
 
 function valueTypeFromCommit(t: Type<StructDesc>): Type<*> {
-  invariant(t.name === 'Commit');
+  invariant(t.desc.name === 'Commit');
   return notNull(t.desc.getField('value'));
 }
 

--- a/js/src/struct.js
+++ b/js/src/struct.js
@@ -113,7 +113,7 @@ export class StructMirror<T: Struct> {
   }
 
   get name(): string {
-    return this.type.name;
+    return this.desc.name;
   }
 
   get(name: string): ?Value {

--- a/js/src/type.js
+++ b/js/src/type.js
@@ -198,11 +198,6 @@ export class Type<T: TypeDesc> extends ValueBase {
     return this._desc;
   }
 
-  get name(): string {
-    invariant(this._desc instanceof StructDesc);
-    return this._desc.name;
-  }
-
   hasUnresolvedCycle(visited: Type[]): boolean {
     if (visited.indexOf(this) >= 0) {
       return false;

--- a/js/src/value-encoder.js
+++ b/js/src/value-encoder.js
@@ -242,12 +242,11 @@ export default class ValueEncoder {
     }
 
     parentStructTypes.push(t);
-    const desc = t.desc;
+    const {desc} = t;
     this.writeKind(t.kind);
-    this._w.writeString(t.name);
+    this._w.writeString(desc.name);
 
-    const count = desc.fieldCount;
-    this._w.writeUint32(count);
+    this._w.writeUint32(desc.fieldCount);
 
     desc.forEachField((name: string, type: Type) => {
       this._w.writeString(name);

--- a/samples/js/aggregate/src/main.js
+++ b/samples/js/aggregate/src/main.js
@@ -64,7 +64,7 @@ async function main(): Promise<void> {
   let out = Promise.resolve(new Map());
 
   await walk(commit.value, input.database, cv => {
-    if (!(cv instanceof Struct) || cv.type.name !== args.struct) {
+    if (!(cv instanceof Struct) || cv.type.desc.name !== args.struct) {
       return;
     }
 


### PR DESCRIPTION
Only struct types have a name property and this was left over from
an earlier refactoring.
