### PR TITLE
Add special encoding to csv imported struct fields

### DIFF
--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -195,7 +195,7 @@ func CamelCaseFieldName(input string) string {
 
 	//Camelcase field
 	if len(splitField) == 1 {
-		output = splitField[0]
+		output = strings.ToLower(splitField[0])
 	} else if len(splitField) > 1 {
 		output = strings.ToLower(splitField[0])
 		for _, field := range splitField[1:] {

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -215,7 +215,7 @@ func CamelCaseFieldName(input string) string {
 	for _, field := range splitFields[1:] {
 		output += strings.Title(strings.ToLower(escapeFields(field, encode)))
 	}
-
+	//Because we are removing characters, we may generate an invalid field name
 	if !IsValidStructFieldName(output) {
 		return ""
 	}
@@ -232,9 +232,9 @@ func escapeFields(input string, encode encodingFunc) string {
 	return output
 }
 
-// EscapeStructField escapes names for use as noms structs. Disallowed characters are encoded as
-// 'Q<hex-encoded-utf8-bytes>'. Note that Q itself is also escaped since it is
-// the escape character.
+// EscapeStructField escapes names for use as noms structs with regards to non CSV imported data.
+// Disallowed characters are encoded as 'Q<hex-encoded-utf8-bytes>'.
+// Note that Q itself is also escaped since it is the escape character.
 func EscapeStructField(input string) string {
 	if !escapeRegex.MatchString(input) && IsValidStructFieldName(input) {
 		return input

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -191,18 +191,18 @@ func CamelCaseFieldName(input string) string {
 
 	strippedField := escapeField(input, encode)
 	splitField := strings.Fields(strippedField)
-	output := ""
+
+	if len(splitField) == 0 {
+		return ""
+	}
 
 	//Camelcase field
-	if len(splitField) == 1 {
-		output = strings.ToLower(splitField[0])
-	} else if len(splitField) > 1 {
-		output = strings.ToLower(splitField[0])
+	output := strings.ToLower(splitField[0])
+	if len(splitField) > 1 {
 		for _, field := range splitField[1:] {
 			output += strings.Title(strings.ToLower(field))
 		}
 	}
-
 	//Because we are removing characters, we may generate an invalid field name
 	//i.e. -- 1A B, we will remove the first bad chars and process until 1aB
 	//1aB is invalid struct field name so we will return ""

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -7,11 +7,11 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"regexp"
-	"sort"
-
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
+	"regexp"
+	"sort"
+	"strings"
 )
 
 var EmptyStructType = MakeStructType("", []string{}, []*Type{})
@@ -169,18 +169,33 @@ func (s1 Struct) Diff(s2 Struct, changes chan<- ValueChanged, closeChan <-chan s
 }
 
 var escapeChar = "Q"
-var headPattern = regexp.MustCompile("[a-zA-PR-Z]")
-var tailPattern = regexp.MustCompile("[a-zA-PR-Z0-9_]")
-var completePattern = regexp.MustCompile("^" + headPattern.String() + tailPattern.String() + "*$")
+var headFieldNamePattern = regexp.MustCompile("[a-zA-Z]")
+var tailFieldNamePattern = regexp.MustCompile("[a-zA-Z0-9_]")
+var escapeRegex = regexp.MustCompile(escapeChar)
 
-// Escapes names for use as noms structs. Disallowed characters are encoded as
+var fieldNameComponentRe = regexp.MustCompile("^" + headFieldNamePattern.String() + tailFieldNamePattern.String() + "*")
+var fieldNameRe = regexp.MustCompile(fieldNameComponentRe.String() + "$")
+
+type encodingFunc func(string, *regexp.Regexp) string
+
+func EscapeFields(input string, encode encodingFunc) string {
+	output := ""
+	pattern := headFieldNamePattern
+	for _, ch := range input {
+		output += encode(string([]rune{ch}), pattern)
+		pattern = tailFieldNamePattern
+	}
+	return output
+}
+
+// EscapeStructField escapes names for use as noms structs. Disallowed characters are encoded as
 // 'Q<hex-encoded-utf8-bytes>'. Note that Q itself is also escaped since it is
 // the escape character.
 func EscapeStructField(input string) string {
-	if completePattern.MatchString(input) {
+
+	if !escapeRegex.MatchString(input) && IsValidStructFieldName(input) {
 		return input
 	}
-
 	encode := func(s1 string, p *regexp.Regexp) string {
 		if p.MatchString(s1) && s1 != escapeChar {
 			return s1
@@ -195,13 +210,45 @@ func EscapeStructField(input string) string {
 		buf.WriteString(hs)
 		return buf.String()
 	}
+	output := EscapeFields(input, encode)
+	verifyFieldName(output)
+	return output
 
-	output := ""
-	pattern := headPattern
-	for _, ch := range input {
-		output += encode(string([]rune{ch}), pattern)
-		pattern = tailPattern
+}
+
+// IsValidStructFieldName returns whether the name is valid as a field name in a struct.
+// Valid names must start with `a-zA-Z` and after that `a-zA-Z0-9_`.
+func IsValidStructFieldName(name string) bool {
+	return fieldNameRe.MatchString(name)
+}
+
+func verifyFieldNames(names []string) {
+	if len(names) == 0 {
+		return
 	}
 
-	return output
+	last := names[0]
+	verifyFieldName(last)
+
+	for i := 1; i < len(names); i++ {
+		verifyFieldName(names[i])
+		if strings.Compare(names[i], last) <= 0 {
+			d.Chk.Fail("Field names must be unique and ordered alphabetically")
+		}
+		last = names[i]
+	}
+}
+
+func verifyName(name, kind string) {
+	d.PanicIfTrue(!IsValidStructFieldName(name), `Invalid struct%s name: "%s"`, kind, name)
+}
+
+func verifyFieldName(name string) {
+	verifyName(name, " field")
+}
+
+func verifyStructName(name string) {
+	if name != "" {
+		verifyName(name, "")
+	}
 }

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -179,24 +179,6 @@ var fieldNameRe = regexp.MustCompile(fieldNameComponentRe.String() + "$")
 
 type encodingFunc func(string, *regexp.Regexp) string
 
-func QEncodeFieldName(input string) string {
-	encode := func(s1 string, p *regexp.Regexp) string {
-		if p.MatchString(s1) && s1 != escapeChar {
-			return s1
-		}
-
-		var hs = fmt.Sprintf("%X", s1)
-		var buf bytes.Buffer
-		buf.WriteString(escapeChar)
-		if len(hs) == 1 {
-			buf.WriteString("0")
-		}
-		buf.WriteString(hs)
-		return buf.String()
-	}
-	return escapeFields(input, encode)
-}
-
 func CamelCaseFieldName(input string) string {
 	encode := func(s1 string, p *regexp.Regexp) string {
 		if p.MatchString(s1) {
@@ -239,7 +221,21 @@ func EscapeStructField(input string) string {
 	if !escapeRegex.MatchString(input) && IsValidStructFieldName(input) {
 		return input
 	}
-	return QEncodeFieldName(input)
+	encode := func(s1 string, p *regexp.Regexp) string {
+		if p.MatchString(s1) && s1 != escapeChar {
+			return s1
+		}
+
+		var hs = fmt.Sprintf("%X", s1)
+		var buf bytes.Buffer
+		buf.WriteString(escapeChar)
+		if len(hs) == 1 {
+			buf.WriteString("0")
+		}
+		buf.WriteString(hs)
+		return buf.String()
+	}
+	return escapeFields(input, encode)
 }
 
 // IsValidStructFieldName returns whether the name is valid as a field name in a struct.

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -6,8 +6,6 @@
 package types
 
 import (
-	"regexp"
-
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 )
@@ -147,44 +145,4 @@ func MakePrimitiveTypeByString(p string) *Type {
 	}
 	d.Chk.Fail("invalid type string: %s", p)
 	return nil
-}
-
-var fieldNameComponentRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*`)
-var fieldNameRe = regexp.MustCompile(fieldNameComponentRe.String() + "$")
-
-func verifyFieldNames(names []string) {
-	if len(names) == 0 {
-		return
-	}
-
-	last := names[0]
-	verifyFieldName(last)
-
-	for i := 1; i < len(names); i++ {
-		verifyFieldName(names[i])
-		if names[i] <= last {
-			d.Chk.Fail("Field names must be unique and ordered alphabetically")
-		}
-		last = names[i]
-	}
-}
-
-// IsValidStructFieldName returns whether the name is valid without as a field name in a struct.
-// Valid names must start with `a-zA-Z` and after that `a-zA-Z0-9_`.
-func IsValidStructFieldName(name string) bool {
-	return fieldNameRe.MatchString(name)
-}
-
-func verifyName(name, kind string) {
-	d.PanicIfTrue(!IsValidStructFieldName(name), `Invalid struct%s name: "%s"`, kind, name)
-}
-
-func verifyFieldName(name string) {
-	verifyName(name, " field")
-}
-
-func verifyStructName(name string) {
-	if name != "" {
-		verifyName(name, "")
-	}
 }

--- a/samples/go/csv/read.go
+++ b/samples/go/csv/read.go
@@ -8,10 +8,8 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
@@ -48,27 +46,10 @@ func KindsToStrings(kinds KindSlice) []string {
 
 //EscapeStructFieldFromCSV removes special characters and replaces spaces with camelCasing (camel case turns to camelCase)
 func EscapeStructFieldFromCSV(input string) string {
-
-	encode := func(s1 string, p *regexp.Regexp) string {
-		if p.MatchString(s1) {
-			return s1
-		}
-		return ""
+	if types.IsValidStructFieldName(input) {
+		return input
 	}
-
-	splitFields := strings.Fields(input)
-	output := types.EscapeFields(splitFields[0], encode)
-
-	if len(splitFields) > 1 {
-		output = strings.ToLower(output)
-	}
-
-	for _, field := range splitFields[1:] {
-		output += strings.Title(strings.ToLower(types.EscapeFields(field, encode)))
-	}
-
-	d.PanicIfTrue(!types.IsValidStructFieldName(output), `"Invalid field name: %s after escaping to %s"`, input, output)
-	return output
+	return types.CamelCaseFieldName(input)
 }
 
 // MakeStructTypeFromHeaders creates a struct type from the headers using |kinds| as the type of each field. If |kinds| is empty, default to strings.

--- a/samples/go/csv/read.go
+++ b/samples/go/csv/read.go
@@ -8,8 +8,10 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
@@ -44,6 +46,31 @@ func KindsToStrings(kinds KindSlice) []string {
 	return strs
 }
 
+//EscapeStructFieldFromCSV removes special characters and replaces spaces with camelCasing (camel case turns to camelCase)
+func EscapeStructFieldFromCSV(input string) string {
+
+	encode := func(s1 string, p *regexp.Regexp) string {
+		if p.MatchString(s1) {
+			return s1
+		}
+		return ""
+	}
+
+	splitFields := strings.Fields(input)
+	output := types.EscapeFields(splitFields[0], encode)
+
+	if len(splitFields) > 1 {
+		output = strings.ToLower(output)
+	}
+
+	for _, field := range splitFields[1:] {
+		output += strings.Title(strings.ToLower(types.EscapeFields(field, encode)))
+	}
+
+	d.PanicIfTrue(!types.IsValidStructFieldName(output), `"Invalid field name: %s after escaping to %s"`, input, output)
+	return output
+}
+
 // MakeStructTypeFromHeaders creates a struct type from the headers using |kinds| as the type of each field. If |kinds| is empty, default to strings.
 func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSlice) (typ *types.Type, fieldOrder []int, kindMap []types.NomsKind) {
 	useStringType := len(kinds) == 0
@@ -54,7 +81,7 @@ func MakeStructTypeFromHeaders(headers []string, structName string, kinds KindSl
 	fieldNames := make(sort.StringSlice, len(headers))
 
 	for i, key := range headers {
-		fn := types.EscapeStructField(key)
+		fn := EscapeStructFieldFromCSV(key)
 		origOrder[fn] = i
 		kind := types.StringKind
 		if !useStringType {

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -134,6 +134,36 @@ g,h,i,j
 	testTrailingHelper(t, dataString)
 }
 
+func TestEscapeStructFieldFromCSV(t *testing.T) {
+	assert := assert.New(t)
+	cases := []string{
+		"a", "a",
+		"1a", "a",
+		"AaZz19_", "AaZz19_",
+		"Q", "Q",
+		"AQ", "AQ",
+		"_content", "content",
+		"Few ¢ents Short", "fewEntsShort",
+		"CAMEL💩case letTerS", "camelcaseLetters",
+		"https://picasaweb.google.com/data", "httpspicasawebgooglecomdata",
+	}
+	panicCases := []string{
+		"💩",
+		"11 1💩",
+		"",
+	}
+
+	for i := 0; i < len(cases); i += 2 {
+		orig, expected := cases[i], cases[i+1]
+		assert.Equal(expected, EscapeStructFieldFromCSV(orig))
+	}
+
+	for _, c := range panicCases {
+		assert.Panics(func() { EscapeStructFieldFromCSV(c) })
+	}
+
+}
+
 func TestReadParseError(t *testing.T) {
 	assert := assert.New(t)
 	ds := datas.NewDatabase(chunks.NewMemoryStore())
@@ -174,12 +204,12 @@ func TestEscapeFieldNames(t *testing.T) {
 
 	l, _ := ReadToList(r, "test", headers, kinds, ds)
 	assert.Equal(uint64(1), l.Len())
-	assert.Equal(types.Number(1), l.Get(0).(types.Struct).Get(types.EscapeStructField("A A")))
+	assert.Equal(types.Number(1), l.Get(0).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 
 	r = NewCSVReader(bytes.NewBufferString(dataString), ',')
 	m := ReadToMap(r, "test", headers, []string{"1"}, kinds, ds)
 	assert.Equal(uint64(1), l.Len())
-	assert.Equal(types.Number(1), m.Get(types.Number(2)).(types.Struct).Get(types.EscapeStructField("A A")))
+	assert.Equal(types.Number(1), m.Get(types.Number(2)).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 }
 
 func TestDefaults(t *testing.T) {

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -148,6 +148,9 @@ func TestEscapeStructFieldFromCSV(t *testing.T) {
 		"https://picasaweb.google.com/data", "httpspicasawebgooglecomdata",
 		"💩", "",
 		"11 1💩", "",
+		"-- A B", "aB",
+		"-- A --", "A",
+		"-- A -- B", "aB",
 	}
 
 	for i := 0; i < len(cases); i += 2 {

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -7,7 +7,6 @@ package csv
 import (
 	"bytes"
 	"encoding/csv"
-	"fmt"
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -153,7 +152,6 @@ func TestEscapeStructFieldFromCSV(t *testing.T) {
 
 	for i := 0; i < len(cases); i += 2 {
 		orig, expected := cases[i], cases[i+1]
-		fmt.Println(cases[i])
 		assert.Equal(expected, EscapeStructFieldFromCSV(orig))
 	}
 }

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -149,7 +149,7 @@ func TestEscapeStructFieldFromCSV(t *testing.T) {
 		"💩", "",
 		"11 1💩", "",
 		"-- A B", "aB",
-		"-- A --", "A",
+		"-- A --", "a",
 		"-- A -- B", "aB",
 	}
 

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -7,6 +7,7 @@ package csv
 import (
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -146,20 +147,14 @@ func TestEscapeStructFieldFromCSV(t *testing.T) {
 		"Few ¢ents Short", "fewEntsShort",
 		"CAMEL💩case letTerS", "camelcaseLetters",
 		"https://picasaweb.google.com/data", "httpspicasawebgooglecomdata",
-	}
-	panicCases := []string{
-		"💩",
-		"11 1💩",
-		"",
+		"💩", "",
+		"11 1💩", "",
 	}
 
 	for i := 0; i < len(cases); i += 2 {
 		orig, expected := cases[i], cases[i+1]
+		fmt.Println(cases[i])
 		assert.Equal(expected, EscapeStructFieldFromCSV(orig))
-	}
-
-	for _, c := range panicCases {
-		assert.Panics(func() { EscapeStructFieldFromCSV(c) })
 	}
 
 }

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -156,7 +156,6 @@ func TestEscapeStructFieldFromCSV(t *testing.T) {
 		fmt.Println(cases[i])
 		assert.Equal(expected, EscapeStructFieldFromCSV(orig))
 	}
-
 }
 
 func TestReadParseError(t *testing.T) {


### PR DESCRIPTION
…n logic, and changes csv importing to strip csv name fields of invalid struct characters and changes spaces in field names to camel case. i.e. camel case is translated to camelCase.

Additional comments and conversation here. I was struggling to undo my fat finger rebase orz.
https://github.com/attic-labs/noms/pull/2437