### PR TITLE
JS: Safari 9 support

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "56.2.1",
+  "version": "56.2.2",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/browser/bytes.js
+++ b/js/src/browser/bytes.js
@@ -58,7 +58,9 @@ export function copy(source: Uint8Array, target: Uint8Array, targetStart: number
 
 export function slice(buff: Uint8Array, start: number, end: number): Uint8Array {
   // Safari does not have slice on typed arrays.
-  return new Uint8Array(buff.buffer, buff.byteOffset + start, end - start);
+  const v = alloc(end - start);
+  copy(buff.subarray(start, end), v, 0);
+  return v;
 }
 
 export function subarray(buff: Uint8Array, start: number, end: number): Uint8Array {

--- a/js/src/browser/bytes.js
+++ b/js/src/browser/bytes.js
@@ -56,11 +56,12 @@ export function copy(source: Uint8Array, target: Uint8Array, targetStart: number
   target.set(source, targetStart);
 }
 
+/**
+ * Slice returns a copy of parts of the bytes starting at `start` ending at `end` (exclusive).
+ */
 export function slice(buff: Uint8Array, start: number, end: number): Uint8Array {
   // Safari does not have slice on typed arrays.
-  const v = alloc(end - start);
-  copy(buff.subarray(start, end), v, 0);
-  return v;
+  return new Uint8Array(buff.buffer.slice(buff.byteOffset + start, buff.byteOffset + end));
 }
 
 export function subarray(buff: Uint8Array, start: number, end: number): Uint8Array {

--- a/js/src/browser/bytes.js
+++ b/js/src/browser/bytes.js
@@ -57,7 +57,8 @@ export function copy(source: Uint8Array, target: Uint8Array, targetStart: number
 }
 
 export function slice(buff: Uint8Array, start: number, end: number): Uint8Array {
-  return buff.slice(start, end);
+  // Safari does not have slice on typed arrays.
+  return new Uint8Array(buff.buffer, buff.byteOffset + start, end - start);
 }
 
 export function subarray(buff: Uint8Array, start: number, end: number): Uint8Array {

--- a/js/src/browser/fetch.js
+++ b/js/src/browser/fetch.js
@@ -26,7 +26,10 @@ function fetch<T>(url: string, responseType: string, options: FetchOptions = {})
   const p = new Promise((resolve, reject) => {
     xhr.onloadend = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve({headers: makeHeaders(xhr), buf: xhr.response});
+        resolve({
+          headers: makeHeaders(xhr),
+          buf: responseType === 'arraybuffer' ? new Uint8Array(xhr.response) : xhr.response,
+        });
       } else {
         reject(new Error(`HTTP Error: ${xhr.status}`));
       }
@@ -76,7 +79,7 @@ function makeHeaders(xhr: XMLHttpRequest): Map<string, string> {
   for (const header of headers) {
     if (header) {
       const [, name, value] = notNull(header.match(/([^:]+): (.*)/));
-      m.set(name, value);
+      m.set(name.toLowerCase(), value);
     }
   }
   return m;

--- a/js/src/browser/fetch.js
+++ b/js/src/browser/fetch.js
@@ -26,10 +26,12 @@ function fetch<T>(url: string, responseType: string, options: FetchOptions = {})
   const p = new Promise((resolve, reject) => {
     xhr.onloadend = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve({
-          headers: makeHeaders(xhr),
-          buf: responseType === 'arraybuffer' ? new Uint8Array(xhr.response) : xhr.response,
-        });
+        // Workaround Flow
+        let buf: any = xhr.response;
+        if (responseType === 'arraybuffer') {
+          buf = new Uint8Array(buf);
+        }
+        resolve({headers: makeHeaders(xhr), buf});
       } else {
         reject(new Error(`HTTP Error: ${xhr.status}`));
       }

--- a/js/src/bytes-test.js
+++ b/js/src/bytes-test.js
@@ -110,14 +110,16 @@ suite('Bytes', () => {
 
   test('slice', () => {
     function test(bytes: any) {
-      const buff = bytes.alloc(3);
+      const buff = bytes.alloc(4);
       buff[0] = 1;
       buff[1] = 2;
       buff[2] = 3;
+      buff[3] = 4;
 
       const b2 = bytes.slice(buff, 1, 3);
       buff[2] = 4;
 
+      assert.equal(b2.length, 2);
       assert.strictEqual(2, b2[0]);
       assert.strictEqual(3, b2[1]);
     }

--- a/js/src/bytes.js
+++ b/js/src/bytes.js
@@ -56,6 +56,9 @@ export function copy(source: Uint8Array, target: Uint8Array, targetStart: number
   }
 }
 
+/**
+ * Slice returns a copy of parts of the bytes starting at `start` ending at `end` (exclusive).
+ */
 export function slice(buff: Uint8Array, start: number, end: number): Uint8Array {
   const v = alloc(end - start);
   // $FlowIssue


### PR DESCRIPTION
- Lower case header names in fetch function
- fetchUint8Array should return an Uint8Array and not an ArrayBuffer
- Safari does not have slice on typed arrays

Fixes #2265