### PR TITLE
Switch to gnuflag

### DIFF
--- a/cmd/noms-ui/noms_ui.go
+++ b/cmd/noms-ui/noms_ui.go
@@ -7,7 +7,6 @@ package main
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -21,6 +20,7 @@ import (
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/julienschmidt/httprouter"
+	flag "github.com/tsuru/gnuflag"
 )
 
 const (
@@ -45,7 +45,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	flag.Parse()
+	flag.Parse(true)
 	flag.Usage = usage
 
 	if len(flag.Args()) == 0 {

--- a/cmd/noms/noms.go
+++ b/cmd/noms/noms.go
@@ -5,9 +5,10 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
+
+	flag "github.com/tsuru/gnuflag"
 )
 
 var commands = []*nomsCommand{
@@ -22,7 +23,7 @@ var commands = []*nomsCommand{
 
 func main() {
 	flag.Usage = usage
-	flag.Parse()
+	flag.Parse(false)
 
 	args := flag.Args()
 	if len(args) < 1 {
@@ -40,7 +41,7 @@ func main() {
 			flags := cmd.Flags()
 			flags.Usage = cmd.Usage
 
-			flags.Parse(args[1:])
+			flags.Parse(true, args[1:])
 			args = flags.Args()
 			if cmd.Nargs != 0 && len(args) < cmd.Nargs {
 				cmd.Usage()

--- a/cmd/noms/noms_command.go
+++ b/cmd/noms/noms_command.go
@@ -5,10 +5,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
+
+	flag "github.com/tsuru/gnuflag"
 )
 
 type nomsCommand struct {

--- a/cmd/noms/noms_diff.go
+++ b/cmd/noms/noms_diff.go
@@ -5,20 +5,20 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/attic-labs/noms/cmd/noms/diff"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/util/outputpager"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var summarize bool
 
 var nomsDiff = &nomsCommand{
 	Run:       runDiff,
-	UsageLine: "diff [-summarize] <object1> <object2>",
+	UsageLine: "diff [--summarize] <object1> <object2>",
 	Short:     "Shows the difference between two objects",
 	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object arguments.",
 	Flags:     setupDiffFlags,

--- a/cmd/noms/noms_ds.go
+++ b/cmd/noms/noms_ds.go
@@ -5,12 +5,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/types"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var toDelete string

--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -20,6 +19,7 @@ import (
 	"github.com/attic-labs/noms/go/util/orderedparallel"
 	"github.com/attic-labs/noms/go/util/outputpager"
 	"github.com/mgutz/ansi"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (

--- a/cmd/noms/noms_log_test.go
+++ b/cmd/noms/noms_log_test.go
@@ -102,17 +102,17 @@ func (s *nomsLogTestSuite) TestNArg() {
 	db.Close()
 
 	dsSpec := spec.CreateValueSpecString("ldb", s.LdbDir, dsName)
-	res, _ := s.Run(main, []string{"log", "-n=1", dsSpec})
+	res, _ := s.Run(main, []string{"log", "-n1", dsSpec})
 	s.NotContains(res, h1.String())
-	res, _ = s.Run(main, []string{"log", "-n=0", dsSpec})
+	res, _ = s.Run(main, []string{"log", "-n0", dsSpec})
 	s.Contains(res, h3.String())
 	s.Contains(res, h2.String())
 	s.Contains(res, h1.String())
 
 	vSpec := spec.CreateValueSpecString("ldb", s.LdbDir, "#"+h3.String())
-	res, _ = s.Run(main, []string{"log", "-n=1", vSpec})
+	res, _ = s.Run(main, []string{"log", "-n1", vSpec})
 	s.NotContains(res, h1.String())
-	res, _ = s.Run(main, []string{"log", "-n=0", vSpec})
+	res, _ = s.Run(main, []string{"log", "-n0", vSpec})
 	s.Contains(res, h3.String())
 	s.Contains(res, h2.String())
 	s.Contains(res, h1.String())
@@ -165,9 +165,9 @@ func (s *nomsLogTestSuite) TestNomsGraph1() {
 	s.NoError(err)
 
 	b1.Database().Close()
-	res, _ := s.Run(main, []string{"log", "-graph", "-show-value=true", spec.CreateValueSpecString("ldb", s.LdbDir, "b1")})
+	res, _ := s.Run(main, []string{"log", "--graph", "--show-value=true", spec.CreateValueSpecString("ldb", s.LdbDir, "b1")})
 	s.Equal(graphRes1, res)
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=false", spec.CreateValueSpecString("ldb", s.LdbDir, "b1")})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=false", spec.CreateValueSpecString("ldb", s.LdbDir, "b1")})
 	s.Equal(diffRes1, res)
 }
 
@@ -197,9 +197,9 @@ func (s *nomsLogTestSuite) TestNomsGraph2() {
 
 	db.Close()
 
-	res, _ := s.Run(main, []string{"log", "-graph", "-show-value=true", spec.CreateValueSpecString("ldb", s.LdbDir, "ba")})
+	res, _ := s.Run(main, []string{"log", "--graph", "--show-value=true", spec.CreateValueSpecString("ldb", s.LdbDir, "ba")})
 	s.Equal(graphRes2, res)
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=false", spec.CreateValueSpecString("ldb", s.LdbDir, "ba")})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=false", spec.CreateValueSpecString("ldb", s.LdbDir, "ba")})
 	s.Equal(diffRes2, res)
 }
 
@@ -238,9 +238,9 @@ func (s *nomsLogTestSuite) TestNomsGraph3() {
 	s.NoError(err)
 
 	db.Close()
-	res, _ := s.Run(main, []string{"log", "-graph", "-show-value=true", spec.CreateValueSpecString("ldb", s.LdbDir, "w")})
+	res, _ := s.Run(main, []string{"log", "--graph", "--show-value=true", spec.CreateValueSpecString("ldb", s.LdbDir, "w")})
 	test.EqualsIgnoreHashes(s.T(), graphRes3, res)
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=false", spec.CreateValueSpecString("ldb", s.LdbDir, "w")})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=false", spec.CreateValueSpecString("ldb", s.LdbDir, "w")})
 	test.EqualsIgnoreHashes(s.T(), diffRes3, res)
 }
 
@@ -268,19 +268,19 @@ func (s *nomsLogTestSuite) TestTruncation() {
 	db.Close()
 
 	dsSpec := spec.CreateValueSpecString("ldb", s.LdbDir, "truncate")
-	res, _ := s.Run(main, []string{"log", "-graph", "-show-value=true", dsSpec})
+	res, _ := s.Run(main, []string{"log", "--graph", "--show-value=true", dsSpec})
 	test.EqualsIgnoreHashes(s.T(), truncRes1, res)
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=false", dsSpec})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=false", dsSpec})
 	test.EqualsIgnoreHashes(s.T(), diffTrunc1, res)
 
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=true", "-max-lines=-1", dsSpec})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=true", "--max-lines=-1", dsSpec})
 	test.EqualsIgnoreHashes(s.T(), truncRes2, res)
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=false", "-max-lines=-1", dsSpec})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=false", "--max-lines=-1", dsSpec})
 	test.EqualsIgnoreHashes(s.T(), diffTrunc2, res)
 
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=true", "-max-lines=0", dsSpec})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=true", "--max-lines=0", dsSpec})
 	test.EqualsIgnoreHashes(s.T(), truncRes3, res)
-	res, _ = s.Run(main, []string{"log", "-graph", "-show-value=false", "-max-lines=0", dsSpec})
+	res, _ = s.Run(main, []string{"log", "--graph", "--show-value=false", "--max-lines=0", dsSpec})
 	test.EqualsIgnoreHashes(s.T(), diffTrunc3, res)
 }
 

--- a/cmd/noms/noms_serve.go
+++ b/cmd/noms/noms_serve.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,6 +13,7 @@ import (
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/util/profile"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (

--- a/cmd/noms/noms_show.go
+++ b/cmd/noms/noms_show.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/outputpager"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var nomsShow = &nomsCommand{

--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/go/util/status"
 	humanize "github.com/dustin/go-humanize"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (

--- a/cmd/noms/noms_version.go
+++ b/cmd/noms/noms_version.go
@@ -5,11 +5,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	"github.com/attic-labs/noms/go/constants"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var nomsVersion = &nomsCommand{

--- a/go/chunks/dynamo_store.go
+++ b/go/chunks/dynamo_store.go
@@ -7,7 +7,6 @@ package chunks
 import (
 	"bytes"
 	"compress/gzip"
-	"flag"
 	"fmt"
 	"io"
 	"sync"
@@ -21,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	flag "github.com/tsuru/gnuflag"
 )
 
 const (

--- a/go/chunks/leveldb_store.go
+++ b/go/chunks/leveldb_store.go
@@ -5,7 +5,6 @@
 package chunks
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"sync"
@@ -18,6 +17,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	flag "github.com/tsuru/gnuflag"
 )
 
 const (

--- a/go/d/check_error.go
+++ b/go/d/check_error.go
@@ -5,9 +5,10 @@
 package d
 
 import (
-	"flag"
 	"fmt"
 	"os"
+
+	flag "github.com/tsuru/gnuflag"
 )
 
 type Exiter interface {

--- a/go/perf/codec-perf-rig/main.go
+++ b/go/perf/codec-perf-rig/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/attic-labs/noms/go/dataset"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/profile"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (
@@ -33,7 +33,7 @@ const structSize = uint64(64)
 
 func main() {
 	profile.RegisterProfileFlags(flag.CommandLine)
-	flag.Parse()
+	flag.Parse(true)
 
 	buildCount := *count
 	insertCount := buildCount / 50

--- a/go/perf/encode-perf-rig/main.go
+++ b/go/perf/encode-perf-rig/main.go
@@ -6,13 +6,13 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"math/big"
 	"os"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	flag "github.com/tsuru/gnuflag"
 )
 
 // used to ensure all of the big.Floats end up with the same precision
@@ -70,7 +70,7 @@ func main() {
 	nBy := flag.Uint64("by", 1, "increment each iteration by this number")
 	nIncrements := flag.Uint64("iterations", 0, "number of iterations to execute")
 	encodingType := flag.String("encoding", "string", "encode/decode as 'string', 'binary', 'binary-int', 'binary-varint'")
-	flag.Parse()
+	flag.Parse(true)
 
 	flag.Usage = func() {
 		fmt.Printf("%s\n", os.Args[0])

--- a/go/perf/hash-perf-rig/main.go
+++ b/go/perf/hash-perf-rig/main.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
-	"flag"
 	"fmt"
 	"hash"
 	"io"
@@ -18,12 +17,13 @@ import (
 	"github.com/codahale/blake2"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/kch42/buzhash"
+	flag "github.com/tsuru/gnuflag"
 )
 
 func main() {
 	useSHA := flag.String("use-sha", "", "<default>=no hashing, 1=sha1, 256=sha256, 512=sha512, blake=blake2b")
 	useBH := flag.Bool("use-bh", false, "whether we buzhash the bytes")
-	flag.Parse()
+	flag.Parse(true)
 
 	flag.Usage = func() {
 		fmt.Printf("%s <big-file>\n", os.Args[0])

--- a/go/spec/dataspec.go
+++ b/go/spec/dataspec.go
@@ -5,7 +5,6 @@
 package spec
 
 import (
-	"flag"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -17,6 +16,7 @@ import (
 	"github.com/attic-labs/noms/go/dataset"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (

--- a/go/util/clienttest/client_test_suite.go
+++ b/go/util/clienttest/client_test_suite.go
@@ -5,13 +5,13 @@
 package clienttest
 
 import (
-	"flag"
 	"io/ioutil"
 	"os"
 	"path"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/testify/suite"
+	flag "github.com/tsuru/gnuflag"
 )
 
 type ClientTestSuite struct {

--- a/go/util/outputpager/page_output.go
+++ b/go/util/outputpager/page_output.go
@@ -5,7 +5,6 @@
 package outputpager
 
 import (
-	"flag"
 	"io"
 	"os"
 	"os/exec"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	goisatty "github.com/mattn/go-isatty"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (

--- a/go/util/profile/profile.go
+++ b/go/util/profile/profile.go
@@ -5,13 +5,13 @@
 package profile
 
 import (
-	"flag"
 	"io"
 	"os"
 	"runtime"
 	"runtime/pprof"
 
 	"github.com/attic-labs/noms/go/d"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (

--- a/samples/go/blob-get/blob_get.go
+++ b/samples/go/blob-get/blob_get.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"github.com/attic-labs/noms/go/util/progressreader"
 	"github.com/attic-labs/noms/go/util/status"
 	humanize "github.com/dustin/go-humanize"
+	flag "github.com/tsuru/gnuflag"
 )
 
 func main() {
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	spec.RegisterDatabaseFlags(flag.CommandLine)
-	flag.Parse()
+	flag.Parse(true)
 
 	if len(flag.Args()) != 2 {
 		d.CheckError(errors.New("expected dataset and file flags"))

--- a/samples/go/counter/counter.go
+++ b/samples/go/counter/counter.go
@@ -5,12 +5,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/types"
+	flag "github.com/tsuru/gnuflag"
 )
 
 func main() {
@@ -21,7 +21,7 @@ func main() {
 
 	spec.RegisterDatabaseFlags(flag.CommandLine)
 
-	flag.Parse()
+	flag.Parse(true)
 
 	if flag.NArg() != 1 {
 		fmt.Fprintln(os.Stderr, "Missing required dataset argument")

--- a/samples/go/csv/csv-export/exporter.go
+++ b/samples/go/csv/csv-export/exporter.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 
@@ -14,15 +13,14 @@ import (
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/samples/go/csv"
-)
-
-var (
-	// Actually the delimiter uses runes, which can be multiple characters long.
-	// https://blog.golang.org/strings
-	delimiter = flag.String("delimiter", ",", "field delimiter for csv file, must be exactly one character long.")
+	flag "github.com/tsuru/gnuflag"
 )
 
 func main() {
+	// Actually the delimiter uses runes, which can be multiple characters long.
+	// https://blog.golang.org/strings
+	delimiter := flag.String("delimiter", ",", "field delimiter for csv file, must be exactly one character long.")
+
 	spec.RegisterDatabaseFlags(flag.CommandLine)
 	profile.RegisterProfileFlags(flag.CommandLine)
 
@@ -31,7 +29,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	flag.Parse()
+	flag.Parse(true)
 
 	if flag.NArg() != 1 {
 		d.CheckError(errors.New("expected dataset arg"))

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -23,8 +22,8 @@ import (
 	"github.com/attic-labs/noms/go/util/progressreader"
 	"github.com/attic-labs/noms/go/util/status"
 	"github.com/attic-labs/noms/samples/go/csv"
-
 	humanize "github.com/dustin/go-humanize"
+	flag "github.com/tsuru/gnuflag"
 )
 
 const (
@@ -34,21 +33,21 @@ const (
 )
 
 func main() {
-	var (
-		// Actually the delimiter uses runes, which can be multiple characters long.
-		// https://blog.golang.org/strings
-		delimiter       = flag.String("delimiter", ",", "field delimiter for csv file, must be exactly one character long.")
-		comment         = flag.String("comment", "", "comment to add to commit's meta data")
-		header          = flag.String("header", "", "header row. If empty, we'll use the first row of the file")
-		name            = flag.String("name", "Row", "struct name. The user-visible name to give to the struct type that will hold each row of data.")
-		columnTypes     = flag.String("column-types", "", "a comma-separated list of types representing the desired type of each column. if absent all types default to be String")
-		path            = flag.String("p", "", "noms path to blob to import")
-		dateFlag        = flag.String("date", "", fmt.Sprintf(`date of commit in ISO 8601 format ("%s"). By default, the current date is used.`, dateFormat))
-		noProgress      = flag.Bool("no-progress", false, "prevents progress from being output if true")
-		destType        = flag.String("dest-type", "list", "the destination type to import to. can be 'list' or 'map:<pk>', where <pk> is the index position (0-based) of the column that is a the unique identifier for the column")
-		skipRecords     = flag.Uint("skip-records", 0, "number of records to skip at beginning of file")
-		destTypePattern = regexp.MustCompile("^(list|map):(\\d+)$")
-	)
+	// Actually the delimiter uses runes, which can be multiple characters long.
+	// https://blog.golang.org/strings
+	delimiter := flag.String("delimiter", ",", "field delimiter for csv file, must be exactly one character long.")
+	comment := flag.String("comment", "", "comment to add to commit's meta data")
+	header := flag.String("header", "", "header row. If empty, we'll use the first row of the file")
+	name := flag.String("name", "Row", "struct name. The user-visible name to give to the struct type that will hold each row of data.")
+	columnTypes := flag.String("column-types", "", "a comma-separated list of types representing the desired type of each column. if absent all types default to be String")
+	pathDescription := "noms path to blob to import"
+	path := flag.String("path", "", pathDescription)
+	flag.StringVar(path, "p", "", pathDescription)
+	dateFlag := flag.String("date", "", fmt.Sprintf(`date of commit in ISO 8601 format ("%s"). By default, the current date is used.`, dateFormat))
+	noProgress := flag.Bool("no-progress", false, "prevents progress from being output if true")
+	destType := flag.String("dest-type", "list", "the destination type to import to. can be 'list' or 'map:<pk>', where <pk> is the index position (0-based) of the column that is a the unique identifier for the column")
+	skipRecords := flag.Uint("skip-records", 0, "number of records to skip at beginning of file")
+	destTypePattern := regexp.MustCompile("^(list|map):(\\d+)$")
 
 	spec.RegisterDatabaseFlags(flag.CommandLine)
 	profile.RegisterProfileFlags(flag.CommandLine)
@@ -58,7 +57,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	flag.Parse()
+	flag.Parse(true)
 
 	var err error
 	switch {

--- a/samples/go/demo-server/main.go
+++ b/samples/go/demo-server/main.go
@@ -5,10 +5,10 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/attic-labs/noms/go/chunks"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (
@@ -27,7 +27,7 @@ func main() {
 	dynFlags := chunks.DynamoFlags("")
 
 	flag.Usage = usage
-	flag.Parse()
+	flag.Parse(true)
 
 	if *portFlag == 0 || *authKeyFlag == "" {
 		usage()

--- a/samples/go/hr/main.go
+++ b/samples/go/hr/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 	"github.com/attic-labs/noms/go/dataset"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/types"
+	flag "github.com/tsuru/gnuflag"
 )
 
 func main() {
@@ -27,7 +27,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\tlist-persons")
 	}
 
-	flag.Parse()
+	flag.Parse(true)
 
 	if flag.NArg() == 0 {
 		fmt.Fprintln(os.Stderr, "Not enough arguments")
@@ -35,7 +35,7 @@ func main() {
 	}
 
 	if *dsStr == "" {
-		fmt.Fprintln(os.Stderr, "Required flag '-ds' not set")
+		fmt.Fprintln(os.Stderr, "Required flag '--ds' not set")
 		return
 	}
 

--- a/samples/go/hr/main_test.go
+++ b/samples/go/hr/main_test.go
@@ -26,19 +26,19 @@ type testSuite struct {
 
 func (s *testSuite) TestRoundTrip() {
 	spec := fmt.Sprintf("ldb:%s::hr", s.LdbDir)
-	stdout, stderr := s.Run(main, []string{"-ds", spec, "list-persons"})
+	stdout, stderr := s.Run(main, []string{"--ds", spec, "list-persons"})
 	s.Equal("No people found\n", stdout)
 	s.Equal("", stderr)
 
-	stdout, stderr = s.Run(main, []string{"-ds", spec, "add-person", "42", "Benjamin Kalman", "Programmer, Barista"})
+	stdout, stderr = s.Run(main, []string{"--ds", spec, "add-person", "42", "Benjamin Kalman", "Programmer, Barista"})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
-	stdout, stderr = s.Run(main, []string{"-ds", spec, "add-person", "43", "Abigail Boodman", "Chief Architect"})
+	stdout, stderr = s.Run(main, []string{"--ds", spec, "add-person", "43", "Abigail Boodman", "Chief Architect"})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
-	stdout, stderr = s.Run(main, []string{"-ds", spec, "list-persons"})
+	stdout, stderr = s.Run(main, []string{"--ds", spec, "list-persons"})
 	s.Equal(`Benjamin Kalman (id: 42, title: Programmer, Barista)
 Abigail Boodman (id: 43, title: Chief Architect)
 `, stdout)
@@ -54,7 +54,7 @@ func (s *testSuite) TestReadCanned() {
 	// Have to copy the canned data elsewhere because just reading the database modifies it.
 	_, err = exec.Command("cp", "-r", p, dst).Output()
 	s.NoError(err)
-	stdout, stderr := s.Run(main, []string{"-ds", fmt.Sprintf("ldb:%s/test-data::hr", dst), "list-persons"})
+	stdout, stderr := s.Run(main, []string{"--ds", fmt.Sprintf("ldb:%s/test-data::hr", dst), "list-persons"})
 	s.Equal(`Aaron Boodman (id: 7, title: Chief Evangelism Officer)
 Samuel Boodman (id: 13, title: VP, Culture)
 `, stdout)
@@ -63,5 +63,5 @@ Samuel Boodman (id: 13, title: VP, Culture)
 
 func (s *testSuite) TestInvalidDatasetSpec() {
 	// Should not crash
-	_, _ = s.Run(main, []string{"-ds", "invalid-dataset", "list-persons"})
+	_, _ = s.Run(main, []string{"--ds", "invalid-dataset", "list-persons"})
 }

--- a/samples/go/json-import/json_importer.go
+++ b/samples/go/json-import/json_importer.go
@@ -7,7 +7,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/util/jsontonoms"
+	flag "github.com/tsuru/gnuflag"
 )
 
 func main() {
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	spec.RegisterDatabaseFlags(flag.CommandLine)
-	flag.Parse()
+	flag.Parse(true)
 
 	if len(flag.Args()) != 2 {
 		d.CheckError(errors.New("expected url and dataset flags"))

--- a/samples/go/url-fetch/fetch.go
+++ b/samples/go/url-fetch/fetch.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +21,7 @@ import (
 	"github.com/attic-labs/noms/go/util/progressreader"
 	"github.com/attic-labs/noms/go/util/status"
 	human "github.com/dustin/go-humanize"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (
@@ -36,7 +36,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\nUsage: %s <dataset> <url-or-local-path>:\n", os.Args[0])
 		flag.PrintDefaults()
 	}
-	flag.Parse()
+	flag.Parse(true)
 
 	if flag.NArg() != 2 {
 		d.CheckErrorNoUsage(errors.New("expected dataset and url arguments"))

--- a/samples/go/xml-import/xml_importer.go
+++ b/samples/go/xml-import/xml_importer.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -21,6 +20,7 @@ import (
 	"github.com/attic-labs/noms/go/util/jsontonoms"
 	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/clbanning/mxj"
+	flag "github.com/tsuru/gnuflag"
 )
 
 var (
@@ -54,7 +54,7 @@ func main() {
 		spec.RegisterDatabaseFlags(flag.CommandLine)
 		profile.RegisterProfileFlags(flag.CommandLine)
 		flag.Usage = customUsage
-		flag.Parse()
+		flag.Parse(true)
 
 		if flag.NArg() != 2 {
 			d.CheckError(errors.New("Expected dataset followed by directory path"))

--- a/tools/run_all_build.go
+++ b/tools/run_all_build.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/tools/runner"
+	flag "github.com/tsuru/gnuflag"
 )
 
 const (
@@ -27,7 +27,7 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n  %s path/to/staging/dir\n", os.Args[0], os.Args[0])
 	}
-	flag.Parse()
+	flag.Parse(true)
 	if flag.Arg(0) == "" {
 		flag.Usage()
 		os.Exit(1)

--- a/vendor/github.com/tsuru/gnuflag/.version
+++ b/vendor/github.com/tsuru/gnuflag/.version
@@ -1,0 +1,2 @@
+https://github.com/tsuru/gnuflag
+86b8c1b864aadcf9c94d67bc607ce3f19cbb9aa2

--- a/vendor/github.com/tsuru/gnuflag/LICENSE
+++ b/vendor/github.com/tsuru/gnuflag/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/tsuru/gnuflag/export_test.go
+++ b/vendor/github.com/tsuru/gnuflag/export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gnuflag
+
+import (
+	"os"
+)
+
+// Additional routines compiled into the package only during testing.
+
+// ResetForTesting clears all flag state and sets the usage function as directed.
+// After calling ResetForTesting, parse errors in flag handling will not
+// exit the program.
+func ResetForTesting(usage func()) {
+	CommandLine = NewFlagSet(os.Args[0], ContinueOnError)
+	Usage = usage
+}

--- a/vendor/github.com/tsuru/gnuflag/flag.go
+++ b/vendor/github.com/tsuru/gnuflag/flag.go
@@ -1,0 +1,936 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+	Package flag implements command-line flag parsing in the GNU style.
+	It is almost exactly the same as the standard flag package,
+	the only difference being the extra argument to Parse.
+
+	Command line flag syntax:
+		-f		// single letter flag
+		-fg		// two single letter flags together
+		--flag	// multiple letter flag
+		--flag x  // non-boolean flags only
+		-f x		// non-boolean flags only
+		-fx		// if f is a non-boolean flag, x is its argument.
+
+	The last three forms are not permitted for boolean flags because the
+	meaning of the command
+		cmd -f *
+	will change if there is a file called 0, false, etc.  There is currently
+	no way to turn off a boolean flag.
+
+	Flag parsing stops after the terminator "--", or just before the first
+	non-flag argument ("-" is a non-flag argument) if the interspersed
+	argument to Parse is false.
+*/
+package gnuflag
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ErrHelp is the error returned if the -help or -h flag is invoked
+// but no such flag is defined.
+var ErrHelp = errors.New("flag: help requested")
+
+// -- bool Value
+type boolValue bool
+
+func newBoolValue(val bool, p *bool) *boolValue {
+	*p = val
+	return (*boolValue)(p)
+}
+
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b = boolValue(v)
+	return err
+}
+
+func (b *boolValue) Get() interface{} { return bool(*b) }
+
+func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+
+func (b *boolValue) IsBoolFlag() bool { return true }
+
+// optional interface to indicate boolean flags that can be
+// supplied without "=value" text
+type boolFlag interface {
+	Value
+	IsBoolFlag() bool
+}
+
+// -- int Value
+type intValue int
+
+func newIntValue(val int, p *int) *intValue {
+	*p = val
+	return (*intValue)(p)
+}
+
+func (i *intValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = intValue(v)
+	return err
+}
+
+func (i *intValue) Get() interface{} { return int(*i) }
+
+func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- int64 Value
+type int64Value int64
+
+func newInt64Value(val int64, p *int64) *int64Value {
+	*p = val
+	return (*int64Value)(p)
+}
+
+func (i *int64Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int64Value(v)
+	return err
+}
+
+func (i *int64Value) Get() interface{} { return int64(*i) }
+
+func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- uint Value
+type uintValue uint
+
+func newUintValue(val uint, p *uint) *uintValue {
+	*p = val
+	return (*uintValue)(p)
+}
+
+func (i *uintValue) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uintValue(v)
+	return err
+}
+
+func (i *uintValue) Get() interface{} { return uint(*i) }
+
+func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- uint64 Value
+type uint64Value uint64
+
+func newUint64Value(val uint64, p *uint64) *uint64Value {
+	*p = val
+	return (*uint64Value)(p)
+}
+
+func (i *uint64Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uint64Value(v)
+	return err
+}
+
+func (i *uint64Value) Get() interface{} { return uint64(*i) }
+
+func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- string Value
+type stringValue string
+
+func newStringValue(val string, p *string) *stringValue {
+	*p = val
+	return (*stringValue)(p)
+}
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+
+func (s *stringValue) Get() interface{} { return string(*s) }
+
+func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+
+// -- float64 Value
+type float64Value float64
+
+func newFloat64Value(val float64, p *float64) *float64Value {
+	*p = val
+	return (*float64Value)(p)
+}
+
+func (f *float64Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = float64Value(v)
+	return err
+}
+
+func (f *float64Value) Get() interface{} { return float64(*f) }
+
+func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+
+// -- time.Duration Value
+type durationValue time.Duration
+
+func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+	*p = val
+	return (*durationValue)(p)
+}
+
+func (d *durationValue) Set(s string) error {
+	v, err := time.ParseDuration(s)
+	*d = durationValue(v)
+	return err
+}
+
+func (d *durationValue) Get() interface{} { return time.Duration(*d) }
+
+func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+
+// Value is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+type Value interface {
+	String() string
+	Set(string) error
+}
+
+// Getter is an interface that allows the contents of a Value to be retrieved.
+// It wraps the Value interface, rather than being part of it, because it
+// appeared after Go 1 and its compatibility rules. All Value types provided
+// by this package satisfy the Getter interface.
+type Getter interface {
+	Value
+	Get() interface{}
+}
+
+// ErrorHandling defines how to handle flag parsing errors.
+type ErrorHandling int
+
+const (
+	ContinueOnError ErrorHandling = iota
+	ExitOnError
+	PanicOnError
+)
+
+// A FlagSet represents a set of defined flags.
+type FlagSet struct {
+	// Usage is the function called when an error occurs while parsing flags.
+	// The field is a function (not a method) that may be changed to point to
+	// a custom error handler.
+	Usage func()
+
+	name             string
+	parsed           bool
+	actual           map[string]*Flag
+	formal           map[string]*Flag
+	args             []string // arguments after flags
+	procArgs         []string // arguments being processed (gnu only)
+	procFlag         string   // flag being processed (gnu only)
+	allowIntersperse bool     // (gnu only)
+	exitOnError      bool     // does the program exit if there's an error?
+	errorHandling    ErrorHandling
+	output           io.Writer // nil means stderr; use out() accessor
+}
+
+// A Flag represents the state of a flag.
+type Flag struct {
+	Name     string // name as it appears on command line
+	Usage    string // help message
+	Value    Value  // value as set
+	DefValue string // default value (as text); for usage message
+}
+
+// sortFlags returns the flags as a slice in lexicographical sorted order.
+func sortFlags(flags map[string]*Flag) []*Flag {
+	list := make(sort.StringSlice, len(flags))
+	i := 0
+	for _, f := range flags {
+		list[i] = f.Name
+		i++
+	}
+	list.Sort()
+	result := make([]*Flag, len(list))
+	for i, name := range list {
+		result[i] = flags[name]
+	}
+	return result
+}
+
+func (f *FlagSet) out() io.Writer {
+	if f.output == nil {
+		return os.Stderr
+	}
+	return f.output
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (f *FlagSet) SetOutput(output io.Writer) {
+	f.output = output
+}
+
+// VisitAll visits the flags in lexicographical order, calling fn for each.
+// It visits all flags, even those not set.
+func (f *FlagSet) VisitAll(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.formal) {
+		fn(flag)
+	}
+}
+
+// VisitAll visits the command-line flags in lexicographical order, calling
+// fn for each.  It visits all flags, even those not set.
+func VisitAll(fn func(*Flag)) {
+	CommandLine.VisitAll(fn)
+}
+
+// Visit visits the flags in lexicographical order, calling fn for each.
+// It visits only those flags that have been set.
+func (f *FlagSet) Visit(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.actual) {
+		fn(flag)
+	}
+}
+
+// Visit visits the command-line flags in lexicographical order, calling fn
+// for each.  It visits only those flags that have been set.
+func Visit(fn func(*Flag)) {
+	CommandLine.Visit(fn)
+}
+
+// Lookup returns the Flag structure of the named flag, returning nil if none exists.
+func (f *FlagSet) Lookup(name string) *Flag {
+	return f.formal[name]
+}
+
+// Lookup returns the Flag structure of the named command-line flag,
+// returning nil if none exists.
+func Lookup(name string) *Flag {
+	return CommandLine.formal[name]
+}
+
+// Set sets the value of the named flag.
+func (f *FlagSet) Set(name, value string) error {
+	flag, ok := f.formal[name]
+	if !ok {
+		return fmt.Errorf("no such flag -%v", name)
+	}
+	err := flag.Value.Set(value)
+	if err != nil {
+		return err
+	}
+	if f.actual == nil {
+		f.actual = make(map[string]*Flag)
+	}
+	f.actual[name] = flag
+	return nil
+}
+
+// Set sets the value of the named command-line flag.
+func Set(name, value string) error {
+	return CommandLine.Set(name, value)
+}
+
+// flagsByLength is a slice of flags implementing sort.Interface,
+// sorting primarily by the length of the flag, and secondarily
+// alphabetically.
+type flagsByLength []*Flag
+
+func (f flagsByLength) Less(i, j int) bool {
+	s1, s2 := f[i].Name, f[j].Name
+	if len(s1) != len(s2) {
+		return len(s1) < len(s2)
+	}
+	return s1 < s2
+}
+func (f flagsByLength) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f flagsByLength) Len() int {
+	return len(f)
+}
+
+// flagsByName is a slice of slices of flags implementing sort.Interface,
+// alphabetically sorting by the name of the first flag in each slice.
+type flagsByName [][]*Flag
+
+func (f flagsByName) Less(i, j int) bool {
+	return f[i][0].Name < f[j][0].Name
+}
+func (f flagsByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f flagsByName) Len() int {
+	return len(f)
+}
+
+// PrintDefaults prints, to standard error unless configured
+// otherwise, the default values of all defined flags in the set.
+// If there is more than one name for a given flag, the usage information and
+// default value from the shortest will be printed (or the least alphabetically
+// if there are several equally short flag names).
+func (f *FlagSet) PrintDefaults() {
+	// group together all flags for a given value
+	flags := make(map[interface{}]flagsByLength)
+	f.VisitAll(func(f *Flag) {
+		flags[f.Value] = append(flags[f.Value], f)
+	})
+
+	// sort the output flags by shortest name for each group.
+	var byName flagsByName
+	for _, f := range flags {
+		sort.Sort(f)
+		byName = append(byName, f)
+	}
+	sort.Sort(byName)
+
+	var line bytes.Buffer
+	for _, fs := range byName {
+		line.Reset()
+		for i, f := range fs {
+			if i > 0 {
+				line.WriteString(", ")
+			}
+			line.WriteString(flagWithMinus(f.Name))
+		}
+		format := "%s  (= %s)\n    %s\n"
+		if _, ok := fs[0].Value.(*stringValue); ok {
+			// put quotes on the value
+			format = "%s (= %q)\n    %s\n"
+		}
+		fmt.Fprintf(f.out(), format, line.Bytes(), fs[0].DefValue, fs[0].Usage)
+	}
+}
+
+// PrintDefaults prints to standard error the default values of all defined command-line flags.
+func PrintDefaults() {
+	CommandLine.PrintDefaults()
+}
+
+// defaultUsage is the default function to print a usage message.
+func defaultUsage(f *FlagSet) {
+	if f.name == "" {
+		fmt.Fprintf(f.out(), "Usage:\n")
+	} else {
+		fmt.Fprintf(f.out(), "Usage of %s:\n", f.name)
+	}
+	f.PrintDefaults()
+}
+
+// NOTE: Usage is not just defaultUsage(CommandLine)
+// because it serves (via godoc flag Usage) as the example
+// for how to write your own usage function.
+
+// Usage prints to standard error a usage message documenting all defined command-line flags.
+// The function is a variable that may be changed to point to a custom function.
+var Usage = func() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	PrintDefaults()
+}
+
+// NFlag returns the number of flags that have been set.
+func (f *FlagSet) NFlag() int { return len(f.actual) }
+
+// NFlag returns the number of command-line flags that have been set.
+func NFlag() int { return len(CommandLine.actual) }
+
+// Arg returns the i'th argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func (f *FlagSet) Arg(i int) string {
+	if i < 0 || i >= len(f.args) {
+		return ""
+	}
+	return f.args[i]
+}
+
+// Arg returns the i'th command-line argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func Arg(i int) string {
+	return CommandLine.Arg(i)
+}
+
+// NArg is the number of arguments remaining after flags have been processed.
+func (f *FlagSet) NArg() int { return len(f.args) }
+
+// NArg is the number of arguments remaining after flags have been processed.
+func NArg() int { return len(CommandLine.args) }
+
+// Args returns the non-flag arguments.
+func (f *FlagSet) Args() []string { return f.args }
+
+// Args returns the non-flag command-line arguments.
+func Args() []string { return CommandLine.args }
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
+	f.Var(newBoolValue(value, p), name, usage)
+}
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func BoolVar(p *bool, name string, value bool, usage string) {
+	CommandLine.Var(newBoolValue(value, p), name, usage)
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVar(p, name, value, usage)
+	return p
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func Bool(name string, value bool, usage string) *bool {
+	return CommandLine.Bool(name, value, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
+	f.Var(newIntValue(value, p), name, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func IntVar(p *int, name string, value int, usage string) {
+	CommandLine.Var(newIntValue(value, p), name, usage)
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func (f *FlagSet) Int(name string, value int, usage string) *int {
+	p := new(int)
+	f.IntVar(p, name, value, usage)
+	return p
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func Int(name string, value int, usage string) *int {
+	return CommandLine.Int(name, value, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
+	f.Var(newInt64Value(value, p), name, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func Int64Var(p *int64, name string, value int64, usage string) {
+	CommandLine.Var(newInt64Value(value, p), name, usage)
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func (f *FlagSet) Int64(name string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64Var(p, name, value, usage)
+	return p
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func Int64(name string, value int64, usage string) *int64 {
+	return CommandLine.Int64(name, value, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
+	f.Var(newUintValue(value, p), name, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func UintVar(p *uint, name string, value uint, usage string) {
+	CommandLine.Var(newUintValue(value, p), name, usage)
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVar(p, name, value, usage)
+	return p
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint(name string, value uint, usage string) *uint {
+	return CommandLine.Uint(name, value, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
+	f.Var(newUint64Value(value, p), name, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func Uint64Var(p *uint64, name string, value uint64, usage string) {
+	CommandLine.Var(newUint64Value(value, p), name, usage)
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func (f *FlagSet) Uint64(name string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64Var(p, name, value, usage)
+	return p
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func Uint64(name string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64(name, value, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
+	f.Var(newStringValue(value, p), name, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func StringVar(p *string, name string, value string, usage string) {
+	CommandLine.Var(newStringValue(value, p), name, usage)
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func (f *FlagSet) String(name string, value string, usage string) *string {
+	p := new(string)
+	f.StringVar(p, name, value, usage)
+	return p
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func String(name string, value string, usage string) *string {
+	return CommandLine.String(name, value, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
+	f.Var(newFloat64Value(value, p), name, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func Float64Var(p *float64, name string, value float64, usage string) {
+	CommandLine.Var(newFloat64Value(value, p), name, usage)
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func (f *FlagSet) Float64(name string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64Var(p, name, value, usage)
+	return p
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func Float64(name string, value float64, usage string) *float64 {
+	return CommandLine.Float64(name, value, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	f.Var(newDurationValue(value, p), name, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	CommandLine.Var(newDurationValue(value, p), name, usage)
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func (f *FlagSet) Duration(name string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVar(p, name, value, usage)
+	return p
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func Duration(name string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.Duration(name, value, usage)
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func (f *FlagSet) Var(value Value, name string, usage string) {
+	// Remember the default value as a string; it won't change.
+	flag := &Flag{name, usage, value, value.String()}
+	_, alreadythere := f.formal[name]
+	if alreadythere {
+		fmt.Fprintf(f.out(), "%s flag redefined: %s\n", f.name, name)
+		panic("flag redefinition") // Happens only if flags are declared with identical names
+	}
+	if f.formal == nil {
+		f.formal = make(map[string]*Flag)
+	}
+	f.formal[name] = flag
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func Var(value Value, name string, usage string) {
+	CommandLine.Var(value, name, usage)
+}
+
+// failf prints to standard error a formatted error and usage message and
+// returns the error.
+func (f *FlagSet) failf(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(f.out(), err)
+	f.usage()
+	return err
+}
+
+// usage calls the Usage method for the flag set, or the usage function if
+// the flag set is CommandLine.
+func (f *FlagSet) usage() {
+	if f.Usage == nil {
+		if f == CommandLine {
+			Usage()
+		} else {
+			defaultUsage(f)
+		}
+	} else {
+		f.Usage()
+	}
+}
+
+func (f *FlagSet) parseOne() (flagName string, long, finished bool, err error) {
+	if len(f.procArgs) == 0 {
+		finished = true
+		return
+	}
+
+	// processing previously encountered single-rune flag
+	if flag := f.procFlag; len(flag) > 0 {
+		_, n := utf8.DecodeRuneInString(flag)
+		f.procFlag = flag[n:]
+		flagName = flag[0:n]
+		return
+	}
+
+	a := f.procArgs[0]
+
+	// one non-flag argument
+	if a == "-" || a == "" || a[0] != '-' {
+		if f.allowIntersperse {
+			f.args = append(f.args, a)
+			f.procArgs = f.procArgs[1:]
+			return
+		}
+		f.args = append(f.args, f.procArgs...)
+		f.procArgs = nil
+		finished = true
+		return
+	}
+
+	// end of flags
+	if f.procArgs[0] == "--" {
+		f.args = append(f.args, f.procArgs[1:]...)
+		f.procArgs = nil
+		finished = true
+		return
+	}
+
+	// long flag signified with "--" prefix
+	if a[1] == '-' {
+		long = true
+		i := strings.Index(a, "=")
+		if i < 0 {
+			f.procArgs = f.procArgs[1:]
+			flagName = a[2:]
+			return
+		}
+		flagName = a[2:i]
+		if flagName == "" {
+			err = fmt.Errorf("empty flag in argument %q", a)
+			return
+		}
+		f.procArgs = f.procArgs[1:]
+		f.procFlag = a[i:]
+		return
+	}
+
+	// some number of single-rune flags
+	a = a[1:]
+	_, n := utf8.DecodeRuneInString(a)
+	flagName = a[0:n]
+	f.procFlag = a[n:]
+	f.procArgs = f.procArgs[1:]
+	return
+}
+
+func flagWithMinus(name string) string {
+	if len(name) > 1 {
+		return "--" + name
+	}
+	return "-" + name
+}
+
+func (f *FlagSet) parseFlagArg(name string, long bool) (finished bool, err error) {
+	m := f.formal
+	flag, alreadythere := m[name] // BUG
+	if !alreadythere {
+		if name == "help" || name == "h" { // special case for nice help message.
+			f.usage()
+			return false, ErrHelp
+		}
+		// TODO print --xxx when flag is more than one rune.
+		return false, f.failf("flag provided but not defined: %s", flagWithMinus(name))
+	}
+	if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() && !strings.HasPrefix(f.procFlag, "=") {
+		// special case: doesn't need an arg, and an arg hasn't
+		// been provided explicitly.
+		if err := fv.Set("true"); err != nil {
+			return false, f.failf("invalid boolean flag %s: %v", name, err)
+		}
+	} else {
+		// It must have a value, which might be the next argument.
+		var hasValue bool
+		var value string
+		if f.procFlag != "" {
+			// value directly follows flag
+			value = f.procFlag
+			if long {
+				if value[0] != '=' {
+					panic("no leading '=' in long flag")
+				}
+				value = value[1:]
+			}
+			hasValue = true
+			f.procFlag = ""
+		}
+		if !hasValue && len(f.procArgs) > 0 {
+			// value is the next arg
+			hasValue = true
+			value, f.procArgs = f.procArgs[0], f.procArgs[1:]
+		}
+		if !hasValue {
+			return false, f.failf("flag needs an argument: %s", flagWithMinus(name))
+		}
+		if err := flag.Value.Set(value); err != nil {
+			return false, f.failf("invalid value %q for flag %s: %v", value, flagWithMinus(name), err)
+		}
+	}
+	if f.actual == nil {
+		f.actual = make(map[string]*Flag)
+	}
+	f.actual[name] = flag
+	return
+}
+
+// Parse parses flag definitions from the argument list, which should not
+// include the command name.  Must be called after all flags in the FlagSet
+// are defined and before flags are accessed by the program.
+// The return value will be ErrHelp if --help or -h was set but not defined.
+// If allowIntersperse is set, arguments and flags can be interspersed, that
+// is flags can follow positional arguments.
+func (f *FlagSet) Parse(allowIntersperse bool, arguments []string) error {
+	f.parsed = true
+	f.procArgs = arguments
+	f.procFlag = ""
+	f.args = nil
+	f.allowIntersperse = allowIntersperse
+	for {
+		name, long, finished, err := f.parseOne()
+		if !finished {
+			if name != "" {
+				finished, err = f.parseFlagArg(name, long)
+			}
+		}
+		if err != nil {
+			switch f.errorHandling {
+			case ContinueOnError:
+				return err
+			case ExitOnError:
+				os.Exit(2)
+			case PanicOnError:
+				panic(err)
+			}
+		}
+		if !finished {
+			continue
+		}
+		if err == nil {
+			break
+		}
+	}
+	return nil
+}
+
+// Parsed reports whether f.Parse has been called.
+func (f *FlagSet) Parsed() bool {
+	return f.parsed
+}
+
+// Parse parses the command-line flags from os.Args[1:].  Must be called
+// after all flags are defined and before flags are accessed by the program.
+// If allowIntersperse is set, arguments and flags can be interspersed, that
+// is flags can follow positional arguments.
+func Parse(allowIntersperse bool) {
+	// Ignore errors; CommandLine is set for ExitOnError.
+	CommandLine.Parse(allowIntersperse, os.Args[1:])
+}
+
+// Parsed returns true if the command-line flags have been parsed.
+func Parsed() bool {
+	return CommandLine.Parsed()
+}
+
+// CommandLine is the default set of command-line flags, parsed from os.Args.
+// The top-level functions such as BoolVar, Arg, and so on are wrappers for the
+// methods of CommandLine.
+var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
+
+// NewFlagSet returns a new, empty flag set with the specified name and
+// error handling property.
+func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
+	f := &FlagSet{
+		name:          name,
+		errorHandling: errorHandling,
+	}
+	return f
+}
+
+// Init sets the name and error handling property for a flag set.
+// By default, the zero FlagSet uses an empty name and the
+// ContinueOnError error handling policy.
+func (f *FlagSet) Init(name string, errorHandling ErrorHandling) {
+	f.name = name
+	f.errorHandling = errorHandling
+}

--- a/vendor/github.com/tsuru/gnuflag/flag_test.go
+++ b/vendor/github.com/tsuru/gnuflag/flag_test.go
@@ -1,0 +1,643 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gnuflag_test
+
+import (
+	"bytes"
+	"fmt"
+	. "github.com/tsuru/gnuflag"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	test_bool     = Bool("test_bool", false, "bool value")
+	test_int      = Int("test_int", 0, "int value")
+	test_int64    = Int64("test_int64", 0, "int64 value")
+	test_uint     = Uint("test_uint", 0, "uint value")
+	test_uint64   = Uint64("test_uint64", 0, "uint64 value")
+	test_string   = String("test_string", "0", "string value")
+	test_float64  = Float64("test_float64", 0, "float64 value")
+	test_duration = Duration("test_duration", 0, "time.Duration value")
+)
+
+func boolString(s string) string {
+	if s == "0" {
+		return "false"
+	}
+	return "true"
+}
+
+func TestEverything(t *testing.T) {
+	m := make(map[string]*Flag)
+	desired := "0"
+	visitor := func(f *Flag) {
+		if len(f.Name) > 5 && f.Name[0:5] == "test_" {
+			m[f.Name] = f
+			ok := false
+			switch {
+			case f.Value.String() == desired:
+				ok = true
+			case f.Name == "test_bool" && f.Value.String() == boolString(desired):
+				ok = true
+			case f.Name == "test_duration" && f.Value.String() == desired+"s":
+				ok = true
+			}
+			if !ok {
+				t.Error("Visit: bad value", f.Value.String(), "for", f.Name)
+			}
+		}
+	}
+	VisitAll(visitor)
+	if len(m) != 8 {
+		t.Error("VisitAll misses some flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	m = make(map[string]*Flag)
+	Visit(visitor)
+	if len(m) != 0 {
+		t.Errorf("Visit sees unset flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now set all flags
+	Set("test_bool", "true")
+	Set("test_int", "1")
+	Set("test_int64", "1")
+	Set("test_uint", "1")
+	Set("test_uint64", "1")
+	Set("test_string", "1")
+	Set("test_float64", "1")
+	Set("test_duration", "1s")
+	desired = "1"
+	Visit(visitor)
+	if len(m) != 8 {
+		t.Error("Visit fails after set")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now test they're visited in sort order.
+	var flagNames []string
+	Visit(func(f *Flag) { flagNames = append(flagNames, f.Name) })
+	if !sort.StringsAreSorted(flagNames) {
+		t.Errorf("flag names not sorted: %v", flagNames)
+	}
+}
+
+func TestGet(t *testing.T) {
+	ResetForTesting(nil)
+	Bool("test_bool", true, "bool value")
+	Int("test_int", 1, "int value")
+	Int64("test_int64", 2, "int64 value")
+	Uint("test_uint", 3, "uint value")
+	Uint64("test_uint64", 4, "uint64 value")
+	String("test_string", "5", "string value")
+	Float64("test_float64", 6, "float64 value")
+	Duration("test_duration", 7, "time.Duration value")
+
+	visitor := func(f *Flag) {
+		if len(f.Name) > 5 && f.Name[0:5] == "test_" {
+			g, ok := f.Value.(Getter)
+			if !ok {
+				t.Errorf("Visit: value does not satisfy Getter: %T", f.Value)
+				return
+			}
+			switch f.Name {
+			case "test_bool":
+				ok = g.Get() == true
+			case "test_int":
+				ok = g.Get() == int(1)
+			case "test_int64":
+				ok = g.Get() == int64(2)
+			case "test_uint":
+				ok = g.Get() == uint(3)
+			case "test_uint64":
+				ok = g.Get() == uint64(4)
+			case "test_string":
+				ok = g.Get() == "5"
+			case "test_float64":
+				ok = g.Get() == float64(6)
+			case "test_duration":
+				ok = g.Get() == time.Duration(7)
+			}
+			if !ok {
+				t.Errorf("Visit: bad value %T(%v) for %s", g.Get(), g.Get(), f.Name)
+			}
+		}
+	}
+	VisitAll(visitor)
+}
+
+func TestUsage(t *testing.T) {
+	called := false
+	ResetForTesting(func() { called = true })
+	f := CommandLine
+	f.SetOutput(nullWriter{})
+	if f.Parse(true, []string{"-x"}) == nil {
+		t.Error("parse did not fail for unknown flag")
+	}
+	if !called {
+		t.Error("did not call Usage for unknown flag")
+	}
+}
+
+var parseTests = []struct {
+	about       string
+	intersperse bool
+	args        []string
+	vals        map[string]interface{}
+	remaining   []string
+	error       string
+}{{
+	about:       "regular args",
+	intersperse: true,
+	args: []string{
+		"--bool2",
+		"--int", "22",
+		"--int64", "0x23",
+		"--uint", "24",
+		"--uint64", "25",
+		"--string", "hello",
+		"--float64", "2718e28",
+		"--duration", "2m",
+		"one - extra - argument",
+	},
+	vals: map[string]interface{}{
+		"bool":     false,
+		"bool2":    true,
+		"int":      22,
+		"int64":    int64(0x23),
+		"uint":     uint(24),
+		"uint64":   uint64(25),
+		"string":   "hello",
+		"float64":  2718e28,
+		"duration": 2 * 60 * time.Second,
+	},
+	remaining: []string{
+		"one - extra - argument",
+	},
+}, {
+	about:       "playing with -",
+	intersperse: true,
+	args: []string{
+		"-a",
+		"-",
+		"-bc",
+		"2",
+		"-de1s",
+		"-f2s",
+		"-g", "3s",
+		"--h",
+		"--long",
+		"--long2", "-4s",
+		"3",
+		"4",
+		"--", "-5",
+	},
+	vals: map[string]interface{}{
+		"a":     true,
+		"b":     true,
+		"c":     true,
+		"d":     true,
+		"e":     "1s",
+		"f":     "2s",
+		"g":     "3s",
+		"h":     true,
+		"long":  true,
+		"long2": "-4s",
+		"z":     "default",
+		"www":   99,
+	},
+	remaining: []string{
+		"-",
+		"2",
+		"3",
+		"4",
+		"-5",
+	},
+}, {
+	about:       "flag after explicit --",
+	intersperse: true,
+	args: []string{
+		"-a",
+		"--",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+		"b": false,
+	},
+	remaining: []string{
+		"-b",
+	},
+}, {
+	about: "flag after end",
+	args: []string{
+		"-a",
+		"foo",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+		"b": false,
+	},
+	remaining: []string{
+		"foo",
+		"-b",
+	},
+}, {
+	about: "arg and flag after explicit end",
+	args: []string{
+		"-a",
+		"--",
+		"foo",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+		"b": false,
+	},
+	remaining: []string{
+		"foo",
+		"-b",
+	},
+}, {
+	about: "boolean args, explicitly and non-explicitly given",
+	args: []string{
+		"--a=false",
+		"--b=true",
+		"--c",
+	},
+	vals: map[string]interface{}{
+		"a": false,
+		"b": true,
+		"c": true,
+	},
+}, {
+	about: "using =",
+	args: []string{
+		"--arble=bar",
+		"--bletch=",
+		"--a=something",
+		"-b=other",
+		"-cdand more",
+		"--curdle=--milk",
+		"--sandwich", "=",
+		"--darn=",
+		"=arg",
+	},
+	vals: map[string]interface{}{
+		"arble":    "bar",
+		"bletch":   "",
+		"a":        "something",
+		"b":        "=other",
+		"c":        true,
+		"d":        "and more",
+		"curdle":   "--milk",
+		"sandwich": "=",
+		"darn":     "",
+	},
+	remaining: []string{"=arg"},
+}, {
+	about: "empty flag #1",
+	args: []string{
+		"--=bar",
+	},
+	error: `empty flag in argument "--=bar"`,
+}, {
+	about: "single-letter equals",
+	args: []string{
+		"-=bar",
+	},
+	error: `flag provided but not defined: -=`,
+}, {
+	about: "empty flag #2",
+	args: []string{
+		"--=",
+	},
+	error: `empty flag in argument "--="`,
+}, {
+	about: "no equals",
+	args: []string{
+		"-=",
+	},
+	error: `flag provided but not defined: -=`,
+}, {
+	args: []string{
+		"-a=true",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+	},
+	error: `invalid value "=true" for flag -a: strconv.ParseBool: parsing "=true": invalid syntax`,
+}, {
+	intersperse: true,
+	args: []string{
+		"-a",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+	},
+	error: "flag provided but not defined: -b",
+}, {
+	intersperse: true,
+	args: []string{
+		"-a",
+	},
+	vals: map[string]interface{}{
+		"a": "default",
+	},
+	error: "flag needs an argument: -a",
+}, {
+	intersperse: true,
+	args: []string{
+		"-a", "b",
+	},
+	vals: map[string]interface{}{
+		"a": 0,
+	},
+	error: `invalid value "b" for flag -a: strconv.ParseInt: parsing "b": invalid syntax`,
+},
+}
+
+func testParse(newFlagSet func() *FlagSet, t *testing.T) {
+	for i, g := range parseTests {
+		t.Logf("test %d. %s", i, g.about)
+		f := newFlagSet()
+		flags := make(map[string]interface{})
+		for name, val := range g.vals {
+			switch val.(type) {
+			case bool:
+				flags[name] = f.Bool(name, false, "bool value "+name)
+			case string:
+				flags[name] = f.String(name, "default", "string value "+name)
+			case int:
+				flags[name] = f.Int(name, 99, "int value "+name)
+			case uint:
+				flags[name] = f.Uint(name, 0, "uint value")
+			case uint64:
+				flags[name] = f.Uint64(name, 0, "uint64 value")
+			case int64:
+				flags[name] = f.Int64(name, 0, "uint64 value")
+			case float64:
+				flags[name] = f.Float64(name, 0, "float64 value")
+			case time.Duration:
+				flags[name] = f.Duration(name, 5*time.Second, "duration value")
+			default:
+				t.Fatalf("unhandled type %T", val)
+			}
+		}
+		err := f.Parse(g.intersperse, g.args)
+		if g.error != "" {
+			if err == nil {
+				t.Errorf("expected error %q got nil", g.error)
+			} else if err.Error() != g.error {
+				t.Errorf("expected error %q got %q", g.error, err.Error())
+			}
+			continue
+		}
+		for name, val := range g.vals {
+			actual := reflect.ValueOf(flags[name]).Elem().Interface()
+			if val != actual {
+				t.Errorf("flag %q, expected %v got %v", name, val, actual)
+			}
+		}
+		if len(f.Args()) != len(g.remaining) {
+			t.Fatalf("remaining args, expected %q got %q", g.remaining, f.Args())
+		}
+		for j, a := range f.Args() {
+			if a != g.remaining[j] {
+				t.Errorf("arg %d, expected %q got %q", j, g.remaining[i], a)
+			}
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	testParse(func() *FlagSet {
+		ResetForTesting(func() {})
+		CommandLine.SetOutput(nullWriter{})
+		return CommandLine
+	}, t)
+}
+
+func TestFlagSetParse(t *testing.T) {
+	testParse(func() *FlagSet {
+		f := NewFlagSet("test", ContinueOnError)
+		f.SetOutput(nullWriter{})
+		return f
+	}, t)
+}
+
+// Declare a user-defined flag type.
+type flagVar []string
+
+func (f *flagVar) String() string {
+	return fmt.Sprint([]string(*f))
+}
+
+func (f *flagVar) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+func TestUserDefined(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var v flagVar
+	flags.Var(&v, "v", "usage")
+	if err := flags.Parse(true, []string{"-v", "1", "-v", "2", "-v3"}); err != nil {
+		t.Error(err)
+	}
+	if len(v) != 3 {
+		t.Fatal("expected 3 args; got ", len(v))
+	}
+	expect := "[1 2 3]"
+	if v.String() != expect {
+		t.Errorf("expected value %q got %q", expect, v.String())
+	}
+}
+
+func TestUserDefinedForCommandLine(t *testing.T) {
+	const help = "HELP"
+	var result string
+	ResetForTesting(func() { result = help })
+	Usage()
+	if result != help {
+		t.Fatalf("got %q; expected %q", result, help)
+	}
+}
+
+// Declare a user-defined boolean flag type.
+type boolFlagVar struct {
+	count int
+}
+
+func (b *boolFlagVar) String() string {
+	return fmt.Sprintf("%d", b.count)
+}
+
+func (b *boolFlagVar) Set(value string) error {
+	if value == "true" {
+		b.count++
+	}
+	return nil
+}
+
+func (b *boolFlagVar) IsBoolFlag() bool {
+	return b.count < 4
+}
+
+func TestUserDefinedBool(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var b boolFlagVar
+	var err error
+	flags.Var(&b, "b", "usage")
+	if err = flags.Parse(true, []string{"-b", "-b", "-b", "-b=true", "-b=false", "-b", "barg", "-b"}); err != nil {
+		if b.count < 4 {
+			t.Error(err)
+		}
+	}
+
+	if b.count != 4 {
+		t.Errorf("want: %d; got: %d", 4, b.count)
+	}
+
+	if err == nil {
+		t.Error("expected error; got none")
+	}
+}
+
+func TestSetOutput(t *testing.T) {
+	var flags FlagSet
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+	flags.Init("test", ContinueOnError)
+	flags.Parse(true, []string{"-unknown"})
+	if out := buf.String(); !strings.Contains(out, "-unknown") {
+		t.Logf("expected output mentioning unknown; got %q", out)
+	}
+}
+
+// This tests that one can reset the flags. This still works but not well, and is
+// superseded by FlagSet.
+func TestChangingArgs(t *testing.T) {
+	ResetForTesting(func() { t.Fatal("bad parse") })
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"cmd", "--before", "subcmd", "--after", "args"}
+	before := Bool("before", false, "")
+	if err := CommandLine.Parse(false, os.Args[1:]); err != nil {
+		t.Fatal(err)
+	}
+	cmd := Arg(0)
+	os.Args = Args()
+	after := Bool("after", false, "")
+	Parse(false)
+	args := Args()
+
+	if !*before || cmd != "subcmd" || !*after || len(args) != 1 || args[0] != "args" {
+		t.Fatalf("expected true subcmd true [args] got %v %v %v %v", *before, cmd, *after, args)
+	}
+}
+
+// Test that -help invokes the usage message and returns ErrHelp.
+func TestHelp(t *testing.T) {
+	var helpCalled = false
+	fs := NewFlagSet("help test", ContinueOnError)
+	fs.SetOutput(nullWriter{})
+	fs.Usage = func() { helpCalled = true }
+	var flag bool
+	fs.BoolVar(&flag, "flag", false, "regular flag")
+	// Regular flag invocation should work
+	err := fs.Parse(true, []string{"--flag"})
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+	if !flag {
+		t.Error("flag was not set by --flag")
+	}
+	if helpCalled {
+		t.Error("help called for regular flag")
+		helpCalled = false // reset for next test
+	}
+	// Help flag should work as expected.
+	err = fs.Parse(true, []string{"--help"})
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != ErrHelp {
+		t.Fatal("expected ErrHelp; got ", err)
+	}
+	if !helpCalled {
+		t.Fatal("help was not called")
+	}
+	// If we define a help flag, that should override.
+	var help bool
+	fs.BoolVar(&help, "help", false, "help flag")
+	helpCalled = false
+	err = fs.Parse(true, []string{"--help"})
+	if err != nil {
+		t.Fatal("expected no error for defined --help; got ", err)
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+}
+
+type nullWriter struct{}
+
+func (nullWriter) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+func TestPrintDefaults(t *testing.T) {
+	f := NewFlagSet("print test", ContinueOnError)
+	f.SetOutput(nullWriter{})
+	var b bool
+	var c int
+	var d string
+	var e float64
+	f.IntVar(&c, "trapclap", 99, "usage not shown")
+	f.IntVar(&c, "c", 99, "c usage")
+
+	f.BoolVar(&b, "bal", false, "usage not shown")
+	f.BoolVar(&b, "x", false, "usage not shown")
+	f.BoolVar(&b, "b", false, "b usage")
+	f.BoolVar(&b, "balalaika", false, "usage not shown")
+
+	f.StringVar(&d, "d", "d default", "d usage")
+
+	f.Float64Var(&e, "elephant", 3.14, "elephant usage")
+
+	var buf bytes.Buffer
+	f.SetOutput(&buf)
+	f.PrintDefaults()
+	f.SetOutput(nullWriter{})
+
+	expect :=
+		`-b, -x, --bal, --balalaika  (= false)
+    b usage
+-c, --trapclap  (= 99)
+    c usage
+-d (= "d default")
+    d usage
+--elephant  (= 3.14)
+    elephant usage
+`
+	if buf.String() != expect {
+		t.Errorf("expect %q got %q", expect, buf.String())
+	}
+}


### PR DESCRIPTION
This is to support:
- shorthands
- Putting commands anywhere (after positional arguments too)
- No need for `=`
