### PR TITLE
Fix path in splore build script

### DIFF
--- a/samples/js/splore/build.py
+++ b/samples/js/splore/build.py
@@ -19,7 +19,7 @@ def pushd(path):
     os.chdir(currentDir)
 
 def main():
-    with pushd('../../../js'):
+    with pushd('../../../js/noms'):
         subprocess.check_call(['npm', 'install'], shell=False)
 
     with pushd('../'):


### PR DESCRIPTION
The path to the noms sdk in the build script was not updated when the
js sdk was moved.