### PR TITLE
Splore: Use demo.noms.io as the default database

### DIFF
--- a/samples/js/splore/src/main.js
+++ b/samples/js/splore/src/main.js
@@ -250,7 +250,7 @@ class Prompt extends React.Component<void, {}, void> {
         Can haz database?
         <form style={{margin:'0.5em 0'}} onSubmit={e => this._handleOnSubmit(e)}>
           <input type='text' ref='db' autoFocus={true} style={inputStyle}
-            defaultValue={params.db || 'http://api.noms.io/-/ds/[user]'}
+            defaultValue={params.db || 'https://demo.noms.io/cli-tour'}
             placeholder='noms database URL'
           />
           <input type='text' ref='token' style={inputStyle}


### PR DESCRIPTION
Changes the default database to `https://demo.noms.io/cli-tour`

Fixes #2217
