### PR TITLE
Let Splore open a noms path

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "58.0.0",
+  "version": "58.1.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/src/noms.js
+++ b/js/src/noms.js
@@ -13,6 +13,7 @@ export {default as Dataset} from './dataset.js';
 export {default as Blob, BlobReader, BlobWriter} from './blob.js';
 export {decodeValue} from './codec.js';
 export {default as Chunk} from './chunk.js';
+export {getHashOfValue} from './get-hash.js';
 export {default as HttpBatchStore} from './http-batch-store.js';
 export {default as MemoryStore} from './memory-store.js';
 export {default as Hash, emptyHash} from './hash.js';

--- a/js/src/specs.js
+++ b/js/src/specs.js
@@ -22,7 +22,6 @@ import type Value from './value.js';
 export class DatabaseSpec {
   scheme: string;
   path: string;
-  authorization: string;
 
   _ms: MemoryStore | null;
 
@@ -67,7 +66,6 @@ export class DatabaseSpec {
   constructor(scheme: string, path: string) {
     this.scheme = scheme;
     this.path = path;
-    this.authorization = '';
     // Cache the MemoryStore for testing, or it will reset every time database() is called.
     this._ms = scheme === 'mem' ? new MemoryStore() : null;
   }
@@ -80,11 +78,8 @@ export class DatabaseSpec {
       case 'mem':
         return new Database(new BatchStoreAdaptor(notNull(this._ms)));
       case 'http':
-      case 'https': {
-        const auth = this.authorization;
-        const opts = auth !== '' ? {headers: {Authorization: `Bearer ${auth}`}} : undefined;
-        return new Database(new HttpBatchStore(`${this.scheme}:${this.path}`, undefined, opts));
-      }
+      case 'https':
+        return new Database(new HttpBatchStore(`${this.scheme}:${this.path}`));
       default:
         throw new Error('Unreached');
     }

--- a/samples/js/splore/src/node.js
+++ b/samples/js/splore/src/node.js
@@ -54,7 +54,7 @@ export default class Node extends React.Component<void, Props, State> {
 
     let text = this.props.text;
     if (this.props.hash) {
-      const url = `/?db=${this.props.db}&hash=${this.props.hash.toString()}`;
+      const url = `/?p=${this.props.db}::#${this.props.hash.toString()}`;
       text = <a href={url}>{text}</a>;
     }
 

--- a/samples/js/splore/src/node.js
+++ b/samples/js/splore/src/node.js
@@ -54,7 +54,7 @@ export default class Node extends React.Component<void, Props, State> {
 
     let text = this.props.text;
     if (this.props.hash) {
-      const url = `/?p=${this.props.db}::#${this.props.hash.toString()}`;
+      const url = `/?db=${this.props.db}&p=#${this.props.hash.toString()}`;
       text = <a href={url}>{text}</a>;
     }
 


### PR DESCRIPTION
Currently Splore can only open a database (db=) or a hash (hash=). This
removes the hash and replaces it with the much more general path (p=).

For example, what used to be:
  ?db=http://demo.noms.io&hash=abcd
is now:
  ?p=http://demo.noms.io::#abcd

and of course more complex paths work, like:
  ?p=http://demo.noms.io::#abcd.field[42].name

I've made 2 changes to the noms API for this:
1. Added support for an authorization token to DatabaseSpec.
2. Exposed getHashOfValue in noms.js.