### PR TITLE
JS: Fix browser version of encodeUtf8

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "57.0.0",
+  "version": "57.0.1",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/browser/bytes.js
+++ b/js/src/browser/bytes.js
@@ -9,7 +9,7 @@ import {SHA512} from 'asmcrypto.js-sha512';
 
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
-const littleEndian = true;
+const dvBigEndian = false;
 
 export function alloc(size: number): Uint8Array {
   return new Uint8Array(size);
@@ -76,7 +76,7 @@ export function encodeUtf8(str: string, buff: Uint8Array, dv: DataView, offset: 
   const strBuff = fromString(str);
   const size = strBuff.byteLength;
 
-  dv.setUint32(offset, size, littleEndian);
+  dv.setUint32(offset, size, dvBigEndian);
   offset += 4;
 
   buff.set(strBuff, offset);

--- a/js/src/bytes-test.js
+++ b/js/src/bytes-test.js
@@ -183,4 +183,24 @@ suite('Bytes', () => {
     test([1, 2, 3, 4, 5]);
     test([2, 3, 4, 5, 10]);
   });
+
+  test('encodeUtf8', () => {
+    function t(str) {
+      const nb = NodeBytes.alloc(100);
+      const ndv = new DataView(nb.buffer, nb.byteOffset, nb.byteLength);
+      const no = NodeBytes.encodeUtf8(str, nb, ndv, 0);
+
+      const bb = BrowserBytes.alloc(100);
+      const bdv = new DataView(bb.buffer, bb.byteOffset, bb.byteLength);
+      const bo = BrowserBytes.encodeUtf8(str, bb, bdv, 0);
+
+      assert.equal(no, bo);
+      for (let i = 0; i < no; i++) {
+        assert.equal(nb[i], bb[i]);
+      }
+    }
+    t('');
+    t('hello');
+    t('💩');
+  });
 });


### PR DESCRIPTION
When we switched to big endian we forgot to update this.

Fixes #2338