### PR TITLE
Fix noms_sync status message to indicate when new dataset is created

### DIFF
--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -79,7 +79,7 @@ func runSync(args []string) int {
 	}()
 
 	sourceRef := types.NewRef(sourceObj)
-	sinkRef, _ := sinkDataset.MaybeHeadRef()
+	sinkRef, sinkExists := sinkDataset.MaybeHeadRef()
 	nonFF := false
 	err = d.Try(func() {
 		defer profile.MaybeStartProfile().Stop()
@@ -102,10 +102,12 @@ func runSync(args []string) int {
 	if last := <-lastProgressCh; last.DoneCount > 0 {
 		status.Printf("Done - Synced %s in %s (%s/s)", humanize.Bytes(last.DoneBytes), since(start), bytesPerSec(last, start))
 		status.Done()
+	} else if !sinkExists {
+		fmt.Println(args[1], "created.")
 	} else if nonFF && !sourceRef.Equals(sinkRef) {
 		fmt.Printf("Abandoning %s; new head is %s\n", sinkRef.TargetHash(), sourceRef.TargetHash())
 	} else {
-		fmt.Println(args[1], "is up to date.")
+		fmt.Println(args[1], "already up to date.")
 	}
 
 	return 0

--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -103,11 +103,11 @@ func runSync(args []string) int {
 		status.Printf("Done - Synced %s in %s (%s/s)", humanize.Bytes(last.DoneBytes), since(start), bytesPerSec(last, start))
 		status.Done()
 	} else if !sinkExists {
-		fmt.Println(args[1], "created.")
+		fmt.Printf("All chunks already exist at destination! Created new dataset %s.\n", args[1])
 	} else if nonFF && !sourceRef.Equals(sinkRef) {
 		fmt.Printf("Abandoning %s; new head is %s\n", sinkRef.TargetHash(), sourceRef.TargetHash())
 	} else {
-		fmt.Println(args[1], "already up to date.")
+		fmt.Printf("Dataset %s is already up to date.\n", args[1])
 	}
 
 	return 0

--- a/cmd/noms/noms_sync_test.go
+++ b/cmd/noms/noms_sync_test.go
@@ -47,7 +47,7 @@ func (s *nomsSyncTestSuite) TestSyncValidation() {
 }
 
 func (s *nomsSyncTestSuite) TestSync() {
-	source1 := dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(s.LdbDir, "", 1, false)), "foo")
+	source1 := dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(s.LdbDir, "", 1, false)), "src")
 	source1, err := source1.CommitValue(types.Number(42))
 	s.NoError(err)
 	source2, err := source1.CommitValue(types.Number(43))
@@ -55,21 +55,26 @@ func (s *nomsSyncTestSuite) TestSync() {
 	source1HeadRef := source1.Head().Hash()
 	source2.Database().Close() // Close Database backing both Datasets
 
-	sourceSpec := spec.CreateValueSpecString("ldb", s.LdbDir, "#"+source1HeadRef.String())
+	sourceSpec := spec.CreateValueSpecString("ldb", s.LdbDir, "#" + source1HeadRef.String())
 	ldb2dir := path.Join(s.TempDir, "ldb2")
-	sinkDatasetSpec := spec.CreateValueSpecString("ldb", ldb2dir, "bar")
-	s.Run(main, []string{"sync", sourceSpec, sinkDatasetSpec})
+	sinkDatasetSpec := spec.CreateValueSpecString("ldb", ldb2dir, "dest")
+	sout, _ := s.Run(main, []string{"sync", sourceSpec, sinkDatasetSpec})
 
-	dest := dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(ldb2dir, "", 1, false)), "bar")
+	s.Regexp("created", sout)
+	dest := dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(ldb2dir, "", 1, false)), "dest")
 	s.True(types.Number(42).Equals(dest.HeadValue()))
 	dest.Database().Close()
 
-	sourceDataset := spec.CreateValueSpecString("ldb", s.LdbDir, "foo")
-	s.Run(main, []string{"sync", sourceDataset, sinkDatasetSpec})
+	sourceDataset := spec.CreateValueSpecString("ldb", s.LdbDir, "src")
+	sout, _ = s.Run(main, []string{"sync", sourceDataset, sinkDatasetSpec})
+	s.Regexp("Synced", sout)
 
-	dest = dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(ldb2dir, "", 1, false)), "bar")
+	dest = dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(ldb2dir, "", 1, false)), "dest")
 	s.True(types.Number(43).Equals(dest.HeadValue()))
 	dest.Database().Close()
+
+	sout, _ = s.Run(main, []string{"sync", sourceDataset, sinkDatasetSpec})
+	s.Regexp("already up to date", sout)
 }
 
 func (s *nomsSyncTestSuite) TestRewind() {

--- a/cmd/noms/noms_sync_test.go
+++ b/cmd/noms/noms_sync_test.go
@@ -60,7 +60,7 @@ func (s *nomsSyncTestSuite) TestSync() {
 	sinkDatasetSpec := spec.CreateValueSpecString("ldb", ldb2dir, "dest")
 	sout, _ := s.Run(main, []string{"sync", sourceSpec, sinkDatasetSpec})
 
-	s.Regexp("created", sout)
+	s.Regexp("Created", sout)
 	dest := dataset.NewDataset(datas.NewDatabase(chunks.NewLevelDBStore(ldb2dir, "", 1, false)), "dest")
 	s.True(types.Number(42).Equals(dest.HeadValue()))
 	dest.Database().Close()
@@ -74,7 +74,7 @@ func (s *nomsSyncTestSuite) TestSync() {
 	dest.Database().Close()
 
 	sout, _ = s.Run(main, []string{"sync", sourceDataset, sinkDatasetSpec})
-	s.Regexp("already up to date", sout)
+	s.Regexp("up to date", sout)
 }
 
 func (s *nomsSyncTestSuite) TestRewind() {


### PR DESCRIPTION
Starting with a very simple change to get my feet wet. 

This is a potential fix for #2053. Originally, syncing a commit to a non-existent dataset and an already sync'ed dataset resulted in the same message: "<src> is up to date"

This fix distinguishes 2 cases:

  - Syncing to a new dataset prints "<dest> created"

  - Syncing to an identical dataset prints "<dest> already up to date"

It also includes additional tests to sanity check the output. Please let me know if it'd be better to put the output tests in a separate test method. That was my first inclination, but I'm new to go and was afraid the repetition might go against the go grain. 