### PR TITLE
Go Marshal: Title case struct names

### DIFF
--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -7,6 +7,7 @@ package marshal
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/attic-labs/noms/go/types"
@@ -20,6 +21,7 @@ import (
 // To unmarshal a Noms struct into a Go struct, Unmarshal matches incoming object
 // fields to the fields used by Marshal (either the struct field name or its tag).
 // Unmarshal will only set exported fields of the struct.
+// The name of the Go struct must match (ignoring case) the name of the Noms struct.
 //
 // To unmarshal a Noms list into a slice, Unmarshal resets the slice length to zero and then appends each element to the slice. If the Go slice was nil a new slice is created.
 //
@@ -235,7 +237,7 @@ func structDecoder(t reflect.Type) decoderFunc {
 	d = func(v types.Value, rv reflect.Value) {
 		s := v.(types.Struct)
 		// If the name is empty then the Go struct has to be anonymous.
-		if s.Type().Desc.(types.StructDesc).Name != name {
+		if !strings.EqualFold(s.Type().Desc.(types.StructDesc).Name, name) {
 			panic(&UnmarshalTypeMismatchError{v, rv.Type(), ", names do not match"})
 		}
 

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -180,6 +180,18 @@ func TestDecode(tt *testing.T) {
 		"b": types.String("abc"),
 		"a": types.Number(42),
 	}), &t3, T3{"abc"})
+
+	// Case of struct name is not relevant when unmarshalling.
+	type aBc struct {
+		E bool
+	}
+	var t4 aBc
+	t(types.NewStruct("abc", types.StructData{
+		"e": types.Bool(true),
+	}), &t4, aBc{true})
+	t(types.NewStruct("Abc", types.StructData{
+		"e": types.Bool(false),
+	}), &t4, aBc{false})
 }
 
 func TestDecodeNilPointer(t *testing.T) {
@@ -212,6 +224,10 @@ func TestDecodeTypeMismatch(t *testing.T) {
 	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
 		"x": types.String("hi"),
 	}), &s, "Cannot unmarshal String into Go value of type int")
+
+	assertDecodeErrorMessage(t, types.NewStruct("T", types.StructData{
+		"x": types.Number(42),
+	}), &s, "Cannot unmarshal struct T {\n  x: Number,\n} into Go value of type marshal.S, names do not match")
 }
 
 func assertDecodeErrorMessage(t *testing.T, v types.Value, ptr interface{}, msg string) {

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -46,6 +46,8 @@ import (
 //
 // Unlike encoding/json Marshal, this does not support "omitempty".
 //
+// The name of the Noms struct is the name of the Go struct where the first character is changed to upper case.
+//
 // Anonymous struct fields are currently not supported.
 //
 // Embedded structs are currently not supported (which is the same as anonymous struct fields).
@@ -176,7 +178,7 @@ func structEncoder(t reflect.Type, parentStructTypes []reflect.Type) encoderFunc
 		}
 	} else {
 		// Cannot precompute the Noms type since there are Noms collections.
-		name := t.Name()
+		name := strings.Title(t.Name())
 		e = func(v reflect.Value) types.Value {
 			data := make(types.StructData, len(fields))
 			for _, f := range fields {
@@ -273,7 +275,7 @@ func typeFields(t reflect.Type, parentStructTypes []reflect.Type) (fields fieldS
 			fieldNames[i] = fs.name
 			fieldTypes[i] = fs.nomsType
 		}
-		structType = types.MakeStructType(t.Name(), fieldNames, fieldTypes)
+		structType = types.MakeStructType(strings.Title(t.Name()), fieldNames, fieldTypes)
 	}
 	return
 }

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -138,6 +138,15 @@ func TestEncode(tt *testing.T) {
 		},
 		C: 1234,
 	})
+
+	type testStruct struct {
+		Str string
+		Num float64
+	}
+	t(types.NewStruct("TestStruct", types.StructData{
+		"num": types.Number(42),
+		"str": types.String("Hello"),
+	}), testStruct{Str: "Hello", Num: 42})
 }
 
 func assertEncodeErrorMessage(t *testing.T, v interface{}, expectedMessage string) {


### PR DESCRIPTION
Make the name of the Noms struct start with a capital letter.

When unmarshalling a struct we now ignore the case.

Towards #2376