### PR TITLE
Handle Blob and Ref in noms diff

### DIFF
--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/dustin/go-humanize"
 )
 
 func shouldDescend(v1, v2 types.Value) bool {
 	kind := v1.Type().Kind()
-	return !types.IsPrimitiveKind(kind) && kind == v2.Type().Kind()
+	return !types.IsPrimitiveKind(kind) && kind == v2.Type().Kind() && kind != types.RefKind
 }
 
 func Diff(w io.Writer, v1, v2 types.Value) error {
@@ -229,7 +230,13 @@ func write(w io.Writer, b []byte) {
 }
 
 func writeEncodedValue(w io.Writer, v types.Value) {
-	d.PanicIfError(types.WriteEncodedValue(w, v))
+	if v.Type().Kind() == types.BlobKind {
+		w.Write([]byte("Blob ("))
+		w.Write([]byte(humanize.Bytes(v.(types.Blob).Len())))
+		w.Write([]byte(")"))
+	} else {
+		d.PanicIfError(types.WriteEncodedValue(w, v))
+	}
 }
 
 func writeEncodedValueWithTags(w io.Writer, v types.Value) {

--- a/cmd/noms/diff/diff_test.go
+++ b/cmd/noms/diff/diff_test.go
@@ -5,9 +5,11 @@
 package diff
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/test"
 	"github.com/attic-labs/testify/assert"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
@@ -203,4 +205,45 @@ func TestNomsListDiff(t *testing.T) {
 	Diff(buf, l1, l2)
 
 	assert.Equal(expected, buf.String())
+}
+
+func TestNomsBlobDiff(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := "-   Blob (2.0 kB)\n+   Blob (11 B)\n"
+	b1 := types.NewBlob(strings.NewReader(strings.Repeat("x", 2*1024)))
+	b2 := types.NewBlob(strings.NewReader("Hello World"))
+	buf := util.NewBuffer(nil)
+	Diff(buf, b1, b2)
+	assert.Equal(expected, buf.String())
+}
+
+func TestNomsTypeDiff(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := "-   List<Number>\n+   List<String>\n"
+	t1 := types.MakeListType(types.NumberType)
+	t2 := types.MakeListType(types.StringType)
+	buf := util.NewBuffer(nil)
+	Diff(buf, t1, t2)
+	assert.Equal(expected, buf.String())
+
+	expected = "-   List<Number>\n+   Set<String>\n"
+	t1 = types.MakeListType(types.NumberType)
+	t2 = types.MakeSetType(types.StringType)
+	buf = util.NewBuffer(nil)
+	Diff(buf, t1, t2)
+	assert.Equal(expected, buf.String())
+}
+
+func TestNomsRefDiff(t *testing.T) {
+	expected := "-   fckcbt7nk5jl4arco2dk7r9nj7abb6ci\n+   i7d3u5gekm48ot419t2cot6cnl7ltcah\n"
+	l1 := createList(1)
+	l2 := createList(2)
+	r1 := types.NewRef(l1)
+	r2 := types.NewRef(l2)
+	buf := util.NewBuffer(nil)
+	Diff(buf, r1, r2)
+
+	test.EqualsIgnoreHashes(t, expected, buf.String())
 }


### PR DESCRIPTION
For Blobs we print:

```
-   Blob (42 kB)
+   Blob (1 B)
```

For Refs we just print the hashes:

```
-   abcdeabcdeabcdeabcde
+   defghdefghdefghdefgh
```

Fixes #2213
