### PR TITLE
Add types.List support merge.ThreeWay()

### DIFF
--- a/go/merge/three_way.go
+++ b/go/merge/three_way.go
@@ -75,8 +75,9 @@ func threeWayMerge(a, b, parent types.Value, vwr types.ValueReadWriter) (merged 
 
 	switch a.Type().Kind() {
 	case types.ListKind:
-		// TODO: Come up with a plan for List (BUG 148)
-		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
+		if aList, bList, pList, ok := listAssert(a, b, parent); ok {
+			return threeWayListMerge(aList, bList, pList)
+		}
 
 	case types.MapKind:
 		if aMap, bMap, pMap, ok := mapAssert(a, b, parent); ok {
@@ -189,6 +190,19 @@ func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter) (
 		panic(fmt.Errorf("Bad key type in diff: %s", change.V.Type().Describe()))
 	}
 	return threeWayOrderedSequenceMerge(parent, aDiff, bDiff, makeGetFunc(a), makeGetFunc(b), makeGetFunc(parent), apply, vwr)
+}
+
+func listAssert(a, b, parent types.Value) (aList, bList, pList types.List, ok bool) {
+	var aOk, bOk, pOk bool
+	aList, aOk = a.(types.List)
+	bList, bOk = b.(types.List)
+	if parent != nil {
+		pList, pOk = parent.(types.List)
+	} else {
+		pList, pOk = types.NewList(), true
+	}
+	ok = aOk && bOk && pOk
+	return
 }
 
 func mapAssert(a, b, parent types.Value) (aMap, bMap, pMap types.Map, ok bool) {

--- a/go/merge/three_way.go
+++ b/go/merge/three_way.go
@@ -201,8 +201,7 @@ func listAssert(a, b, parent types.Value) (aList, bList, pList types.List, ok bo
 	} else {
 		pList, pOk = types.NewList(), true
 	}
-	ok = aOk && bOk && pOk
-	return
+	return aList, bList, pList, aOk && bOk && pOk
 }
 
 func mapAssert(a, b, parent types.Value) (aMap, bMap, pMap types.Map, ok bool) {
@@ -214,8 +213,7 @@ func mapAssert(a, b, parent types.Value) (aMap, bMap, pMap types.Map, ok bool) {
 	} else {
 		pMap, pOk = types.NewMap(), true
 	}
-	ok = aOk && bOk && pOk
-	return
+	return aMap, bMap, pMap, aOk && bOk && pOk
 }
 
 func refAssert(a, b, parent types.Value, vwr types.ValueReadWriter) (aValue, bValue, pValue types.Value, ok bool) {
@@ -248,8 +246,7 @@ func setAssert(a, b, parent types.Value) (aSet, bSet, pSet types.Set, ok bool) {
 	} else {
 		pSet, pOk = types.NewSet(), true
 	}
-	ok = aOk && bOk && pOk
-	return
+	return aSet, bSet, pSet, aOk && bOk && pOk
 }
 
 func structAssert(a, b, parent types.Value) (aStruct, bStruct, pStruct types.Struct, ok bool) {

--- a/go/merge/three_way_list.go
+++ b/go/merge/three_way_list.go
@@ -1,0 +1,119 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package merge
+
+import (
+	"fmt"
+
+	"github.com/attic-labs/noms/go/types"
+)
+
+func threeWayListMerge(a, b, parent types.List) (merged types.List, err error) {
+	aSpliceChan, bSpliceChan := make(chan types.Splice), make(chan types.Splice)
+	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		a.Diff(parent, aSpliceChan, aStopChan)
+		close(aSpliceChan)
+	}()
+	go func() {
+		b.Diff(parent, bSpliceChan, bStopChan)
+		close(bSpliceChan)
+	}()
+
+	stopAndDrain := func(stop chan<- struct{}, drain <-chan types.Splice) {
+		close(stop)
+		for range drain {
+		}
+	}
+
+	defer stopAndDrain(aStopChan, aSpliceChan)
+	defer stopAndDrain(bStopChan, bSpliceChan)
+
+	zeroSplice := types.Splice{}
+	zeroToEmpty := func(sp types.Splice) types.Splice {
+		if sp == zeroSplice {
+			return types.Splice{types.SPLICE_UNASSIGNED, types.SPLICE_UNASSIGNED, types.SPLICE_UNASSIGNED, types.SPLICE_UNASSIGNED}
+		}
+		return sp
+	}
+
+	merged = parent
+	offset := uint64(0)
+	emptySplice := zeroToEmpty(types.Splice{})
+	aSplice, bSplice := emptySplice, emptySplice
+	for {
+		// Get the next splice from both a and b. If either diff(a, parent) or diff(b, parent) is complete, aSplice or bSplice will get an empty types.Splice. Generally, though, this allows us to proceed through both diffs in (key) order, considering the "current" splice from both diffs at the same time.
+		if aSplice == emptySplice {
+			aSplice = zeroToEmpty(<-aSpliceChan)
+		}
+		if bSplice == emptySplice {
+			bSplice = zeroToEmpty(<-bSpliceChan)
+		}
+		// Both channels are producing zero values, so we're done.
+		if aSplice == emptySplice && bSplice == emptySplice {
+			break
+		}
+		if overlap(aSplice, bSplice) {
+			if canMerge(a, b, aSplice, bSplice) {
+				splice := merge(aSplice, bSplice)
+				merged = apply(a, merged, offset, splice)
+				offset += splice.SpAdded - splice.SpRemoved
+				aSplice, bSplice = emptySplice, emptySplice
+				continue
+			}
+			return parent, newMergeConflict("Overlapping splices: %s vs %s", describeSplice(aSplice), describeSplice(bSplice))
+		}
+		if aSplice.SpAt < bSplice.SpAt {
+			merged = apply(a, merged, offset, aSplice)
+			offset += aSplice.SpAdded - aSplice.SpRemoved
+			aSplice = emptySplice
+			continue
+		}
+		merged = apply(b, merged, offset, bSplice)
+		offset += bSplice.SpAdded - bSplice.SpRemoved
+		bSplice = emptySplice
+	}
+
+	return merged, nil
+}
+
+func overlap(s1, s2 types.Splice) bool {
+	earlier, later := s1, s2
+	if s2.SpAt < s1.SpAt {
+		earlier, later = s2, s1
+	}
+	return s1.SpAt == s2.SpAt || earlier.SpAt+earlier.SpRemoved > later.SpAt
+}
+
+func canMerge(a, b types.List, aSplice, bSplice types.Splice) bool {
+	if aSplice != bSplice {
+		return false
+	}
+	// TODO: Add List.IterFrom() and use that to compare added values.
+	for i := uint64(0); i < aSplice.SpAdded; i++ {
+		if !a.Get(aSplice.SpFrom + i).Equals(b.Get(bSplice.SpFrom + i)) {
+			return false
+		}
+	}
+	return true
+}
+
+func merge(s1, s2 types.Splice) types.Splice {
+	return s1
+}
+
+func apply(source, target types.List, offset uint64, s types.Splice) types.List {
+	// TODO: Add List.IterFrom() and use that to build up toAdd.
+	toAdd := make(types.ValueSlice, s.SpAdded)
+	for i := range toAdd {
+		toAdd[i] = source.Get(s.SpFrom + uint64(i))
+	}
+	return target.Splice(s.SpAt+offset, s.SpRemoved, toAdd...)
+}
+
+func describeSplice(s types.Splice) string {
+	return fmt.Sprintf("%d elements removed at %d; adding %d elements", s.SpRemoved, s.SpAt, s.SpAdded)
+}

--- a/go/merge/three_way_list_test.go
+++ b/go/merge/three_way_list_test.go
@@ -1,0 +1,139 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package merge
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/suite"
+)
+
+func TestThreeWayListMerge(t *testing.T) {
+	suite.Run(t, &ThreeWayListMergeSuite{})
+}
+
+type ThreeWayListMergeSuite struct {
+	ThreeWayMergeSuite
+}
+
+func (s *ThreeWayListMergeSuite) SetupSuite() {
+	s.create = func(i seq) (val types.Value) {
+		if i != nil {
+			items := valsToTypesValues(s.create, i.items()...)
+			val = types.NewList(items...)
+		}
+		return
+	}
+	s.typeStr = "List"
+}
+
+var p = items{"a", "b", "c", "d", "e"}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_DoNothing() {
+	s.tryThreeWayMerge(nil, nil, p, p, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_NoLengthChange() {
+	a := items{"a", 1, "c", "d", "e"}
+	b := items{"a", "b", "c", 2, "e"}
+	m := items{"a", 1, "c", 2, "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_HandleEmpty() {
+	s.tryThreeWayMerge(p, items{}, items{}, p, nil)
+	s.tryThreeWayMerge(items{}, p, items{}, p, nil)
+	s.tryThreeWayMerge(p, p, items{}, p, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_HandleNil() {
+	s.tryThreeWayMerge(p, items{}, nil, p, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_MakeLonger() {
+	a := items{"a", 1, 2, "c", "d", "e"}
+	b := items{"a", "b", "c", 3, "e"}
+	m := items{"a", 1, 2, "c", 3, "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_MakeShorter() {
+	a := items{"a", "c", "d", "e"}
+	b := items{"a", "b", "c", 3, "e"}
+	m := items{"a", "c", 3, "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_BothSidesRemove() {
+	a := items{"a", "c", "d", "e"}
+	b := items{"a", "b", "c", "e"}
+	m := items{"a", "c", "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_OverlapSameRemoveNoInsert() {
+	a := items{"a", "d", "e"}
+	b := items{"a", "d", "e"}
+	m := items{"a", "d", "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_OverlapSameRemoveSameInsert() {
+	a := items{"a", 1, 2, 3, "d", "e"}
+	b := items{"a", 1, 2, 3, "d", "e"}
+	m := items{"a", 1, 2, 3, "d", "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_RemoveUpToOtherSideInsertionPoint() {
+	a := items{"a", 1, 2, "c", "d", "e"}
+	b := items{"a", "b", 3, "c", "d", "e"}
+	m := items{"a", 1, 2, 3, "c", "d", "e"}
+	s.tryThreeWayMerge(a, b, p, m, nil)
+	s.tryThreeWayMerge(b, a, p, m, nil)
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_ConflictingAppends() {
+	a := append(p, 1)
+	b := append(p, 2)
+	s.tryThreeWayConflict(s.create(a), s.create(b), s.create(p), "Overlapping splices: 0 elements removed at 5; adding 1 elements")
+	s.tryThreeWayConflict(s.create(b), s.create(a), s.create(p), "Overlapping splices: 0 elements removed at 5; adding 1 elements")
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_OverlappingRemoves() {
+	a := p[:4]
+	b := p[:3]
+	s.tryThreeWayConflict(s.create(a), s.create(b), s.create(p), "Overlapping splices: 1 elements removed at 4")
+	s.tryThreeWayConflict(s.create(b), s.create(a), s.create(p), "Overlapping splices: 2 elements removed at 3")
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_SameRemoveAddPrefix() {
+	a := items{"a", "b", "c", 1}
+	b := items{"a", "b", "c", 1, 2}
+	s.tryThreeWayConflict(s.create(a), s.create(b), s.create(p), "Overlapping splices: 2 elements removed at 3; adding 1 elements")
+	s.tryThreeWayConflict(s.create(b), s.create(a), s.create(p), "Overlapping splices: 2 elements removed at 3; adding 2 elements")
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_RemoveSupersetAddPrefix() {
+	a := items{"a", "b", "c", 1, 2}
+	b := items{"a", "b", "c", "d", 1}
+	s.tryThreeWayConflict(s.create(a), s.create(b), s.create(p), "Overlapping splices: 2 elements removed at 3; adding 2 elements")
+	s.tryThreeWayConflict(s.create(b), s.create(a), s.create(p), "Overlapping splices: 1 elements removed at 4; adding 1 elements")
+}
+
+func (s *ThreeWayListMergeSuite) TestThreeWayMerge_RemoveOtherSideInsertionPoint() {
+	a := items{"a", "c", "d", "e"}
+	b := items{"a", 1, "b", "c", "d", "e"}
+	s.tryThreeWayConflict(s.create(a), s.create(b), s.create(p), "Overlapping splices: 1 elements removed at 1; adding 0 elements")
+	s.tryThreeWayConflict(s.create(b), s.create(a), s.create(p), "Overlapping splices: 0 elements removed at 1; adding 1 elements")
+}

--- a/go/merge/three_way_test.go
+++ b/go/merge/three_way_test.go
@@ -28,10 +28,12 @@ func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp seq, vs types.ValueRe
 }
 
 func (s *ThreeWayMergeSuite) tryThreeWayConflict(a, b, p types.Value, contained string) {
-	_, err := ThreeWay(a, b, p, nil)
+	m, err := ThreeWay(a, b, p, nil)
 	if s.Error(err) {
 		s.Contains(err.Error(), contained)
+		return
 	}
+	s.Fail("Expected error!", "Got successful merge: %s", types.EncodedValue(m))
 }
 
 func valsToTypesValues(f func(seq) types.Value, items ...interface{}) []types.Value {


### PR DESCRIPTION
While the code in threeWayListMerge() starts similarly to that
in threeWayOrderedSequenceMerge(), the types of the channels
are different and trying to shoehorn them together would
remove a lot of clarity just for the sake of sharing maybe
15 lines of code.

Toward #148