### PR TITLE
Marshal and Unmarshal handling of interface{}

### DIFF
--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -28,11 +28,13 @@ import (
 // To unmarshal a Noms map into a Go map, Unmarshal decodes Noms key and values into corresponding Go array elements. If the Go map was nil a new map is created.
 //
 // When unmarshalling onto `interface{}` the following rules are used:
-//  - types.Bool -> bool
-//  - types.List -> []interface{}
-//  - types.Map -> map[interface{}]interface{}
-//  - types.Number -> float64
-//  - types.String -> string
+//  - `types.Bool` -> `bool`
+//  - `types.List` -> `[]T`, where `T` is determined recursively using the same rules.
+//  - `types.Map` -> `map[T]V`, where `T` and `V` is determined recursively using the same rules.
+//  - `types.Number` -> `float64`
+//  - `types.String` -> `string`
+//  - `types.Union` -> `interface`
+//  - Everything else an error
 //
 // Unmarshal returns an UnmarshalTypeMismatchError if:
 //  - a Noms value is not appropriate for a given target type

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -549,3 +549,42 @@ func TestDecodeMapWrongNomsType(t *testing.T) {
 	var m map[string]int
 	assertDecodeErrorMessage(t, types.NewList(types.String("a"), types.Number(1)), &m, "Cannot unmarshal List<Number | String> into Go value of type map[string]int")
 }
+
+func TestDecodeOntoInterface(t *testing.T) {
+	assert := assert.New(t)
+
+	var i interface{}
+	err := Unmarshal(types.Number(1), &i)
+	assert.NoError(err)
+	assert.Equal(float64(1), i)
+
+	err = Unmarshal(types.String("abc"), &i)
+	assert.NoError(err)
+	assert.Equal("abc", i)
+
+	err = Unmarshal(types.Bool(true), &i)
+	assert.NoError(err)
+	assert.Equal(true, i)
+
+	err = Unmarshal(types.NewList(types.String("abc")), &i)
+	assert.NoError(err)
+	assert.Equal([]interface{}{"abc"}, i)
+
+	err = Unmarshal(types.NewMap(types.String("abc"), types.Number(1)), &i)
+	assert.NoError(err)
+	assert.Equal(map[interface{}]interface{}{"abc": float64(1)}, i)
+}
+
+func TestDecodeOntoNonSupportedInterface(t *testing.T) {
+	type I interface {
+		M() int
+	}
+	var i I
+	assertDecodeErrorMessage(t, types.Number(1), &i, "Type is not supported, type: marshal.I")
+}
+
+func TestDecodeOntoInterfaceStruct(t *testing.T) {
+	// Not implemented because it requires Go 1.7.
+	var i interface{}
+	assertDecodeErrorMessage(t, types.NewStruct("", types.StructData{}), &i, "Cannot unmarshal struct {} into Go value of type nil")
+}

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -568,11 +568,19 @@ func TestDecodeOntoInterface(t *testing.T) {
 
 	err = Unmarshal(types.NewList(types.String("abc")), &i)
 	assert.NoError(err)
-	assert.Equal([]interface{}{"abc"}, i)
+	assert.Equal([]string{"abc"}, i)
 
 	err = Unmarshal(types.NewMap(types.String("abc"), types.Number(1)), &i)
 	assert.NoError(err)
-	assert.Equal(map[interface{}]interface{}{"abc": float64(1)}, i)
+	assert.Equal(map[string]float64{"abc": float64(1)}, i)
+
+	err = Unmarshal(types.NewList(types.String("a"), types.Bool(true), types.Number(42)), &i)
+	assert.NoError(err)
+	assert.Equal([]interface{}{"a", true, float64(42)}, i)
+
+	err = Unmarshal(types.NewMap(types.String("a"), types.Bool(true), types.Number(42), types.NewList()), &i)
+	assert.NoError(err)
+	assert.Equal(map[interface{}]interface{}{"a": true, float64(42): []interface{}{}}, i)
 }
 
 func TestDecodeOntoNonSupportedInterface(t *testing.T) {
@@ -586,5 +594,5 @@ func TestDecodeOntoNonSupportedInterface(t *testing.T) {
 func TestDecodeOntoInterfaceStruct(t *testing.T) {
 	// Not implemented because it requires Go 1.7.
 	var i interface{}
-	assertDecodeErrorMessage(t, types.NewStruct("", types.StructData{}), &i, "Cannot unmarshal struct {} into Go value of type nil")
+	assertDecodeErrorMessage(t, types.NewStruct("", types.StructData{}), &i, "Cannot unmarshal struct {} into Go value of type interface {}")
 }

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -52,7 +52,9 @@ import (
 //
 // Noms values (values implementing types.Value) are copied over without any change.
 //
-// Go pointers, complex, interface (non types.Value), function are not supported. Attempting to encode such a value causes Marshal to return an UnsupportedTypeError.
+// When marshalling `interface{}` the dynamic type is used.
+//
+// Go pointers, complex, function are not supported. Attempting to encode such a value causes Marshal to return an UnsupportedTypeError.
 //
 func Marshal(v interface{}) (nomsValue types.Value, err error) {
 	defer func() {

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -95,6 +95,7 @@ func (e *InvalidTagError) Error() string {
 }
 
 var nomsValueInterface = reflect.TypeOf((*types.Value)(nil)).Elem()
+var emptyInterface = reflect.TypeOf((*interface{})(nil)).Elem()
 
 type encoderFunc func(v reflect.Value) types.Value
 

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -141,6 +141,12 @@ func typeEncoder(t reflect.Type, parentStructTypes []reflect.Type) encoderFunc {
 		return listEncoder(t, parentStructTypes)
 	case reflect.Map:
 		return mapEncoder(t, parentStructTypes)
+	case reflect.Interface:
+		return func(v reflect.Value) types.Value {
+			// Get the dynamic type.
+			v2 := reflect.ValueOf(v.Interface())
+			return typeEncoder(v2.Type(), parentStructTypes)(v2)
+		}
 	default:
 		panic(&UnsupportedTypeError{Type: t})
 	}

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -325,3 +325,28 @@ func TestEncodeMap(t *testing.T) {
 	assert.NoError(err)
 	assert.True(types.NewMap().Equals(v))
 }
+
+func TestEncodeInterface(t *testing.T) {
+	assert := assert.New(t)
+
+	var i interface{}
+	i = []string{"a", "b"}
+	v, err := Marshal(i)
+	assert.NoError(err)
+	assert.True(types.NewList(types.String("a"), types.String("b")).Equals(v))
+
+	i = map[interface{}]interface{}{"a": true, struct{ Name string }{"b"}: 42}
+	v, err = Marshal(i)
+	assert.NoError(err)
+	assert.True(types.NewMap(
+		types.String("a"), types.Bool(true),
+		types.NewStruct("", types.StructData{"name": types.String("b")}), types.Number(42),
+	).Equals(v))
+}
+
+type TestInterface interface {
+	M()
+}
+type TestImpl int
+
+func (impl TestImpl) M() {}


### PR DESCRIPTION
When unmarshalling onto `interface{}` the following rules are used:
 - `types.Bool` -> `bool`
 - `types.List` -> `[]interface{}`
 - `types.Map` -> `map[interface{}]interface{}`
 - `types.Number` -> `float64`
 - `types.String` -> `string`

Towards #2376