### PR TITLE
Validate type of new Root in root/ POST handler

### DIFF
--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -91,6 +91,7 @@ func (ds *databaseCommon) datasetsFromRef(datasetsRef hash.Hash) *types.Map {
 }
 
 func (ds *databaseCommon) commit(datasetID string, commit types.Struct) error {
+	d.PanicIfTrue(!IsCommitType(commit.Type()), "Can't commit a non-Commit struct to dataset %s", datasetID)
 	return ds.doCommit(datasetID, commit)
 }
 

--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -218,9 +218,10 @@ func (suite *HTTPBatchStoreSuite) TestPutChunksBackpressure() {
 }
 
 func (suite *HTTPBatchStoreSuite) TestRoot() {
-	c := chunks.NewChunk([]byte("abc"))
-	suite.True(suite.cs.UpdateRoot(c.Hash(), hash.Hash{}))
-	suite.Equal(c.Hash(), suite.store.Root())
+	c := types.EncodeValue(types.NewMap(), nil)
+	suite.cs.Put(c)
+	suite.True(suite.store.UpdateRoot(c.Hash(), hash.Hash{}))
+	suite.Equal(c.Hash(), suite.cs.Root())
 }
 
 func (suite *HTTPBatchStoreSuite) TestVersionMismatch() {
@@ -230,7 +231,8 @@ func (suite *HTTPBatchStoreSuite) TestVersionMismatch() {
 }
 
 func (suite *HTTPBatchStoreSuite) TestUpdateRoot() {
-	c := chunks.NewChunk([]byte("abc"))
+	c := types.EncodeValue(types.NewMap(), nil)
+	suite.cs.Put(c)
 	suite.True(suite.store.UpdateRoot(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.cs.Root())
 }
@@ -238,7 +240,8 @@ func (suite *HTTPBatchStoreSuite) TestUpdateRoot() {
 func (suite *HTTPBatchStoreSuite) TestUpdateRootWithParams() {
 	u := fmt.Sprintf("http://localhost:9000?access_token=%s&other=19", testAuthToken)
 	store := newAuthenticatingHTTPBatchStoreForTest(suite, u)
-	c := chunks.NewChunk([]byte("abc"))
+	c := types.EncodeValue(types.NewMap(), nil)
+	suite.cs.Put(c)
 	suite.True(store.UpdateRoot(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.cs.Root())
 }


### PR DESCRIPTION
In the server side of the Remote Databse, the handler for
UpdateRoot now verifies that the new proposed Root is of a
legal type: empty map OR Map\<String, Ref\<Commit-like>>

Fixes #2116