### PR TITLE
Make perf suite testdata path configurable by -perf.testdata flag

### DIFF
--- a/go/perf/suite/suite_test.go
+++ b/go/perf/suite/suite_test.go
@@ -29,6 +29,7 @@ func (s *testSuite) TestInterestingStuff() {
 	assert.NotNil(s.T)
 	assert.NotNil(s.W)
 	assert.NotEqual("", s.AtticLabs)
+	assert.NotEqual("", s.Testdata)
 	assert.NotEqual("", s.DatabaseSpec)
 
 	val := types.Bool(true)

--- a/samples/go/csv/csv-import/perf_test.go
+++ b/samples/go/csv/csv-import/perf_test.go
@@ -49,7 +49,7 @@ func (s *perfSuite) Test01ImportSfCrimeBlobFromTestdata() {
 
 	s.Pause(func() {
 		// The raw data is split into a bunch of files foo.a, foo.b, etc.
-		glob, err := filepath.Glob(path.Join(s.AtticLabs, "testdata", "sf-crime", "2016-07-28.*"))
+		glob, err := filepath.Glob(path.Join(s.Testdata, "sf-crime", "2016-07-28.*"))
 		assert.NoError(err)
 
 		raw = make([]io.Reader, len(glob))


### PR DESCRIPTION
Needed by Jenkins shared workspaces.