### PR TITLE
Allow Dataset HEAD to be set to non-fastforward commits

### DIFF
--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -85,10 +85,8 @@ func runSync(args []string) int {
 		sinkDataset.Pull(sourceStore, sourceRef, p, progressCh)
 
 		var err error
-		if sourceRef.Height() > sinkRef.Height() {
-			sinkDataset, err = sinkDataset.FastForward(sourceRef)
-		}
-		if sourceRef.Height() <= sinkRef.Height() || err == datas.ErrMergeNeeded {
+		sinkDataset, err = sinkDataset.FastForward(sourceRef)
+		if err == datas.ErrMergeNeeded {
 			sinkDataset, err = sinkDataset.SetHead(sourceRef)
 			nonFF = true
 		}

--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -122,6 +122,6 @@ func IsCommitType(t *types.Type) bool {
 	return types.IsSubtype(valueCommitType, t)
 }
 
-func isRefOfCommitType(t *types.Type) bool {
+func IsRefOfCommitType(t *types.Type) bool {
 	return t.Kind() == types.RefKind && IsCommitType(getRefElementType(t))
 }

--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -40,6 +40,8 @@ type Database interface {
 	// Delete removes the Dataset named datasetID from the map at the root of the Database. The Dataset data is not necessarily cleaned up at this time, but may be garbage collected in the future. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the database is always returned.
 	Delete(datasetID string) (Database, error)
 
+	SetHead(datasetID string, commit types.Struct) (Database, error)
+
 	has(hash hash.Hash) bool
 	validatingBatchStore() types.BatchStore
 }

--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -34,12 +34,13 @@ type Database interface {
 	// Datasets returns the root of the database which is a MapOfStringToRefOfCommit where string is a datasetID.
 	Datasets() types.Map
 
-	// Commit updates the Commit that datasetID in this database points at. All Values that have been written to this Database are guaranteed to be persistent after Commit(). If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the database is always returned.
+	// Commit updates the Commit that datasetID in this database points at. All Values that have been written to this Database are guaranteed to be persistent after Commit(). If the update cannot be performed, e.g., because of a conflict, error will be non-nil. The newest snapshot of the database is always returned.
 	Commit(datasetID string, commit types.Struct) (Database, error)
 
 	// Delete removes the Dataset named datasetID from the map at the root of the Database. The Dataset data is not necessarily cleaned up at this time, but may be garbage collected in the future. If the update cannot be performed, e.g., because of a conflict, error will non-nil. The newest snapshot of the database is always returned.
 	Delete(datasetID string) (Database, error)
 
+	// SetHead sets the Commit that datasetID in this database points at. All Values that have been written to this Database are guaranteed to be persistent after SetHead(). If the update cannot be performed, e.g., because of a conflict, error will be non-nil. The newest snapshot of the database is always returned.
 	SetHead(datasetID string, commit types.Struct) (Database, error)
 
 	has(hash hash.Hash) bool

--- a/go/datas/local_database.go
+++ b/go/datas/local_database.go
@@ -25,12 +25,17 @@ func newLocalDatabase(cs chunks.ChunkStore) *LocalDatabase {
 }
 
 func (lds *LocalDatabase) Commit(datasetID string, commit types.Struct) (Database, error) {
-	err := lds.commit(datasetID, commit)
+	err := lds.doCommit(datasetID, commit)
 	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
 }
 
 func (lds *LocalDatabase) Delete(datasetID string) (Database, error) {
 	err := lds.doDelete(datasetID)
+	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
+}
+
+func (lds *LocalDatabase) SetHead(datasetID string, commit types.Struct) (Database, error) {
+	err := lds.doSetHead(datasetID, commit)
 	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
 }
 

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -18,15 +18,20 @@ type PullProgress struct {
 }
 
 // Pull objects that descends from sourceRef from srcDB to sinkDB. sinkHeadRef should point to a Commit (in sinkDB) that's an ancestor of sourceRef. This allows the algorithm to figure out which portions of data are already present in sinkDB and skip copying them.
-func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) {
+func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) (rewind bool) {
 	srcQ, sinkQ := &types.RefByHeight{sourceRef}, &types.RefByHeight{sinkHeadRef}
+
+	// If the sourceRef points to an object already in sinkDB, there's nothing to do.
+	if sinkDB.has(sourceRef.TargetHash()) {
+		return true
+	}
 
 	// We generally expect that sourceRef descends from sinkHeadRef, so that walking down from sinkHeadRef yields useful hints. If it's not even in the srcDB, then just clear out sinkQ right now and don't bother.
 	if !srcDB.has(sinkHeadRef.TargetHash()) {
 		sinkQ.PopBack()
 	}
 
-	// Since we expect sourceRef to descend from sinkHeadRef, we assume srcDB has a superset of the data in sinkDB. There are some cases where, logically, the code wants to read data it knows to be in sinkDB. In this case, it doesn't actually matter which Database the data comes from, so as an optimization we use whichever is a LocalDatabase -- if either is.
+	// Since we expect sinkHeadRef to descend from sourceRef, we assume srcDB has a superset of the data in sinkDB. There are some cases where, logically, the code wants to read data it knows to be in sinkDB. In this case, it doesn't actually matter which Database the data comes from, so as an optimization we use whichever is a LocalDatabase -- if either is.
 	mostLocalDB := srcDB
 	if _, ok := sinkDB.(*LocalDatabase); ok {
 		mostLocalDB = sinkDB
@@ -144,6 +149,7 @@ func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency 
 		}
 	}
 	sinkDB.validatingBatchStore().AddHints(hints)
+	return false
 }
 
 type traverseResult struct {
@@ -239,7 +245,7 @@ func traverseSink(sinkRef types.Ref, db Database) traverseResult {
 }
 
 func traverseCommon(comRef, sinkHead types.Ref, db Database) traverseResult {
-	if comRef.Height() > 1 && isRefOfCommitType(comRef.Type()) {
+	if comRef.Height() > 1 && IsRefOfCommitType(comRef.Type()) {
 		commit := comRef.TargetValue(db).(types.Struct)
 		// We don't want to traverse the parents of sinkHead, but we still want to traverse its Value on the sinkDB side. We also still want to traverse all children, in both the srcDB and sinkDB, of any common Commit that is not at the Head of sinkDB.
 		exclusionSet := types.NewSet()

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -18,12 +18,12 @@ type PullProgress struct {
 }
 
 // Pull objects that descends from sourceRef from srcDB to sinkDB. sinkHeadRef should point to a Commit (in sinkDB) that's an ancestor of sourceRef. This allows the algorithm to figure out which portions of data are already present in sinkDB and skip copying them.
-func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) (rewind bool) {
+func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) {
 	srcQ, sinkQ := &types.RefByHeight{sourceRef}, &types.RefByHeight{sinkHeadRef}
 
 	// If the sourceRef points to an object already in sinkDB, there's nothing to do.
 	if sinkDB.has(sourceRef.TargetHash()) {
-		return true
+		return
 	}
 
 	// We generally expect that sourceRef descends from sinkHeadRef, so that walking down from sinkHeadRef yields useful hints. If it's not even in the srcDB, then just clear out sinkQ right now and don't bother.
@@ -149,7 +149,7 @@ func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency 
 		}
 	}
 	sinkDB.validatingBatchStore().AddHints(hints)
-	return false
+	return
 }
 
 type traverseResult struct {

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -149,7 +149,6 @@ func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency 
 		}
 	}
 	sinkDB.validatingBatchStore().AddHints(hints)
-	return
 }
 
 type traverseResult struct {

--- a/go/datas/remote_database_client.go
+++ b/go/datas/remote_database_client.go
@@ -27,12 +27,17 @@ func (rds *RemoteDatabaseClient) validatingBatchStore() (bs types.BatchStore) {
 }
 
 func (rds *RemoteDatabaseClient) Commit(datasetID string, commit types.Struct) (Database, error) {
-	err := rds.commit(datasetID, commit)
+	err := rds.doCommit(datasetID, commit)
 	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
 }
 
 func (rds *RemoteDatabaseClient) Delete(datasetID string) (Database, error) {
 	err := rds.doDelete(datasetID)
+	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
+}
+
+func (rds *RemoteDatabaseClient) SetHead(datasetID string, commit types.Struct) (Database, error) {
+	err := rds.doCommit(datasetID, commit)
 	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
 }
 

--- a/go/datas/remote_database_client.go
+++ b/go/datas/remote_database_client.go
@@ -37,7 +37,7 @@ func (rds *RemoteDatabaseClient) Delete(datasetID string) (Database, error) {
 }
 
 func (rds *RemoteDatabaseClient) SetHead(datasetID string, commit types.Struct) (Database, error) {
-	err := rds.doCommit(datasetID, commit)
+	err := rds.doSetHead(datasetID, commit)
 	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
 }
 

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -255,7 +255,7 @@ func handleRootPost(w http.ResponseWriter, req *http.Request, ps URLParams, cs c
 func isMapOfStringToRefOfCommit(m types.Map) bool {
 	mapTypes := m.Type().Desc.(types.CompoundDesc).ElemTypes
 	keyType, valType := mapTypes[0], mapTypes[1]
-	return keyType.Kind() == types.StringKind && (isRefOfCommitType(valType) || isUnionOfRefOfCommitType(valType))
+	return keyType.Kind() == types.StringKind && (IsRefOfCommitType(valType) || isUnionOfRefOfCommitType(valType))
 }
 
 func isUnionOfRefOfCommitType(t *types.Type) bool {
@@ -263,7 +263,7 @@ func isUnionOfRefOfCommitType(t *types.Type) bool {
 		return false
 	}
 	for _, et := range t.Desc.(types.CompoundDesc).ElemTypes {
-		if !isRefOfCommitType(et) {
+		if !IsRefOfCommitType(et) {
 			return false
 		}
 	}

--- a/go/dataset/dataset.go
+++ b/go/dataset/dataset.go
@@ -116,6 +116,8 @@ func (ds *Dataset) FastForward(newHeadRef types.Ref) (sink Dataset, err error) {
 	sink = *ds
 	if currentHeadRef, ok := sink.MaybeHeadRef(); ok && newHeadRef == currentHeadRef {
 		return
+	} else if newHeadRef.Height() <= currentHeadRef.Height() {
+		return sink, datas.ErrMergeNeeded
 	}
 
 	for err = datas.ErrOptimisticLockFailed; err == datas.ErrOptimisticLockFailed; sink, err = sink.commitNewHead(newHeadRef) {

--- a/go/dataset/dataset.go
+++ b/go/dataset/dataset.go
@@ -103,12 +103,12 @@ func (ds *Dataset) Commit(v types.Value, opts CommitOptions) (Dataset, error) {
 }
 
 // Pull objects that descend from sourceRef in srcDB into sinkDB, using at most the given degree of concurrency. Progress will be reported over progressCh as the algorithm works. Objects that are already present in ds will not be pulled over.
-func (ds *Dataset) Pull(sourceDB datas.Database, sourceRef types.Ref, concurrency int, progressCh chan datas.PullProgress) (fastForward bool) {
+func (ds *Dataset) Pull(sourceDB datas.Database, sourceRef types.Ref, concurrency int, progressCh chan datas.PullProgress) {
 	sinkHeadRef := types.Ref{}
 	if currentHeadRef, ok := ds.MaybeHeadRef(); ok {
 		sinkHeadRef = currentHeadRef
 	}
-	return datas.Pull(sourceDB, ds.Database(), sourceRef, sinkHeadRef, concurrency, progressCh)
+	datas.Pull(sourceDB, ds.Database(), sourceRef, sinkHeadRef, concurrency, progressCh)
 }
 
 // FastForward takes a types.Ref to a Commit object and makes it the new Head of ds iff it is a descendant of the current Head. Intended to be used e.g. after a call to Pull(). If the update cannot be performed, e.g., because another process moved the current Head out from under you, err will be non-nil. The newest snapshot of the Dataset is always returned, so the caller an easily retry using the latest.

--- a/go/dataset/pull_test.go
+++ b/go/dataset/pull_test.go
@@ -73,7 +73,9 @@ func TestPullTopDown(t *testing.T) {
 	source, err = source.CommitValue(updatedValue)
 	assert.NoError(err)
 
-	sink, err = sink.Pull(source.Database(), types.NewRef(source.Head()), 1, nil)
+	srcHeadRef := types.NewRef(source.Head())
+	sink.Pull(source.Database(), srcHeadRef, 1, nil)
+	sink, err = sink.FastForward(srcHeadRef)
 	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }
@@ -94,7 +96,9 @@ func TestPullFirstCommitTopDown(t *testing.T) {
 	source, err := source.CommitValue(sourceInitialValue)
 	assert.NoError(err)
 
-	sink, err = sink.Pull(source.Database(), types.NewRef(source.Head()), 1, nil)
+	srcHeadRef := types.NewRef(source.Head())
+	sink.Pull(source.Database(), srcHeadRef, 1, nil)
+	sink, err = sink.FastForward(srcHeadRef)
 	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }
@@ -113,7 +117,9 @@ func TestPullDeepRefTopDown(t *testing.T) {
 	source, err := source.CommitValue(sourceInitialValue)
 	assert.NoError(err)
 
-	sink, err = sink.Pull(source.Database(), types.NewRef(source.Head()), 1, nil)
+	srcHeadRef := types.NewRef(source.Head())
+	sink.Pull(source.Database(), srcHeadRef, 1, nil)
+	sink, err = sink.FastForward(srcHeadRef)
 	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }
@@ -154,10 +160,14 @@ func TestPullWithMeta(t *testing.T) {
 	assert.NoError(err)
 	h4 := source.Head()
 
-	sink, err = sink.Pull(source.Database(), types.NewRef(h2), 1, nil)
+	srcHeadRef := types.NewRef(h2)
+	sink.Pull(source.Database(), srcHeadRef, 1, nil)
+	sink, err = sink.FastForward(srcHeadRef)
 	assert.NoError(err)
 
-	sink, err = sink.Pull(source.Database(), types.NewRef(h4), 1, nil)
+	srcHeadRef = types.NewRef(h4)
+	sink.Pull(source.Database(), srcHeadRef, 1, nil)
+	sink, err = sink.FastForward(srcHeadRef)
 	assert.NoError(err)
 	assert.True(source.Head().Equals(sink.Head()))
 }


### PR DESCRIPTION
The Dataset.Commit() code pathway still enforces fast-forward-only
behavior, but a new SetHead() method allows the HEAD of a Dataset to
be forced to any other Commit.

noms sync detects the case where the source Commit is not a descendent
of the provided sink Dataset's HEAD and uses the new API to force the
sink to the desired new Commit, printing out the now-abandoned old
HEAD.

Fixes #2240