### PR TITLE
Go: Add three-way merge for types.Struct

### DIFF
--- a/go/merge/three_way.go
+++ b/go/merge/three_way.go
@@ -108,7 +108,7 @@ func threeWayMerge(a, b, parent types.Value, vwr types.ValueReadWriter) (merged 
 	return parent, newTypeConflict()
 }
 
-func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged types.Map, err error) {
+func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged types.Value, err error) {
 	aChangeChan, bChangeChan := make(chan types.ValueChanged), make(chan types.ValueChanged)
 	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
 
@@ -120,95 +120,77 @@ func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged
 		b.DiffLeftRight(parent, bChangeChan, bStopChan)
 		close(bChangeChan)
 	}()
-	stopAndDrain := func(stop chan<- struct{}, drain <-chan types.ValueChanged) {
-		close(stop)
-		for range drain {
-		}
-	}
+
 	defer stopAndDrain(aStopChan, aChangeChan)
 	defer stopAndDrain(bStopChan, bChangeChan)
 
-	merged = parent
-	aChange, bChange := types.ValueChanged{}, types.ValueChanged{}
-	for {
-		// Get the next change from both a and b. If either diff(a, parent) or diff(b, parent) is complete, aChange or bChange will get an empty types.ValueChanged containing a nil Value. Generally, though, this allows us to proceed through both diffs in (key) order, considering the "current" change from both diffs at the same time.
-		if aChange.V == nil {
-			aChange = <-aChangeChan
+	apply := func(target types.Value, change types.ValueChanged, newVal types.Value) types.Value {
+		switch change.ChangeType {
+		case types.DiffChangeAdded, types.DiffChangeModified:
+			return target.(types.Map).Set(change.V, newVal)
+		case types.DiffChangeRemoved:
+			return target.(types.Map).Remove(change.V)
+		default:
+			panic("Not Reached")
 		}
-		if bChange.V == nil {
-			bChange = <-bChangeChan
-		}
+	}
+	return threeWayOrderedSequenceMerge(parent, aChangeChan, bChangeChan, a.Get, b.Get, parent.Get, apply, vwr)
+}
 
-		// Both channels are producing zero values, so we're done.
-		if aChange.V == nil && bChange.V == nil {
-			break
-		}
+func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter) (merged types.Value, err error) {
+	aChangeChan, bChangeChan := make(chan types.ValueChanged), make(chan types.ValueChanged)
+	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
 
-		// Since diff generates changes in key-order, and we never skip over a change without processing it, we can simply compare the keys at which aChange and bChange occurred to determine if either is safe to apply to the merge result without further processing. This is because if, e.g. aChange.V.Less(bChange.V), we know that the diff of b will never generate a change at that key. If it was going to, it would have done so on an earlier iteration of this loop and been processed at that time.
-		// It's also obviously OK to apply a change if only one diff is generating any changes, e.g. aChange.V is non-nil and bChange.V is nil.
-		if aChange.V != nil && (bChange.V == nil || aChange.V.Less(bChange.V)) {
-			merged = apply(merged, aChange, a.Get(aChange.V))
-			aChange = types.ValueChanged{}
-			continue
-		} else if bChange.V != nil && (aChange.V == nil || bChange.V.Less(aChange.V)) {
-			merged = apply(merged, bChange, b.Get(bChange.V))
-			bChange = types.ValueChanged{}
-			continue
-		}
-		d.PanicIfTrue(!aChange.V.Equals(bChange.V), "Diffs have skewed!") // Sanity check.
+	go func() {
+		a.Diff(parent, aChangeChan, aStopChan)
+		close(aChangeChan)
+	}()
+	go func() {
+		b.Diff(parent, bChangeChan, bStopChan)
+		close(bChangeChan)
+	}()
 
-		// If the two diffs generate different kinds of changes at the same key, conflict.
-		if aChange.ChangeType != bChange.ChangeType {
-			return parent, newMergeConflict("Conflict:\n%s\nvs\n%s\n", describeChange(aChange), describeChange(bChange))
-		}
+	defer stopAndDrain(aStopChan, aChangeChan)
+	defer stopAndDrain(bStopChan, bChangeChan)
 
-		aValue, bValue := a.Get(aChange.V), b.Get(bChange.V)
-		if aChange.ChangeType == types.DiffChangeRemoved || aValue.Equals(bValue) {
-			// If both diffs generated a remove, or if the new value is the same in both, merge is fine.
-			merged = apply(merged, aChange, aValue)
-		} else {
-			// There's one case that might still be OK even if aValue and bValue differ: different, but mergeable, compound values of the same type being added/modified at the same key, e.g. a Map being added to both a and b. If either is a primitive, or Values of different Kinds were added, though, we're in conflict.
-			if unmergeable(aValue, bValue) {
-				return parent, newMergeConflict("Conflict:\n%s = %s\nvs\n%s = %s", describeChange(aChange), types.EncodedValue(aValue), describeChange(bChange), types.EncodedValue(bValue))
+	makeGetFunc := func(s types.Struct) getFunc {
+		return func(key types.Value) types.Value {
+			if field, ok := key.(types.String); ok {
+				if val, present := s.MaybeGet(string(field)); present {
+					return val
+				}
+				return nil
 			}
-			// TODO: Add concurrency.
-			mergedValue, err := threeWayMerge(aValue, bValue, parent.Get(aChange.V), vwr)
-			if err != nil {
-				return parent, err
-			}
-			merged = merged.Set(aChange.V, mergedValue)
+			panic(fmt.Errorf("Bad key type in diff: %s", key.Type().Describe()))
 		}
-		aChange, bChange = types.ValueChanged{}, types.ValueChanged{}
 	}
-	return merged, nil
+
+	apply := func(target types.Value, change types.ValueChanged, newVal types.Value) types.Value {
+		// Right now, this always iterates over all fields to create a new Struct, because there's no API for adding/removing a field from an existing struct type.
+		if f, ok := change.V.(types.String); ok {
+			field := string(f)
+			// fmt.Println("Applying change", describeChange(change))
+			data := types.StructData{}
+			desc := target.Type().Desc.(types.StructDesc)
+			desc.IterFields(func(name string, t *types.Type) {
+				if name != field {
+					data[name] = target.(types.Struct).Get(name)
+				}
+			})
+			if change.ChangeType == types.DiffChangeAdded || change.ChangeType == types.DiffChangeModified {
+				data[field] = newVal
+			}
+			return types.NewStruct(desc.Name, data)
+		}
+		panic(fmt.Errorf("Bad key type in diff: %s", change.V.Type().Describe()))
+	}
+	return threeWayOrderedSequenceMerge(parent, aChangeChan, bChangeChan, makeGetFunc(a), makeGetFunc(b), makeGetFunc(parent), apply, vwr)
 }
 
-func apply(target types.Map, change types.ValueChanged, newVal types.Value) types.Map {
-	switch change.ChangeType {
-	case types.DiffChangeAdded, types.DiffChangeModified:
-		return target.Set(change.V, newVal)
-	case types.DiffChangeRemoved:
-		return target.Remove(change.V)
-	default:
-		panic("Not Reached")
+func stopAndDrain(stop chan<- struct{}, drain <-chan types.ValueChanged) {
+	close(stop)
+	for range drain {
 	}
-}
-
-func describeChange(change types.ValueChanged) string {
-	op := ""
-	switch change.ChangeType {
-	case types.DiffChangeAdded:
-		op = "added"
-	case types.DiffChangeModified:
-		op = "modded"
-	case types.DiffChangeRemoved:
-		op = "removed"
-	}
-	return fmt.Sprintf("%s %s", op, types.EncodedValue(change.V))
-}
-
-func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter) (merged types.Struct, err error) {
-	return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
 }
 
 func mapAssert(a, b, parent types.Value) (aMap, bMap, pMap types.Map, ok bool) {
@@ -249,11 +231,16 @@ func structAssert(a, b, parent types.Value) (aStruct, bStruct, pStruct types.Str
 	var aOk, bOk, pOk bool
 	aStruct, aOk = a.(types.Struct)
 	bStruct, bOk = b.(types.Struct)
-	if parent != nil {
-		pStruct, pOk = parent.(types.Struct)
-	} else {
-		pStruct, pOk = aStruct, true
+	if aOk && bOk {
+		aDesc, bDesc := a.Type().Desc.(types.StructDesc), b.Type().Desc.(types.StructDesc)
+		if aDesc.Name == bDesc.Name {
+			if parent != nil {
+				pStruct, pOk = parent.(types.Struct)
+			} else {
+				pStruct, pOk = types.NewStruct(aDesc.Name, nil), true
+			}
+			return aStruct, bStruct, pStruct, pOk
+		}
 	}
-	ok = aOk && bOk && pOk && aStruct.Type().Equals(bStruct.Type()) && aStruct.Type().Equals(pStruct.Type())
 	return
 }

--- a/go/merge/three_way_ordered_sequence.go
+++ b/go/merge/three_way_ordered_sequence.go
@@ -1,0 +1,259 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package merge
+
+import (
+	"fmt"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/types"
+)
+
+// ErrMergeConflict indicates that a merge attempt failed and must be resolved manually for the provided reason.
+type ErrMergeConflict struct {
+	msg string
+}
+
+func (e *ErrMergeConflict) Error() string {
+	return e.msg
+}
+
+func newMergeConflict(format string, args ...interface{}) *ErrMergeConflict {
+	return &ErrMergeConflict{fmt.Sprintf(format, args...)}
+}
+
+// ThreeWay attempts a three-way merge between two candidates and a common ancestor. It considers the three of them recursively, applying some simple rules to identify conflicts:
+//  - If any of the three nodes are different NomsKinds: conflict
+//  - If we are dealing with a map:
+//    - If the same key is both removed and inserted wrt parent: conflict
+//    - If the same key is inserted wrt parent, but with different values: conflict
+//  - If we are dealing with a struct:
+//    - If the same field is both removed and inserted wrt parent: conflict
+//    - If the same field is inserted wrt parent, but with different values: conflict
+//  - If we are dealing with a list:
+//    - If the same index is both removed and inserted wrt parent: conflict
+//    - If the same index is inserted wrt parent, but with different values: conflict
+//  - If we are dealing with a set:
+//    - If the same object is both removed and inserted wrt parent: conflict
+//
+// All other modifications are allowed.
+// Currently, ThreeWay() only works on types.Map.
+func ThreeWay(a, b, parent types.Value, vwr types.ValueReadWriter) (merged types.Value, err error) {
+	if a == nil && b == nil {
+		return parent, nil
+	} else if a == nil {
+		return parent, newMergeConflict("Cannot merge nil Value with %s.", b.Type().Describe())
+	} else if b == nil {
+		return parent, newMergeConflict("Cannot merge %s with nil value.", a.Type().Describe())
+	} else if unmergeable(a, b) {
+		return parent, newMergeConflict("Cannot merge %s with %s.", a.Type().Describe(), b.Type().Describe())
+	}
+
+	return threeWayMerge(a, b, parent, vwr)
+}
+
+// a and b cannot be merged if they are of different NomsKind, or if at least one of the two is nil, or if either is a Noms primitive.
+func unmergeable(a, b types.Value) bool {
+	if a != nil && b != nil {
+		aKind, bKind := a.Type().Kind(), b.Type().Kind()
+		return aKind != bKind || types.IsPrimitiveKind(aKind) || types.IsPrimitiveKind(bKind)
+	}
+	return true
+}
+
+func threeWayMerge(a, b, parent types.Value, vwr types.ValueReadWriter) (merged types.Value, err error) {
+	d.PanicIfTrue(a == nil || b == nil, "Merge candidates cannont be nil: a = %v, b = %v", a, b)
+	newTypeConflict := func() *ErrMergeConflict {
+		pDescription := "<nil>"
+		if parent != nil {
+			pDescription = parent.Type().Describe()
+		}
+		return newMergeConflict("Cannot merge %s and %s on top of %s.", a.Type().Describe(), b.Type().Describe(), pDescription)
+	}
+
+	switch a.Type().Kind() {
+	case types.ListKind:
+		// TODO: Come up with a plan for List (BUG 148)
+		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
+
+	case types.MapKind:
+		if aMap, bMap, pMap, ok := mapAssert(a, b, parent); ok {
+			return threeWayMapMerge(aMap, bMap, pMap, vwr)
+		}
+
+	case types.RefKind:
+		if aValue, bValue, pValue, ok := refAssert(a, b, parent, vwr); ok {
+			merged, err := threeWayMerge(aValue, bValue, pValue, vwr)
+			if err != nil {
+				return parent, err
+			}
+			return vwr.WriteValue(merged), nil
+		}
+
+	case types.SetKind:
+		// TODO: Implement plan from BUG148
+		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
+
+	case types.StructKind:
+		if aStruct, bStruct, pStruct, ok := structAssert(a, b, parent); ok {
+			return threeWayStructMerge(aStruct, bStruct, pStruct, vwr)
+		}
+
+	default:
+		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
+
+	}
+	return parent, newTypeConflict()
+}
+
+func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged types.Map, err error) {
+	aChangeChan, bChangeChan := make(chan types.ValueChanged), make(chan types.ValueChanged)
+	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		a.DiffLeftRight(parent, aChangeChan, aStopChan)
+		close(aChangeChan)
+	}()
+	go func() {
+		b.DiffLeftRight(parent, bChangeChan, bStopChan)
+		close(bChangeChan)
+	}()
+	stopAndDrain := func(stop chan<- struct{}, drain <-chan types.ValueChanged) {
+		close(stop)
+		for range drain {
+		}
+	}
+	defer stopAndDrain(aStopChan, aChangeChan)
+	defer stopAndDrain(bStopChan, bChangeChan)
+
+	merged = parent
+	aChange, bChange := types.ValueChanged{}, types.ValueChanged{}
+	for {
+		// Get the next change from both a and b. If either diff(a, parent) or diff(b, parent) is complete, aChange or bChange will get an empty types.ValueChanged containing a nil Value. Generally, though, this allows us to proceed through both diffs in (key) order, considering the "current" change from both diffs at the same time.
+		if aChange.V == nil {
+			aChange = <-aChangeChan
+		}
+		if bChange.V == nil {
+			bChange = <-bChangeChan
+		}
+
+		// Both channels are producing zero values, so we're done.
+		if aChange.V == nil && bChange.V == nil {
+			break
+		}
+
+		// Since diff generates changes in key-order, and we never skip over a change without processing it, we can simply compare the keys at which aChange and bChange occurred to determine if either is safe to apply to the merge result without further processing. This is because if, e.g. aChange.V.Less(bChange.V), we know that the diff of b will never generate a change at that key. If it was going to, it would have done so on an earlier iteration of this loop and been processed at that time.
+		// It's also obviously OK to apply a change if only one diff is generating any changes, e.g. aChange.V is non-nil and bChange.V is nil.
+		if aChange.V != nil && (bChange.V == nil || aChange.V.Less(bChange.V)) {
+			merged = apply(merged, aChange, a.Get(aChange.V))
+			aChange = types.ValueChanged{}
+			continue
+		} else if bChange.V != nil && (aChange.V == nil || bChange.V.Less(aChange.V)) {
+			merged = apply(merged, bChange, b.Get(bChange.V))
+			bChange = types.ValueChanged{}
+			continue
+		}
+		d.PanicIfTrue(!aChange.V.Equals(bChange.V), "Diffs have skewed!") // Sanity check.
+
+		// If the two diffs generate different kinds of changes at the same key, conflict.
+		if aChange.ChangeType != bChange.ChangeType {
+			return parent, newMergeConflict("Conflict:\n%s\nvs\n%s\n", describeChange(aChange), describeChange(bChange))
+		}
+
+		aValue, bValue := a.Get(aChange.V), b.Get(bChange.V)
+		if aChange.ChangeType == types.DiffChangeRemoved || aValue.Equals(bValue) {
+			// If both diffs generated a remove, or if the new value is the same in both, merge is fine.
+			merged = apply(merged, aChange, aValue)
+		} else {
+			// There's one case that might still be OK even if aValue and bValue differ: different, but mergeable, compound values of the same type being added/modified at the same key, e.g. a Map being added to both a and b. If either is a primitive, or Values of different Kinds were added, though, we're in conflict.
+			if unmergeable(aValue, bValue) {
+				return parent, newMergeConflict("Conflict:\n%s = %s\nvs\n%s = %s", describeChange(aChange), types.EncodedValue(aValue), describeChange(bChange), types.EncodedValue(bValue))
+			}
+			// TODO: Add concurrency.
+			mergedValue, err := threeWayMerge(aValue, bValue, parent.Get(aChange.V), vwr)
+			if err != nil {
+				return parent, err
+			}
+			merged = merged.Set(aChange.V, mergedValue)
+		}
+		aChange, bChange = types.ValueChanged{}, types.ValueChanged{}
+	}
+	return merged, nil
+}
+
+func apply(target types.Map, change types.ValueChanged, newVal types.Value) types.Map {
+	switch change.ChangeType {
+	case types.DiffChangeAdded, types.DiffChangeModified:
+		return target.Set(change.V, newVal)
+	case types.DiffChangeRemoved:
+		return target.Remove(change.V)
+	default:
+		panic("Not Reached")
+	}
+}
+
+func describeChange(change types.ValueChanged) string {
+	op := ""
+	switch change.ChangeType {
+	case types.DiffChangeAdded:
+		op = "added"
+	case types.DiffChangeModified:
+		op = "modded"
+	case types.DiffChangeRemoved:
+		op = "removed"
+	}
+	return fmt.Sprintf("%s %s", op, types.EncodedValue(change.V))
+}
+
+func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter) (merged types.Struct, err error) {
+	return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
+}
+
+func mapAssert(a, b, parent types.Value) (aMap, bMap, pMap types.Map, ok bool) {
+	var aOk, bOk, pOk bool
+	aMap, aOk = a.(types.Map)
+	bMap, bOk = b.(types.Map)
+	if parent != nil {
+		pMap, pOk = parent.(types.Map)
+	} else {
+		pMap, pOk = types.NewMap(), true
+	}
+	ok = aOk && bOk && pOk
+	return
+}
+
+func refAssert(a, b, parent types.Value, vwr types.ValueReadWriter) (aValue, bValue, pValue types.Value, ok bool) {
+	var aOk, bOk, pOk bool
+	var aRef, bRef, pRef types.Ref
+	aRef, aOk = a.(types.Ref)
+	bRef, bOk = b.(types.Ref)
+	if !aOk || !bOk {
+		return
+	}
+
+	aValue = aRef.TargetValue(vwr)
+	bValue = bRef.TargetValue(vwr)
+	if parent != nil {
+		if pRef, pOk = parent.(types.Ref); pOk {
+			pValue = pRef.TargetValue(vwr)
+		}
+	} else {
+		pOk = true // parent == nil is still OK. It just leaves pValue as nil.
+	}
+	return aValue, bValue, pValue, aOk && bOk && pOk
+}
+
+func structAssert(a, b, parent types.Value) (aStruct, bStruct, pStruct types.Struct, ok bool) {
+	var aOk, bOk, pOk bool
+	aStruct, aOk = a.(types.Struct)
+	bStruct, bOk = b.(types.Struct)
+	if parent != nil {
+		pStruct, pOk = parent.(types.Struct)
+	} else {
+		pStruct, pOk = aStruct, true
+	}
+	ok = aOk && bOk && pOk && aStruct.Type().Equals(bStruct.Type()) && aStruct.Type().Equals(pStruct.Type())
+	return
+}

--- a/go/merge/three_way_ordered_sequence.go
+++ b/go/merge/three_way_ordered_sequence.go
@@ -11,123 +11,10 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-// ErrMergeConflict indicates that a merge attempt failed and must be resolved manually for the provided reason.
-type ErrMergeConflict struct {
-	msg string
-}
+type applyFunc func(types.Value, types.ValueChanged, types.Value) types.Value
+type getFunc func(types.Value) types.Value
 
-func (e *ErrMergeConflict) Error() string {
-	return e.msg
-}
-
-func newMergeConflict(format string, args ...interface{}) *ErrMergeConflict {
-	return &ErrMergeConflict{fmt.Sprintf(format, args...)}
-}
-
-// ThreeWay attempts a three-way merge between two candidates and a common ancestor. It considers the three of them recursively, applying some simple rules to identify conflicts:
-//  - If any of the three nodes are different NomsKinds: conflict
-//  - If we are dealing with a map:
-//    - If the same key is both removed and inserted wrt parent: conflict
-//    - If the same key is inserted wrt parent, but with different values: conflict
-//  - If we are dealing with a struct:
-//    - If the same field is both removed and inserted wrt parent: conflict
-//    - If the same field is inserted wrt parent, but with different values: conflict
-//  - If we are dealing with a list:
-//    - If the same index is both removed and inserted wrt parent: conflict
-//    - If the same index is inserted wrt parent, but with different values: conflict
-//  - If we are dealing with a set:
-//    - If the same object is both removed and inserted wrt parent: conflict
-//
-// All other modifications are allowed.
-// Currently, ThreeWay() only works on types.Map.
-func ThreeWay(a, b, parent types.Value, vwr types.ValueReadWriter) (merged types.Value, err error) {
-	if a == nil && b == nil {
-		return parent, nil
-	} else if a == nil {
-		return parent, newMergeConflict("Cannot merge nil Value with %s.", b.Type().Describe())
-	} else if b == nil {
-		return parent, newMergeConflict("Cannot merge %s with nil value.", a.Type().Describe())
-	} else if unmergeable(a, b) {
-		return parent, newMergeConflict("Cannot merge %s with %s.", a.Type().Describe(), b.Type().Describe())
-	}
-
-	return threeWayMerge(a, b, parent, vwr)
-}
-
-// a and b cannot be merged if they are of different NomsKind, or if at least one of the two is nil, or if either is a Noms primitive.
-func unmergeable(a, b types.Value) bool {
-	if a != nil && b != nil {
-		aKind, bKind := a.Type().Kind(), b.Type().Kind()
-		return aKind != bKind || types.IsPrimitiveKind(aKind) || types.IsPrimitiveKind(bKind)
-	}
-	return true
-}
-
-func threeWayMerge(a, b, parent types.Value, vwr types.ValueReadWriter) (merged types.Value, err error) {
-	d.PanicIfTrue(a == nil || b == nil, "Merge candidates cannont be nil: a = %v, b = %v", a, b)
-	newTypeConflict := func() *ErrMergeConflict {
-		pDescription := "<nil>"
-		if parent != nil {
-			pDescription = parent.Type().Describe()
-		}
-		return newMergeConflict("Cannot merge %s and %s on top of %s.", a.Type().Describe(), b.Type().Describe(), pDescription)
-	}
-
-	switch a.Type().Kind() {
-	case types.ListKind:
-		// TODO: Come up with a plan for List (BUG 148)
-		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
-
-	case types.MapKind:
-		if aMap, bMap, pMap, ok := mapAssert(a, b, parent); ok {
-			return threeWayMapMerge(aMap, bMap, pMap, vwr)
-		}
-
-	case types.RefKind:
-		if aValue, bValue, pValue, ok := refAssert(a, b, parent, vwr); ok {
-			merged, err := threeWayMerge(aValue, bValue, pValue, vwr)
-			if err != nil {
-				return parent, err
-			}
-			return vwr.WriteValue(merged), nil
-		}
-
-	case types.SetKind:
-		// TODO: Implement plan from BUG148
-		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
-
-	case types.StructKind:
-		if aStruct, bStruct, pStruct, ok := structAssert(a, b, parent); ok {
-			return threeWayStructMerge(aStruct, bStruct, pStruct, vwr)
-		}
-
-	default:
-		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
-
-	}
-	return parent, newTypeConflict()
-}
-
-func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged types.Map, err error) {
-	aChangeChan, bChangeChan := make(chan types.ValueChanged), make(chan types.ValueChanged)
-	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
-
-	go func() {
-		a.DiffLeftRight(parent, aChangeChan, aStopChan)
-		close(aChangeChan)
-	}()
-	go func() {
-		b.DiffLeftRight(parent, bChangeChan, bStopChan)
-		close(bChangeChan)
-	}()
-	stopAndDrain := func(stop chan<- struct{}, drain <-chan types.ValueChanged) {
-		close(stop)
-		for range drain {
-		}
-	}
-	defer stopAndDrain(aStopChan, aChangeChan)
-	defer stopAndDrain(bStopChan, bChangeChan)
-
+func threeWayOrderedSequenceMerge(parent types.Value, aChangeChan, bChangeChan <-chan types.ValueChanged, aGetFunc, bGetFunc, pGetFunc getFunc, apply applyFunc, vwr types.ValueReadWriter) (merged types.Value, err error) {
 	merged = parent
 	aChange, bChange := types.ValueChanged{}, types.ValueChanged{}
 	for {
@@ -147,11 +34,11 @@ func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged
 		// Since diff generates changes in key-order, and we never skip over a change without processing it, we can simply compare the keys at which aChange and bChange occurred to determine if either is safe to apply to the merge result without further processing. This is because if, e.g. aChange.V.Less(bChange.V), we know that the diff of b will never generate a change at that key. If it was going to, it would have done so on an earlier iteration of this loop and been processed at that time.
 		// It's also obviously OK to apply a change if only one diff is generating any changes, e.g. aChange.V is non-nil and bChange.V is nil.
 		if aChange.V != nil && (bChange.V == nil || aChange.V.Less(bChange.V)) {
-			merged = apply(merged, aChange, a.Get(aChange.V))
+			merged = apply(merged, aChange, aGetFunc(aChange.V))
 			aChange = types.ValueChanged{}
 			continue
 		} else if bChange.V != nil && (aChange.V == nil || bChange.V.Less(aChange.V)) {
-			merged = apply(merged, bChange, b.Get(bChange.V))
+			merged = apply(merged, bChange, bGetFunc(bChange.V))
 			bChange = types.ValueChanged{}
 			continue
 		}
@@ -162,7 +49,7 @@ func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged
 			return parent, newMergeConflict("Conflict:\n%s\nvs\n%s\n", describeChange(aChange), describeChange(bChange))
 		}
 
-		aValue, bValue := a.Get(aChange.V), b.Get(bChange.V)
+		aValue, bValue := aGetFunc(aChange.V), bGetFunc(bChange.V)
 		if aChange.ChangeType == types.DiffChangeRemoved || aValue.Equals(bValue) {
 			// If both diffs generated a remove, or if the new value is the same in both, merge is fine.
 			merged = apply(merged, aChange, aValue)
@@ -172,26 +59,15 @@ func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter) (merged
 				return parent, newMergeConflict("Conflict:\n%s = %s\nvs\n%s = %s", describeChange(aChange), types.EncodedValue(aValue), describeChange(bChange), types.EncodedValue(bValue))
 			}
 			// TODO: Add concurrency.
-			mergedValue, err := threeWayMerge(aValue, bValue, parent.Get(aChange.V), vwr)
+			mergedValue, err := threeWayMerge(aValue, bValue, pGetFunc(aChange.V), vwr)
 			if err != nil {
 				return parent, err
 			}
-			merged = merged.Set(aChange.V, mergedValue)
+			merged = apply(merged, aChange, mergedValue)
 		}
 		aChange, bChange = types.ValueChanged{}, types.ValueChanged{}
 	}
 	return merged, nil
-}
-
-func apply(target types.Map, change types.ValueChanged, newVal types.Value) types.Map {
-	switch change.ChangeType {
-	case types.DiffChangeAdded, types.DiffChangeModified:
-		return target.Set(change.V, newVal)
-	case types.DiffChangeRemoved:
-		return target.Remove(change.V)
-	default:
-		panic("Not Reached")
-	}
 }
 
 func describeChange(change types.ValueChanged) string {
@@ -205,55 +81,4 @@ func describeChange(change types.ValueChanged) string {
 		op = "removed"
 	}
 	return fmt.Sprintf("%s %s", op, types.EncodedValue(change.V))
-}
-
-func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter) (merged types.Struct, err error) {
-	return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
-}
-
-func mapAssert(a, b, parent types.Value) (aMap, bMap, pMap types.Map, ok bool) {
-	var aOk, bOk, pOk bool
-	aMap, aOk = a.(types.Map)
-	bMap, bOk = b.(types.Map)
-	if parent != nil {
-		pMap, pOk = parent.(types.Map)
-	} else {
-		pMap, pOk = types.NewMap(), true
-	}
-	ok = aOk && bOk && pOk
-	return
-}
-
-func refAssert(a, b, parent types.Value, vwr types.ValueReadWriter) (aValue, bValue, pValue types.Value, ok bool) {
-	var aOk, bOk, pOk bool
-	var aRef, bRef, pRef types.Ref
-	aRef, aOk = a.(types.Ref)
-	bRef, bOk = b.(types.Ref)
-	if !aOk || !bOk {
-		return
-	}
-
-	aValue = aRef.TargetValue(vwr)
-	bValue = bRef.TargetValue(vwr)
-	if parent != nil {
-		if pRef, pOk = parent.(types.Ref); pOk {
-			pValue = pRef.TargetValue(vwr)
-		}
-	} else {
-		pOk = true // parent == nil is still OK. It just leaves pValue as nil.
-	}
-	return aValue, bValue, pValue, aOk && bOk && pOk
-}
-
-func structAssert(a, b, parent types.Value) (aStruct, bStruct, pStruct types.Struct, ok bool) {
-	var aOk, bOk, pOk bool
-	aStruct, aOk = a.(types.Struct)
-	bStruct, bOk = b.(types.Struct)
-	if parent != nil {
-		pStruct, pOk = parent.(types.Struct)
-	} else {
-		pStruct, pOk = aStruct, true
-	}
-	ok = aOk && bOk && pOk && aStruct.Type().Equals(bStruct.Type()) && aStruct.Type().Equals(pStruct.Type())
-	return
 }

--- a/go/merge/three_way_test.go
+++ b/go/merge/three_way_test.go
@@ -8,215 +8,189 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/go/types"
-	"github.com/attic-labs/testify/assert"
+	"github.com/attic-labs/testify/suite"
 )
+
+func TestThreeWayMapMerge(t *testing.T) {
+	suite.Run(t, &ThreeWayMapMergeSuite{})
+}
+
+func TestThreeWayStructMerge(t *testing.T) {
+	suite.Run(t, &ThreeWayStructMergeSuite{})
+}
+
+type kvs []interface{}
+
+func (kv kvs) remove(k interface{}) kvs {
+	out := make(kvs, 0, len(kv))
+	for i := 0; i < len(kv); i++ {
+		if kv[i] == k {
+			i++ // skip kv[i] and kv[i+1]
+			continue
+		}
+		out = append(out, kv[i])
+	}
+	return out
+}
+
+func (kv kvs) set(k, v interface{}) kvs {
+	out := make(kvs, len(kv))
+	for i := 0; i < len(kv); i++ {
+		out[i] = kv[i]
+		if kv[i] == k {
+			i++
+			out[i] = v
+		}
+	}
+	return out
+}
 
 var (
-	aa1      = []interface{}{"a1", "a-one", "a2", "a-two", "a3", "a-three", "a4", "a-four"}
-	aa1a     = []interface{}{"a1", "a-one", "a2", "a-two", "a3", "a-three-diff", "a4", "a-four", "a6", "a-six"}
-	aa1b     = []interface{}{"a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five"}
-	aaMerged = []interface{}{"a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five", "a6", "a-six"}
+	aa1      = kvs{"a1", "a-one", "a2", "a-two", "a3", "a-three", "a4", "a-four"}
+	aa1a     = kvs{"a1", "a-one", "a2", "a-two", "a3", "a-three-diff", "a4", "a-four", "a6", "a-six"}
+	aa1b     = kvs{"a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five"}
+	aaMerged = kvs{"a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five", "a6", "a-six"}
 
-	mm1       = []interface{}{}
-	mm1a      = []interface{}{"k1", []interface{}{"a", 0}}
-	mm1b      = []interface{}{"k1", []interface{}{"b", 1}}
-	mm1Merged = []interface{}{"k1", []interface{}{"a", 0, "b", 1}}
+	mm1       = kvs{}
+	mm1a      = kvs{"k1", kvs{"a", 0}}
+	mm1b      = kvs{"k1", kvs{"b", 1}}
+	mm1Merged = kvs{"k1", kvs{"a", 0, "b", 1}}
 
-	mm2       = []interface{}{"k2", aa1, "k3", "k-three"}
-	mm2a      = []interface{}{"k1", []interface{}{"a", 0}, "k2", aa1a, "k3", "k-three", "k4", "k-four"}
-	mm2b      = []interface{}{"k1", []interface{}{"b", 1}, "k2", aa1b}
-	mm2Merged = []interface{}{"k1", []interface{}{"a", 0, "b", 1}, "k2", aaMerged, "k4", "k-four"}
+	mm2       = kvs{"k2", aa1, "k3", "k-three"}
+	mm2a      = kvs{"k1", kvs{"a", 0}, "k2", aa1a, "k3", "k-three", "k4", "k-four"}
+	mm2b      = kvs{"k1", kvs{"b", 1}, "k2", aa1b}
+	mm2Merged = kvs{"k1", kvs{"a", 0, "b", 1}, "k2", aaMerged, "k4", "k-four"}
 )
 
-func tryThreeWayMerge(t *testing.T, a, b, p, expected types.Value, vs types.ValueReadWriter) {
-	merged, err := ThreeWay(a, b, p, vs)
-	if assert.NoError(t, err) {
-		assert.True(t, expected.Equals(merged), "%s != %s", types.EncodedValue(expected), types.EncodedValue(merged))
+type ThreeWayMergeSuite struct {
+	suite.Suite
+	create  func(kvs) types.Value
+	typeStr string
+}
+
+type ThreeWayMapMergeSuite struct {
+	ThreeWayMergeSuite
+}
+
+func (s *ThreeWayMapMergeSuite) SetupSuite() {
+	s.create = func(kv kvs) (val types.Value) {
+		if kv != nil {
+			keyValues := valsToTypesValues(s.create, kv...)
+			val = types.NewMap(keyValues...)
+		}
+		return
+	}
+	s.typeStr = "Map"
+}
+
+type ThreeWayStructMergeSuite struct {
+	ThreeWayMergeSuite
+}
+
+func (s *ThreeWayStructMergeSuite) SetupSuite() {
+	s.create = func(kv kvs) (val types.Value) {
+		if kv != nil {
+			fields := types.StructData{}
+			for i := 0; i < len(kv); i += 2 {
+				fields[kv[i].(string)] = valToTypesValue(s.create, kv[i+1])
+			}
+			val = types.NewStruct("TestStruct", fields)
+		}
+		return
+	}
+	s.typeStr = "struct"
+}
+
+func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp kvs, vs types.ValueReadWriter) {
+	merged, err := ThreeWay(s.create(a), s.create(b), s.create(p), vs)
+	if s.NoError(err) {
+		expected := s.create(exp)
+		s.True(expected.Equals(merged), "%s != %s", types.EncodedValue(expected), types.EncodedValue(merged))
 	}
 }
 
-func tryThreeWayConflict(t *testing.T, a, b, p types.Value, contained string) {
+func (s *ThreeWayMergeSuite) tryThreeWayConflict(a, b, p types.Value, contained string) {
 	_, err := ThreeWay(a, b, p, nil)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), contained)
+	if s.Error(err) {
+		s.Contains(err.Error(), contained)
 	}
 }
 
-func TestThreeWayMergeMap_DoNothing(t *testing.T) {
-	tryThreeWayMerge(t, nil, nil, cm(aa1), cm(aa1), nil)
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_DoNothing() {
+	s.tryThreeWayMerge(nil, nil, aa1, aa1, nil)
 }
 
-func TestThreeWayMergeMap_NoRecursion(t *testing.T) {
-	tryThreeWayMerge(t, cm(aa1a), cm(aa1b), cm(aa1), cm(aaMerged), nil)
-	tryThreeWayMerge(t, cm(aa1b), cm(aa1a), cm(aa1), cm(aaMerged), nil)
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_NoRecursion() {
+	s.tryThreeWayMerge(aa1a, aa1b, aa1, aaMerged, nil)
+	s.tryThreeWayMerge(aa1b, aa1a, aa1, aaMerged, nil)
 }
 
-func TestThreeWayMergeMap_RecursiveCreate(t *testing.T) {
-	tryThreeWayMerge(t, cm(mm1a), cm(mm1b), cm(mm1), cm(mm1Merged), nil)
-	tryThreeWayMerge(t, cm(mm1b), cm(mm1a), cm(mm1), cm(mm1Merged), nil)
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_RecursiveCreate() {
+	s.tryThreeWayMerge(mm1a, mm1b, mm1, mm1Merged, nil)
+	s.tryThreeWayMerge(mm1b, mm1a, mm1, mm1Merged, nil)
 }
 
-func TestThreeWayMergeMap_RecursiveCreateNil(t *testing.T) {
-	tryThreeWayMerge(t, cm(mm1a), cm(mm1b), nil, cm(mm1Merged), nil)
-	tryThreeWayMerge(t, cm(mm1b), cm(mm1a), nil, cm(mm1Merged), nil)
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_RecursiveCreateNil() {
+	s.tryThreeWayMerge(mm1a, mm1b, nil, mm1Merged, nil)
+	s.tryThreeWayMerge(mm1b, mm1a, nil, mm1Merged, nil)
 }
 
-func TestThreeWayMergeMap_RecursiveMerge(t *testing.T) {
-	tryThreeWayMerge(t, cm(mm2a), cm(mm2b), cm(mm2), cm(mm2Merged), nil)
-	tryThreeWayMerge(t, cm(mm2b), cm(mm2a), cm(mm2), cm(mm2Merged), nil)
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_RecursiveMerge() {
+	s.tryThreeWayMerge(mm2a, mm2b, mm2, mm2Merged, nil)
+	s.tryThreeWayMerge(mm2b, mm2a, mm2, mm2Merged, nil)
 }
 
-func TestThreeWayMergeMap_RefMerge(t *testing.T) {
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_RefMerge() {
 	vs := types.NewTestValueStore()
 
 	strRef := vs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
 
-	create := func(kv ...interface{}) types.Map {
-		return cm(kv)
-	}
-	m := create("r2", vs.WriteValue(cm(aa1)))
-	ma := create("r1", strRef, "r2", vs.WriteValue(cm(aa1a)))
-	mb := create("r1", strRef, "r2", vs.WriteValue(cm(aa1b)))
-	mMerged := create("r1", strRef, "r2", vs.WriteValue(cm(aaMerged)))
+	m := kvs{"r2", vs.WriteValue(s.create(aa1))}
+	ma := kvs{"r1", strRef, "r2", vs.WriteValue(s.create(aa1a))}
+	mb := kvs{"r1", strRef, "r2", vs.WriteValue(s.create(aa1b))}
+	mMerged := kvs{"r1", strRef, "r2", vs.WriteValue(s.create(aaMerged))}
 	vs.Flush()
 
-	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
-	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
+	s.tryThreeWayMerge(ma, mb, m, mMerged, vs)
+	s.tryThreeWayMerge(mb, ma, m, mMerged, vs)
 }
 
-func TestThreeWayMergeMap_RecursiveMultiLevelMerge(t *testing.T) {
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_RecursiveMultiLevelMerge() {
 	vs := types.NewTestValueStore()
 
-	create := func(kv ...interface{}) types.Map {
-		return cm(kv)
-	}
-	m := create("mm1", cm(mm1), "mm2", vs.WriteValue(cm(mm2)))
-	ma := create("mm1", cm(mm1a), "mm2", vs.WriteValue(cm(mm2a)))
-	mb := create("mm1", cm(mm1b), "mm2", vs.WriteValue(cm(mm2b)))
-	mMerged := create("mm1", cm(mm1Merged), "mm2", vs.WriteValue(cm(mm2Merged)))
+	m := kvs{"mm1", mm1, "mm2", vs.WriteValue(s.create(mm2))}
+	ma := kvs{"mm1", mm1a, "mm2", vs.WriteValue(s.create(mm2a))}
+	mb := kvs{"mm1", mm1b, "mm2", vs.WriteValue(s.create(mm2b))}
+	mMerged := kvs{"mm1", mm1Merged, "mm2", vs.WriteValue(s.create(mm2Merged))}
 	vs.Flush()
 
-	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
-	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
+	s.tryThreeWayMerge(ma, mb, m, mMerged, vs)
+	s.tryThreeWayMerge(mb, ma, m, mMerged, vs)
 }
 
-func TestThreeWayMergeMap_NilConflict(t *testing.T) {
-	tryThreeWayConflict(t, nil, cm(mm2b), cm(mm2), "Cannot merge nil Value with")
-	tryThreeWayConflict(t, cm(mm2a), nil, cm(mm2), "with nil value.")
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_NilConflict() {
+	s.tryThreeWayConflict(nil, s.create(mm2b), s.create(mm2), "Cannot merge nil Value with")
+	s.tryThreeWayConflict(s.create(mm2a), nil, s.create(mm2), "with nil value.")
 }
 
-func TestThreeWayMergeMap_ImmediateConflict(t *testing.T) {
-	tryThreeWayConflict(t, types.NewSet(), cm(mm2b), cm(mm2), "Cannot merge Set<> with Map")
-	tryThreeWayConflict(t, cm(mm2b), types.NewSet(), cm(mm2), "Cannot merge Map")
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_ImmediateConflict() {
+	s.tryThreeWayConflict(types.NewSet(), s.create(mm2b), s.create(mm2), "Cannot merge Set<> with "+s.typeStr)
+	s.tryThreeWayConflict(s.create(mm2b), types.NewSet(), s.create(mm2), "Cannot merge "+s.typeStr)
 }
 
-func TestThreeWayMergeMap_NestedConflict(t *testing.T) {
-	tryThreeWayConflict(t, cm(mm2a).Set(types.String("k2"), types.NewSet()), cm(mm2b), cm(mm2), types.EncodedValue(types.NewSet()))
-	tryThreeWayConflict(t, cm(mm2a).Set(types.String("k2"), types.NewSet()), cm(mm2b), cm(mm2), types.EncodedValue(cm(aa1b)))
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_NestedConflict() {
+	a := mm2a.set("k2", types.NewSet())
+	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), types.EncodedValue(types.NewSet()))
+	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), types.EncodedValue(s.create(aa1b)))
 }
 
-func TestThreeWayMergeMap_NestedConflictingOperation(t *testing.T) {
-	key := types.String("k2")
-	tryThreeWayConflict(t, cm(mm2a).Remove(key), cm(mm2b), cm(mm2), "removed "+types.EncodedValue(key))
-	tryThreeWayConflict(t, cm(mm2a).Remove(key), cm(mm2b), cm(mm2), "modded "+types.EncodedValue(key))
+func (s *ThreeWayMergeSuite) TestThreeWayMergeMap_NestedConflictingOperation() {
+	a := mm2a.remove("k2")
+	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), `removed "k2"`)
+	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), `modded "k2"`)
 }
 
-func TestThreeWayMergeStruct_DoNothing(t *testing.T) {
-	tryThreeWayMerge(t, nil, nil, cs(aa1), cs(aa1), nil)
-}
-
-func TestThreeWayMergeStruct_NoRecursion(t *testing.T) {
-	tryThreeWayMerge(t, cs(aa1a), cs(aa1b), cs(aa1), cs(aaMerged), nil)
-	tryThreeWayMerge(t, cs(aa1b), cs(aa1a), cs(aa1), cs(aaMerged), nil)
-}
-
-func TestThreeWayMergeStruct_RecursiveCreate(t *testing.T) {
-	tryThreeWayMerge(t, cs(mm1a), cs(mm1b), cs(mm1), cs(mm1Merged), nil)
-	tryThreeWayMerge(t, cs(mm1b), cs(mm1a), cs(mm1), cs(mm1Merged), nil)
-}
-
-func TestThreeWayMergeStruct_RecursiveCreateNil(t *testing.T) {
-	tryThreeWayMerge(t, cs(mm1a), cs(mm1b), nil, cs(mm1Merged), nil)
-	tryThreeWayMerge(t, cs(mm1b), cs(mm1a), nil, cs(mm1Merged), nil)
-}
-
-func TestThreeWayMergeStruct_RecursiveMerge(t *testing.T) {
-	tryThreeWayMerge(t, cs(mm2a), cs(mm2b), cs(mm2), cs(mm2Merged), nil)
-	tryThreeWayMerge(t, cs(mm2b), cs(mm2a), cs(mm2), cs(mm2Merged), nil)
-}
-
-func TestThreeWayMergeStruct_RefMerge(t *testing.T) {
-	vs := types.NewTestValueStore()
-
-	strRef := vs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
-
-	create := func(kv ...interface{}) types.Struct {
-		return cs(kv)
-	}
-	m := create("r2", vs.WriteValue(cs(aa1)))
-	ma := create("r1", strRef, "r2", vs.WriteValue(cs(aa1a)))
-	mb := create("r1", strRef, "r2", vs.WriteValue(cs(aa1b)))
-	mMerged := create("r1", strRef, "r2", vs.WriteValue(cs(aaMerged)))
-	vs.Flush()
-
-	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
-	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
-}
-
-func TestThreeWayMergeStruct_RecursiveMultiLevelMerge(t *testing.T) {
-	vs := types.NewTestValueStore()
-
-	create := func(kv ...interface{}) types.Struct {
-		return cs(kv)
-	}
-	m := create("mm1", cs(mm1), "mm2", vs.WriteValue(cs(mm2)))
-	ma := create("mm1", cs(mm1a), "mm2", vs.WriteValue(cs(mm2a)))
-	mb := create("mm1", cs(mm1b), "mm2", vs.WriteValue(cs(mm2b)))
-	mMerged := create("mm1", cs(mm1Merged), "mm2", vs.WriteValue(cs(mm2Merged)))
-	vs.Flush()
-
-	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
-	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
-}
-
-func TestThreeWayMergeStruct_NilConflict(t *testing.T) {
-	tryThreeWayConflict(t, nil, cs(mm2b), cs(mm2), "Cannot merge nil Value with")
-	tryThreeWayConflict(t, cs(mm2a), nil, cs(mm2), "with nil value.")
-}
-
-func TestThreeWayMergeStruct_ImmediateConflict(t *testing.T) {
-	tryThreeWayConflict(t, types.NewSet(), cs(mm2b), cs(mm2), "Cannot merge Set<> with struct")
-	tryThreeWayConflict(t, cs(mm2b), types.NewSet(), cs(mm2), "Cannot merge struct")
-}
-
-func TestThreeWayMergeStruct_NestedConflict(t *testing.T) {
-	a := cs([]interface{}{"k2", "not-a-struct"})
-	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), "not-a-struct")
-	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), types.EncodedValue(cs(aa1b)))
-}
-
-func TestThreeWayMergeStruct_NestedConflictingOperation(t *testing.T) {
-	key := "k2"
-	a := cs([]interface{}{"k3", "k-three"})
-	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), "removed "+types.EncodedValue(types.String(key)))
-	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), "modded "+types.EncodedValue(types.String(key)))
-}
-
-func cm(kv []interface{}) types.Map {
-	keyValues := valsToTypesValues(func(kv []interface{}) types.Value { return cm(kv) }, kv...)
-	return types.NewMap(keyValues...)
-}
-
-func cs(kv []interface{}) types.Struct {
-	fields := types.StructData{}
-	recurse := func(kv []interface{}) types.Value { return cs(kv) }
-	for i := 0; i < len(kv); i += 2 {
-		fields[kv[i].(string)] = valToTypesValue(recurse, kv[i+1])
-	}
-	return types.NewStruct("TestStruct", fields)
-}
-
-func valsToTypesValues(f func([]interface{}) types.Value, kv ...interface{}) []types.Value {
+func valsToTypesValues(f func(kvs) types.Value, kv ...interface{}) []types.Value {
 	keyValues := []types.Value{}
 	for _, e := range kv {
 		v := valToTypesValue(f, e)
@@ -225,14 +199,14 @@ func valsToTypesValues(f func([]interface{}) types.Value, kv ...interface{}) []t
 	return keyValues
 }
 
-func valToTypesValue(f func([]interface{}) types.Value, v interface{}) types.Value {
+func valToTypesValue(f func(kvs) types.Value, v interface{}) types.Value {
 	var v1 types.Value
 	switch t := v.(type) {
 	case string:
 		v1 = types.String(t)
 	case int:
 		v1 = types.Number(t)
-	case []interface{}:
+	case kvs:
 		v1 = f(t)
 	case types.Value:
 		v1 = t

--- a/go/merge/three_way_test.go
+++ b/go/merge/three_way_test.go
@@ -12,79 +12,27 @@ import (
 )
 
 var (
-	aa1      = createMap("a1", "a-one", "a2", "a-two", "a3", "a-three", "a4", "a-four")
-	aa1a     = createMap("a1", "a-one", "a2", "a-two", "a3", "a-three-diff", "a4", "a-four", "a6", "a-six")
-	aa1b     = createMap("a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five")
-	aaMerged = createMap("a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five", "a6", "a-six")
+	aa1      = []interface{}{"a1", "a-one", "a2", "a-two", "a3", "a-three", "a4", "a-four"}
+	aa1a     = []interface{}{"a1", "a-one", "a2", "a-two", "a3", "a-three-diff", "a4", "a-four", "a6", "a-six"}
+	aa1b     = []interface{}{"a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five"}
+	aaMerged = []interface{}{"a1", "a-one", "a3", "a-three-diff", "a4", "a-four", "a5", "a-five", "a6", "a-six"}
 
-	mm1       = createMap()
-	mm1a      = createMap("k1", createMap(0, "a"))
-	mm1b      = createMap("k1", createMap(1, "b"))
-	mm1Merged = createMap("k1", createMap(0, "a", 1, "b"))
+	mm1       = []interface{}{}
+	mm1a      = []interface{}{"k1", []interface{}{"a", 0}}
+	mm1b      = []interface{}{"k1", []interface{}{"b", 1}}
+	mm1Merged = []interface{}{"k1", []interface{}{"a", 0, "b", 1}}
 
-	mm2       = createMap("k2", aa1, "k3", "k-three")
-	mm2a      = createMap("k1", createMap(0, "a"), "k2", aa1a, "k3", "k-three", "k4", "k-four")
-	mm2b      = createMap("k1", createMap(1, "b"), "k2", aa1b)
-	mm2Merged = createMap("k1", createMap(0, "a", 1, "b"), "k2", aaMerged, "k4", "k-four")
+	mm2       = []interface{}{"k2", aa1, "k3", "k-three"}
+	mm2a      = []interface{}{"k1", []interface{}{"a", 0}, "k2", aa1a, "k3", "k-three", "k4", "k-four"}
+	mm2b      = []interface{}{"k1", []interface{}{"b", 1}, "k2", aa1b}
+	mm2Merged = []interface{}{"k1", []interface{}{"a", 0, "b", 1}, "k2", aaMerged, "k4", "k-four"}
 )
 
 func tryThreeWayMerge(t *testing.T, a, b, p, expected types.Value, vs types.ValueReadWriter) {
 	merged, err := ThreeWay(a, b, p, vs)
 	if assert.NoError(t, err) {
-		assert.True(t, expected.Equals(merged))
+		assert.True(t, expected.Equals(merged), "%s != %s", types.EncodedValue(expected), types.EncodedValue(merged))
 	}
-}
-
-func TestThreeWayMergeMap_DoNothing(t *testing.T) {
-	tryThreeWayMerge(t, nil, nil, aa1, aa1, nil)
-}
-
-func TestThreeWayMergeMap_NoRecursion(t *testing.T) {
-	tryThreeWayMerge(t, aa1a, aa1b, aa1, aaMerged, nil)
-	tryThreeWayMerge(t, aa1b, aa1a, aa1, aaMerged, nil)
-}
-
-func TestThreeWayMergeMap_RecursiveCreate(t *testing.T) {
-	tryThreeWayMerge(t, mm1a, mm1b, mm1, mm1Merged, nil)
-	tryThreeWayMerge(t, mm1b, mm1a, mm1, mm1Merged, nil)
-}
-
-func TestThreeWayMergeMap_RecursiveCreateNil(t *testing.T) {
-	tryThreeWayMerge(t, mm1a, mm1b, nil, mm1Merged, nil)
-	tryThreeWayMerge(t, mm1b, mm1a, nil, mm1Merged, nil)
-}
-
-func TestThreeWayMergeMap_RecursiveMerge(t *testing.T) {
-	tryThreeWayMerge(t, mm2a, mm2b, mm2, mm2Merged, nil)
-	tryThreeWayMerge(t, mm2b, mm2a, mm2, mm2Merged, nil)
-}
-
-func TestThreeWayMergeMap_RefMerge(t *testing.T) {
-	vs := types.NewTestValueStore()
-
-	strRef := vs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
-
-	m := createMap("r2", vs.WriteValue(aa1))
-	ma := createMap("r1", strRef, "r2", vs.WriteValue(aa1a))
-	mb := createMap("r1", strRef, "r2", vs.WriteValue(aa1b))
-	mMerged := createMap("r1", strRef, "r2", vs.WriteValue(aaMerged))
-	vs.Flush()
-
-	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
-	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
-}
-
-func TestThreeWayMergeMap_RecursiveMultiLevelMerge(t *testing.T) {
-	vs := types.NewTestValueStore()
-
-	m := createMap("mm1", mm1, "mm2", vs.WriteValue(mm2))
-	ma := createMap("mm1", mm1a, "mm2", vs.WriteValue(mm2a))
-	mb := createMap("mm1", mm1b, "mm2", vs.WriteValue(mm2b))
-	mMerged := createMap("mm1", mm1Merged, "mm2", vs.WriteValue(mm2Merged))
-	vs.Flush()
-
-	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
-	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
 }
 
 func tryThreeWayConflict(t *testing.T, a, b, p types.Value, contained string) {
@@ -94,48 +42,198 @@ func tryThreeWayConflict(t *testing.T, a, b, p types.Value, contained string) {
 	}
 }
 
+func TestThreeWayMergeMap_DoNothing(t *testing.T) {
+	tryThreeWayMerge(t, nil, nil, cm(aa1), cm(aa1), nil)
+}
+
+func TestThreeWayMergeMap_NoRecursion(t *testing.T) {
+	tryThreeWayMerge(t, cm(aa1a), cm(aa1b), cm(aa1), cm(aaMerged), nil)
+	tryThreeWayMerge(t, cm(aa1b), cm(aa1a), cm(aa1), cm(aaMerged), nil)
+}
+
+func TestThreeWayMergeMap_RecursiveCreate(t *testing.T) {
+	tryThreeWayMerge(t, cm(mm1a), cm(mm1b), cm(mm1), cm(mm1Merged), nil)
+	tryThreeWayMerge(t, cm(mm1b), cm(mm1a), cm(mm1), cm(mm1Merged), nil)
+}
+
+func TestThreeWayMergeMap_RecursiveCreateNil(t *testing.T) {
+	tryThreeWayMerge(t, cm(mm1a), cm(mm1b), nil, cm(mm1Merged), nil)
+	tryThreeWayMerge(t, cm(mm1b), cm(mm1a), nil, cm(mm1Merged), nil)
+}
+
+func TestThreeWayMergeMap_RecursiveMerge(t *testing.T) {
+	tryThreeWayMerge(t, cm(mm2a), cm(mm2b), cm(mm2), cm(mm2Merged), nil)
+	tryThreeWayMerge(t, cm(mm2b), cm(mm2a), cm(mm2), cm(mm2Merged), nil)
+}
+
+func TestThreeWayMergeMap_RefMerge(t *testing.T) {
+	vs := types.NewTestValueStore()
+
+	strRef := vs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
+
+	create := func(kv ...interface{}) types.Map {
+		return cm(kv)
+	}
+	m := create("r2", vs.WriteValue(cm(aa1)))
+	ma := create("r1", strRef, "r2", vs.WriteValue(cm(aa1a)))
+	mb := create("r1", strRef, "r2", vs.WriteValue(cm(aa1b)))
+	mMerged := create("r1", strRef, "r2", vs.WriteValue(cm(aaMerged)))
+	vs.Flush()
+
+	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
+	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
+}
+
+func TestThreeWayMergeMap_RecursiveMultiLevelMerge(t *testing.T) {
+	vs := types.NewTestValueStore()
+
+	create := func(kv ...interface{}) types.Map {
+		return cm(kv)
+	}
+	m := create("mm1", cm(mm1), "mm2", vs.WriteValue(cm(mm2)))
+	ma := create("mm1", cm(mm1a), "mm2", vs.WriteValue(cm(mm2a)))
+	mb := create("mm1", cm(mm1b), "mm2", vs.WriteValue(cm(mm2b)))
+	mMerged := create("mm1", cm(mm1Merged), "mm2", vs.WriteValue(cm(mm2Merged)))
+	vs.Flush()
+
+	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
+	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
+}
+
 func TestThreeWayMergeMap_NilConflict(t *testing.T) {
-	tryThreeWayConflict(t, nil, mm2b, mm2, "Cannot merge nil Value with")
-	tryThreeWayConflict(t, mm2a, nil, mm2, "with nil value.")
+	tryThreeWayConflict(t, nil, cm(mm2b), cm(mm2), "Cannot merge nil Value with")
+	tryThreeWayConflict(t, cm(mm2a), nil, cm(mm2), "with nil value.")
 }
 
 func TestThreeWayMergeMap_ImmediateConflict(t *testing.T) {
-	tryThreeWayConflict(t, types.NewSet(), mm2b, mm2, "Cannot merge Set<> with Map")
-	tryThreeWayConflict(t, mm2b, types.NewSet(), mm2, "Cannot merge Map")
+	tryThreeWayConflict(t, types.NewSet(), cm(mm2b), cm(mm2), "Cannot merge Set<> with Map")
+	tryThreeWayConflict(t, cm(mm2b), types.NewSet(), cm(mm2), "Cannot merge Map")
 }
 
 func TestThreeWayMergeMap_NestedConflict(t *testing.T) {
-	tryThreeWayConflict(t, mm2a.Set(types.String("k2"), types.NewSet()), mm2b, mm2, types.EncodedValue(types.NewSet()))
-	tryThreeWayConflict(t, mm2a.Set(types.String("k2"), types.NewSet()), mm2b, mm2, types.EncodedValue(aa1b))
+	tryThreeWayConflict(t, cm(mm2a).Set(types.String("k2"), types.NewSet()), cm(mm2b), cm(mm2), types.EncodedValue(types.NewSet()))
+	tryThreeWayConflict(t, cm(mm2a).Set(types.String("k2"), types.NewSet()), cm(mm2b), cm(mm2), types.EncodedValue(cm(aa1b)))
 }
 
 func TestThreeWayMergeMap_NestedConflictingOperation(t *testing.T) {
 	key := types.String("k2")
-	tryThreeWayConflict(t, mm2a.Remove(key), mm2b, mm2, "removed "+types.EncodedValue(key))
-	tryThreeWayConflict(t, mm2a.Remove(key), mm2b, mm2, "modded "+types.EncodedValue(key))
+	tryThreeWayConflict(t, cm(mm2a).Remove(key), cm(mm2b), cm(mm2), "removed "+types.EncodedValue(key))
+	tryThreeWayConflict(t, cm(mm2a).Remove(key), cm(mm2b), cm(mm2), "modded "+types.EncodedValue(key))
 }
 
-func createMap(kv ...interface{}) types.Map {
-	keyValues := valsToTypesValues(kv...)
+func TestThreeWayMergeStruct_DoNothing(t *testing.T) {
+	tryThreeWayMerge(t, nil, nil, cs(aa1), cs(aa1), nil)
+}
+
+func TestThreeWayMergeStruct_NoRecursion(t *testing.T) {
+	tryThreeWayMerge(t, cs(aa1a), cs(aa1b), cs(aa1), cs(aaMerged), nil)
+	tryThreeWayMerge(t, cs(aa1b), cs(aa1a), cs(aa1), cs(aaMerged), nil)
+}
+
+func TestThreeWayMergeStruct_RecursiveCreate(t *testing.T) {
+	tryThreeWayMerge(t, cs(mm1a), cs(mm1b), cs(mm1), cs(mm1Merged), nil)
+	tryThreeWayMerge(t, cs(mm1b), cs(mm1a), cs(mm1), cs(mm1Merged), nil)
+}
+
+func TestThreeWayMergeStruct_RecursiveCreateNil(t *testing.T) {
+	tryThreeWayMerge(t, cs(mm1a), cs(mm1b), nil, cs(mm1Merged), nil)
+	tryThreeWayMerge(t, cs(mm1b), cs(mm1a), nil, cs(mm1Merged), nil)
+}
+
+func TestThreeWayMergeStruct_RecursiveMerge(t *testing.T) {
+	tryThreeWayMerge(t, cs(mm2a), cs(mm2b), cs(mm2), cs(mm2Merged), nil)
+	tryThreeWayMerge(t, cs(mm2b), cs(mm2a), cs(mm2), cs(mm2Merged), nil)
+}
+
+func TestThreeWayMergeStruct_RefMerge(t *testing.T) {
+	vs := types.NewTestValueStore()
+
+	strRef := vs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
+
+	create := func(kv ...interface{}) types.Struct {
+		return cs(kv)
+	}
+	m := create("r2", vs.WriteValue(cs(aa1)))
+	ma := create("r1", strRef, "r2", vs.WriteValue(cs(aa1a)))
+	mb := create("r1", strRef, "r2", vs.WriteValue(cs(aa1b)))
+	mMerged := create("r1", strRef, "r2", vs.WriteValue(cs(aaMerged)))
+	vs.Flush()
+
+	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
+	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
+}
+
+func TestThreeWayMergeStruct_RecursiveMultiLevelMerge(t *testing.T) {
+	vs := types.NewTestValueStore()
+
+	create := func(kv ...interface{}) types.Struct {
+		return cs(kv)
+	}
+	m := create("mm1", cs(mm1), "mm2", vs.WriteValue(cs(mm2)))
+	ma := create("mm1", cs(mm1a), "mm2", vs.WriteValue(cs(mm2a)))
+	mb := create("mm1", cs(mm1b), "mm2", vs.WriteValue(cs(mm2b)))
+	mMerged := create("mm1", cs(mm1Merged), "mm2", vs.WriteValue(cs(mm2Merged)))
+	vs.Flush()
+
+	tryThreeWayMerge(t, ma, mb, m, mMerged, vs)
+	tryThreeWayMerge(t, mb, ma, m, mMerged, vs)
+}
+
+func TestThreeWayMergeStruct_NilConflict(t *testing.T) {
+	tryThreeWayConflict(t, nil, cs(mm2b), cs(mm2), "Cannot merge nil Value with")
+	tryThreeWayConflict(t, cs(mm2a), nil, cs(mm2), "with nil value.")
+}
+
+func TestThreeWayMergeStruct_ImmediateConflict(t *testing.T) {
+	tryThreeWayConflict(t, types.NewSet(), cs(mm2b), cs(mm2), "Cannot merge Set<> with struct")
+	tryThreeWayConflict(t, cs(mm2b), types.NewSet(), cs(mm2), "Cannot merge struct")
+}
+
+func TestThreeWayMergeStruct_NestedConflict(t *testing.T) {
+	a := cs([]interface{}{"k2", "not-a-struct"})
+	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), "not-a-struct")
+	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), types.EncodedValue(cs(aa1b)))
+}
+
+func TestThreeWayMergeStruct_NestedConflictingOperation(t *testing.T) {
+	key := "k2"
+	a := cs([]interface{}{"k3", "k-three"})
+	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), "removed "+types.EncodedValue(types.String(key)))
+	tryThreeWayConflict(t, a, cs(mm2b), cs(mm2), "modded "+types.EncodedValue(types.String(key)))
+}
+
+func cm(kv []interface{}) types.Map {
+	keyValues := valsToTypesValues(func(kv []interface{}) types.Value { return cm(kv) }, kv...)
 	return types.NewMap(keyValues...)
 }
 
-func valsToTypesValues(kv ...interface{}) []types.Value {
+func cs(kv []interface{}) types.Struct {
+	fields := types.StructData{}
+	recurse := func(kv []interface{}) types.Value { return cs(kv) }
+	for i := 0; i < len(kv); i += 2 {
+		fields[kv[i].(string)] = valToTypesValue(recurse, kv[i+1])
+	}
+	return types.NewStruct("TestStruct", fields)
+}
+
+func valsToTypesValues(f func([]interface{}) types.Value, kv ...interface{}) []types.Value {
 	keyValues := []types.Value{}
 	for _, e := range kv {
-		v := valToTypesValue(e)
+		v := valToTypesValue(f, e)
 		keyValues = append(keyValues, v)
 	}
 	return keyValues
 }
 
-func valToTypesValue(v interface{}) types.Value {
+func valToTypesValue(f func([]interface{}) types.Value, v interface{}) types.Value {
 	var v1 types.Value
 	switch t := v.(type) {
 	case string:
 		v1 = types.String(t)
 	case int:
 		v1 = types.Number(t)
+	case []interface{}:
+		v1 = f(t)
 	case types.Value:
 		v1 = t
 	}


### PR DESCRIPTION
merge.ThreeWay() is now willing to merge Structs as well as Maps, as long
as the Structs are all named the name thing. Other rules are the same
as for Map.

Toward #148