### PR TITLE
fixing typos, stale comments, broken link

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -38,7 +38,7 @@ A database has two responsibilities: it provides storage of [content-addressed](
 
 A Noms database can be implemented on top of any underlying storage system that provides key/value storage with at least optional optimistic concurrency. We only use optimistic concurrency to store the current value of each dataset. Chunks themselves are immutable.
 
-We have implementations of Noms databases on top of [LevelDB](https://github.com/google/leveldb) (usually used locally), our own [HTTP protocol](https://github.com/attic-labs/noms/blob/master/datas/database_server.go) (used for working with a remote database), [Amazon Dynamo](https://aws.amazon.com/dynamodb/), and [memory](https://github.com/attic-labs/noms/blob/master/js/src/memory-store.js) (mainly used for testing).
+We have implementations of Noms databases on top of [LevelDB](https://github.com/google/leveldb) (usually used locally), our own [HTTP protocol](https://github.com/attic-labs/noms/blob/master/go/datas/database_server.go) (used for working with a remote database), [Amazon Dynamo](https://aws.amazon.com/dynamodb/), and [memory](https://github.com/attic-labs/noms/blob/master/js/src/memory-store.js) (mainly used for testing).
 
 Here's an example of creating an http-backed database using the [JavaScript Noms SDK](js-tour.md):
 

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -81,7 +81,7 @@ type MemoryStoreFactory struct {
 }
 
 func (f *MemoryStoreFactory) CreateStore(ns string) ChunkStore {
-	d.Chk.True(f.stores != nil, "Cannot use LevelDBStoreFactory after Shutter().")
+	d.Chk.True(f.stores != nil, "Cannot use MemoryStore after Shutter().")
 	if cs, present := f.stores[ns]; present {
 		return cs
 	}

--- a/go/types/batch_store.go
+++ b/go/types/batch_store.go
@@ -19,7 +19,7 @@ type BatchStore interface {
 	// IsValidating indicates whether this implementation can internally enforce chunk validity & completeness. If a BatchStore supports this, it must also support "staging" of writes -- that is, allowing chunks to be written which reference chunks which have yet to be written.
 	IsValidating() bool
 
-	// Get returns from the store the Value Chunk by r. If r is absent from the store, chunks.EmptyChunk is returned.
+	// Get returns from the store the Value Chunk by h. If h is absent from the store, chunks.EmptyChunk is returned.
 	Get(h hash.Hash) chunks.Chunk
 
 	// SchedulePut enqueues a write for the Chunk c with the given refHeight. Typically, the Value which was encoded to provide c can also be queried for its refHeight. The call may or may not block until c is persisted. The provided hints are used to assist in validation. Validation requires checking that all refs embedded in c are themselves valid, which could naively be done by resolving each one. Instead, hints provides a (smaller) set of refs that point to Chunks that themselves contain many of c's refs. Thus, by checking only the hinted Chunks, c can be validated with fewer read operations.

--- a/go/walk/walk.go
+++ b/go/walk/walk.go
@@ -88,7 +88,7 @@ func doTreeWalkP(v types.Value, vr types.ValueReader, cb SomeCallback, concurren
 		target := r.TargetHash()
 		v := vr.ReadValue(target)
 		if v == nil {
-			f.fail(fmt.Errorf("Attempt to copy absent ref:%s", target.String()))
+			f.fail(fmt.Errorf("Attempt to visit absent ref:%s", target.String()))
 			return
 		}
 		processVal(v, &r)


### PR DESCRIPTION
The link to "HTTP protocol" in the intro doc is broken.
The other changes are updating out-of-date comments and error messages.