### PR TITLE
Change "Amazon Dynamo" to "Amazon DynamoDB"

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -38,7 +38,7 @@ A database has two responsibilities: it provides storage of [content-addressed](
 
 A Noms database can be implemented on top of any underlying storage system that provides key/value storage with at least optional optimistic concurrency. We only use optimistic concurrency to store the current value of each dataset. Chunks themselves are immutable.
 
-We have implementations of Noms databases on top of [LevelDB](https://github.com/google/leveldb) (usually used locally), our own [HTTP protocol](https://github.com/attic-labs/noms/blob/master/go/datas/database_server.go) (used for working with a remote database), [Amazon Dynamo](https://aws.amazon.com/dynamodb/), and [memory](https://github.com/attic-labs/noms/blob/master/js/src/memory-store.js) (mainly used for testing).
+We have implementations of Noms databases on top of [LevelDB](https://github.com/google/leveldb) (usually used locally), our own [HTTP protocol](https://github.com/attic-labs/noms/blob/master/go/datas/database_server.go) (used for working with a remote database), [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), and [memory](https://github.com/attic-labs/noms/blob/master/js/src/memory-store.js) (mainly used for testing).
 
 Here's an example of creating an http-backed database using the [JavaScript Noms SDK](js-tour.md):
 


### PR DESCRIPTION
Nitpick: "Amazon Dynamo" mention in the intro should be "Amazon DynamoDB".

[Amazon Dynamo](https://en.wikipedia.org/wiki/Dynamo_(storage_system)) is a particular system with which `DynamoStore` does not interact.