### PR TITLE
Drive js docs from npm script

### DIFF
--- a/js/noms/.gitignore
+++ b/js/noms/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+generated-docs

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -34,6 +34,7 @@
     "chai": "^3.5.0",
     "chokidar": "^1.6.0",
     "commander": "^2.9.0",
+    "documentation": "^4.0.0-beta10",
     "flow-bin": "0.30.0",
     "fs-extra": "^0.30.0",
     "mocha": "^2.5.3"
@@ -46,7 +47,8 @@
     "compile": "npm run compile-to-commonjs",
     "compile-to-commonjs": "BABEL_ENV=production babel -d dist/commonjs src/ > /dev/null",
     "copy-flow-files": "npm run copy-flow-files-commonjs",
-    "copy-flow-files-commonjs": "node build/copy-flow-files.js -d dist/commonjs/ src/"
+    "copy-flow-files-commonjs": "node build/copy-flow-files.js -d dist/commonjs/ src/",
+    "build-docs": "documentation build --name Noms --project-version $npm_package_version --document-exported --infer-private ^_ --github --format html --output generated-docs/$npm_package_version/ src/noms.js"
   },
   "browser": {
     "./src/bytes.js": "./src/browser/bytes.js",

--- a/tools/build-js-documentation.py
+++ b/tools/build-js-documentation.py
@@ -30,33 +30,16 @@ def main():
 
     noms_dir = os.path.join(workspace, 'src/github.com/attic-labs/noms')
     noms_js_dir = os.path.join(noms_dir, 'js/noms')
-    with open(os.path.join(noms_js_dir, 'package.json')) as pkg:
-        data = json.load(pkg)
-
-    version = data['version']
-
-    # This directory does not really matter
-    os.chdir(workspace)
 
     env = copy.copy(os.environ)
     env.update({
         'PATH': '%s:%s' % (os.getenv('PATH'), node_bin),
     })
 
-    call_with_env(['npm', 'install', 'documentation'], env)
+    os.chdir(noms_js_dir)
 
-    cmd = [
-        os.path.join(workspace, 'node_modules', '.bin', 'documentation'), 'build',
-        os.path.join(noms_js_dir, 'src', 'noms.js'),
-        '--name', 'Noms',
-        '--document-exported',
-        '--infer-private', '^_',
-        '--github',
-        '--format', 'html',
-        '--output', os.path.join(workspace, 'build', version),
-        '--project-version', version
-    ]
-    call_with_env(cmd, env)
+    call_with_env(['npm', 'install'], env)
+    call_with_env(['npm', 'run' 'build-docs'], env)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Turns out that documentationjs reads the babelrc file from js/noms
which leads to us having to do npm install in js/noms. Therefore
putting the dev deps in there and running the script from there
makes things cleaner.

It also allows doing:

  npm run build-docs

Towards #1471