### PR TITLE
Add missing ==nil check to list diff

### DIFF
--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -68,7 +68,7 @@ func diffLists(w io.Writer, p types.Path, v1, v2 types.List) (err error) {
 
 		if splice.SpRemoved == splice.SpAdded {
 			// Heuristic: list only has modifications.
-			for i := uint64(0); i < splice.SpRemoved; i++ {
+			for i := uint64(0); i < splice.SpRemoved && err == nil; i++ {
 				lastEl := v1.Get(splice.SpAt + i)
 				newEl := v2.Get(splice.SpFrom + i)
 				if shouldDescend(lastEl, newEl) {


### PR DESCRIPTION
This isn't triggering any problem in particular, I just noticed it. All
it meant was that noms log might take unnecessarily long with list diff
when there are a lot of changes.