### PR TITLE
Use best set/map diff in noms diff

### DIFF
--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -17,16 +17,27 @@ type (
 	valueFunc func(k types.Value) types.Value
 )
 
+type diffWriter struct {
+	w         io.Writer
+	leftRight bool
+}
+
+func (w diffWriter) Write(p []byte) (n int, err error) {
+	return w.w.Write(p)
+}
+
 func shouldDescend(v1, v2 types.Value) bool {
 	kind := v1.Type().Kind()
 	return !types.IsPrimitiveKind(kind) && kind == v2.Type().Kind() && kind != types.RefKind
 }
 
-func Diff(w io.Writer, v1, v2 types.Value) error {
-	return diff(w, types.Path{}, nil, v1, v2)
+// Writes the Diff from |v1| to |v2| to |w|.
+// If |leftRight| is true then the left-diff diff is used for ordered sequences - see Diff vs DiffLeftRight in Set and Map.
+func Diff(w io.Writer, v1, v2 types.Value, leftRight bool) error {
+	return diff(diffWriter{w, leftRight}, types.Path{}, nil, v1, v2)
 }
 
-func diff(w io.Writer, p types.Path, key, v1, v2 types.Value) error {
+func diff(w diffWriter, p types.Path, key, v1, v2 types.Value) error {
 	if v1.Equals(v2) {
 		return nil
 	}
@@ -50,7 +61,7 @@ func diff(w io.Writer, p types.Path, key, v1, v2 types.Value) error {
 	return line(w, ADD, key, v2)
 }
 
-func diffLists(w io.Writer, p types.Path, v1, v2 types.List) (err error) {
+func diffLists(w diffWriter, p types.Path, v1, v2 types.List) (err error) {
 	spliceChan := make(chan types.Splice)
 	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
 
@@ -106,9 +117,13 @@ func diffLists(w io.Writer, p types.Path, v1, v2 types.List) (err error) {
 	return
 }
 
-func diffMaps(w io.Writer, p types.Path, v1, v2 types.Map) error {
+func diffMaps(w diffWriter, p types.Path, v1, v2 types.Map) error {
 	return diffOrdered(w, p, line, func(cc chan<- types.ValueChanged, sc <-chan struct{}) {
-		v2.DiffLeftRight(v1, cc, sc)
+		if w.leftRight {
+			v2.DiffLeftRight(v1, cc, sc)
+		} else {
+			v2.Diff(v1, cc, sc)
+		}
 	},
 		func(k types.Value) types.Value { return k },
 		func(k types.Value) types.Value { return v1.Get(k) },
@@ -116,7 +131,7 @@ func diffMaps(w io.Writer, p types.Path, v1, v2 types.Map) error {
 	)
 }
 
-func diffStructs(w io.Writer, p types.Path, v1, v2 types.Struct) error {
+func diffStructs(w diffWriter, p types.Path, v1, v2 types.Struct) error {
 	return diffOrdered(w, p, field, func(cc chan<- types.ValueChanged, sc <-chan struct{}) {
 		v2.Diff(v1, cc, sc)
 	},
@@ -126,9 +141,13 @@ func diffStructs(w io.Writer, p types.Path, v1, v2 types.Struct) error {
 	)
 }
 
-func diffSets(w io.Writer, p types.Path, v1, v2 types.Set) error {
+func diffSets(w diffWriter, p types.Path, v1, v2 types.Set) error {
 	return diffOrdered(w, p, line, func(cc chan<- types.ValueChanged, sc <-chan struct{}) {
-		v2.DiffLeftRight(v1, cc, sc)
+		if w.leftRight {
+			v2.DiffLeftRight(v1, cc, sc)
+		} else {
+			v2.Diff(v1, cc, sc)
+		}
 	},
 		func(k types.Value) types.Value { return nil },
 		func(k types.Value) types.Value { return k },
@@ -136,7 +155,7 @@ func diffSets(w io.Writer, p types.Path, v1, v2 types.Set) error {
 	)
 }
 
-func diffOrdered(w io.Writer, p types.Path, lf lineFunc, df diffFunc, kf, v1, v2 valueFunc) (err error) {
+func diffOrdered(w diffWriter, p types.Path, lf lineFunc, df diffFunc, kf, v1, v2 valueFunc) (err error) {
 	changeChan := make(chan types.ValueChanged)
 	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
 

--- a/cmd/noms/diff/diff.go
+++ b/cmd/noms/diff/diff.go
@@ -31,8 +31,8 @@ func shouldDescend(v1, v2 types.Value) bool {
 	return !types.IsPrimitiveKind(kind) && kind == v2.Type().Kind() && kind != types.RefKind
 }
 
-// Writes the Diff from |v1| to |v2| to |w|.
-// If |leftRight| is true then the left-diff diff is used for ordered sequences - see Diff vs DiffLeftRight in Set and Map.
+// Diff writes the diff from |v1| to |v2| to |w|.
+// If |leftRight| is true then the left-right diff is used for ordered sequences - see Diff vs DiffLeftRight in Set and Map.
 func Diff(w io.Writer, v1, v2 types.Value, leftRight bool) error {
 	return diff(diffWriter{w, leftRight}, types.Path{}, nil, v1, v2)
 }

--- a/cmd/noms/diff/diff_test.go
+++ b/cmd/noms/diff/diff_test.go
@@ -5,13 +5,14 @@
 package diff
 
 import (
+	"bytes"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/test"
 	"github.com/attic-labs/testify/assert"
-	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 var (
@@ -24,6 +25,14 @@ var (
 	mm3x = createMap("m1", "m-one", "v2", "m-two", "m3", "m-three-diff", "m4", aa1x)
 	mm4  = createMap("n1", "n-one", "n2", "n-two", "n3", "n-three", "n4", aa1)
 )
+
+type testFunc func(w io.Writer, v1, v2 types.Value)
+
+func makeTestFunc(leftRight bool) testFunc {
+	return func(w io.Writer, v1, v2 types.Value) {
+		Diff(w, v1, v2, leftRight)
+	}
+}
 
 func valToTypesValue(v interface{}) types.Value {
 	var v1 types.Value
@@ -82,29 +91,29 @@ func TestNomsMapdiff(t *testing.T) {
   }
 `
 
-	m1 := createMap("map-1", mm1, "map-2", mm2, "map-3", mm3, "map-4", mm4)
-	m2 := createMap("map-1", mm1, "map-2", mm2, "map-3", mm3x, "map-4", mm4)
-	buf := util.NewBuffer(nil)
-	Diff(buf, m1, m2)
+	tf := func(f testFunc) {
+		m1 := createMap("map-1", mm1, "map-2", mm2, "map-3", mm3, "map-4", mm4)
+		m2 := createMap("map-1", mm1, "map-2", mm2, "map-3", mm3x, "map-4", mm4)
+		buf := &bytes.Buffer{}
+		f(buf, m1, m2)
 
-	assert.Equal(expected, buf.String())
+		assert.Equal(expected, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }
 
 func TestNomsSetDiff(t *testing.T) {
 	assert := assert.New(t)
 
-	expected := `(root) {
+	expected1 := `(root) {
 -   "five"
 +   "five-diff"
   }
 `
-	s1 := createSet("one", "three", "five", "seven", "nine")
-	s2 := createSet("one", "three", "five-diff", "seven", "nine")
-	buf := util.NewBuffer(nil)
-	Diff(buf, s1, s2)
-	assert.Equal(expected, buf.String())
 
-	expected = `(root) {
+	expected2 := `(root) {
 +   {  // 4 items
 +     "m1": "m-one",
 +     "m3": "m-three-diff",
@@ -129,11 +138,24 @@ func TestNomsSetDiff(t *testing.T) {
 -   }
   }
 `
-	s1 = createSet(mm1, mm2, mm3, mm4)
-	s2 = createSet(mm1, mm2, mm3x, mm4)
-	buf = util.NewBuffer(nil)
-	Diff(buf, s1, s2)
-	assert.Equal(expected, buf.String())
+
+	s1 := createSet("one", "three", "five", "seven", "nine")
+	s2 := createSet("one", "three", "five-diff", "seven", "nine")
+	s3 := createSet(mm1, mm2, mm3, mm4)
+	s4 := createSet(mm1, mm2, mm3x, mm4)
+
+	tf := func(f testFunc) {
+		buf := &bytes.Buffer{}
+		f(buf, s1, s2)
+		assert.Equal(expected1, buf.String())
+
+		buf = &bytes.Buffer{}
+		f(buf, s3, s4)
+		assert.Equal(expected2, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }
 
 func TestNomsStructDiff(t *testing.T) {
@@ -164,37 +186,38 @@ func TestNomsStructDiff(t *testing.T) {
 	m1 := createMap("one", 1, "two", 2, "three", s1, "four", "four")
 	m2 := createMap("one", 1, "two", 2, "three", s2, "four", "four-diff")
 
-	buf := util.NewBuffer(nil)
-	Diff(buf, m1, m2)
-	assert.Equal(expected, buf.String())
+	tf := func(f testFunc) {
+		buf := &bytes.Buffer{}
+		f(buf, m1, m2)
+		assert.Equal(expected, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }
 
 func TestNomsListDiff(t *testing.T) {
 	assert := assert.New(t)
 
-	expected := `(root) {
+	expected1 := `(root) {
 -   2
 +   22
 -   44
   }
 `
+
 	l1 := createList(1, 2, 3, 4, 44, 5, 6)
 	l2 := createList(1, 22, 3, 4, 5, 6)
-	buf := util.NewBuffer(nil)
-	Diff(buf, l1, l2)
-	assert.Equal(expected, buf.String())
 
-	expected = `(root) {
+	expected2 := `(root) {
 +   "seven"
   }
 `
-	l1 = createList("one", "two", "three", "four", "five", "six")
-	l2 = createList("one", "two", "three", "four", "five", "six", "seven")
-	buf = util.NewBuffer(nil)
-	Diff(buf, l1, l2)
-	assert.Equal(expected, buf.String())
 
-	expected = `[2] {
+	l3 := createList("one", "two", "three", "four", "five", "six")
+	l4 := createList("one", "two", "three", "four", "five", "six", "seven")
+
+	expected3 := `[2] {
 -   "m3": "m-three"
 +   "m3": "m-three-diff"
   }
@@ -203,12 +226,27 @@ func TestNomsListDiff(t *testing.T) {
 +   "a1": "a-one-diff"
   }
 `
-	l1 = createList(mm1, mm2, mm3, mm4)
-	l2 = createList(mm1, mm2, mm3x, mm4)
-	buf = util.NewBuffer(nil)
-	Diff(buf, l1, l2)
 
-	assert.Equal(expected, buf.String())
+	l5 := createList(mm1, mm2, mm3, mm4)
+	l6 := createList(mm1, mm2, mm3x, mm4)
+
+	tf := func(f testFunc) {
+		buf := &bytes.Buffer{}
+		f(buf, l1, l2)
+		assert.Equal(expected1, buf.String())
+
+		buf = &bytes.Buffer{}
+		f(buf, l3, l4)
+		assert.Equal(expected2, buf.String())
+
+		buf = &bytes.Buffer{}
+		f(buf, l5, l6)
+
+		assert.Equal(expected3, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }
 
 func TestNomsBlobDiff(t *testing.T) {
@@ -217,27 +255,40 @@ func TestNomsBlobDiff(t *testing.T) {
 	expected := "-   Blob (2.0 kB)\n+   Blob (11 B)\n"
 	b1 := types.NewBlob(strings.NewReader(strings.Repeat("x", 2*1024)))
 	b2 := types.NewBlob(strings.NewReader("Hello World"))
-	buf := util.NewBuffer(nil)
-	Diff(buf, b1, b2)
-	assert.Equal(expected, buf.String())
+
+	tf := func(f testFunc) {
+		buf := &bytes.Buffer{}
+		f(buf, b1, b2)
+		assert.Equal(expected, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }
 
 func TestNomsTypeDiff(t *testing.T) {
 	assert := assert.New(t)
 
-	expected := "-   List<Number>\n+   List<String>\n"
+	expected1 := "-   List<Number>\n+   List<String>\n"
 	t1 := types.MakeListType(types.NumberType)
 	t2 := types.MakeListType(types.StringType)
-	buf := util.NewBuffer(nil)
-	Diff(buf, t1, t2)
-	assert.Equal(expected, buf.String())
 
-	expected = "-   List<Number>\n+   Set<String>\n"
-	t1 = types.MakeListType(types.NumberType)
-	t2 = types.MakeSetType(types.StringType)
-	buf = util.NewBuffer(nil)
-	Diff(buf, t1, t2)
-	assert.Equal(expected, buf.String())
+	expected2 := "-   List<Number>\n+   Set<String>\n"
+	t3 := types.MakeListType(types.NumberType)
+	t4 := types.MakeSetType(types.StringType)
+
+	tf := func(f testFunc) {
+		buf := &bytes.Buffer{}
+		f(buf, t1, t2)
+		assert.Equal(expected1, buf.String())
+
+		buf = &bytes.Buffer{}
+		f(buf, t3, t4)
+		assert.Equal(expected2, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }
 
 func TestNomsRefDiff(t *testing.T) {
@@ -246,8 +297,14 @@ func TestNomsRefDiff(t *testing.T) {
 	l2 := createList(2)
 	r1 := types.NewRef(l1)
 	r2 := types.NewRef(l2)
-	buf := util.NewBuffer(nil)
-	Diff(buf, r1, r2)
 
-	test.EqualsIgnoreHashes(t, expected, buf.String())
+	tf := func(f testFunc) {
+		buf := &bytes.Buffer{}
+		f(buf, r1, r2)
+
+		test.EqualsIgnoreHashes(t, expected, buf.String())
+	}
+
+	tf(makeTestFunc(true))
+	tf(makeTestFunc(false))
 }

--- a/cmd/noms/diff/diff_test.go
+++ b/cmd/noms/diff/diff_test.go
@@ -6,7 +6,6 @@ package diff
 
 import (
 	"bytes"
-	"io"
 	"strings"
 	"testing"
 
@@ -25,14 +24,6 @@ var (
 	mm3x = createMap("m1", "m-one", "v2", "m-two", "m3", "m-three-diff", "m4", aa1x)
 	mm4  = createMap("n1", "n-one", "n2", "n-two", "n3", "n-three", "n4", aa1)
 )
-
-type testFunc func(w io.Writer, v1, v2 types.Value)
-
-func makeTestFunc(leftRight bool) testFunc {
-	return func(w io.Writer, v1, v2 types.Value) {
-		Diff(w, v1, v2, leftRight)
-	}
-}
 
 func valToTypesValue(v interface{}) types.Value {
 	var v1 types.Value
@@ -91,17 +82,17 @@ func TestNomsMapdiff(t *testing.T) {
   }
 `
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		m1 := createMap("map-1", mm1, "map-2", mm2, "map-3", mm3, "map-4", mm4)
 		m2 := createMap("map-1", mm1, "map-2", mm2, "map-3", mm3x, "map-4", mm4)
 		buf := &bytes.Buffer{}
-		f(buf, m1, m2)
+		Diff(buf, m1, m2, leftRight)
 
 		assert.Equal(expected, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }
 
 func TestNomsSetDiff(t *testing.T) {
@@ -144,18 +135,18 @@ func TestNomsSetDiff(t *testing.T) {
 	s3 := createSet(mm1, mm2, mm3, mm4)
 	s4 := createSet(mm1, mm2, mm3x, mm4)
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
-		f(buf, s1, s2)
+		Diff(buf, s1, s2, leftRight)
 		assert.Equal(expected1, buf.String())
 
 		buf = &bytes.Buffer{}
-		f(buf, s3, s4)
+		Diff(buf, s3, s4, leftRight)
 		assert.Equal(expected2, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }
 
 func TestNomsStructDiff(t *testing.T) {
@@ -186,14 +177,14 @@ func TestNomsStructDiff(t *testing.T) {
 	m1 := createMap("one", 1, "two", 2, "three", s1, "four", "four")
 	m2 := createMap("one", 1, "two", 2, "three", s2, "four", "four-diff")
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
-		f(buf, m1, m2)
+		Diff(buf, m1, m2, leftRight)
 		assert.Equal(expected, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }
 
 func TestNomsListDiff(t *testing.T) {
@@ -230,23 +221,23 @@ func TestNomsListDiff(t *testing.T) {
 	l5 := createList(mm1, mm2, mm3, mm4)
 	l6 := createList(mm1, mm2, mm3x, mm4)
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
-		f(buf, l1, l2)
+		Diff(buf, l1, l2, leftRight)
 		assert.Equal(expected1, buf.String())
 
 		buf = &bytes.Buffer{}
-		f(buf, l3, l4)
+		Diff(buf, l3, l4, leftRight)
 		assert.Equal(expected2, buf.String())
 
 		buf = &bytes.Buffer{}
-		f(buf, l5, l6)
+		Diff(buf, l5, l6, leftRight)
 
 		assert.Equal(expected3, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }
 
 func TestNomsBlobDiff(t *testing.T) {
@@ -256,14 +247,14 @@ func TestNomsBlobDiff(t *testing.T) {
 	b1 := types.NewBlob(strings.NewReader(strings.Repeat("x", 2*1024)))
 	b2 := types.NewBlob(strings.NewReader("Hello World"))
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
-		f(buf, b1, b2)
+		Diff(buf, b1, b2, leftRight)
 		assert.Equal(expected, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }
 
 func TestNomsTypeDiff(t *testing.T) {
@@ -277,18 +268,18 @@ func TestNomsTypeDiff(t *testing.T) {
 	t3 := types.MakeListType(types.NumberType)
 	t4 := types.MakeSetType(types.StringType)
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
-		f(buf, t1, t2)
+		Diff(buf, t1, t2, leftRight)
 		assert.Equal(expected1, buf.String())
 
 		buf = &bytes.Buffer{}
-		f(buf, t3, t4)
+		Diff(buf, t3, t4, leftRight)
 		assert.Equal(expected2, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }
 
 func TestNomsRefDiff(t *testing.T) {
@@ -298,13 +289,13 @@ func TestNomsRefDiff(t *testing.T) {
 	r1 := types.NewRef(l1)
 	r2 := types.NewRef(l2)
 
-	tf := func(f testFunc) {
+	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
-		f(buf, r1, r2)
+		Diff(buf, r1, r2, leftRight)
 
 		test.EqualsIgnoreHashes(t, expected, buf.String())
 	}
 
-	tf(makeTestFunc(true))
-	tf(makeTestFunc(false))
+	tf(true)
+	tf(false)
 }

--- a/cmd/noms/noms_diff.go
+++ b/cmd/noms/noms_diff.go
@@ -56,6 +56,6 @@ func runDiff(args []string) int {
 	pgr := outputpager.Start()
 	defer pgr.Stop()
 
-	diff.Diff(pgr.Writer, value1, value2)
+	diff.Diff(pgr.Writer, value1, value2, false)
 	return 0
 }

--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -19,8 +19,8 @@ import (
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/orderedparallel"
 	"github.com/attic-labs/noms/go/util/outputpager"
-	"github.com/mgutz/ansi"
 	flag "github.com/juju/gnuflag"
+	"github.com/mgutz/ansi"
 )
 
 var (
@@ -266,7 +266,7 @@ func writeDiffLines(node LogNode, db datas.Database, maxLines, lineno int, w io.
 	}
 
 	parentCommit := parent.(types.Ref).TargetValue(db).(types.Struct)
-	err = diff.Diff(mlw, parentCommit.Get(datas.ValueField), node.commit.Get(datas.ValueField))
+	err = diff.Diff(mlw, parentCommit.Get(datas.ValueField), node.commit.Get(datas.ValueField), true)
 	d.PanicIfNotType(err, MaxLinesErr)
 	if err != nil {
 		mlw.forceWrite([]byte("...\n"))


### PR DESCRIPTION
In 7c103344 I changed noms log to use left-right diff so that it
completes faster, but it changed noms diff to use left-right as well.
Noms diff is supposed to use best diff.