### PR TITLE
Go: Add List.IteratorAt() and use in list merging

### DIFF
--- a/go/types/list.go
+++ b/go/types/list.go
@@ -185,6 +185,14 @@ func (l List) IterAll(f listIterAllFunc) {
 	})
 }
 
+func (l List) Iterator() ListIterator {
+	return l.IteratorAt(0)
+}
+
+func (l List) IteratorAt(index uint64) ListIterator {
+	return ListIterator{newCursorAtIndex(l.seq, index)}
+}
+
 func (l List) Diff(last List, changes chan<- Splice, closeChan <-chan struct{}) {
 	l.DiffWithLimit(last, changes, closeChan, DEFAULT_MAX_SPLICE_MATRIX_SIZE)
 }

--- a/go/types/list_iterator.go
+++ b/go/types/list_iterator.go
@@ -1,0 +1,24 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, verlion 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"github.com/attic-labs/noms/go/d"
+)
+
+// ListIterator can be used to efficiently iterate through a Noms List starting at an index of your choice.
+type ListIterator struct {
+	*sequenceCursor
+}
+
+// Next returns subsequent Values from a List, starting with the index at which the iterator was created. If there are no more Values, Next() returns nil.
+func (li ListIterator) Next() (out Value) {
+	d.Chk.True(li.sequenceCursor != nil, "Cannot use a nil ListIterator")
+	if li.valid() {
+		out = li.current().(Value)
+		li.advance()
+	}
+	return
+}

--- a/go/types/list_iterator.go
+++ b/go/types/list_iterator.go
@@ -10,15 +10,15 @@ import (
 
 // ListIterator can be used to efficiently iterate through a Noms List starting at an index of your choice.
 type ListIterator struct {
-	*sequenceCursor
+	cursor *sequenceCursor
 }
 
 // Next returns subsequent Values from a List, starting with the index at which the iterator was created. If there are no more Values, Next() returns nil.
 func (li ListIterator) Next() (out Value) {
-	d.Chk.True(li.sequenceCursor != nil, "Cannot use a nil ListIterator")
-	if li.valid() {
-		out = li.current().(Value)
-		li.advance()
+	d.Chk.True(li.cursor != nil, "Cannot use a nil ListIterator")
+	if li.cursor.valid() {
+		out = li.cursor.current().(Value)
+		li.cursor.advance()
 	}
 	return
 }

--- a/go/types/list_iterator_test.go
+++ b/go/types/list_iterator_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestListIterator(t *testing.T) {
+	assert := assert.New(t)
+
+	numbers := append(generateNumbersAsValues(10), Number(20), Number(25))
+	l := NewList(numbers...)
+	i := l.Iterator()
+	vs := iterToSlice(i)
+	assert.True(vs.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
+
+	i = l.IteratorAt(3)
+	vs = iterToSlice(i)
+	assert.True(vs.Equals(numbers[3:]), "Expected: %v != actual: %v", numbers, vs)
+
+	i = l.IteratorAt(l.Len())
+	assert.Nil(i.Next())
+}

--- a/go/types/opcache.go
+++ b/go/types/opcache.go
@@ -13,7 +13,7 @@ import (
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
+	ldbIterator "github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
@@ -52,7 +52,7 @@ type ldbOpCache struct {
 }
 
 type ldbOpCacheIterator struct {
-	iter iterator.Iterator
+	iter ldbIterator.Iterator
 	vr   ValueReader
 }
 

--- a/go/types/set_iterator_test.go
+++ b/go/types/set_iterator_test.go
@@ -11,26 +11,6 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
-func iterToSlice(iter SetIterator) ValueSlice {
-	vs := ValueSlice{}
-	for {
-		v := iter.Next()
-		if v == nil {
-			break
-		}
-		vs = append(vs, v)
-	}
-	return vs
-}
-
-func intsToValueSlice(ints ...int) ValueSlice {
-	vs := ValueSlice{}
-	for _, i := range ints {
-		vs = append(vs, Number(i))
-	}
-	return vs
-}
-
 func TestSetIterator(t *testing.T) {
 	assert := assert.New(t)
 

--- a/go/types/util_test.go
+++ b/go/types/util_test.go
@@ -9,17 +9,41 @@ import (
 	"github.com/attic-labs/noms/go/hash"
 )
 
-var generateNumbersAsValues = func(n int) []Value {
+type iterator interface {
+	Next() Value
+}
+
+func iterToSlice(iter iterator) ValueSlice {
+	vs := ValueSlice{}
+	for {
+		v := iter.Next()
+		if v == nil {
+			break
+		}
+		vs = append(vs, v)
+	}
+	return vs
+}
+
+func intsToValueSlice(ints ...int) ValueSlice {
+	vs := ValueSlice{}
+	for _, i := range ints {
+		vs = append(vs, Number(i))
+	}
+	return vs
+}
+
+func generateNumbersAsValues(n int) []Value {
 	d.Chk.True(n > 0, "must be an integer greater than zero")
 	return generateNumbersAsValuesFromToBy(0, n, 1)
 }
 
-var generateNumbersAsValueSlice = func(n int) ValueSlice {
+func generateNumbersAsValueSlice(n int) ValueSlice {
 	d.Chk.True(n > 0, "must be an integer greater than zero")
 	return generateNumbersAsValuesFromToBy(0, n, 1)
 }
 
-var generateNumbersAsValuesFromToBy = func(from, to, by int) ValueSlice {
+func generateNumbersAsValuesFromToBy(from, to, by int) ValueSlice {
 	d.Chk.True(to > from, "to must be greater than from")
 	d.Chk.True(by > 0, "must be an integer greater than zero")
 	nums := []Value{}
@@ -29,10 +53,11 @@ var generateNumbersAsValuesFromToBy = func(from, to, by int) ValueSlice {
 	return nums
 }
 
-var generateNumbersAsStructs = func(n int) ValueSlice {
+func generateNumbersAsStructs(n int) ValueSlice {
 	return generateNumbersAsValuesFromToBy(0, n, 1)
 }
-var generateNumbersAsStructsFromToBy = func(from, to, by int) ValueSlice {
+
+func generateNumbersAsStructsFromToBy(from, to, by int) ValueSlice {
 	d.Chk.True(to > from, "to must be greater than from")
 	d.Chk.True(by > 0, "must be an integer greater than zero")
 	nums := []Value{}
@@ -42,7 +67,7 @@ var generateNumbersAsStructsFromToBy = func(from, to, by int) ValueSlice {
 	return nums
 }
 
-var generateNumbersAsRefOfStructs = func(n int) []Value {
+func generateNumbersAsRefOfStructs(n int) []Value {
 	d.Chk.True(n > 0, "must be an integer greater than zero")
 	vs := NewTestValueStore()
 	nums := []Value{}


### PR DESCRIPTION
When merge.ThreeWay() merges list splices, it frequently needs to
extract a slice of a List or check whether a given range of values is
exactly equal in two different Lists. Repeatedly Getting elements from
a List is expensive, because it creates a new cursor internally every
time. Adding IteratorAt(idx uint64) allows code to iterate over a
range of a List while only creating a cursor once. This allows a slice
of Values to be extracted or used in comparisons efficiently.

Toward #2445