### PR TITLE
Add a perf test for CSV map import

### DIFF
--- a/go/perf/suite/suite.go
+++ b/go/perf/suite/suite.go
@@ -206,37 +206,6 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 	db, err := spec.GetDatabase(*perfFlag)
 	assert.NoError(err)
 
-	// This is the temporary database for tests to use.
-	//
-	// * Why not use a local database + memory store?
-	// Firstly, because the spec would be "mem", and the spec library doesn't know how to reuse stores.
-	// Secondly, because it's an unrealistic performance measurement.
-	//
-	// * Why use a remote (HTTP) database?
-	// It's more realistic to exercise the HTTP stack, even if it's just talking over localhost.
-	//
-	// * Why provide an option for leveldb vs memory underlying store?
-	// Again, leveldb is more realistic than memory, and in common cases disk space > memory space.
-	// However, on this developer's laptop, there is actually very little disk space, and a lot of memory;
-	// plus making the test run a little bit faster locally is nice.
-	var chunkStore chunks.ChunkStore
-	if *perfMemFlag {
-		chunkStore = chunks.NewMemoryStore()
-	} else {
-		ldbDir := suite.TempDir("suite.suite")
-		chunkStore = chunks.NewLevelDBStoreUseFlags(ldbDir, "")
-	}
-
-	server := datas.NewRemoteDatabaseServer(chunkStore, 0)
-	portChan := make(chan int)
-	server.Ready = func() { portChan <- server.Port() }
-	go server.Run()
-	defer server.Stop()
-
-	port := <-portChan
-	suite.DatabaseSpec = fmt.Sprintf("http://localhost:%d", port)
-	suite.Database = datas.NewRemoteDatabase(suite.DatabaseSpec, "")
-
 	// List of test runs, each a map of test name => timing info.
 	testReps := make([]testRep, *perfRepeatFlag)
 
@@ -274,6 +243,10 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 
 	for repIdx := 0; repIdx < *perfRepeatFlag; repIdx++ {
 		testReps[repIdx] = testRep{}
+
+		serverHost, stopServerFn := suite.startServer()
+		suite.DatabaseSpec = serverHost
+		suite.Database = datas.NewRemoteDatabase(serverHost, "")
 
 		if t, ok := suiteT.(SetupRepSuite); ok {
 			t.SetupRep()
@@ -321,6 +294,8 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 		if t, ok := suiteT.(TearDownRepSuite); ok {
 			t.TearDownRep()
 		}
+
+		stopServerFn()
 	}
 
 	if t, ok := suiteT.(testifySuite.TearDownAllSuite); ok {
@@ -362,9 +337,7 @@ func (suite *PerfSuite) Pause(fn func()) {
 
 func callSafe(name string, fun reflect.Value, args ...interface{}) (err interface{}) {
 	defer func() {
-		if r := recover(); r != nil {
-			err = r
-		}
+		//err = recover()
 	}()
 	funArgs := make([]reflect.Value, len(args))
 	for i, arg := range args {
@@ -420,4 +393,37 @@ func (suite *PerfSuite) getGitHead(dir string) string {
 		return ""
 	}
 	return strings.TrimSpace(stdout.String())
+}
+
+func (suite *PerfSuite) startServer() (host string, stopFn func()) {
+	// This is the temporary database for tests to use.
+	//
+	// * Why not use a local database + memory store?
+	// Firstly, because the spec would be "mem", and the spec library doesn't know how to reuse stores.
+	// Secondly, because it's an unrealistic performance measurement.
+	//
+	// * Why use a remote (HTTP) database?
+	// It's more realistic to exercise the HTTP stack, even if it's just talking over localhost.
+	//
+	// * Why provide an option for leveldb vs memory underlying store?
+	// Again, leveldb is more realistic than memory, and in common cases disk space > memory space.
+	// However, on this developer's laptop, there is actually very little disk space, and a lot of memory;
+	// plus making the test run a little bit faster locally is nice.
+	var chunkStore chunks.ChunkStore
+	if *perfMemFlag {
+		chunkStore = chunks.NewMemoryStore()
+	} else {
+		ldbDir := suite.TempDir("suite.suite")
+		chunkStore = chunks.NewLevelDBStoreUseFlags(ldbDir, "")
+	}
+
+	server := datas.NewRemoteDatabaseServer(chunkStore, 0)
+	portChan := make(chan int)
+	server.Ready = func() { portChan <- server.Port() }
+	go server.Run()
+
+	port := <-portChan
+	host = fmt.Sprintf("http://localhost:%d", port)
+	stopFn = func() { server.Stop() }
+	return
 }

--- a/go/perf/suite/suite.go
+++ b/go/perf/suite/suite.go
@@ -337,7 +337,7 @@ func (suite *PerfSuite) Pause(fn func()) {
 
 func callSafe(name string, fun reflect.Value, args ...interface{}) (err interface{}) {
 	defer func() {
-		//err = recover()
+		err = recover()
 	}()
 	funArgs := make([]reflect.Value, len(args))
 	for i, arg := range args {

--- a/samples/go/csv/csv-import/perf_test.go
+++ b/samples/go/csv/csv-import/perf_test.go
@@ -93,7 +93,6 @@ func (s *perfSuite) TestParseSfCrime() {
 	defer s.closeGlob(files)
 
 	reader := csv.NewCSVReader(io.MultiReader(files...), ',')
-
 	for {
 		_, err := reader.Read()
 		if err != nil {
@@ -108,18 +107,20 @@ func (s *perfSuite) TestParseSfCrime() {
 //
 // Large CSV files in testdata are broken up into foo.a, foo.b, etc to get
 // around GitHub file size restrictions.
-func (s *perfSuite) openGlob(pattern ...string) (files []io.Reader) {
+func (s *perfSuite) openGlob(pattern ...string) []io.Reader {
 	assert := s.NewAssert()
 
 	glob, err := filepath.Glob(path.Join(pattern...))
 	assert.NoError(err)
 
-	for _, m := range glob {
+	files := make([]io.Reader, len(glob))
+	for i, m := range glob {
 		f, err := os.Open(m)
 		assert.NoError(err)
-		files = append(files, io.Reader(f))
+		files[i] = f
 	}
-	return
+
+	return files
 }
 
 // closeGlob closes all of the files, designed to be used with openGlob.


### PR DESCRIPTION
Currently we only have a perf test for CSV list import, which uses the
sf-crime dataset. This test uses the 43MB sf-registered-businesses
dataset instead, since sf-crime is too slow. Which is ironic, since we
normally parse sf-crime into a map.

I've also tightened up some of the other perf tests.
- Pause the blob import tests during commit, because commit is much
  faster the first time. I'll be able to reduce the test repetitions.
- Make the pure CSV parsing test use a smaller dataset, it doesn't need
  to use something as large as ny-vehicle-registrations.
