### PR TITLE
Remove NewSerializer

### DIFF
--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -172,14 +172,12 @@ func handleGetRefs(w http.ResponseWriter, req *http.Request, ps URLParams, cs ch
 	writer := respWriter(req, w)
 	defer writer.Close()
 
-	sz := chunks.NewSerializer(writer)
 	for _, h := range hashes {
 		c := cs.Get(h)
 		if !c.IsEmpty() {
-			sz.Put(c)
+			chunks.Serialize(c, writer)
 		}
 	}
-	sz.Close()
 }
 
 func extractHashes(req *http.Request) hash.HashSlice {

--- a/samples/go/demo-server/web_server_test.go
+++ b/samples/go/demo-server/web_server_test.go
@@ -87,11 +87,9 @@ func TestWriteValue(t *testing.T) {
 	err = binary.Write(body, binary.BigEndian, uint32(0))
 	assert.NoError(err)
 
-	sz := chunks.NewSerializer(body)
-	sz.Put(chunk1)
-	sz.Put(chunk2)
-	sz.Put(chunk3)
-	sz.Close()
+	chunks.Serialize(chunk1, body)
+	chunks.Serialize(chunk2, body)
+	chunks.Serialize(chunk3, body)
 
 	w = httptest.NewRecorder()
 	r, err = newRequest("POST", dbName+constants.WriteValuePath+"?access_token="+authKey, ioutil.NopCloser(body))


### PR DESCRIPTION
NewSerializer spun up a goroutine within itself. We've decided
this is an anti-pattern. Furthermore, we were using this inside
our remote database handler code, and a panic inside that goroutine
could take down the server. The callsites now use Serialize() directly.

Fixes #2169
