### PR TITLE
Tweak "Deleted dataset..." message

### DIFF
--- a/cmd/noms/noms_ds.go
+++ b/cmd/noms/noms_ds.go
@@ -43,7 +43,7 @@ func runDs(args []string) int {
 		d.CheckError(err)
 		defer store.Close()
 
-		fmt.Printf("Deleted dataset %v (was %v)\n\n", set.ID(), oldCommitRef.TargetHash().String())
+		fmt.Printf("Deleted %v (was #%v)\n", toDelete, oldCommitRef.TargetHash().String())
 	} else {
 		if len(args) != 1 {
 			d.CheckError(fmt.Errorf("Database arg missing"))

--- a/cmd/noms/noms_ds_test.go
+++ b/cmd/noms/noms_ds_test.go
@@ -72,7 +72,7 @@ func (s *nomsDsTestSuite) TestNomsDs() {
 
 	// delete one dataset, print message at delete
 	rtnVal, _ = s.Run(main, []string{"ds", "-d", datasetName})
-	s.Equal("Deleted dataset "+id+" (was 6ebc05f71q4sk2psi534fom9se228161)\n\n", rtnVal)
+	s.Equal("Deleted "+datasetName+" (was #6ebc05f71q4sk2psi534fom9se228161)\n", rtnVal)
 
 	// print datasets, just one left
 	rtnVal, _ = s.Run(main, []string{"ds", dbSpec})
@@ -80,7 +80,7 @@ func (s *nomsDsTestSuite) TestNomsDs() {
 
 	// delete the second dataset
 	rtnVal, _ = s.Run(main, []string{"ds", "-d", dataset2Name})
-	s.Equal("Deleted dataset "+id2+" (was f5qtovr9mv7mjj2uoq7flcfpksgf0s2j)\n\n", rtnVal)
+	s.Equal("Deleted "+dataset2Name+" (was #f5qtovr9mv7mjj2uoq7flcfpksgf0s2j)\n", rtnVal)
 
 	// print datasets, none left
 	rtnVal, _ = s.Run(main, []string{"ds", dbSpec})


### PR DESCRIPTION
It (a) had a spurious blank line, (b) should print the dataset path not
just its ID, (c) should include the # for the hash. Now it says:

> noms ds -d path/to/db::my-dataset
Deleted path/to/db::my-dataset (was #lvnbmpj94r9h3nuaj1t0m4jeqp25o1ve)
>