### PR TITLE
add csv-import --detect-column-types option

### DIFF
--- a/samples/go/csv/read.go
+++ b/samples/go/csv/read.go
@@ -14,7 +14,7 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-// StringToKind maps names of valid NomsKinds (e.g. Bool, Float32, etc) to their associated types.NomsKind
+// StringToKind maps names of valid NomsKinds (e.g. Bool, Number, etc) to their associated types.NomsKind
 var StringToKind = func(kindMap map[types.NomsKind]string) map[string]types.NomsKind {
 	m := map[string]types.NomsKind{}
 	for k, v := range kindMap {


### PR DESCRIPTION
a piece of #2263 and a portion of #1610 - avoiding the performance issues of doing this on the actual import by instead making this option only do the detection and then writing the results to stdout (e.g. not performing the import) 