### PR TITLE
Add a friendly message to the base path of the noms server

### DIFF
--- a/go/constants/http.go
+++ b/go/constants/http.go
@@ -9,4 +9,5 @@ const (
 	GetRefsPath    = "/getRefs/"
 	HasRefsPath    = "/hasRefs/"
 	WriteValuePath = "/writeValue/"
+	BasePath       = "/"
 )

--- a/go/datas/database_server.go
+++ b/go/datas/database_server.go
@@ -67,6 +67,7 @@ func (s *remoteDatabaseServer) Run() {
 	router.OPTIONS(constants.RootPath, s.corsHandle(noopHandle))
 	router.POST(constants.WriteValuePath, s.corsHandle(s.makeHandle(HandleWriteValue)))
 	router.OPTIONS(constants.WriteValuePath, s.corsHandle(noopHandle))
+	router.GET(constants.BasePath, s.corsHandle(s.makeHandle(HandleBaseGet)))
 
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -29,6 +29,7 @@ type Handler func(w http.ResponseWriter, req *http.Request, ps URLParams, cs chu
 
 // NomsVersionHeader is the name of the header that Noms clients and servers must set in every request/response.
 const NomsVersionHeader = "x-noms-vers"
+const nomsBaseHtml = "<html><head></head><body><p>Hi. This is a Noms HTTP server.</p><p>To learn more, visit <a href=\"https://github.com/attic-labs/noms\">our github project</a>.</p></body></html>"
 
 var (
 	// HandleWriteValue is meant to handle HTTP POST requests to the writeValue/ server endpoint. The payload should be an appropriately-ordered sequence of Chunks to be validated and stored on the server.
@@ -50,6 +51,10 @@ var (
 	// HandleWriteValue is meant to handle HTTP POST requests to the root/ server endpoint. This is used to update the Root to point to a new Chunk.
 	// TODO: Nice comment about what headers it expects/honors, payload format, and error responses.
 	HandleRootPost = versionCheck(handleRootPost)
+
+	// HandleBaseGet is meant to handle HTTP GET requests to the / server endpoint. This is used to give a friendly message to users.
+	// TODO: Nice comment about what headers it expects/honors, payload format, and error responses.
+	HandleBaseGet = handleBaseGet
 )
 
 func versionCheck(hndlr Handler) Handler {
@@ -250,6 +255,13 @@ func handleRootPost(w http.ResponseWriter, req *http.Request, ps URLParams, cs c
 		w.WriteHeader(http.StatusConflict)
 		return
 	}
+}
+
+func handleBaseGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt chunks.ChunkStore) {
+	d.PanicIfTrue(req.Method != "GET", "Expected get method.")
+
+	fmt.Fprintf(w, nomsBaseHtml)
+	w.Header().Add("content-type", "text/html")
 }
 
 func isMapOfStringToRefOfCommit(m types.Map) bool {

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -249,6 +249,21 @@ func TestHandleGetRoot(t *testing.T) {
 	}
 }
 
+func TestHandleGetBase(t *testing.T) {
+	assert := assert.New(t)
+	cs := chunks.NewTestStore()
+	c := chunks.NewChunk([]byte("abc"))
+	cs.Put(c)
+	assert.True(cs.UpdateRoot(c.Hash(), hash.Hash{}))
+
+	w := httptest.NewRecorder()
+	HandleBaseGet(w, newRequest("GET", "", "", nil, nil), params{}, cs)
+
+	if assert.Equal(http.StatusOK, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
+		assert.Equal([]byte(nomsBaseHtml), w.Body.Bytes())
+	}
+}
+
 func TestHandlePostRoot(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()


### PR DESCRIPTION
Add a friendly message to the base path of the noms server, as opposed to an unfriendly and generic 404