### PR TITLE
changing order of args to match JS and be more logical

### DIFF
--- a/doc/cli-tour.md
+++ b/doc/cli-tour.md
@@ -158,7 +158,7 @@ open /tmp/film-location.csv and edit it, then:
 
 ```
 > csv-import -column-types=String,String,String,String,String,String,String,Number,String,String,String \
-    /tmp/noms::films /tmp/film-locations.csv
+    /tmp/film-locations.csv /tmp/noms::films
 ```
 
 #noms diff

--- a/samples/go/csv/README.md
+++ b/samples/go/csv/README.md
@@ -7,7 +7,7 @@ Imports a CSV file as `List<T>` where `T` is a struct with fields corresponding 
 ```
 $ cd csv-import
 $ go build
-$ ./csv-import http://localhost:8000:foo <PATH>
+$ ./csv-import <PATH> http://localhost:8000:foo
 ```
 
 ## Some places for CSV files

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -85,6 +85,7 @@ func main() {
 	var r io.Reader
 	var size uint64
 	var filePath string
+	var dataSetArgN int
 
 	if *path != "" {
 		db, val, err := spec.GetPath(*path)
@@ -99,6 +100,7 @@ func main() {
 		defer db.Close()
 		r = blob.Reader()
 		size = blob.Len()
+		dataSetArgN = 0
 	} else {
 		filePath = flag.Arg(0)
 		res, err := os.Open(filePath)
@@ -108,6 +110,7 @@ func main() {
 		d.CheckError(err)
 		r = res
 		size = uint64(fi.Size())
+		dataSetArgN = 1
 	}
 
 	if !*noProgress {
@@ -143,7 +146,7 @@ func main() {
 		headers = strings.Split(*header, string(comma))
 	}
 
-	ds, err := spec.GetDataset(flag.Arg(1))
+	ds, err := spec.GetDataset(flag.Arg(dataSetArgN))
 	d.CheckError(err)
 	defer ds.Database().Close()
 

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -53,7 +53,7 @@ func main() {
 	profile.RegisterProfileFlags(flag.CommandLine)
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: csv-import [options] <dataset> <csvfile>?\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: csv-import [options] <csvfile> <dataset>\n\n")
 		flag.PrintDefaults()
 	}
 
@@ -100,7 +100,7 @@ func main() {
 		r = blob.Reader()
 		size = blob.Len()
 	} else {
-		filePath = flag.Arg(1)
+		filePath = flag.Arg(0)
 		res, err := os.Open(filePath)
 		d.CheckError(err)
 		defer res.Close()
@@ -143,7 +143,7 @@ func main() {
 		headers = strings.Split(*header, string(comma))
 	}
 
-	ds, err := spec.GetDataset(flag.Arg(0))
+	ds, err := spec.GetDataset(flag.Arg(1))
 	d.CheckError(err)
 	defer ds.Database().Close()
 

--- a/samples/go/csv/csv-import/importer_test.go
+++ b/samples/go/csv/csv-import/importer_test.go
@@ -61,7 +61,7 @@ func (s *testSuite) TestCSVImporter() {
 
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
-	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number", dataspec, input.Name()})
+	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number", input.Name(), dataspec})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
@@ -123,7 +123,7 @@ func (s *testSuite) TestCSVImporterToMap() {
 
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
-	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number,Number", "--dest-type", "map:1", dataspec, input.Name()})
+	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number,Number", "--dest-type", "map:1", input.Name(), dataspec})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
@@ -154,7 +154,7 @@ func (s *testSuite) TestCSVImporterWithPipe() {
 
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
-	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number", "--delimiter", "|", dataspec, input.Name()})
+	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number", "--delimiter", "|", input.Name(), dataspec})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
@@ -182,7 +182,7 @@ func (s *testSuite) TestCSVImporterWithExternalHeader() {
 
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
-	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number", "--header", "x,y", dataspec, input.Name()})
+	stdout, stderr := s.Run(main, []string{"--no-progress", "--column-types", "String,Number", "--header", "x,y", input.Name(), dataspec})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
@@ -219,7 +219,7 @@ func (s *testSuite) TestCSVImportSkipRecords() {
 
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
-	stdout, stderr := s.Run(main, []string{"--no-progress", "--skip-records", "2", dataspec, input.Name()})
+	stdout, stderr := s.Run(main, []string{"--no-progress", "--skip-records", "2", input.Name(), dataspec})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 
@@ -250,7 +250,7 @@ func (s *testSuite) TestCSVImportSkipRecordsCustomHeader() {
 
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
-	stdout, stderr := s.Run(main, []string{"--no-progress", "--skip-records", "1", "--header", "x,y", dataspec, input.Name()})
+	stdout, stderr := s.Run(main, []string{"--no-progress", "--skip-records", "1", "--header", "x,y", input.Name(), dataspec})
 	s.Equal("", stdout)
 	s.Equal("", stderr)
 

--- a/samples/go/url-fetch/fetch.go
+++ b/samples/go/url-fetch/fetch.go
@@ -33,7 +33,7 @@ func main() {
 	spec.RegisterDatabaseFlags(flag.CommandLine)
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\nUsage: %s <dataset> <url-or-local-path>:\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Fetches a URL (or file) into a noms blob\n\nUsage: %s <url-or-local-path> <dataset>:\n", os.Args[0])
 		flag.PrintDefaults()
 	}
 	flag.Parse(true)
@@ -42,11 +42,11 @@ func main() {
 		d.CheckErrorNoUsage(errors.New("expected dataset and url arguments"))
 	}
 
-	ds, err := spec.GetDataset(flag.Arg(0))
+	ds, err := spec.GetDataset(flag.Arg(1))
 	d.CheckErrorNoUsage(err)
 	defer ds.Database().Close()
 
-	url := flag.Arg(1)
+	url := flag.Arg(0)
 	fileOrUrl := "file"
 	start = time.Now()
 

--- a/samples/go/xml-import/xml_importer.go
+++ b/samples/go/xml-import/xml_importer.go
@@ -28,7 +28,7 @@ var (
 	customUsage = func() {
 		fmtString := `%s walks the given directory, looking for .xml files. When it finds one, the entity inside is parsed into nested Noms maps/lists and committed to the dataset indicated on the command line.`
 		fmt.Fprintf(os.Stderr, fmtString, os.Args[0])
-		fmt.Fprintf(os.Stderr, "\n\nUsage: %s [options] <dataset> <path/to/root/directory>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\n\nUsage: %s [options] <path/to/root/directory> <dataset>\n", os.Args[0])
 		flag.PrintDefaults()
 	}
 )
@@ -57,10 +57,10 @@ func main() {
 		flag.Parse(true)
 
 		if flag.NArg() != 2 {
-			d.CheckError(errors.New("Expected dataset followed by directory path"))
+			d.CheckError(errors.New("Expected directory path followed by dataset"))
 		}
-		dir := flag.Arg(1)
-		ds, err := spec.GetDataset(flag.Arg(0))
+		dir := flag.Arg(0)
+		ds, err := spec.GetDataset(flag.Arg(1))
 		d.CheckError(err)
 
 		defer profile.MaybeStartProfile().Stop()


### PR DESCRIPTION
addressing bug #2103, also aligning arg order to match what is to happen, e.g.:

> csv-import <this-file> <to-this-dataset>
> url-fetch <this-url> <and-store-to-this-dataset>
> xml-import <from-this-file-or-directory> <store-to-this-dataset>

Blob-get already follows this pattern:

> blob-get <from-this-dataset-path> <store-to-this-file>
> (arguable if the <store-to-this-file> is needed since csv-export writes to stdout)

Json-import already follows this pattern too:

> json-import <from-this-url-path> <store-to-this-dataset>
