### PR TITLE
Allow merge.ThreeWay() to operate across DBs

### DIFF
--- a/go/merge/three_way_keyval_test.go
+++ b/go/merge/three_way_keyval_test.go
@@ -140,6 +140,27 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefMerge() {
 	s.tryThreeWayMerge(mb, ma, m, mMerged, vs)
 }
 
+func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefMergeAcrossDBs() {
+	avs := types.NewTestValueStore()
+	bvs := types.NewTestValueStore()
+	pvs := types.NewTestValueStore()
+
+	aStrRef := avs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
+	bStrRef := bvs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
+	pStrRef := pvs.WriteValue(types.NewStruct("Foo", types.StructData{"life": types.Number(42)}))
+
+	m := kvs{"r2", pvs.WriteValue(s.create(aa1))}
+	ma := kvs{"r1", aStrRef, "r2", avs.WriteValue(s.create(aa1a))}
+	mb := kvs{"r1", bStrRef, "r2", bvs.WriteValue(s.create(aa1b))}
+	mMerged := kvs{"r1", pStrRef, "r2", pvs.WriteValue(s.create(aaMerged))}
+	avs.Flush()
+	bvs.Flush()
+	pvs.Flush()
+
+	s.tryThreeWayMerge(ma, mb, m, mMerged, avs, bvs, pvs)
+	s.tryThreeWayMerge(mb, ma, m, mMerged, bvs, avs, pvs)
+}
+
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RecursiveMultiLevelMerge() {
 	vs := types.NewTestValueStore()
 

--- a/go/merge/three_way_ordered_sequence.go
+++ b/go/merge/three_way_ordered_sequence.go
@@ -15,7 +15,7 @@ type diffFunc func(chan<- types.ValueChanged, <-chan struct{})
 type applyFunc func(types.Value, types.ValueChanged, types.Value) types.Value
 type getFunc func(types.Value) types.Value
 
-func threeWayOrderedSequenceMerge(parent types.Value, aDiff, bDiff diffFunc, aGet, bGet, pGet getFunc, apply applyFunc, vwr types.ValueReadWriter) (merged types.Value, err error) {
+func threeWayOrderedSequenceMerge(parent types.Value, aDiff, bDiff diffFunc, aGet, bGet, pGet getFunc, apply applyFunc, vwrs mergeVWRs) (merged types.Value, err error) {
 	aChangeChan, bChangeChan := make(chan types.ValueChanged), make(chan types.ValueChanged)
 	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
 
@@ -75,7 +75,7 @@ func threeWayOrderedSequenceMerge(parent types.Value, aDiff, bDiff diffFunc, aGe
 				return parent, newMergeConflict("Conflict:\n%s = %s\nvs\n%s = %s", describeChange(aChange), types.EncodedValue(aValue), describeChange(bChange), types.EncodedValue(bValue))
 			}
 			// TODO: Add concurrency.
-			mergedValue, err := threeWayMerge(aValue, bValue, pGet(aChange.V), vwr)
+			mergedValue, err := threeWayMerge(aValue, bValue, pGet(aChange.V), vwrs)
 			if err != nil {
 				return parent, err
 			}

--- a/go/merge/three_way_test.go
+++ b/go/merge/three_way_test.go
@@ -19,8 +19,16 @@ type ThreeWayMergeSuite struct {
 	typeStr string
 }
 
-func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp seq, vs types.ValueReadWriter) {
-	merged, err := ThreeWay(s.create(a), s.create(b), s.create(p), vs)
+func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp seq, stores ...types.ValueReadWriter) {
+	var merged types.Value
+	var err error
+	if len(stores) == 1 {
+		merged, err = ThreeWay(s.create(a), s.create(b), s.create(p), stores[0], stores[0], stores[0])
+	} else if len(stores) == 3 {
+		merged, err = ThreeWay(s.create(a), s.create(b), s.create(p), stores[0], stores[1], stores[2])
+	} else {
+		s.Fail("Must try merge.ThreeWay() with either one or three ValueReadWriters")
+	}
 	if s.NoError(err) {
 		expected := s.create(exp)
 		s.True(expected.Equals(merged), "%s != %s", types.EncodedValue(expected), types.EncodedValue(merged))
@@ -28,7 +36,7 @@ func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp seq, vs types.ValueRe
 }
 
 func (s *ThreeWayMergeSuite) tryThreeWayConflict(a, b, p types.Value, contained string) {
-	m, err := ThreeWay(a, b, p, nil)
+	m, err := ThreeWay(a, b, p, nil, nil, nil)
 	if s.Error(err) {
 		s.Contains(err.Error(), contained)
 		return


### PR DESCRIPTION
Much like Diff, we want to be able to merge values from different
databases. Unlike Diff, Merge needs to be able to resolve Refs --
which requires a ValueReadWriter that has access to the referenced
Value. So, merge.ThreeWay() now takes a ValueReadWriter for each Value
being considered for the merge -- the parent and both descendants.

Towards #148