### PR TITLE
Make sure that set/map diff has completed before returning from noms log

### DIFF
--- a/cmd/noms/diff/summary.go
+++ b/cmd/noms/diff/summary.go
@@ -6,7 +6,7 @@ import (
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/status"
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 )
 
 // Summary prints a summary of the diff between two values to stdout.
@@ -31,7 +31,7 @@ func Summary(value1, value2 types.Value) {
 			plural = "values"
 		}
 	}
-	// waitChan := make(chan struct{})
+
 	ch := make(chan diffSummaryProgress)
 	go func() {
 		diffSummary(ch, value1, value2)
@@ -84,7 +84,6 @@ func diffSummaryList(ch chan<- diffSummaryProgress, v1, v2 types.List) {
 	spliceChan := make(chan types.Splice)
 	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
 
-	defer stop(stopChan)
 	go func() {
 		v2.Diff(v1, spliceChan, stopChan)
 		close(spliceChan)
@@ -119,15 +118,12 @@ func diffSummaryStructs(ch chan<- diffSummaryProgress, v1, v2 types.Struct) {
 	})
 }
 
-type diffFunc func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{})
-
 func diffSummaryValueChanged(ch chan<- diffSummaryProgress, oldSize, newSize uint64, f diffFunc) {
 	ch <- diffSummaryProgress{OldSize: oldSize, NewSize: newSize}
 
 	changeChan := make(chan types.ValueChanged)
 	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
 
-	defer stop(stopChan)
 	go func() {
 		f(changeChan, stopChan)
 		close(changeChan)

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -59,11 +59,20 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 	return outChan
 }
 
+// Computes the diff from |last| to |s| using "best" algorithm, which balances returning results early vs completing quickly.
 func (m Map) Diff(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	if m.Equals(last) {
 		return
 	}
 	orderedSequenceDiffBest(last.seq, m.seq, changes, closeChan)
+}
+
+// Like Diff() but uses a left-to-right streaming approach, optimised for returning results early, but not completing quickly.
+func (m Map) DiffLeftRight(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
+	if m.Equals(last) {
+		return
+	}
+	orderedSequenceDiffLeftRight(last.seq, m.seq, changes, closeChan)
 }
 
 // Collection interface

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -59,7 +59,7 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 	return outChan
 }
 
-// Computes the diff from |last| to |s| using "best" algorithm, which balances returning results early vs completing quickly.
+// Computes the diff from |last| to |m| using "best" algorithm, which balances returning results early vs completing quickly.
 func (m Map) Diff(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	if m.Equals(last) {
 		return

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -30,11 +30,20 @@ func NewSet(v ...Value) Set {
 	return newSet(seq.Done(nil).(orderedSequence))
 }
 
+// Computes the diff from |last| to |s| using "best" algorithm, which balances returning results early vs completing quickly.
 func (s Set) Diff(last Set, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	if s.Equals(last) {
 		return
 	}
 	orderedSequenceDiffBest(last.seq, s.seq, changes, closeChan)
+}
+
+// Like Diff() but uses a left-to-right streaming approach, optimised for returning results early, but not completing quickly.
+func (s Set) DiffLeftRight(last Set, changes chan<- ValueChanged, closeChan <-chan struct{}) {
+	if s.Equals(last) {
+		return
+	}
+	orderedSequenceDiffLeftRight(last.seq, s.seq, changes, closeChan)
 }
 
 // Collection interface


### PR DESCRIPTION
This fixes https://github.com/attic-labs/noms/issues/2235 where set/map
diff was still running when noms log has finished, and already closed
its database. Commonly this would crash.

I've removed panic-based control flow to make error handling explicit,
and added a "DiffLeftRight" method to set/map so that noms log completes
ASAP. See the issue for details.
