### PR TITLE
csv-analyze to detect column types and primary keys

### DIFF
--- a/samples/go/csv/csv-analyze/.gitignore
+++ b/samples/go/csv/csv-analyze/.gitignore
@@ -1,0 +1,1 @@
+csv-analyze

--- a/samples/go/csv/csv-analyze/analyze.go
+++ b/samples/go/csv/csv-analyze/analyze.go
@@ -1,0 +1,87 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/profile"
+	"github.com/attic-labs/noms/samples/go/csv"
+	flag "github.com/juju/gnuflag"
+)
+
+func main() {
+	// Actually the delimiter uses runes, which can be multiple characters long.
+	// https://blog.golang.org/strings
+	delimiter := flag.String("delimiter", ",", "field delimiter for csv file, must be exactly one character long.")
+	header := flag.String("header", "", "header row. If empty, we'll use the first row of the file")
+	skipRecords := flag.Uint("skip-records", 0, "number of records to skip at beginning of file")
+	detectColumnTypes := flag.Bool("detect-column-types", false, "detect column types by analyzing a portion of csv file")
+	detectPrimaryKeys := flag.Bool("detect-pk", false, "detect primary key candidates by analyzing a portion of csv file")
+	numSamples := flag.Int("num-samples", 1000000, "number of records to use for samples")
+	numFieldsInPK := flag.Int("num-fields-pk", 3, "maximum number of columns to consider when detecting PKs")
+
+	profile.RegisterProfileFlags(flag.CommandLine)
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: csv-analyze [options] <csvfile>\n\n")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse(true)
+
+	var err error
+	switch {
+	case flag.NArg() == 0:
+		err = errors.New("Maybe you put options after the csvfile?")
+	case flag.NArg() > 1:
+		err = errors.New("Too many arguments")
+	}
+	d.CheckError(err)
+
+	defer profile.MaybeStartProfile().Stop()
+
+	var r io.Reader
+	var filePath string
+
+	filePath = flag.Arg(0)
+	res, err := os.Open(filePath)
+	d.CheckError(err)
+	defer res.Close()
+	r = res
+
+	comma, err := csv.StringToRune(*delimiter)
+	d.CheckErrorNoUsage(err)
+
+	cr := csv.NewCSVReader(r, comma)
+	csv.SkipRecords(cr, *skipRecords)
+
+	var headers []string
+	if *header == "" {
+		headers, err = cr.Read()
+		d.PanicIfError(err)
+	} else {
+		headers = strings.Split(*header, string(comma))
+	}
+
+	kinds := []types.NomsKind{}
+	if *detectColumnTypes {
+		kinds = csv.GetSchema(cr, *numSamples, len(headers))
+		fmt.Fprintf(os.Stdout, "kinds detected: %v\n", strings.Join(csv.KindsToStrings(kinds), ","))
+	}
+
+	if *detectPrimaryKeys {
+		pks := csv.FindPrimaryKeys(cr, *numSamples, *numFieldsInPK, len(headers))
+		for _, pk := range pks {
+			fmt.Fprintf(os.Stdout, "pk: (%v) - %s\n", pk, strings.Join(csv.GetFieldNamesFromIndices(headers, pk), ","))
+		}
+	}
+}

--- a/samples/go/csv/csv-analyze/analyze.go
+++ b/samples/go/csv/csv-analyze/analyze.go
@@ -75,13 +75,13 @@ func main() {
 	kinds := []types.NomsKind{}
 	if *detectColumnTypes {
 		kinds = csv.GetSchema(cr, *numSamples, len(headers))
-		fmt.Fprintf(os.Stdout, "kinds detected: %v\n", strings.Join(csv.KindsToStrings(kinds), ","))
+		fmt.Fprintf(os.Stdout, "%v\n", strings.Join(csv.KindsToStrings(kinds), ","))
 	}
 
 	if *detectPrimaryKeys {
 		pks := csv.FindPrimaryKeys(cr, *numSamples, *numFieldsInPK, len(headers))
 		for _, pk := range pks {
-			fmt.Fprintf(os.Stdout, "pk: (%v) - %s\n", pk, strings.Join(csv.GetFieldNamesFromIndices(headers, pk), ","))
+			fmt.Fprintf(os.Stdout, "%s\n", strings.Join(csv.GetFieldNamesFromIndices(headers, pk), ","))
 		}
 	}
 }

--- a/samples/go/csv/csv-analyze/analyze.go
+++ b/samples/go/csv/csv-analyze/analyze.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -38,14 +37,10 @@ func main() {
 
 	flag.Parse(true)
 
-	var err error
-	switch {
-	case flag.NArg() == 0:
-		err = errors.New("Maybe you put options after the csvfile?")
-	case flag.NArg() > 1:
-		err = errors.New("Too many arguments")
+	if flag.NArg() != 1 {
+		flag.Usage()
+		return
 	}
-	d.CheckError(err)
 
 	defer profile.MaybeStartProfile().Stop()
 
@@ -75,7 +70,7 @@ func main() {
 	kinds := []types.NomsKind{}
 	if *detectColumnTypes {
 		kinds = csv.GetSchema(cr, *numSamples, len(headers))
-		fmt.Fprintf(os.Stdout, "%v\n", strings.Join(csv.KindsToStrings(kinds), ","))
+		fmt.Fprintf(os.Stdout, "%s\n", strings.Join(csv.KindsToStrings(kinds), ","))
 	}
 
 	if *detectPrimaryKeys {

--- a/samples/go/csv/csv-analyze/analyze_test.go
+++ b/samples/go/csv/csv-analyze/analyze_test.go
@@ -1,0 +1,93 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/util/clienttest"
+	"github.com/attic-labs/testify/suite"
+)
+
+func TestCSVAnalyze(t *testing.T) {
+	suite.Run(t, &csvAnalyzeTestSuite{})
+}
+
+type csvAnalyzeTestSuite struct {
+	clienttest.ClientTestSuite
+	tmpFileName string
+}
+
+func writeSampleData(w io.Writer) {
+	_, err := io.WriteString(w, "Date,Time,Temperature\n")
+	d.Chk.NoError(err)
+
+	// 30 samples of String,String,Number
+	for i := 0; i < 30; i++ {
+		_, err = io.WriteString(w, fmt.Sprintf("08/14/2016,12:%d,73.4%d\n", i, i))
+		d.Chk.NoError(err)
+	}
+
+	// an extra sample of String,String,String to have detect types with smaller samples only find Number
+	_, err = io.WriteString(w, fmt.Sprintf("08/14/2016,13:01,none\n"))
+	d.Chk.NoError(err)
+
+	// an extra sample of a duplicate Date,Temperature to have detect pk rule it out (with smaller samples)
+	_, err = io.WriteString(w, fmt.Sprintf("08/14/2016,13:02,73.42\n"))
+	d.Chk.NoError(err)
+}
+
+func (s *csvAnalyzeTestSuite) SetupTest() {
+	input, err := ioutil.TempFile(s.TempDir, "")
+	d.Chk.NoError(err)
+	s.tmpFileName = input.Name()
+	writeSampleData(input)
+	defer input.Close()
+}
+
+func (s *csvAnalyzeTestSuite) TearDownTest() {
+	os.Remove(s.tmpFileName)
+}
+
+func (s *csvAnalyzeTestSuite) TestCSVAnalyzeDetectColumnTypes() {
+	stdout, stderr := s.Run(main, []string{"--detect-column-types=1", s.tmpFileName})
+	s.Equal("String,String,String\n", stdout)
+	s.Equal("", stderr)
+}
+
+func (s *csvAnalyzeTestSuite) TestCSVAnalyzeDetectColumnTypesSamples20() {
+	stdout, stderr := s.Run(main, []string{"--detect-column-types=1", "--num-samples=20", s.tmpFileName})
+	s.Equal("String,String,Number\n", stdout)
+	s.Equal("", stderr)
+}
+
+func (s *csvAnalyzeTestSuite) TestCSVAnalyzeDetectPrimaryKeys() {
+	stdout, stderr := s.Run(main, []string{"--detect-pk=1", s.tmpFileName})
+	s.Equal("Time\nDate,Time\nTime,Temperature\nDate,Time,Temperature\n", stdout)
+	s.Equal("", stderr)
+}
+
+func (s *csvAnalyzeTestSuite) TestCSVAnalyzeDetectPrimaryKeysSamples20() {
+	stdout, stderr := s.Run(main, []string{"--detect-pk=1", "--num-samples=20", s.tmpFileName})
+	s.Equal("Time\nTemperature\nDate,Time\nDate,Temperature\nTime,Temperature\nDate,Time,Temperature\n", stdout)
+	s.Equal("", stderr)
+}
+
+func (s *csvAnalyzeTestSuite) TestCSVAnalyzeDetectPrimaryKeysSingleField() {
+	stdout, stderr := s.Run(main, []string{"--detect-pk=1", "--num-fields-pk=1", s.tmpFileName})
+	s.Equal("Time\n", stdout)
+	s.Equal("", stderr)
+}
+
+func (s *csvAnalyzeTestSuite) TestCSVAnalyzeDetectPrimaryKeysTwoFields() {
+	stdout, stderr := s.Run(main, []string{"--detect-pk=1", "--num-fields-pk=2", s.tmpFileName})
+	s.Equal("Time\nDate,Time\nTime,Temperature\n", stdout)
+	s.Equal("", stderr)
+}

--- a/samples/go/csv/csv_reader.go
+++ b/samples/go/csv/csv_reader.go
@@ -32,7 +32,13 @@ func (r reader) Read(p []byte) (n int, err error) {
 	return
 }
 
-// NewCSVReader returns a new csv.Reader that splits on comma and asserts that all rows contain the same number of fields as the first.
+func SkipRecords(r *csv.Reader, n uint) {
+	for i := uint(0); i < n; i++ {
+		r.Read()
+	}
+}
+
+// NewCSVReader returns a new csv.Reader that splits on comma
 func NewCSVReader(res io.Reader, comma rune) *csv.Reader {
 	bufRes := bufio.NewReader(res)
 	r := csv.NewReader(reader{r: bufRes})

--- a/samples/go/csv/schema_test.go
+++ b/samples/go/csv/schema_test.go
@@ -239,7 +239,6 @@ func TestSchemaDetection(t *testing.T) {
 				types.StringKind},
 		},
 	)
-
 	test(
 		[][]string{
 			[]string{fmt.Sprintf("%d", uint64(1<<63))},
@@ -251,7 +250,6 @@ func TestSchemaDetection(t *testing.T) {
 				types.StringKind},
 		},
 	)
-
 	test(
 		[][]string{
 			[]string{fmt.Sprintf("%d", uint64(1<<32))},
@@ -263,4 +261,91 @@ func TestSchemaDetection(t *testing.T) {
 				types.StringKind},
 		},
 	)
+}
+
+func TestCombinationsWithLength(t *testing.T) {
+	assert := assert.New(t)
+	test := func(input []int, length int, expect [][]int) {
+		combinations := make([][]int, 0)
+		combinationsWithLength(input, length, func(combination []int) {
+			combinations = append(combinations, append([]int{}, combination...))
+		})
+
+		assert.Equal(expect, combinations)
+	}
+	test([]int{0}, 1, [][]int{
+		[]int{0},
+	})
+	test([]int{1}, 1, [][]int{
+		[]int{1},
+	})
+	test([]int{0, 1}, 1, [][]int{
+		[]int{0},
+		[]int{1},
+	})
+	test([]int{0, 1}, 2, [][]int{
+		[]int{0, 1},
+	})
+	test([]int{70, 80, 90, 100}, 1, [][]int{
+		[]int{70},
+		[]int{80},
+		[]int{90},
+		[]int{100},
+	})
+	test([]int{70, 80, 90, 100}, 2, [][]int{
+		[]int{70, 80},
+		[]int{70, 90},
+		[]int{70, 100},
+		[]int{80, 90},
+		[]int{80, 100},
+		[]int{90, 100},
+	})
+	test([]int{70, 80, 90, 100}, 3, [][]int{
+		[]int{70, 80, 90},
+		[]int{70, 80, 100},
+		[]int{70, 90, 100},
+		[]int{80, 90, 100},
+	})
+}
+
+func TestCombinationsWithLengthFromTo(t *testing.T) {
+	assert := assert.New(t)
+	test := func(input []int, smallestLength, largestLength int, expect [][]int) {
+		combinations := make([][]int, 0)
+		combinationsLengthsFromTo(input, smallestLength, largestLength, func(combination []int) {
+			combinations = append(combinations, append([]int{}, combination...))
+		})
+
+		assert.Equal(expect, combinations)
+	}
+	test([]int{0}, 1, 1, [][]int{
+		[]int{0},
+	})
+	test([]int{1}, 1, 1, [][]int{
+		[]int{1},
+	})
+	test([]int{0, 1}, 1, 2, [][]int{
+		[]int{0},
+		[]int{1},
+		[]int{0, 1},
+	})
+	test([]int{0, 1}, 2, 2, [][]int{
+		[]int{0, 1},
+	})
+	test([]int{70, 80, 90, 100}, 1, 3, [][]int{
+		[]int{70},
+		[]int{80},
+		[]int{90},
+		[]int{100},
+		[]int{70, 80},
+		[]int{70, 90},
+		[]int{70, 100},
+		[]int{80, 90},
+		[]int{80, 100},
+		[]int{90, 100},
+		[]int{70, 80, 90},
+		[]int{70, 80, 100},
+		[]int{70, 90, 100},
+		[]int{80, 90, 100},
+	})
 }


### PR DESCRIPTION
Work in progress, but feedback welcome any time.

- create csv-analyze
- add initial version of detection of PKs
- move detect-columns from csv-import to csv-analyze

Working toward #1956, #2263, related to #1610.
