### PR TITLE
Go marshal

### DIFF
--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -21,7 +21,7 @@ import (
 // fields to the fields used by Marshal (either the struct field name or its tag).
 // Unmarshal will only set exported fields of the struct.
 //
-// If a Noms value is not appropriate for a given target type, or if a Noms number overflows the target type, Unmarshal returns a UnmarshalTypeMismatchError or OverflowError respectively
+// If a Noms value is not appropriate for a given target type, or if a Noms number overflows the target type, Unmarshal returns a UnmarshalTypeMismatchError.
 //
 func Unmarshal(v types.Value, out interface{}) (err error) {
 	defer func() {

--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -71,7 +71,7 @@ type UnmarshalTypeMismatchError struct {
 }
 
 func (e *UnmarshalTypeMismatchError) Error() string {
-	return "Cannot unmarshal " + e.Value.Type().Describe() + " into Go value of type " + e.Type.String() + e.details
+	return fmt.Sprintf("Cannot unmarshal %s into Go value of type %s%s", e.Value.Type().Describe(), e.Type.String(), e.details)
 }
 
 // OverflowError describes a Noms value that was not appropriate for a value of a specific Go number type.
@@ -164,8 +164,7 @@ type decField struct {
 }
 
 func structDecoder(t reflect.Type) decoderFunc {
-	// TODO: Is this handling wrong noms type?
-	if t.Implements(nomsValueType) {
+	if t.Implements(nomsValueInterface) {
 		return nomsValueDecoder
 	}
 
@@ -196,6 +195,7 @@ func structDecoder(t reflect.Type) decoderFunc {
 
 	d = func(v types.Value, rv reflect.Value) {
 		s := v.(types.Struct)
+		// If the name is empty then the Go struct has to be anonymous.
 		if s.Type().Desc.(types.StructDesc).Name != name {
 			panic(&UnmarshalTypeMismatchError{v, rv.Type(), ", names do not match"})
 		}

--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -1,0 +1,227 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package marshal
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+
+	"github.com/attic-labs/noms/go/types"
+)
+
+// Unmarshal converts a Noms value into a Go value. It decodes v and stores the result
+// in the value pointed to by out.
+//
+// Unmarshal uses the inverse of the encodings that Marshal uses with the following additional rules:
+//
+// To unmarshal a Noms struct into a Go struct, Unmarshal matches incoming object
+// fields to the fields used by Marshal (either the struct field name or its tag).
+// Unmarshal will only set exported fields of the struct.
+//
+// If a Noms value is not appropriate for a given target type, or if a Noms number overflows the target type, Unmarshal returns a UnmarshalTypeMismatchError or OverflowError respectively
+//
+func Unmarshal(v types.Value, out interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			if s, ok := r.(string); ok {
+				panic(s)
+			}
+			err = r.(error)
+		}
+	}()
+
+	rv := reflect.ValueOf(out)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return &InvalidUnmarshalError{reflect.TypeOf(out)}
+	}
+	rv = rv.Elem()
+	d := typeDecoder(rv.Type())
+	d(v, rv)
+	return
+}
+
+// InvalidUnmarshalError describes an invalid argument passed to Unmarshal. (The argument to Unmarshal must be a non-nil pointer.)
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+func (e *InvalidUnmarshalError) Error() string {
+	if e.Type == nil {
+		return "Cannot unmarshal into Go nil value"
+	}
+
+	if e.Type.Kind() != reflect.Ptr {
+		return "Cannot unmarshal into Go non pointer of type " + e.Type.String()
+	}
+	return "Cannot unmarshal into Go nil pointer of type " + e.Type.String()
+}
+
+// UnmarshalTypeMismatchError describes a Noms value that was not appropriate for a value of a specific Go type.
+type UnmarshalTypeMismatchError struct {
+	Value   types.Value
+	Type    reflect.Type // type of Go value it could not be assigned to
+	details string
+}
+
+func (e *UnmarshalTypeMismatchError) Error() string {
+	return "Cannot unmarshal " + e.Value.Type().Describe() + " into Go value of type " + e.Type.String() + e.details
+}
+
+// OverflowError describes a Noms value that was not appropriate for a value of a specific Go number type.
+type OverflowError struct {
+	Value types.Number
+	Type  reflect.Type // type of Go value it could not be assigned to
+}
+
+func (e *OverflowError) Error() string {
+	return fmt.Sprintf("Cannot unmarshal %g into Go value of type %s", e.Value, e.Type)
+}
+
+type decoderFunc func(v types.Value, rv reflect.Value)
+
+func typeDecoder(t reflect.Type) decoderFunc {
+	switch t.Kind() {
+	case reflect.Bool:
+		return boolDecoder
+	case reflect.Float32, reflect.Float64:
+		return floatDecoder
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return intDecoder
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return uintDecoder
+	case reflect.String:
+		return stringDecoder
+	case reflect.Struct, reflect.Interface:
+		return structDecoder(t)
+	default:
+		panic(&UnsupportedTypeError{Type: t})
+	}
+}
+func boolDecoder(v types.Value, rv reflect.Value) {
+	if b, ok := v.(types.Bool); ok {
+		rv.SetBool(bool(b))
+	} else {
+		panic(&UnmarshalTypeMismatchError{v, rv.Type(), ""})
+	}
+}
+
+func stringDecoder(v types.Value, rv reflect.Value) {
+	if s, ok := v.(types.String); ok {
+		rv.SetString(string(s))
+	} else {
+		panic(&UnmarshalTypeMismatchError{v, rv.Type(), ""})
+	}
+}
+
+func floatDecoder(v types.Value, rv reflect.Value) {
+	if n, ok := v.(types.Number); ok {
+		rv.SetFloat(float64(n))
+	} else {
+		panic(&UnmarshalTypeMismatchError{v, rv.Type(), ""})
+	}
+}
+
+func intDecoder(v types.Value, rv reflect.Value) {
+	if n, ok := v.(types.Number); ok {
+		i := int64(n)
+		if rv.OverflowInt(i) {
+			panic(&OverflowError{n, rv.Type()})
+		}
+		rv.SetInt(i)
+	} else {
+		panic(&UnmarshalTypeMismatchError{v, rv.Type(), ""})
+	}
+}
+
+func uintDecoder(v types.Value, rv reflect.Value) {
+	if n, ok := v.(types.Number); ok {
+		u := uint64(n)
+		if rv.OverflowUint(u) {
+			panic(&OverflowError{n, rv.Type()})
+		}
+		rv.SetUint(u)
+	} else {
+		panic(&UnmarshalTypeMismatchError{v, rv.Type(), ""})
+	}
+}
+
+var structDecoderCache struct {
+	sync.RWMutex
+	m map[reflect.Type]decoderFunc
+}
+
+type decField struct {
+	name    string
+	decoder decoderFunc
+	index   int
+}
+
+func structDecoder(t reflect.Type) decoderFunc {
+	// TODO: Is this handling wrong noms type?
+	if t.Implements(nomsValueType) {
+		return nomsValueDecoder
+	}
+
+	structDecoderCache.RLock()
+	d := structDecoderCache.m[t]
+	structDecoderCache.RUnlock()
+	if d != nil {
+		return d
+	}
+
+	name := t.Name()
+	fields := make([]decField, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		validateField(f, t)
+
+		tags := f.Tag.Get("noms")
+		if tags == "-" {
+			continue
+		}
+
+		fields = append(fields, decField{
+			name:    getFieldName(tags, f),
+			decoder: typeDecoder(f.Type),
+			index:   i,
+		})
+	}
+
+	d = func(v types.Value, rv reflect.Value) {
+		s := v.(types.Struct)
+		if s.Type().Desc.(types.StructDesc).Name != name {
+			panic(&UnmarshalTypeMismatchError{v, rv.Type(), ", names do not match"})
+		}
+
+		for _, f := range fields {
+			sf := rv.Field(f.index)
+			fv, ok := s.MaybeGet(f.name)
+			if !ok {
+				panic(&UnmarshalTypeMismatchError{v, rv.Type(), ", missing field \"" + f.name + "\""})
+			}
+			f.decoder(fv, sf)
+		}
+	}
+
+	structDecoderCache.Lock()
+	if structDecoderCache.m == nil {
+		structDecoderCache.m = map[reflect.Type]decoderFunc{}
+	}
+	structDecoderCache.m[t] = d
+	structDecoderCache.Unlock()
+	return d
+}
+
+func nomsValueDecoder(v types.Value, rv reflect.Value) {
+	if !reflect.TypeOf(v).AssignableTo(rv.Type()) {
+		panic(&UnmarshalTypeMismatchError{v, rv.Type(), ""})
+	}
+	rv.Set(reflect.ValueOf(v))
+}

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -250,7 +250,7 @@ func TestDecodeInvalidTypes(tt *testing.T) {
 
 func TestDecodeOverflows(tt *testing.T) {
 	t := func(p interface{}, n float64, ts string) {
-		assertDecodeErrorMessage(tt, types.Number(n), p, fmt.Sprintf("Cannot unmarshal %g into Go value of type %s", n, ts))
+		assertDecodeErrorMessage(tt, types.Number(n), p, fmt.Sprintf("Cannot unmarshal Number into Go value of type %s (%g does not fit in %s)", ts, n, ts))
 	}
 
 	var ui8 uint8

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -106,15 +106,15 @@ func TestDecode(tt *testing.T) {
 	}
 
 	var list types.List
-	list2 := types.NewList()
+	list2 := types.NewList(types.Number(42))
 	t(list2, &list, list2)
 
 	var m types.Map
-	map2 := types.NewMap()
+	map2 := types.NewMap(types.Number(42), types.String("Hi"))
 	t(map2, &m, map2)
 
 	var set types.Set
-	set2 := types.NewSet()
+	set2 := types.NewSet(types.String("Bye"))
 	t(set2, &set, set2)
 
 	var blob types.Blob
@@ -165,10 +165,10 @@ func TestDecode(tt *testing.T) {
 			"b": types.Bool(false),
 			"c": types.String("bye"),
 		}),
-		"def": types.NewList(),
+		"def": types.NewList(types.Number(42)),
 	}), &t2, T2{
 		TestStruct{false, 1, "bye"},
-		types.NewList(),
+		types.NewList(types.Number(42)),
 	})
 
 	// extra fields

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -1,0 +1,385 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package marshal
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestDecode(tt *testing.T) {
+	assert := assert.New(tt)
+
+	t := func(v types.Value, ptr interface{}, expected interface{}) {
+		p := reflect.ValueOf(ptr)
+		assert.Equal(reflect.Ptr, p.Type().Kind())
+		err := Unmarshal(v, p.Interface())
+		assert.NoError(err)
+		assert.Equal(expected, p.Elem().Interface())
+
+		// Also test that types.Value is passed through
+		var v2 types.Value
+		err = Unmarshal(v, &v2)
+		assert.NoError(err)
+		assert.True(v.Equals(v2))
+	}
+
+	for _, n := range []float32{0, 42, 3.14159265359, math.MaxFloat32} {
+		var f32 float32
+		t(types.Number(n), &f32, float32(n))
+	}
+
+	for _, n := range []float64{0, 42, 3.14159265359, math.MaxFloat64} {
+		var f64 float64
+		t(types.Number(n), &f64, float64(n))
+	}
+
+	for _, n := range []int8{0, 42, math.MaxInt8} {
+		var i8 int8
+		t(types.Number(n), &i8, int8(n))
+	}
+
+	for _, n := range []int16{0, 42, math.MaxInt16} {
+		var i16 int16
+		t(types.Number(n), &i16, int16(n))
+	}
+
+	for _, n := range []int32{0, 42, math.MaxInt32} {
+		var i32 int32
+		t(types.Number(n), &i32, int32(n))
+	}
+
+	// int is at least int32
+	for _, n := range []int{0, 42, math.MaxInt32} {
+		var i int
+		t(types.Number(n), &i, int(n))
+	}
+
+	// There is precision loss for values above Math.pow(2, 53) - 1
+	for _, n := range []int64{0, 42, int64(math.Pow(2, 53) - 1)} {
+		var i64 int64
+		t(types.Number(n), &i64, int64(n))
+	}
+
+	for _, n := range []uint8{0, 42, math.MaxUint8} {
+		var ui8 uint8
+		t(types.Number(n), &ui8, uint8(n))
+	}
+
+	for _, n := range []uint16{0, 42, math.MaxUint16} {
+		var ui16 uint16
+		t(types.Number(n), &ui16, uint16(n))
+	}
+
+	for _, n := range []uint32{0, 42, math.MaxInt32} {
+		var ui32 uint32
+		t(types.Number(n), &ui32, uint32(n))
+	}
+
+	// uint is at least uint32
+	for _, n := range []uint{0, 42, math.MaxInt32} {
+		var ui uint
+		t(types.Number(n), &ui, uint(n))
+	}
+
+	// There is precision loss for values above Math.pow(2, 53) - 1
+	for _, n := range []uint64{0, 42, uint64(math.Pow(2, 53) - 1)} {
+		var ui64 uint64
+		t(types.Number(n), &ui64, uint64(n))
+	}
+
+	var b bool
+	t(types.Bool(true), &b, true)
+	t(types.Bool(false), &b, false)
+
+	for _, s := range []string{"", "s", "hello", "💩"} {
+		var s2 string
+		t(types.String(s), &s2, s)
+	}
+
+	var list types.List
+	list2 := types.NewList()
+	t(list2, &list, list2)
+
+	var m types.Map
+	map2 := types.NewMap()
+	t(map2, &m, map2)
+
+	var set types.Set
+	set2 := types.NewSet()
+	t(set2, &set, set2)
+
+	var blob types.Blob
+	blob2 := types.NewBlob(bytes.NewBufferString("hello"))
+	t(blob2, &blob, blob2)
+
+	type TestStruct struct {
+		B bool
+		A float64
+		C string
+	}
+	var ts TestStruct
+	t(types.NewStruct("TestStruct", types.StructData{
+		"b": types.Bool(true),
+		"a": types.Number(42),
+		"c": types.String("hi"),
+	}), &ts, TestStruct{true, 42, "hi"})
+	// again to test the caching
+	t(types.NewStruct("TestStruct", types.StructData{
+		"b": types.Bool(false),
+		"a": types.Number(555),
+		"c": types.String("hello"),
+	}), &ts, TestStruct{false, 555, "hello"})
+
+	var as struct {
+		X int32
+		Y bool
+	}
+	t(types.NewStruct("", types.StructData{
+		"y": types.Bool(true),
+		"x": types.Number(42),
+	}), &as, struct {
+		X int32
+		Y bool
+	}{
+		42,
+		true,
+	})
+
+	type T2 struct {
+		Abc TestStruct
+		Def types.List
+	}
+	var t2 T2
+	t(types.NewStruct("T2", types.StructData{
+		"abc": types.NewStruct("TestStruct", types.StructData{
+			"a": types.Number(1),
+			"b": types.Bool(false),
+			"c": types.String("bye"),
+		}),
+		"def": types.NewList(),
+	}), &t2, T2{
+		TestStruct{false, 1, "bye"},
+		types.NewList(),
+	})
+
+	// extra fields
+	type T3 struct {
+		B string
+	}
+	var t3 T3
+	t(types.NewStruct("T3", types.StructData{
+		"b": types.String("abc"),
+		"a": types.Number(42),
+	}), &t3, T3{"abc"})
+}
+
+func TestDecodeNilPointer(t *testing.T) {
+	var x *bool = nil
+	assertDecodeErrorMessage(t, types.Bool(true), x, "Cannot unmarshal into Go nil pointer of type *bool")
+}
+
+func TestDecodeNonPointer(t *testing.T) {
+	b := true
+	assertDecodeErrorMessage(t, types.Bool(true), b, "Cannot unmarshal into Go non pointer of type bool")
+}
+
+func TestDecodeNil(t *testing.T) {
+	err := Unmarshal(types.Bool(true), nil)
+	assert.Error(t, err)
+	assert.Equal(t, "Cannot unmarshal into Go nil value", err.Error())
+}
+
+func TestDecodeTypeMismatch(t *testing.T) {
+	var b bool
+	assertDecodeErrorMessage(t, types.Number(42), &b, "Cannot unmarshal Number into Go value of type bool")
+
+	var blob types.Blob
+	assertDecodeErrorMessage(t, types.NewList(), &blob, "Cannot unmarshal List<> into Go value of type types.Blob")
+
+	type S struct {
+		X int
+	}
+	var s S
+	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
+		"x": types.String("hi"),
+	}), &s, "Cannot unmarshal String into Go value of type int")
+}
+
+func assertDecodeErrorMessage(t *testing.T, v types.Value, ptr interface{}, msg string) {
+	p := reflect.ValueOf(ptr)
+	err := Unmarshal(v, p.Interface())
+	assert.Error(t, err)
+	assert.Equal(t, msg, err.Error())
+}
+
+func TestDecodeInvalidTypes(tt *testing.T) {
+	t := func(p interface{}, ts string) {
+		assertDecodeErrorMessage(tt, types.Number(42), p, "Type is not supported, type: "+ts)
+	}
+
+	var slice []bool
+	t(&slice, "[]bool")
+
+	var array [2]bool
+	t(&array, "[2]bool")
+
+	var m map[string]bool
+	t(&m, "map[string]bool")
+
+	var ptr *bool
+	t(&ptr, "*bool")
+
+	var c chan bool
+	t(&c, "chan bool")
+
+	type Nested struct {
+		X *bool
+	}
+	var n Nested
+	t(&n, "*bool")
+}
+
+func TestDecodeOverflows(tt *testing.T) {
+	t := func(p interface{}, n float64, ts string) {
+		assertDecodeErrorMessage(tt, types.Number(n), p, fmt.Sprintf("Cannot unmarshal %g into Go value of type %s", n, ts))
+	}
+
+	var ui8 uint8
+	t(&ui8, 256, "uint8")
+	t(&ui8, -1, "uint8")
+
+	var ui16 uint16
+	t(&ui16, math.Pow(2, 16), "uint16")
+	t(&ui16, -1, "uint16")
+
+	var ui32 uint32
+	t(&ui32, math.Pow(2, 32), "uint32")
+	t(&ui32, -1, "uint32")
+
+	var i8 int8
+	t(&i8, 128, "int8")
+	t(&i8, -128-1, "int8")
+
+	var i16 int16
+	t(&i16, math.Pow(2, 15), "int16")
+	t(&i16, -math.Pow(2, 15)-1, "int16")
+
+	var i32 int32
+	t(&i32, math.Pow(2, 31), "int32")
+	t(&i32, -math.Pow(2, 31)-1, "int32")
+}
+
+func TestDecodeMissingField(t *testing.T) {
+	type S struct {
+		A int32
+		B bool
+	}
+	var s S
+	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
+		"a": types.Number(42),
+	}), &s, "Cannot unmarshal struct S {\n  a: Number,\n} into Go value of type marshal.S, missing field \"b\"")
+}
+
+func TestDecodeEmbeddedStruct(tt *testing.T) {
+	type EmbeddedStruct struct{}
+	type TestStruct struct {
+		EmbeddedStruct
+	}
+	var ts TestStruct
+	assertDecodeErrorMessage(tt, types.String("hi"), &ts, "Embedded structs are not supported, type: marshal.TestStruct")
+}
+
+func TestDecodeNonExportedField(tt *testing.T) {
+	type TestStruct struct {
+		x int
+	}
+	var ts TestStruct
+	assertDecodeErrorMessage(tt, types.String("hi"), &ts, "Non exported fields are not supported, type: marshal.TestStruct")
+}
+
+func TestDecodeWrongStructName(tt *testing.T) {
+	type TestStruct struct {
+		X int
+	}
+	var ts TestStruct
+	assertDecodeErrorMessage(tt, types.NewStruct("Abc", types.StructData{
+		"X": types.Number(42),
+	}), &ts, "Cannot unmarshal struct Abc {\n  X: Number,\n} into Go value of type marshal.TestStruct, names do not match")
+}
+
+func TestDecodeTaggingSkip(t *testing.T) {
+	assert := assert.New(t)
+
+	type S struct {
+		A int32 `noms:"-"`
+		B bool
+	}
+	var s S
+	err := Unmarshal(types.NewStruct("S", types.StructData{
+		"b": types.Bool(true),
+	}), &s)
+	assert.NoError(err)
+	assert.Equal(S{0, true}, s)
+
+	var s2 S
+	Unmarshal(types.NewStruct("S", types.StructData{
+		"a": types.Number(42),
+		"b": types.Bool(true),
+	}), &s2)
+	assert.Equal(S{0, true}, s2)
+
+	s3 := S{555, true}
+	err = Unmarshal(types.NewStruct("S", types.StructData{
+		"a": types.Number(42),
+		"b": types.Bool(false),
+	}), &s3)
+	assert.NoError(err)
+	assert.Equal(S{555, false}, s3)
+}
+
+func TestDecodeNamedFields(t *testing.T) {
+	assert := assert.New(t)
+
+	type S struct {
+		Aaa int  `noms:"a"`
+		Bbb bool `noms:"B"`
+		Ccc string
+	}
+	var s S
+	err := Unmarshal(types.NewStruct("S", types.StructData{
+		"a":   types.Number(42),
+		"B":   types.Bool(true),
+		"ccc": types.String("Hi"),
+	}), &s)
+	assert.NoError(err)
+	assert.Equal(S{42, true, "Hi"}, s)
+}
+
+func TestDecodeInvalidNamedFields(t *testing.T) {
+	type S struct {
+		A int `noms:"1a"`
+	}
+	var s S
+	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
+		"a": types.Number(42),
+	}), &s, "Invalid struct field name: 1a")
+}
+
+func TestDecodeInvalidNomsType(t *testing.T) {
+	type S struct {
+		A types.List
+	}
+	var s S
+	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
+		"a": types.NewMap(types.String("A"), types.Number(1)),
+	}), &s, "Cannot unmarshal Map<String, Number> into Go value of type types.List")
+}

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -20,13 +20,13 @@ import (
 //
 // Marshal traverses the value v recursively. Marshal uses the following type-dependent encodings:
 //
-// Boolean values encode as Noms types.Bool.
+// Boolean values are encoded as Noms types.Bool.
 //
-// Floating point and integer values encode as Noms types.Number. At the moment this might lead to some loss in precision because types.Number currently takes a float64.
+// Floating point and integer values are encoded as Noms types.Number. At the moment this might lead to some loss in precision because types.Number currently takes a float64.
 //
-// String values encode as Noms types.String.
+// String values are encoded as Noms types.String.
 //
-// Struct values encode as Noms structs (types.Struct). Each exported struct field becomes a member of the struct unless
+// Struct values are encoded as Noms structs (types.Struct). Each exported struct field becomes a member of the struct unless
 //   - the field's tag is "-"
 // The structs default field name is the struct field name where the first character is lower cased,
 // but can be specified in the struct field's tag value. The "noms" key in

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// Package marshal implements encoding and decoding of Noms values. The mapping between JSON objects and Go values is described  in the documentation for the Marshal and Unmarshal functions.
+// Package marshal implements encoding and decoding of Noms values. The mapping between Noms objects and Go values is described  in the documentation for the Marshal and Unmarshal functions.
 package marshal
 
 import (
@@ -26,11 +26,11 @@ import (
 //
 // String values are encoded as Noms types.String.
 //
-// Struct values are encoded as Noms structs (types.Struct). Each exported struct field becomes a member of the struct unless
+// Struct values are encoded as Noms structs (types.Struct). Each exported Go struct field becomes a member of the Noms struct unless
 //   - the field's tag is "-"
-// The structs default field name is the struct field name where the first character is lower cased,
-// but can be specified in the struct field's tag value. The "noms" key in
-// the struct field's tag value is the field name. Examples:
+// The Noms struct default field name is the Go struct field name where the first character is lower cased,
+// but can be specified in the Go struct field's tag value. The "noms" key in
+// the Go struct field's tag value is the field name. Examples:
 //
 //   // Field is ignored.
 //   Field int `noms:"-"`
@@ -39,11 +39,13 @@ import (
 //   MyName int
 //
 //   // Field appears in a Noms struct as key "myName".
-//   Field int `json:"myName"`
+//   Field int `noms:"myName"`
 //
 // Unlike encoding/json Marshal, this does not support "omitempty".
 //
 // Anonymous struct fields are currently not supported.
+//
+// Embedded structs are currently not supported (which is the same as anonymous struct fields).
 //
 // Noms values (values implementing types.Value) are copied over without any change.
 //
@@ -91,7 +93,7 @@ func (e *InvalidTagError) Error() string {
 	return e.message
 }
 
-var nomsValueType = reflect.TypeOf((*types.Value)(nil)).Elem()
+var nomsValueInterface = reflect.TypeOf((*types.Value)(nil)).Elem()
 
 type encoderFunc func(v reflect.Value) types.Value
 
@@ -139,7 +141,7 @@ func typeEncoder(t reflect.Type) encoderFunc {
 }
 
 func structEncoder(t reflect.Type) encoderFunc {
-	if t.Implements(nomsValueType) {
+	if t.Implements(nomsValueInterface) {
 		return nomsValueEncoder
 	}
 
@@ -270,7 +272,7 @@ func nomsType(t reflect.Type) *types.Type {
 
 // structNomsType returns the noms types.Type if it can be determined from the reflect.Type. Note that we can only determine the type for a subset of noms types since the Go type does not fully reflect it. In this cases this returns nil and we have to wait until we have a value to be able to determine the type.
 func structNomsType(t reflect.Type) *types.Type {
-	if t.Implements(nomsValueType) {
+	if t.Implements(nomsValueInterface) {
 		// Use Name because List and Blob are convertible to each other on Go.
 		switch t.Name() {
 		case "Blob":

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -1,0 +1,291 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Package marshal implements encoding and decoding of Noms values. The mapping between JSON objects and Go values is described  in the documentation for the Marshal and Unmarshal functions.
+package marshal
+
+import (
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/attic-labs/noms/go/types"
+)
+
+// Marshal converts a Go value to a Noms value.
+//
+// Marshal traverses the value v recursively. Marshal uses the following type-dependent encodings:
+//
+// Boolean values encode as Noms types.Bool.
+//
+// Floating point and integer values encode as Noms types.Number. At the moment this might lead to some loss in precision because types.Number currently takes a float64.
+//
+// String values encode as Noms types.String.
+//
+// Struct values encode as Noms structs (types.Struct). Each exported struct field becomes a member of the struct unless
+//   - the field's tag is "-"
+// The structs default field name is the struct field name where the first character is lower cased,
+// but can be specified in the struct field's tag value. The "noms" key in
+// the struct field's tag value is the field name. Examples:
+//
+//   // Field is ignored.
+//   Field int `noms:"-"`
+//
+//   // Field appears in a Noms struct as field "myName".
+//   MyName int
+//
+//   // Field appears in a Noms struct as key "myName".
+//   Field int `json:"myName"`
+//
+// Unlike encoding/json Marshal, this does not support "omitempty".
+//
+// Anonymous struct fields are currently not supported.
+//
+// Noms values (values implementing types.Value) are copied over without any change.
+//
+// Go maps, slices, arrays, pointers, complex, interface (non types.Value), function are not supported. Attempting to encode such a value causes Marshal to return an UnsupportedTypeError.
+//
+func Marshal(v interface{}) (nomsValue types.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			if s, ok := r.(string); ok {
+				panic(s)
+			}
+			err = r.(error)
+		}
+	}()
+	rv := reflect.ValueOf(v)
+	encoder := typeEncoder(rv.Type())
+	nomsValue = encoder(rv)
+	return
+}
+
+// UnsupportedTypeError is returned by encode when attempting
+// to encode an unsupported value type.
+type UnsupportedTypeError struct {
+	Type    reflect.Type
+	Message string
+}
+
+func (e *UnsupportedTypeError) Error() string {
+	msg := e.Message
+	if msg == "" {
+		msg = "Type is not supported"
+	}
+	return msg + ", type: " + e.Type.String()
+}
+
+// InvalidTagError is returned by encode and decode when the struct field tag is invalid. For example if the field name is not a valid Noms struct field name.
+type InvalidTagError struct {
+	message string
+}
+
+func (e *InvalidTagError) Error() string {
+	return e.message
+}
+
+var nomsValueType = reflect.TypeOf((*types.Value)(nil)).Elem()
+
+type encoderFunc func(v reflect.Value) types.Value
+
+func boolEncoder(v reflect.Value) types.Value {
+	return types.Bool(v.Bool())
+}
+
+func float64Encoder(v reflect.Value) types.Value {
+	return types.Number(v.Float())
+}
+
+func intEncoder(v reflect.Value) types.Value {
+
+	return types.Number(float64(v.Int()))
+}
+func uintEncoder(v reflect.Value) types.Value {
+	return types.Number(float64(v.Uint()))
+}
+
+func stringEncoder(v reflect.Value) types.Value {
+	return types.String(v.String())
+}
+
+func nomsValueEncoder(v reflect.Value) types.Value {
+	return v.Interface().(types.Value)
+}
+
+func typeEncoder(t reflect.Type) encoderFunc {
+	switch t.Kind() {
+	case reflect.Bool:
+		return boolEncoder
+	case reflect.Float64, reflect.Float32:
+		return float64Encoder
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return intEncoder
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return uintEncoder
+	case reflect.String:
+		return stringEncoder
+	case reflect.Struct:
+		return structEncoder(t)
+	default:
+		panic(&UnsupportedTypeError{Type: t})
+	}
+}
+
+func structEncoder(t reflect.Type) encoderFunc {
+	if t.Implements(nomsValueType) {
+		return nomsValueEncoder
+	}
+
+	structEncoderCache.RLock()
+	e := structEncoderCache.m[t]
+	structEncoderCache.RUnlock()
+	if e != nil {
+		return e
+	}
+
+	fields, structType := typeFields(t)
+	if structType != nil {
+		e = func(v reflect.Value) types.Value {
+			values := make([]types.Value, len(fields))
+			for i, f := range fields {
+				values[i] = f.encoder(v.Field(f.index))
+			}
+			return types.NewStructWithType(structType, values)
+		}
+	} else {
+		// Cannot precompute the type since there are noms collections.
+		name := t.Name()
+		e = func(v reflect.Value) types.Value {
+			data := make(types.StructData, len(fields))
+			for _, f := range fields {
+				data[f.name] = f.encoder(v.Field(f.index))
+			}
+			return types.NewStruct(name, data)
+		}
+	}
+
+	structEncoderCache.Lock()
+	if structEncoderCache.m == nil {
+		structEncoderCache.m = map[reflect.Type]encoderFunc{}
+	}
+	structEncoderCache.m[t] = e
+	structEncoderCache.Unlock()
+
+	return e
+}
+
+type field struct {
+	name     string
+	encoder  encoderFunc
+	index    int
+	nomsType *types.Type
+}
+
+type fieldSlice []field
+
+func (fs fieldSlice) Len() int           { return len(fs) }
+func (fs fieldSlice) Swap(i, j int)      { fs[i], fs[j] = fs[j], fs[i] }
+func (fs fieldSlice) Less(i, j int) bool { return fs[i].name < fs[j].name }
+
+var structEncoderCache struct {
+	sync.RWMutex
+	m map[reflect.Type]encoderFunc
+}
+
+func getFieldName(fieldName string, f reflect.StructField) string {
+	if fieldName == "" {
+		fieldName = strings.ToLower(f.Name[:1]) + f.Name[1:]
+	}
+	if !types.IsValidStructFieldName(fieldName) {
+		panic(&InvalidTagError{"Invalid struct field name: " + fieldName})
+	}
+	return fieldName
+}
+
+func validateField(f reflect.StructField, t reflect.Type) {
+	if f.Anonymous {
+		panic(&UnsupportedTypeError{t, "Embedded structs are not supported"})
+	}
+	if unicode.IsLower(rune(f.Name[0])) { // we only allow ascii so this is fine
+		panic(&UnsupportedTypeError{t, "Non exported fields are not supported"})
+	}
+}
+
+func typeFields(t reflect.Type) (fields fieldSlice, structType *types.Type) {
+	canComputeStructType := true
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		validateField(f, t)
+		nt := nomsType(f.Type)
+		if nt == nil {
+			canComputeStructType = false
+		}
+		tags := f.Tag.Get("noms")
+		if tags == "-" {
+			continue
+		}
+
+		fields = append(fields, field{
+			name:     getFieldName(tags, f),
+			encoder:  typeEncoder(f.Type),
+			index:    i,
+			nomsType: nt,
+		})
+	}
+	sort.Sort(fields)
+	if canComputeStructType {
+		fieldNames := make([]string, len(fields))
+		fieldTypes := make([]*types.Type, len(fields))
+		for i, fs := range fields {
+			fieldNames[i] = fs.name
+			fieldTypes[i] = fs.nomsType
+		}
+		structType = types.MakeStructType(t.Name(), fieldNames, fieldTypes)
+	}
+	return
+}
+
+func nomsType(t reflect.Type) *types.Type {
+	switch t.Kind() {
+	case reflect.Bool:
+		return types.BoolType
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return types.NumberType
+	case reflect.String:
+		return types.StringType
+	case reflect.Struct:
+		return structNomsType(t)
+	default:
+		// This will be reported as an error at a different layer.
+		return nil
+	}
+}
+
+// structNomsType returns the noms types.Type if it can be determined from the reflect.Type. Note that we can only determine the type for a subset of noms types since the Go type does not fully reflect it. In this cases this returns nil and we have to wait until we have a value to be able to determine the type.
+func structNomsType(t reflect.Type) *types.Type {
+	if t.Implements(nomsValueType) {
+		// Use Name because List and Blob are convertible to each other on Go.
+		switch t.Name() {
+		case "Blob":
+			return types.BlobType
+		case "Bool":
+			return types.BoolType
+		case "Number":
+			return types.NumberType
+		case "String":
+			return types.StringType
+		}
+		// The rest of the noms types need the value to get the exact type.
+		return nil
+	}
+
+	_, structType := typeFields(t)
+	return structType
+}

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -1,0 +1,199 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package marshal
+
+import (
+	"math"
+	"testing"
+
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestEncode(tt *testing.T) {
+	t := func(exp types.Value, v interface{}) {
+		actual, err := Marshal(v)
+		assert.NoError(tt, err)
+		assert.True(tt, exp.Equals(actual))
+
+		// Encode again for fallthrough
+		actual2, err := Marshal(actual)
+		assert.NoError(tt, err)
+		assert.True(tt, exp.Equals(actual2))
+	}
+
+	for _, n := range []float32{0, 42, 3.14159265359, math.MaxFloat32} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	for _, n := range []float64{0, 42, 3.14159265359, 9007199254740991, math.MaxFloat64} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	for _, n := range []int8{0, 42, math.MaxInt8} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	for _, n := range []int16{0, 42, math.MaxInt16} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	for _, n := range []int32{0, 42, math.MaxInt32} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	// int is at least int32
+	for _, n := range []int{0, 42, math.MaxInt32} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	for _, n := range []int64{0, 42, math.MaxInt64} {
+		t(types.Number(n), n)
+		t(types.Number(-n), -n)
+	}
+
+	for _, n := range []uint8{0, 42, math.MaxUint8} {
+		t(types.Number(n), n)
+	}
+
+	for _, n := range []uint16{0, 42, math.MaxUint16} {
+		t(types.Number(n), n)
+	}
+
+	for _, n := range []uint32{0, 42, math.MaxUint32} {
+		t(types.Number(n), n)
+	}
+
+	// uint is at least uint32
+	for _, n := range []uint{0, 42, math.MaxUint32} {
+		t(types.Number(n), n)
+	}
+
+	for _, n := range []uint64{0, 42, math.MaxUint64} {
+		t(types.Number(n), n)
+	}
+
+	t(types.Bool(true), true)
+	t(types.Bool(false), false)
+
+	for _, s := range []string{"", "s", "hello", "💩"} {
+		t(types.String(s), s)
+	}
+
+	t(types.NewList(), types.NewList())
+	t(types.NewMap(), types.NewMap())
+	t(types.NewSet(), types.NewSet())
+
+	type TestStruct struct {
+		Str string
+		Num float64
+	}
+	t(types.NewStruct("TestStruct", types.StructData{
+		"num": types.Number(42),
+		"str": types.String("Hello"),
+	}), TestStruct{Str: "Hello", Num: 42})
+	// Same again to test caching
+	t(types.NewStruct("TestStruct", types.StructData{
+		"num": types.Number(1),
+		"str": types.String("Bye"),
+	}), TestStruct{Str: "Bye", Num: 1})
+
+	anonStruct := struct {
+		B bool
+	}{
+		true,
+	}
+	t(types.NewStruct("", types.StructData{
+		"b": types.Bool(true),
+	}), anonStruct)
+
+	type TestNestedStruct struct {
+		A types.List
+		B TestStruct
+		C float64
+	}
+	t(types.NewStruct("TestNestedStruct", types.StructData{
+		"a": types.NewList(types.String("hi")),
+		"b": types.NewStruct("TestStruct", types.StructData{
+			"str": types.String("bye"),
+			"num": types.Number(5678),
+		}),
+		"c": types.Number(1234),
+	}), TestNestedStruct{
+		A: types.NewList(types.String("hi")),
+		B: TestStruct{
+			Str: "bye",
+			Num: 5678,
+		},
+		C: 1234,
+	})
+}
+
+func assertEncodeErrorMessage(t *testing.T, v interface{}, expectedMessage string) {
+	_, err := Marshal(v)
+	assert.Error(t, err)
+	assert.Equal(t, expectedMessage, err.Error())
+}
+
+func TestEncodeEmbeddedStruct(t *testing.T) {
+	type EmbeddedStruct struct{}
+	type TestStruct struct {
+		EmbeddedStruct
+	}
+	assertEncodeErrorMessage(t, TestStruct{EmbeddedStruct{}}, "Embedded structs are not supported, type: marshal.TestStruct")
+}
+
+func TestEncodeNonExportedField(t *testing.T) {
+	type TestStruct struct {
+		x int
+	}
+	assertEncodeErrorMessage(t, TestStruct{1}, "Non exported fields are not supported, type: marshal.TestStruct")
+}
+
+func TestEncodeTaggingSkip(t *testing.T) {
+	assert := assert.New(t)
+
+	type S struct {
+		Abc int `noms:"-"`
+		Def bool
+	}
+	s := S{42, true}
+	v, err := Marshal(s)
+	assert.NoError(err)
+	assert.True(types.NewStruct("S", types.StructData{
+		"def": types.Bool(true),
+	}).Equals(v))
+}
+
+func TestEncodeNamedFields(t *testing.T) {
+	assert := assert.New(t)
+
+	type S struct {
+		Aaa int  `noms:"a"`
+		Bbb bool `noms:"B"`
+		Ccc string
+	}
+	s := S{42, true, "Hi"}
+	v, err := Marshal(s)
+	assert.NoError(err)
+	assert.True(types.NewStruct("S", types.StructData{
+		"a":   types.Number(42),
+		"B":   types.Bool(true),
+		"ccc": types.String("Hi"),
+	}).Equals(v))
+}
+
+func TestEncodeInvalidNamedFields(t *testing.T) {
+	type S struct {
+		A int `noms:"1a"`
+	}
+	assertEncodeErrorMessage(t, S{42}, "Invalid struct field name: 1a")
+}

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -5,6 +5,7 @@
 package marshal
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"testing"
@@ -89,9 +90,10 @@ func TestEncode(tt *testing.T) {
 		t(types.String(s), s)
 	}
 
-	t(types.NewList(), types.NewList())
-	t(types.NewMap(), types.NewMap())
-	t(types.NewSet(), types.NewSet())
+	t(types.NewList(types.Number(42)), types.NewList(types.Number(42)))
+	t(types.NewMap(types.Number(42), types.String("hi")), types.NewMap(types.Number(42), types.String("hi")))
+	t(types.NewSet(types.String("bye")), types.NewSet(types.String("bye")))
+	t(types.NewBlob(bytes.NewBufferString("hello")), types.NewBlob(bytes.NewBufferString("hello")))
 
 	type TestStruct struct {
 		Str string

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -5,6 +5,7 @@
 package marshal
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -196,4 +197,38 @@ func TestEncodeInvalidNamedFields(t *testing.T) {
 		A int `noms:"1a"`
 	}
 	assertEncodeErrorMessage(t, S{42}, "Invalid struct field name: 1a")
+}
+
+func ExampleMarshal() {
+	type Person struct {
+		Given string
+		Male  bool
+	}
+	arya, err := Marshal(Person{"Arya", false})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("Given: %s, Male: %t\n", arya.(types.Struct).Get("given").(types.String), arya.(types.Struct).Get("male").(types.Bool))
+	// Output: Given: Arya, Male: false
+}
+
+func ExampleUnmarshal() {
+	type Person struct {
+		Given string
+		Male  bool
+	}
+	var rickon Person
+	err := Unmarshal(types.NewStruct("Person", types.StructData{
+		"given": types.String("Rickon"),
+		"male":  types.Bool(true),
+	}), &rickon)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("Given: %s, Male: %t\n", rickon.Given, rickon.Male)
+	// Output: Given: Rickon, Male: true
 }

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -168,8 +168,14 @@ func verifyFieldNames(names []string) {
 	}
 }
 
+// IsValidStructFieldName returns whether the name is valid without as a field name in a struct.
+// Valid names must start with `a-zA-Z` and after that `a-zA-Z0-9_`.
+func IsValidStructFieldName(name string) bool {
+	return fieldNameRe.MatchString(name)
+}
+
 func verifyName(name, kind string) {
-	d.PanicIfTrue(!fieldNameRe.MatchString(name), `Invalid struct%s name: "%s"`, kind, name)
+	d.PanicIfTrue(!IsValidStructFieldName(name), `Invalid struct%s name: "%s"`, kind, name)
 }
 
 func verifyFieldName(name string) {


### PR DESCRIPTION
Basic support for creating Noms value from Go values as well as reading
Noms values onto Go values.

Typical usage:

```
// Go to Noms
type T struct {
  S string
  N int32
}
nomsVal, err := marshal.Marshal(T{"Hi", 42})

// Noms to Go
var goVal T
err = marshal.Unmarshal(types.NewStruct("T", types.StructData{
  "S": types.String("Bye"),
  "N": types.Number(555),
}, &goVal)
```

Fixes #1591