### PR TITLE
Print percentages in diff summary

### DIFF
--- a/cmd/noms/diff/summary.go
+++ b/cmd/noms/diff/summary.go
@@ -172,5 +172,5 @@ func formatStatus(acc diffSummaryProgress, singular, plural string) {
 	oldValues := pluralize(singular, plural, acc.OldSize)
 	newValues := pluralize(singular, plural, acc.NewSize)
 
-	status.Printf("%s, %s, %s, (%s vs %s)", insertions, deletions, changes, oldValues, newValues)
+	status.Printf("%s (%.2f%%), %s (%.2f%%), %s (%.2f%%), (%s vs %s)", insertions, (float64(100*acc.Adds) / float64(acc.OldSize)), deletions, (float64(100*acc.Removes) / float64(acc.OldSize)), changes, (float64(100*acc.Changes) / float64(acc.OldSize)), oldValues, newValues)
 }

--- a/cmd/noms/noms_diff_test.go
+++ b/cmd/noms/noms_diff_test.go
@@ -59,7 +59,7 @@ func (s *nomsDiffTestSuite) TestNomsDiffSummarize() {
 
 	out, _ := s.Run(main, []string{"diff", "--summarize", r1, r2})
 	s.Contains(out, "Comparing commit values")
-	s.Contains(out, "1 insertion, 1 deletion, 0 changes, (1 value vs 1 value)")
+	s.Contains(out, "1 insertion (100.00%), 1 deletion (100.00%), 0 changes (0.00%), (1 value vs 1 value)")
 
 	out, _ = s.Run(main, []string{"diff", "--summarize", r1 + ".value", r2 + ".value"})
 	s.NotContains(out, "Comparing commit values")
@@ -73,5 +73,5 @@ func (s *nomsDiffTestSuite) TestNomsDiffSummarize() {
 	r4 := spec.CreateHashSpecString("ldb", s.LdbDir, ds.HeadRef().TargetHash()) + ".value"
 
 	out, _ = s.Run(main, []string{"diff", "--summarize", r3, r4})
-	s.Contains(out, "1 insertion, 2 deletions, 0 changes, (4 values vs 3 values)")
+	s.Contains(out, "1 insertion (25.00%), 2 deletions (50.00%), 0 changes (0.00%), (4 values vs 3 values)")
 }


### PR DESCRIPTION
For example:

```
0 insertions (0.00%), 5,405 deletions (0.28%), 45 changes (0.00%), (1,938,935 entries vs 1,933,530 entries)
```

Towards #2031
