### PR TITLE
JS: Fix subtype issue with unions as elem types

### DIFF
--- a/go/types/assert_type.go
+++ b/go/types/assert_type.go
@@ -12,7 +12,7 @@ func assertSubtype(t *Type, v Value) {
 	}
 }
 
-// IsSubtype determines whether concreteType is a subtype is requiredType. For example, `Number` is a subtype of `Number | String`.
+// IsSubtype determines whether concreteType is a subtype of requiredType. For example, `Number` is a subtype of `Number | String`.
 func IsSubtype(requiredType, concreteType *Type) bool {
 	return isSubtype(requiredType, concreteType, nil)
 }

--- a/go/types/assert_type_test.go
+++ b/go/types/assert_type_test.go
@@ -341,7 +341,7 @@ func TestIsSubtypeEmptySruct(tt *testing.T) {
 	assert.True(tt, IsSubtype(t2, t1))
 }
 
-func TestIsSubtypeCompundUnion(tt *testing.T) {
+func TestIsSubtypeCompoundUnion(tt *testing.T) {
 	rt := MakeListType(EmptyStructType)
 
 	st1 := MakeStructType("One", []string{"a"}, []*Type{NumberType})

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "59.0.1",
+  "version": "59.0.2",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/assert-type-test.js
+++ b/js/noms/src/assert-type-test.js
@@ -328,4 +328,19 @@ suite('validate type', () => {
     assert.isFalse(isSubtype(tc, tb, []));
   });
 
+  test('isSubtype compound union', () => {
+    const emptyStructType = makeStructType('', [], []);
+    const rt = makeListType(emptyStructType);
+
+    const st1 = makeStructType('One', ['a'], [numberType]);
+    const st2 = makeStructType('Two', ['b'], [stringType]);
+    const ct = makeListType(makeUnionType([st1, st2]));
+
+    assert.isTrue(isSubtype(rt, ct));
+    assert.isFalse(isSubtype(ct, rt));
+
+    const ct2 = makeListType(makeUnionType([st1, st2, numberType]));
+    assert.isFalse(isSubtype(rt, ct2));
+    assert.isFalse(isSubtype(ct2, rt));
+  });
 });

--- a/js/noms/src/assert-type.js
+++ b/js/noms/src/assert-type.js
@@ -115,11 +115,12 @@ function isSubtypeInternal(requiredType: Type<any>, concreteType: Type<any>,
   invariant(false);
 }
 
-// compoundSubtype is called when comparing the element types of two compound types. This is the
-// only case where a concrete type may have be a union type.
+/**
+ * compoundSubtype is called when comparing the element types of two compound types.
+ * This is the only case where a concrete type may have be a union type.
+ */
 function compoundSubtype(requiredType: Type<any>, concreteType: Type<any>,
                          parentStructTypes: Type<any>[]): boolean {
-  // In a compound type it is OK to have an empty union.
   if (concreteType.kind === Kind.Union) {
     for (let i = 0; i < concreteType.desc.elemTypes.length; i++) {
       if (!isSubtypeInternal(requiredType, concreteType.desc.elemTypes[i], parentStructTypes)) {

--- a/js/noms/src/assert-type.js
+++ b/js/noms/src/assert-type.js
@@ -39,11 +39,15 @@ export default function assertSubtype(requiredType: Type<any>, v: Value): void {
   assert(isSubtype(requiredType, getTypeOfValue(v)), v, requiredType);
 }
 
+/**
+ * IsSubtype determines whether `concreteType` is a subtype of `requiredType`. For example,
+ * `Number` is a subtype of `Number | String`.
+ */
 export function isSubtype(requiredType: Type<any>, concreteType: Type<any>): boolean {
   return isSubtypeInternal(requiredType, concreteType, []);
 }
 
-export function isSubtypeInternal(requiredType: Type<any>, concreteType: Type<any>,
+function isSubtypeInternal(requiredType: Type<any>, concreteType: Type<any>,
                                   parentStructTypes: Type<any>[]): boolean {
   if (equals(requiredType, concreteType)) {
     return true;
@@ -111,10 +115,17 @@ export function isSubtypeInternal(requiredType: Type<any>, concreteType: Type<an
   invariant(false);
 }
 
+// compoundSubtype is called when comparing the element types of two compound types. This is the
+// only case where a concrete type may have be a union type.
 function compoundSubtype(requiredType: Type<any>, concreteType: Type<any>,
                          parentStructTypes: Type<any>[]): boolean {
   // In a compound type it is OK to have an empty union.
-  if (concreteType.kind === Kind.Union && concreteType.desc.elemTypes.length === 0) {
+  if (concreteType.kind === Kind.Union) {
+    for (let i = 0; i < concreteType.desc.elemTypes.length; i++) {
+      if (!isSubtypeInternal(requiredType, concreteType.desc.elemTypes[i], parentStructTypes)) {
+        return false;
+      }
+    }
     return true;
   }
   return isSubtypeInternal(requiredType, concreteType, parentStructTypes);


### PR DESCRIPTION
For compound types (List, Set, Map, Ref) the concrete type may be a
union. If that is the case all the types in the union must be a
subtype of the concrete type's element type.

`C<T | V>` is a subtype of `C<S>` iff T is a subtype of S and V is a
subtype of S.
