### PR TITLE
Make the output pager close the pipes it creates

### DIFF
--- a/cmd/noms/noms_diff.go
+++ b/cmd/noms/noms_diff.go
@@ -5,11 +5,8 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/attic-labs/noms/cmd/noms/diff"
 	"github.com/attic-labs/noms/go/d"
@@ -55,17 +52,9 @@ func runDiff(args []string) int {
 		return 0
 	}
 
-	var w io.Writer
-	if pager := outputpager.NewOrNil(); pager != nil {
-		w = pager.Writer
-		defer pager.Stop()
-		go pager.RunAndExit()
-	} else {
-		bw := bufio.NewWriter(os.Stdout)
-		defer bw.Flush()
-		w = bw
-	}
+	pgr := outputpager.Start()
+	defer pgr.Stop()
 
-	diff.Diff(w, value1, value2)
+	diff.Diff(pgr.Writer, value1, value2)
 	return 0
 }

--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -5,13 +5,11 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
 	"io"
 	"math"
-	"os"
 	"strings"
 
 	"github.com/attic-labs/noms/cmd/noms/diff"
@@ -96,19 +94,11 @@ func runLog(args []string) int {
 		close(inChan)
 	}()
 
-	var w io.Writer
-	if pager := outputpager.NewOrNil(); pager != nil {
-		w = pager.Writer
-		defer pager.Stop()
-		go pager.RunAndExit()
-	} else {
-		bw := bufio.NewWriter(os.Stdout)
-		defer bw.Flush()
-		w = bw
-	}
+	pgr := outputpager.Start()
+	defer pgr.Stop()
 
 	for commitBuff := range outChan {
-		io.Copy(w, bytes.NewReader(commitBuff.([]byte)))
+		io.Copy(pgr.Writer, bytes.NewReader(commitBuff.([]byte)))
 	}
 	return 0
 }

--- a/cmd/noms/noms_show.go
+++ b/cmd/noms/noms_show.go
@@ -5,10 +5,8 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/attic-labs/noms/go/d"
@@ -42,18 +40,10 @@ func runShow(args []string) int {
 		return 0
 	}
 
-	var w io.Writer
-	if pager := outputpager.NewOrNil(); pager != nil {
-		w = pager.Writer
-		defer pager.Stop()
-		go pager.RunAndExit()
-	} else {
-		bw := bufio.NewWriter(os.Stdout)
-		defer bw.Flush()
-		w = bw
-	}
+	pgr := outputpager.Start()
+	defer pgr.Stop()
 
-	types.WriteEncodedValueWithTags(w, value)
-	w.Write([]byte{'\n'})
+	types.WriteEncodedValueWithTags(pgr.Writer, value)
+	fmt.Fprintln(pgr.Writer)
 	return 0
 }


### PR DESCRIPTION
This makes less exit properly - before, it wasn't properly restoring the
terminal sometimes, and keyboard input stopped working.
Fixes https://github.com/attic-labs/noms/issues/2180.
