### PR TITLE
Update merge.ThreeWay() to allow very basic custom conflict resolution

### DIFF
--- a/go/merge/candidate.go
+++ b/go/merge/candidate.go
@@ -1,0 +1,99 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package merge
+
+import (
+	"fmt"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/types"
+)
+
+// candidate represents a collection that is a candidate to be merged. This interface exists to wrap Maps, Sets and Structs with a common API so that threeWayOrderedSequenceMerge() can remain agnostic to which kind of collections it's actually working with.
+type candidate interface {
+	diff(parent candidate, change chan<- types.ValueChanged, stop <-chan struct{})
+	get(k types.Value) types.Value
+	pathConcat(change types.ValueChanged, path types.Path) (out types.Path)
+	toValue() types.Value
+}
+
+type mapCandidate struct {
+	m types.Map
+}
+
+func (mc mapCandidate) diff(p candidate, change chan<- types.ValueChanged, stop <-chan struct{}) {
+	mc.m.Diff(p.(mapCandidate).m, change, stop)
+}
+
+func (mc mapCandidate) get(k types.Value) types.Value {
+	return mc.m.Get(k)
+}
+
+func (mc mapCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
+	out = append(out, path...)
+	if kind := change.V.Type().Kind(); kind == types.BoolKind || kind == types.StringKind || kind == types.NumberKind {
+		out = append(out, types.NewIndexPath(change.V))
+	} else {
+		out = append(out, types.NewHashIndexPath(change.V.Hash()))
+	}
+	return
+}
+
+func (mc mapCandidate) toValue() types.Value {
+	return mc.m
+}
+
+type setCandidate struct {
+	s types.Set
+}
+
+func (sc setCandidate) diff(p candidate, change chan<- types.ValueChanged, stop <-chan struct{}) {
+	sc.s.Diff(p.(setCandidate).s, change, stop)
+}
+
+func (sc setCandidate) get(k types.Value) types.Value {
+	return k
+}
+
+func (sc setCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
+	out = append(out, path...)
+	if kind := change.V.Type().Kind(); kind == types.BoolKind || kind == types.StringKind || kind == types.NumberKind {
+		out = append(out, types.NewIndexPath(change.V))
+	} else {
+		out = append(out, types.NewHashIndexPath(change.V.Hash()))
+	}
+	return
+}
+
+func (sc setCandidate) toValue() types.Value {
+	return sc.s
+}
+
+type structCandidate struct {
+	s types.Struct
+}
+
+func (sc structCandidate) diff(p candidate, change chan<- types.ValueChanged, stop <-chan struct{}) {
+	sc.s.Diff(p.(structCandidate).s, change, stop)
+}
+
+func (sc structCandidate) get(key types.Value) types.Value {
+	if field, ok := key.(types.String); ok {
+		val, _ := sc.s.MaybeGet(string(field))
+		return val
+	}
+	panic(fmt.Errorf("Bad key type in diff: %s", key.Type().Describe()))
+}
+
+func (sc structCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
+	out = append(out, path...)
+	str, ok := change.V.(types.String)
+	d.PanicIfTrue(!ok, "Field names must be strings, not %s", change.V.Type().Describe())
+	return append(out, types.NewFieldPath(string(str)))
+}
+
+func (sc structCandidate) toValue() types.Value {
+	return sc.s
+}

--- a/go/merge/candidate.go
+++ b/go/merge/candidate.go
@@ -11,12 +11,15 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-// candidate represents a collection that is a candidate to be merged. This interface exists to wrap Maps, Sets and Structs with a common API so that threeWayOrderedSequenceMerge() can remain agnostic to which kind of collections it's actually working with.
+// candidate represents a collection that is a candidate to be merged. This
+// interface exists to wrap Maps, Sets and Structs with a common API so that
+// threeWayOrderedSequenceMerge() can remain agnostic to which kind of
+// collections it's actually working with.
 type candidate interface {
 	diff(parent candidate, change chan<- types.ValueChanged, stop <-chan struct{})
 	get(k types.Value) types.Value
 	pathConcat(change types.ValueChanged, path types.Path) (out types.Path)
-	toValue() types.Value
+	getValue() types.Value
 }
 
 type mapCandidate struct {
@@ -41,7 +44,7 @@ func (mc mapCandidate) pathConcat(change types.ValueChanged, path types.Path) (o
 	return
 }
 
-func (mc mapCandidate) toValue() types.Value {
+func (mc mapCandidate) getValue() types.Value {
 	return mc.m
 }
 
@@ -67,7 +70,7 @@ func (sc setCandidate) pathConcat(change types.ValueChanged, path types.Path) (o
 	return
 }
 
-func (sc setCandidate) toValue() types.Value {
+func (sc setCandidate) getValue() types.Value {
 	return sc.s
 }
 
@@ -94,6 +97,6 @@ func (sc structCandidate) pathConcat(change types.ValueChanged, path types.Path)
 	return append(out, types.NewFieldPath(string(str)))
 }
 
-func (sc structCandidate) toValue() types.Value {
+func (sc structCandidate) getValue() types.Value {
 	return sc.s
 }

--- a/go/merge/three_way.go
+++ b/go/merge/three_way.go
@@ -11,6 +11,8 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
+type ResolveFunc func(aChange, bChange types.ValueChanged, a, b types.Value, path types.Path) (change types.ValueChanged, merged types.Value, ok bool)
+
 // ErrMergeConflict indicates that a merge attempt failed and must be resolved manually for the provided reason.
 type ErrMergeConflict struct {
 	msg string
@@ -24,7 +26,8 @@ func newMergeConflict(format string, args ...interface{}) *ErrMergeConflict {
 	return &ErrMergeConflict{fmt.Sprintf(format, args...)}
 }
 
-// ThreeWay attempts a three-way merge between two candidates and a common ancestor. It considers the three of them recursively, applying some simple rules to identify conflicts:
+// ThreeWay attempts a three-way merge between two candidates and a common ancestor.
+// It considers the three of them recursively, applying some simple rules to identify conflicts:
 //  - If any of the three nodes are different NomsKinds: conflict
 //  - If we are dealing with a map:
 //    - If the same key is both removed and inserted wrt parent: conflict
@@ -40,7 +43,7 @@ func newMergeConflict(format string, args ...interface{}) *ErrMergeConflict {
 //
 // All other modifications are allowed.
 // ThreeWay() works on types.Map, types.Set, and types.Struct.
-func ThreeWay(a, b, parent types.Value, vwr types.ValueReadWriter, progress chan struct{}) (merged types.Value, err error) {
+func ThreeWay(a, b, parent types.Value, vwr types.ValueReadWriter, resolve ResolveFunc, progress chan struct{}) (merged types.Value, err error) {
 	if a == nil && b == nil {
 		return parent, nil
 	} else if a == nil {
@@ -51,7 +54,11 @@ func ThreeWay(a, b, parent types.Value, vwr types.ValueReadWriter, progress chan
 		return parent, newMergeConflict("Cannot merge %s with %s.", a.Type().Describe(), b.Type().Describe())
 	}
 
-	return threeWayMerge(a, b, parent, vwr, progress)
+	if resolve == nil {
+		resolve = defaultResolve
+	}
+	m := &merger{vwr, resolve, progress}
+	return m.threeWay(a, b, parent, types.Path{})
 }
 
 // a and b cannot be merged if they are of different NomsKind, or if at least one of the two is nil, or if either is a Noms primitive.
@@ -63,23 +70,26 @@ func unmergeable(a, b types.Value) bool {
 	return true
 }
 
-func updateProgress(progress chan struct{}) {
+type merger struct {
+	vwr      types.ValueReadWriter
+	resolve  ResolveFunc
+	progress chan<- struct{}
+}
+
+func defaultResolve(aChange, bChange types.ValueChanged, a, b types.Value, p types.Path) (change types.ValueChanged, merged types.Value, ok bool) {
+	return
+}
+
+func updateProgress(progress chan<- struct{}) {
 	// TODO: Eventually we'll want more information than a single bit :).
 	if progress != nil {
 		progress <- struct{}{}
 	}
 }
 
-func threeWayMerge(a, b, parent types.Value, vwr types.ValueReadWriter, progress chan struct{}) (merged types.Value, err error) {
-	defer updateProgress(progress)
+func (m *merger) threeWay(a, b, parent types.Value, path types.Path) (merged types.Value, err error) {
+	defer updateProgress(m.progress)
 	d.PanicIfTrue(a == nil || b == nil, "Merge candidates cannont be nil: a = %v, b = %v", a, b)
-	newTypeConflict := func() *ErrMergeConflict {
-		pDescription := "<nil>"
-		if parent != nil {
-			pDescription = parent.Type().Describe()
-		}
-		return newMergeConflict("Cannot merge %s and %s on top of %s.", a.Type().Describe(), b.Type().Describe(), pDescription)
-	}
 
 	switch a.Type().Kind() {
 	case types.ListKind:
@@ -89,100 +99,80 @@ func threeWayMerge(a, b, parent types.Value, vwr types.ValueReadWriter, progress
 
 	case types.MapKind:
 		if aMap, bMap, pMap, ok := mapAssert(a, b, parent); ok {
-			return threeWayMapMerge(aMap, bMap, pMap, vwr, progress)
+			return m.threeWayMapMerge(aMap, bMap, pMap, path)
 		}
 
 	case types.RefKind:
-		if aValue, bValue, pValue, ok := refAssert(a, b, parent, vwr); ok {
-			merged, err := threeWayMerge(aValue, bValue, pValue, vwr, progress)
+		if aValue, bValue, pValue, ok := refAssert(a, b, parent, m.vwr); ok {
+			merged, err := m.threeWay(aValue, bValue, pValue, path)
 			if err != nil {
 				return parent, err
 			}
-			return vwr.WriteValue(merged), nil
+			return m.vwr.WriteValue(merged), nil
 		}
 
 	case types.SetKind:
 		if aSet, bSet, pSet, ok := setAssert(a, b, parent); ok {
-			return threeWaySetMerge(aSet, bSet, pSet, vwr, progress)
+			return m.threeWaySetMerge(aSet, bSet, pSet, path)
 		}
 
 	case types.StructKind:
 		if aStruct, bStruct, pStruct, ok := structAssert(a, b, parent); ok {
-			return threeWayStructMerge(aStruct, bStruct, pStruct, vwr, progress)
+			return m.threeWayStructMerge(aStruct, bStruct, pStruct, path)
 		}
-
-	default:
-		return parent, newMergeConflict("Cannot merge %s.", a.Type().Describe())
-
 	}
-	return parent, newTypeConflict()
+
+	pDescription := "<nil>"
+	if parent != nil {
+		pDescription = parent.Type().Describe()
+	}
+	return parent, newMergeConflict("Cannot merge %s and %s on top of %s.", a.Type().Describe(), b.Type().Describe(), pDescription)
 }
 
-func threeWayMapMerge(a, b, parent types.Map, vwr types.ValueReadWriter, progress chan struct{}) (merged types.Value, err error) {
-	aDiff := func(change chan<- types.ValueChanged, stop <-chan struct{}) {
-		a.Diff(parent, change, stop)
-	}
-	bDiff := func(change chan<- types.ValueChanged, stop <-chan struct{}) {
-		b.Diff(parent, change, stop)
+func (m *merger) threeWayMapMerge(a, b, parent types.Map, path types.Path) (merged types.Value, err error) {
+	type mapLike interface {
+		Set(k, v types.Value) types.Map
+		Remove(k types.Value) types.Map
 	}
 	apply := func(target types.Value, change types.ValueChanged, newVal types.Value) types.Value {
-		defer updateProgress(progress)
+		defer updateProgress(m.progress)
 		switch change.ChangeType {
 		case types.DiffChangeAdded, types.DiffChangeModified:
-			return target.(types.Map).Set(change.V, newVal)
+			return target.(mapLike).Set(change.V, newVal)
 		case types.DiffChangeRemoved:
-			return target.(types.Map).Remove(change.V)
+			return target.(mapLike).Remove(change.V)
 		default:
 			panic("Not Reached")
 		}
 	}
-	return threeWayOrderedSequenceMerge(parent, aDiff, bDiff, a.Get, b.Get, parent.Get, apply, vwr, progress)
+	return m.threeWayOrderedSequenceMerge(mapCandidate{a}, mapCandidate{b}, mapCandidate{parent}, apply, path)
 }
 
-func threeWaySetMerge(a, b, parent types.Set, vwr types.ValueReadWriter, progress chan struct{}) (merged types.Value, err error) {
-	aDiff := func(change chan<- types.ValueChanged, stop <-chan struct{}) {
-		a.Diff(parent, change, stop)
-	}
-	bDiff := func(change chan<- types.ValueChanged, stop <-chan struct{}) {
-		b.Diff(parent, change, stop)
-	}
-	getSelf := func(v types.Value) types.Value {
-		return v
+func (m *merger) threeWaySetMerge(a, b, parent types.Set, path types.Path) (merged types.Value, err error) {
+	type setLike interface {
+		Insert(values ...types.Value) types.Set
+		Remove(valus ...types.Value) types.Set
 	}
 	apply := func(target types.Value, change types.ValueChanged, ignored types.Value) types.Value {
-		defer updateProgress(progress)
+		defer updateProgress(m.progress)
 		switch change.ChangeType {
 		case types.DiffChangeAdded, types.DiffChangeModified:
-			return target.(types.Set).Insert(change.V)
+			return target.(setLike).Insert(change.V)
 		case types.DiffChangeRemoved:
-			return target.(types.Set).Remove(change.V)
+			return target.(setLike).Remove(change.V)
 		default:
 			panic("Not Reached")
 		}
 	}
-	return threeWayOrderedSequenceMerge(parent, aDiff, bDiff, getSelf, getSelf, getSelf, apply, vwr, progress)
+	return m.threeWayOrderedSequenceMerge(setCandidate{a}, setCandidate{b}, setCandidate{parent}, apply, path)
 }
 
-func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter, progress chan struct{}) (merged types.Value, err error) {
-	aDiff := func(change chan<- types.ValueChanged, stop <-chan struct{}) {
-		a.Diff(parent, change, stop)
+func (m *merger) threeWayStructMerge(a, b, parent types.Struct, path types.Path) (merged types.Value, err error) {
+	type structLike interface {
+		Get(string) types.Value
 	}
-	bDiff := func(change chan<- types.ValueChanged, stop <-chan struct{}) {
-		b.Diff(parent, change, stop)
-	}
-
-	makeGetFunc := func(s types.Struct) getFunc {
-		return func(key types.Value) types.Value {
-			if field, ok := key.(types.String); ok {
-				val, _ := s.MaybeGet(string(field))
-				return val
-			}
-			panic(fmt.Errorf("Bad key type in diff: %s", key.Type().Describe()))
-		}
-	}
-
 	apply := func(target types.Value, change types.ValueChanged, newVal types.Value) types.Value {
-		defer updateProgress(progress)
+		defer updateProgress(m.progress)
 		// Right now, this always iterates over all fields to create a new Struct, because there's no API for adding/removing a field from an existing struct type.
 		if f, ok := change.V.(types.String); ok {
 			field := string(f)
@@ -190,7 +180,7 @@ func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter, p
 			desc := target.Type().Desc.(types.StructDesc)
 			desc.IterFields(func(name string, t *types.Type) {
 				if name != field {
-					data[name] = target.(types.Struct).Get(name)
+					data[name] = target.(structLike).Get(name)
 				}
 			})
 			if change.ChangeType == types.DiffChangeAdded || change.ChangeType == types.DiffChangeModified {
@@ -200,7 +190,81 @@ func threeWayStructMerge(a, b, parent types.Struct, vwr types.ValueReadWriter, p
 		}
 		panic(fmt.Errorf("Bad key type in diff: %s", change.V.Type().Describe()))
 	}
-	return threeWayOrderedSequenceMerge(parent, aDiff, bDiff, makeGetFunc(a), makeGetFunc(b), makeGetFunc(parent), apply, vwr, progress)
+	return m.threeWayOrderedSequenceMerge(structCandidate{a}, structCandidate{b}, structCandidate{parent}, apply, path)
+}
+
+type candidate interface {
+	types.Value
+	diff(parent types.Value, change chan<- types.ValueChanged, stop <-chan struct{})
+	get(k types.Value) types.Value
+	pathConcat(change types.ValueChanged, path types.Path) (out types.Path)
+}
+
+type mapCandidate struct {
+	types.Map
+}
+
+func (mc mapCandidate) diff(p types.Value, change chan<- types.ValueChanged, stop <-chan struct{}) {
+	mc.Diff(p.(mapCandidate).Map, change, stop)
+}
+
+func (mc mapCandidate) get(k types.Value) types.Value {
+	return mc.Get(k)
+}
+
+func (mc mapCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
+	out = append(out, path...)
+	if kind := change.V.Type().Kind(); kind == types.BoolKind || kind == types.StringKind || kind == types.NumberKind {
+		out = append(out, types.NewIndexPath(change.V))
+	} else {
+		out = append(out, types.NewHashIndexPath(change.V.Hash()))
+	}
+	return
+}
+
+type setCandidate struct {
+	types.Set
+}
+
+func (sc setCandidate) diff(p types.Value, change chan<- types.ValueChanged, stop <-chan struct{}) {
+	sc.Diff(p.(setCandidate).Set, change, stop)
+}
+
+func (sc setCandidate) get(k types.Value) types.Value {
+	return k
+}
+
+func (sc setCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
+	out = append(out, path...)
+	if kind := change.V.Type().Kind(); kind == types.BoolKind || kind == types.StringKind || kind == types.NumberKind {
+		out = append(out, types.NewIndexPath(change.V))
+	} else {
+		out = append(out, types.NewHashIndexPath(change.V.Hash()))
+	}
+	return
+}
+
+type structCandidate struct {
+	types.Struct
+}
+
+func (sc structCandidate) diff(p types.Value, change chan<- types.ValueChanged, stop <-chan struct{}) {
+	sc.Diff(p.(structCandidate).Struct, change, stop)
+}
+
+func (sc structCandidate) get(key types.Value) types.Value {
+	if field, ok := key.(types.String); ok {
+		val, _ := sc.MaybeGet(string(field))
+		return val
+	}
+	panic(fmt.Errorf("Bad key type in diff: %s", key.Type().Describe()))
+}
+
+func (sc structCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
+	out = append(out, path...)
+	str, ok := change.V.(types.String)
+	d.PanicIfTrue(!ok, "Field names must be strings, not %s", change.V.Type().Describe())
+	return append(out, types.NewFieldPath(string(str)))
 }
 
 func listAssert(a, b, parent types.Value) (aList, bList, pList types.List, ok bool) {

--- a/go/merge/three_way_keyval_test.go
+++ b/go/merge/three_way_keyval_test.go
@@ -153,6 +153,38 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RecursiveMultiLevelMerge() 
 	s.tryThreeWayMerge(mb, ma, m, mMerged, vs)
 }
 
+func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_CustomMerge() {
+	vs := types.NewTestValueStore()
+
+	p := kvs{"k1", "k-one", "k2", "k-two", "mm1", mm1, "s1", "s-one"}
+	a := kvs{"k1", "k-won", "k2", "k-too", "mm1", mm1, "s1", "s-one", "n1", kvs{"a", "1"}}
+	b := kvs{"k2", "k-two", "mm1", "mm-one", "s1", "s-one", "n1", kvs{"a", "2"}}
+	exp := kvs{"k2", "k-too", "mm1", "mm-one", "s1", "s-one", "n1", kvs{"a", "1"}}
+
+	expectedConflictPaths := [][]string{{"k1"}, {"n1", "a"}}
+	conflictPaths := []types.Path{}
+	resolve := func(aChange, bChange types.ValueChanged, aVal, bVal types.Value, p types.Path) (change types.ValueChanged, merged types.Value, ok bool) {
+		conflictPaths = append(conflictPaths, p)
+		if _, ok := aVal.(types.Map); ok || bChange.ChangeType == types.DiffChangeRemoved {
+			return bChange, bVal, true
+		}
+		return aChange, aVal, true
+	}
+
+	merged, err := ThreeWay(s.create(a), s.create(b), s.create(p), vs, resolve, nil)
+	if s.NoError(err) {
+		expected := s.create(exp)
+		s.True(expected.Equals(merged), "%s != %s", types.EncodedValue(expected), types.EncodedValue(merged))
+	}
+	if s.Len(conflictPaths, len(expectedConflictPaths), "Wrong number of conflicts!") {
+		for i := 0; i < len(conflictPaths); i++ {
+			for j, c := range conflictPaths[i] {
+				s.Contains(c.String(), expectedConflictPaths[i][j])
+			}
+		}
+	}
+}
+
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_NilConflict() {
 	s.tryThreeWayConflict(nil, s.create(mm2b), s.create(mm2), "Cannot merge nil Value with")
 	s.tryThreeWayConflict(s.create(mm2a), nil, s.create(mm2), "with nil value.")

--- a/go/merge/three_way_keyval_test.go
+++ b/go/merge/three_way_keyval_test.go
@@ -163,9 +163,9 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_CustomMerge() {
 
 	expectedConflictPaths := [][]string{{"k1"}, {"n1", "a"}}
 	conflictPaths := []types.Path{}
-	resolve := func(aChange, bChange types.ValueChanged, aVal, bVal types.Value, p types.Path) (change types.ValueChanged, merged types.Value, ok bool) {
+	resolve := func(aChange, bChange types.DiffChangeType, aVal, bVal types.Value, p types.Path) (change types.DiffChangeType, merged types.Value, ok bool) {
 		conflictPaths = append(conflictPaths, p)
-		if _, ok := aVal.(types.Map); ok || bChange.ChangeType == types.DiffChangeRemoved {
+		if _, ok := aVal.(types.Map); ok || bChange == types.DiffChangeRemoved {
 			return bChange, bVal, true
 		}
 		return aChange, aVal, true

--- a/go/merge/three_way_ordered_sequence.go
+++ b/go/merge/three_way_ordered_sequence.go
@@ -11,20 +11,18 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-type diffFunc func(chan<- types.ValueChanged, <-chan struct{})
 type applyFunc func(types.Value, types.ValueChanged, types.Value) types.Value
-type getFunc func(types.Value) types.Value
 
-func threeWayOrderedSequenceMerge(parent types.Value, aDiff, bDiff diffFunc, aGet, bGet, pGet getFunc, apply applyFunc, vwr types.ValueReadWriter, progress chan struct{}) (merged types.Value, err error) {
+func (m *merger) threeWayOrderedSequenceMerge(a, b, parent candidate, apply applyFunc, path types.Path) (merged types.Value, err error) {
 	aChangeChan, bChangeChan := make(chan types.ValueChanged), make(chan types.ValueChanged)
 	aStopChan, bStopChan := make(chan struct{}, 1), make(chan struct{}, 1)
 
 	go func() {
-		aDiff(aChangeChan, aStopChan)
+		a.diff(parent, aChangeChan, aStopChan)
 		close(aChangeChan)
 	}()
 	go func() {
-		bDiff(bChangeChan, bStopChan)
+		b.diff(parent, bChangeChan, bStopChan)
 		close(bChangeChan)
 	}()
 
@@ -50,40 +48,56 @@ func threeWayOrderedSequenceMerge(parent types.Value, aDiff, bDiff diffFunc, aGe
 		// Since diff generates changes in key-order, and we never skip over a change without processing it, we can simply compare the keys at which aChange and bChange occurred to determine if either is safe to apply to the merge result without further processing. This is because if, e.g. aChange.V.Less(bChange.V), we know that the diff of b will never generate a change at that key. If it was going to, it would have done so on an earlier iteration of this loop and been processed at that time.
 		// It's also obviously OK to apply a change if only one diff is generating any changes, e.g. aChange.V is non-nil and bChange.V is nil.
 		if aChange.V != nil && (bChange.V == nil || aChange.V.Less(bChange.V)) {
-			merged = apply(merged, aChange, aGet(aChange.V))
+			merged = apply(merged, aChange, a.get(aChange.V))
 			aChange = types.ValueChanged{}
 			continue
 		} else if bChange.V != nil && (aChange.V == nil || bChange.V.Less(aChange.V)) {
-			merged = apply(merged, bChange, bGet(bChange.V))
+			merged = apply(merged, bChange, b.get(bChange.V))
 			bChange = types.ValueChanged{}
 			continue
 		}
 		d.PanicIfTrue(!aChange.V.Equals(bChange.V), "Diffs have skewed!") // Sanity check.
 
-		// If the two diffs generate different kinds of changes at the same key, conflict.
-		if aChange.ChangeType != bChange.ChangeType {
-			return parent, newMergeConflict("Conflict:\n%s\nvs\n%s\n", describeChange(aChange), describeChange(bChange))
+		change, mergedVal, err := m.mergeChanges(aChange, bChange, a, b, parent, apply, path)
+		if err != nil {
+			return parent, err
 		}
-
-		aValue, bValue := aGet(aChange.V), bGet(bChange.V)
-		if aChange.ChangeType == types.DiffChangeRemoved || aValue.Equals(bValue) {
-			// If both diffs generated a remove, or if the new value is the same in both, merge is fine.
-			merged = apply(merged, aChange, aValue)
-		} else {
-			// There's one case that might still be OK even if aValue and bValue differ: different, but mergeable, compound values of the same type being added/modified at the same key, e.g. a Map being added to both a and b. If either is a primitive, or Values of different Kinds were added, though, we're in conflict.
-			if unmergeable(aValue, bValue) {
-				return parent, newMergeConflict("Conflict:\n%s = %s\nvs\n%s = %s", describeChange(aChange), types.EncodedValue(aValue), describeChange(bChange), types.EncodedValue(bValue))
-			}
-			// TODO: Add concurrency.
-			mergedValue, err := threeWayMerge(aValue, bValue, pGet(aChange.V), vwr, progress)
-			if err != nil {
-				return parent, err
-			}
-			merged = apply(merged, aChange, mergedValue)
-		}
+		merged = apply(merged, change, mergedVal)
 		aChange, bChange = types.ValueChanged{}, types.ValueChanged{}
 	}
 	return merged, nil
+}
+
+func (m *merger) mergeChanges(aChange, bChange types.ValueChanged, a, b, p candidate, apply applyFunc, path types.Path) (change types.ValueChanged, mergedVal types.Value, err error) {
+	path = a.pathConcat(aChange, path)
+	aValue, bValue := a.get(aChange.V), b.get(bChange.V)
+	// If the two diffs generate different kinds of changes at the same key, conflict.
+	if aChange.ChangeType != bChange.ChangeType {
+		if change, mergedVal, ok := m.resolve(aChange, bChange, aValue, bValue, path); ok {
+			return change, mergedVal, nil
+		}
+		return change, nil, newMergeConflict("Conflict:\n%s\nvs\n%s\n", describeChange(aChange), describeChange(bChange))
+	}
+
+	if aChange.ChangeType == types.DiffChangeRemoved || aValue.Equals(bValue) {
+		// If both diffs generated a remove, or if the new value is the same in both, merge is fine.
+		return aChange, aValue, nil
+	}
+
+	// There's one case that might still be OK even if aValue and bValue differ: different, but mergeable, compound values of the same type being added/modified at the same key, e.g. a Map being added to both a and b. If either is a primitive, or Values of different Kinds were added, though, we're in conflict.
+	if !unmergeable(aValue, bValue) {
+		// TODO: Add concurrency.
+		var err error
+		if mergedVal, err = m.threeWay(aValue, bValue, p.get(aChange.V), path); err == nil {
+			return aChange, mergedVal, nil
+		}
+		return change, nil, err
+	}
+
+	if change, mergedVal, ok := m.resolve(aChange, bChange, aValue, bValue, path); ok {
+		return change, mergedVal, nil
+	}
+	return change, nil, newMergeConflict("Conflict:\n%s = %s\nvs\n%s = %s", describeChange(aChange), types.EncodedValue(aValue), describeChange(bChange), types.EncodedValue(bValue))
 }
 
 func stopAndDrain(stop chan<- struct{}, drain <-chan types.ValueChanged) {

--- a/go/merge/three_way_ordered_sequence.go
+++ b/go/merge/three_way_ordered_sequence.go
@@ -60,12 +60,12 @@ func (m *merger) threeWayOrderedSequenceMerge(a, b, parent candidate, apply appl
 
 		change, mergedVal, err := m.mergeChanges(aChange, bChange, a, b, parent, apply, path)
 		if err != nil {
-			return parent.toValue(), err
+			return parent.getValue(), err
 		}
 		merged = apply(merged, change, mergedVal)
 		aChange, bChange = types.ValueChanged{}, types.ValueChanged{}
 	}
-	return merged.toValue(), nil
+	return merged.getValue(), nil
 }
 
 func (m *merger) mergeChanges(aChange, bChange types.ValueChanged, a, b, p candidate, apply applyFunc, path types.Path) (change types.ValueChanged, mergedVal types.Value, err error) {

--- a/go/merge/three_way_test.go
+++ b/go/merge/three_way_test.go
@@ -20,7 +20,7 @@ type ThreeWayMergeSuite struct {
 }
 
 func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp seq, vs types.ValueReadWriter) {
-	merged, err := ThreeWay(s.create(a), s.create(b), s.create(p), vs, nil)
+	merged, err := ThreeWay(s.create(a), s.create(b), s.create(p), vs, nil, nil)
 	if s.NoError(err) {
 		expected := s.create(exp)
 		s.True(expected.Equals(merged), "%s != %s", types.EncodedValue(expected), types.EncodedValue(merged))
@@ -28,7 +28,7 @@ func (s *ThreeWayMergeSuite) tryThreeWayMerge(a, b, p, exp seq, vs types.ValueRe
 }
 
 func (s *ThreeWayMergeSuite) tryThreeWayConflict(a, b, p types.Value, contained string) {
-	m, err := ThreeWay(a, b, p, nil, nil)
+	m, err := ThreeWay(a, b, p, nil, nil, nil)
 	if s.Error(err) {
 		s.Contains(err.Error(), contained)
 		return

--- a/samples/go/noms-merge/main.go
+++ b/samples/go/noms-merge/main.go
@@ -133,14 +133,14 @@ func cliResolve(in io.Reader, out io.Writer, aType, bType types.DiffChangeType, 
 			}
 			switch a := a.(type) {
 			case types.Bool:
-				return aType, types.Bool(bool(a) || bool(b.(types.Bool))), true
+				merged = types.Bool(bool(a) || bool(b.(types.Bool)))
 			case types.Number:
-				return aType, types.Number(float64(a) + float64(b.(types.Number))), true
+				merged = types.Number(float64(a) + float64(b.(types.Number)))
 			case types.String:
-				concatenated := string(a) + string(b.(types.String))
-				fmt.Fprintln(out, "Replacing with", concatenated)
-				return aType, types.String(concatenated), true
+				merged = types.String(string(a) + string(b.(types.String)))
 			}
+			fmt.Fprintln(out, "Replacing with", types.EncodedValue(merged))
+			return aType, merged, true
 		}
 	}
 }


### PR DESCRIPTION
This patch modifies merge.ThreeWay() to take a callback that allows
for custom conflict resolution. The noms-merge command-line tool uses
this to inject a callback that accepts input from the console
dictating whether to accept the value from the 'left' or 'right' merge
candidates.

Toward #2445