### PR TITLE
Support reading from stdin in url-fetch

### DIFF
--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -107,7 +107,7 @@ func (s Struct) MaybeGet(n string) (Value, bool) {
 func (s Struct) Get(n string) Value {
 	_, i := s.desc().findField(n)
 	if i == -1 {
-		d.Chk.Fail(`Struct has no field "%s"`, n)
+		d.Chk.Fail(fmt.Sprintf(`Struct has no field "%s"`, n))
 	}
 	return s.values[i]
 }
@@ -115,7 +115,7 @@ func (s Struct) Get(n string) Value {
 func (s Struct) Set(n string, v Value) Struct {
 	f, i := s.desc().findField(n)
 	if i == -1 {
-		d.Chk.Fail(`Struct has no field "%s"`, n)
+		d.Chk.Fail(fmt.Sprintf(`Struct has no field "%s"`, n))
 	}
 	assertSubtype(f.t, v)
 	values := make([]Value, len(s.values))

--- a/samples/go/url-fetch/fetch.go
+++ b/samples/go/url-fetch/fetch.go
@@ -35,12 +35,12 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\n")
 		fmt.Fprintf(os.Stderr, "Usage: %s <dataset> [url-or-local-path?]\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "       Leave url-or-local-path empty to read from stdin.")
+		fmt.Fprintf(os.Stderr, "Leave url-or-local-path empty to read from stdin.\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse(true)
 
-	if flag.NArg() == 0 {
+	if flag.NArg() != 1 && flag.NArg() != 2 {
 		flag.Usage()
 		os.Exit(-1)
 	}

--- a/samples/go/url-fetch/fetch.go
+++ b/samples/go/url-fetch/fetch.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,29 +29,38 @@ var (
 
 func main() {
 	comment := flag.String("comment", "", "comment to add to commit's meta data")
+	stdin := flag.Bool("stdin", false, "read blob from stdin")
+
 	spec.RegisterDatabaseFlags(flag.CommandLine)
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\nUsage: %s <dataset> <url-or-local-path>:\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s [-stdin] <dataset> [url-or-local-path]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Either -stdin or a url/path must be given.\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse(true)
 
-	if flag.NArg() != 2 {
-		d.CheckErrorNoUsage(errors.New("expected dataset and url arguments"))
+	if !*stdin && flag.NArg() != 2 {
+		flag.Usage()
+		os.Exit(-1)
 	}
+
+	start = time.Now()
 
 	ds, err := spec.GetDataset(flag.Arg(0))
 	d.CheckErrorNoUsage(err)
 	defer ds.Database().Close()
 
-	url := flag.Arg(1)
-	fileOrUrl := "file"
-	start = time.Now()
+	var r io.Reader
+	var contentLength int64
+	var sourceType, sourceVal string
 
-	var pr io.Reader
-
-	if strings.HasPrefix(url, "http") {
+	if *stdin {
+		r = os.Stdin
+		contentLength = -1
+		sourceType, sourceVal = "file", "stdin"
+	} else if url := flag.Arg(1); strings.HasPrefix(url, "http") {
 		resp, err := http.Get(url)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not fetch url %s, error: %s\n", url, err)
@@ -65,8 +73,9 @@ func main() {
 			return
 		}
 
-		pr = progressreader.New(resp.Body, getStatusPrinter(resp.ContentLength))
-		fileOrUrl = "url"
+		r = resp.Body
+		contentLength = resp.ContentLength
+		sourceType, sourceVal = "url", url
 	} else {
 		// assume it's a file
 		f, err := os.Open(url)
@@ -81,12 +90,14 @@ func main() {
 			return
 		}
 
-		pr = progressreader.New(f, getStatusPrinter(s.Size()))
-		fileOrUrl = "file"
+		r = f
+		contentLength = s.Size()
+		sourceType, sourceVal = "file", url
 	}
 
+	pr := progressreader.New(r, getStatusPrinter(contentLength))
 	b := types.NewStreamingBlob(pr, ds.Database())
-	mi := metaInfoForCommit(fileOrUrl, url, *comment)
+	mi := metaInfoForCommit(sourceType, sourceVal, *comment)
 	ds, err = ds.Commit(b, dataset.CommitOptions{Meta: mi})
 	if err != nil {
 		d.Chk.Equal(datas.ErrMergeNeeded, err)
@@ -98,11 +109,11 @@ func main() {
 	fmt.Println("Done")
 }
 
-func metaInfoForCommit(fileOrUrl, source, comment string) types.Struct {
+func metaInfoForCommit(sourceType, sourceVal, comment string) types.Struct {
 	date := time.Now().UTC().Format("2006-01-02T15:04:05-0700")
 	metaValues := map[string]types.Value{
-		"date":    types.String(date),
-		fileOrUrl: types.String(source),
+		"date":     types.String(date),
+		sourceType: types.String(sourceVal),
 	}
 	if comment != "" {
 		metaValues["comment"] = types.String(comment)

--- a/samples/go/url-fetch/fetch.go
+++ b/samples/go/url-fetch/fetch.go
@@ -35,8 +35,8 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s [-stdin] <dataset> [url-or-local-path]\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "Either -stdin or a url/path must be given.\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s [--stdin] <dataset> [url-or-local-path]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Either --stdin or a url/path must be given.\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse(true)

--- a/samples/go/url-fetch/fetch_test.go
+++ b/samples/go/url-fetch/fetch_test.go
@@ -43,7 +43,7 @@ func (s *testSuite) TestImportFromStdin() {
 
 	dsName := spec.CreateValueSpecString("ldb", s.LdbDir, "ds")
 	// Run() will return when blobOut is closed.
-	s.Run(main, []string{"-stdin", dsName})
+	s.Run(main, []string{"--stdin", dsName})
 
 	db, blob, err := spec.GetPath(dsName + ".value")
 	assert.NoError(err)

--- a/samples/go/url-fetch/fetch_test.go
+++ b/samples/go/url-fetch/fetch_test.go
@@ -1,0 +1,58 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/spec"
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/clienttest"
+	"github.com/attic-labs/testify/suite"
+)
+
+func TestFetch(t *testing.T) {
+	suite.Run(t, &testSuite{})
+}
+
+type testSuite struct {
+	clienttest.ClientTestSuite
+}
+
+func (s *testSuite) TestImportFromStdin() {
+	assert := s.Assert()
+
+	oldStdin := os.Stdin
+	newStdin, blobOut, err := os.Pipe()
+	assert.NoError(err)
+
+	os.Stdin = newStdin
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
+	go func() {
+		blobOut.Write([]byte("abcdef"))
+		blobOut.Close()
+	}()
+
+	dsName := spec.CreateValueSpecString("ldb", s.LdbDir, "ds")
+	// Run() will return when blobOut is closed.
+	s.Run(main, []string{"-stdin", dsName})
+
+	db, blob, err := spec.GetPath(dsName + ".value")
+	assert.NoError(err)
+
+	expected := types.NewBlob(bytes.NewBufferString("abcdef"))
+	assert.True(expected.Equals(blob))
+
+	meta := db.Head("ds").Get(datas.MetaField).(types.Struct)
+	assert.Equal("stdin", string(meta.Get("file").(types.String)))
+
+	db.Close()
+}

--- a/samples/go/url-fetch/fetch_test.go
+++ b/samples/go/url-fetch/fetch_test.go
@@ -43,7 +43,7 @@ func (s *testSuite) TestImportFromStdin() {
 
 	dsName := spec.CreateValueSpecString("ldb", s.LdbDir, "ds")
 	// Run() will return when blobOut is closed.
-	s.Run(main, []string{"--stdin", dsName})
+	s.Run(main, []string{dsName})
 
 	db, blob, err := spec.GetPath(dsName + ".value")
 	assert.NoError(err)
@@ -52,7 +52,10 @@ func (s *testSuite) TestImportFromStdin() {
 	assert.True(expected.Equals(blob))
 
 	meta := db.Head("ds").Get(datas.MetaField).(types.Struct)
-	assert.Equal("stdin", string(meta.Get("file").(types.String)))
+	// The meta should only have a "date" field.
+	metaDesc := meta.Type().Desc.(types.StructDesc)
+	assert.Equal(1, metaDesc.Len())
+	assert.NotNil(metaDesc.Field("date"))
 
 	db.Close()
 }


### PR DESCRIPTION
I need this in the short term because CSV raw files are too large to
check into github, so they need to be split up. It's easier to just do
"cat * | url-fetch -stdin" than recombining them on the file system.