### PR TITLE
Tweak interface/type embedding in databaseCommon

### DIFF
--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -15,8 +15,7 @@ import (
 // Database provides versioned storage for noms values. Each Database instance represents one moment in history. Heads() returns the Commit from each active fork at that moment. The Commit() method returns a new Database, representing a new moment in history.
 type Database interface {
 	// To implement types.ValueWriter, Database implementations provide WriteValue(). WriteValue() writes v to this Database, though v is not guaranteed to be be persistent until after a subsequent Commit(). The return value is the Ref of v.
-	types.ValueWriter
-	types.ValueReader
+	types.ValueReadWriter
 	io.Closer
 
 	// MaybeHead returns the current Head Commit of this Database, which contains the current root of the Database's value tree, if available. If not, it returns a new Commit and 'false'.

--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -14,8 +14,8 @@ import (
 )
 
 type databaseCommon struct {
+	*types.ValueStore
 	cch      *cachingChunkHaver
-	vs       *types.ValueStore
 	rt       chunks.RootTracker
 	rootRef  hash.Hash
 	datasets *types.Map
@@ -27,7 +27,7 @@ var (
 )
 
 func newDatabaseCommon(cch *cachingChunkHaver, vs *types.ValueStore, rt chunks.RootTracker) databaseCommon {
-	return databaseCommon{cch: cch, vs: vs, rt: rt, rootRef: rt.Root()}
+	return databaseCommon{ValueStore: vs, cch: cch, rt: rt, rootRef: rt.Root()}
 }
 
 func (ds *databaseCommon) MaybeHead(datasetID string) (types.Struct, bool) {
@@ -78,16 +78,8 @@ func (ds *databaseCommon) has(h hash.Hash) bool {
 	return ds.cch.Has(h)
 }
 
-func (ds *databaseCommon) ReadValue(r hash.Hash) types.Value {
-	return ds.vs.ReadValue(r)
-}
-
-func (ds *databaseCommon) WriteValue(v types.Value) types.Ref {
-	return ds.vs.WriteValue(v)
-}
-
 func (ds *databaseCommon) Close() error {
-	return ds.vs.Close()
+	return ds.ValueStore.Close()
 }
 
 func (ds *databaseCommon) doSetHead(datasetID string, commit types.Struct) error {

--- a/go/datas/local_database.go
+++ b/go/datas/local_database.go
@@ -26,24 +26,24 @@ func newLocalDatabase(cs chunks.ChunkStore) *LocalDatabase {
 
 func (lds *LocalDatabase) Commit(datasetID string, commit types.Struct) (Database, error) {
 	err := lds.doCommit(datasetID, commit)
-	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
+	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.ValueStore, lds.rt), lds.cs}, err
 }
 
 func (lds *LocalDatabase) Delete(datasetID string) (Database, error) {
 	err := lds.doDelete(datasetID)
-	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
+	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.ValueStore, lds.rt), lds.cs}, err
 }
 
 func (lds *LocalDatabase) SetHead(datasetID string, commit types.Struct) (Database, error) {
 	err := lds.doSetHead(datasetID, commit)
-	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.vs, lds.rt), lds.cs}, err
+	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.ValueStore, lds.rt), lds.cs}, err
 }
 
 func (lds *LocalDatabase) validatingBatchStore() (bs types.BatchStore) {
-	bs = lds.vs.BatchStore()
+	bs = lds.ValueStore.BatchStore()
 	if !bs.IsValidating() {
 		bs = newLocalBatchStore(lds.cs)
-		lds.vs = types.NewValueStore(bs)
+		lds.ValueStore = types.NewValueStore(bs)
 		lds.rt = bs
 	}
 	d.Chk.True(bs.IsValidating())

--- a/go/datas/remote_database_client.go
+++ b/go/datas/remote_database_client.go
@@ -21,24 +21,24 @@ func NewRemoteDatabase(baseURL, auth string) *RemoteDatabaseClient {
 }
 
 func (rds *RemoteDatabaseClient) validatingBatchStore() (bs types.BatchStore) {
-	bs = rds.vs.BatchStore()
+	bs = rds.ValueStore.BatchStore()
 	d.Chk.True(bs.IsValidating())
 	return
 }
 
 func (rds *RemoteDatabaseClient) Commit(datasetID string, commit types.Struct) (Database, error) {
 	err := rds.doCommit(datasetID, commit)
-	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
+	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.ValueStore, rds.rt)}, err
 }
 
 func (rds *RemoteDatabaseClient) Delete(datasetID string) (Database, error) {
 	err := rds.doDelete(datasetID)
-	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
+	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.ValueStore, rds.rt)}, err
 }
 
 func (rds *RemoteDatabaseClient) SetHead(datasetID string, commit types.Struct) (Database, error) {
 	err := rds.doSetHead(datasetID, commit)
-	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.vs, rds.rt)}, err
+	return &RemoteDatabaseClient{newDatabaseCommon(rds.cch, rds.ValueStore, rds.rt)}, err
 }
 
 func (f RemoteStoreFactory) CreateStore(ns string) Database {


### PR DESCRIPTION
In service of streaming set and map mutators, it'd be helpful for
ValueStore to implement some methods that are exposed only to other
code within the types package, even when a ValueStore is embedded
in a Database. That said, we don't want those methods to become a
part of the public Database API.

To enable this, this patch changes databaseCommon to embed a
*types.ValueStore, instead of composing one. This causes all the
ValueStore methods to be a part of the databaseCommon API, but
since all the Database construction methods return a Database by
interface, stuff like BatchStore() all gets masked. Thus, callers
still can't access ValueStore methods. Databases are passed into
the types package as ValueReadWriters, though, so code in there
can call any method on that interface -- including unexported stuff.