### PR TITLE
Improve code based on tool analysis feeback

### DIFF
--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -256,7 +256,7 @@ func writeCommitLines(node LogNode, maxLines, lineno int, w io.Writer) (lineCnt 
 func writeDiffLines(node LogNode, db datas.Database, maxLines, lineno int, w io.Writer) (lineCnt int, err error) {
 	mlw := &maxLineWriter{numLines: lineno, maxLines: maxLines, node: node, dest: w, needsPrefix: true, showGraph: showGraph}
 	parents := node.commit.Get(datas.ParentsField).(types.Set)
-	var parent types.Value = nil
+	var parent types.Value
 	if parents.Len() > 0 {
 		parent = parents.First()
 	}

--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -146,5 +146,3 @@ func (ds *databaseCommon) tryUpdateRoot(currentDatasets types.Map, currentRootRe
 	}
 	return
 }
-
-

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -195,7 +195,7 @@ func TestDecode(tt *testing.T) {
 }
 
 func TestDecodeNilPointer(t *testing.T) {
-	var x *bool = nil
+	var x *bool
 	assertDecodeErrorMessage(t, types.Bool(true), x, "Cannot unmarshal into Go nil pointer of type *bool")
 }
 

--- a/go/spec/dataspec.go
+++ b/go/spec/dataspec.go
@@ -164,8 +164,8 @@ func parsePathSpec(spec string) (pathSpec, error) {
 	return pathSpec{dbSpec, path}, nil
 }
 
-func (s databaseSpec) String() string {
-	return s.Protocol + ":" + s.Path
+func (spec databaseSpec) String() string {
+	return spec.Protocol + ":" + spec.Path
 }
 
 func (spec databaseSpec) Database() (ds datas.Database, err error) {
@@ -195,8 +195,8 @@ func (spec datasetSpec) Dataset() (dataset.Dataset, error) {
 	return dataset.NewDataset(store, spec.DatasetName), nil
 }
 
-func (s datasetSpec) String() string {
-	return s.DbSpec.String() + "::" + s.DatasetName
+func (spec datasetSpec) String() string {
+	return spec.DbSpec.String() + "::" + spec.DatasetName
 }
 
 func (spec datasetSpec) Value() (datas.Database, types.Value, error) {

--- a/go/types/edit_distance.go
+++ b/go/types/edit_distance.go
@@ -37,14 +37,14 @@ func (s Splice) String() string {
 	return fmt.Sprintf("[%d, %d, %d, %d]", s.SpAt, s.SpRemoved, s.SpAdded, s.SpFrom)
 }
 
-func uint64_min(a, b uint64) uint64 {
+func uint64Min(a, b uint64) uint64 {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func uint64_min3(a, b, c uint64) uint64 {
+func uint64Min3(a, b, c uint64) uint64 {
 	if a < b {
 		if a < c {
 			return a
@@ -74,7 +74,7 @@ func addSplice(splices []Splice, s Splice) []Splice {
 }
 
 func calcSplices(previousLength uint64, currentLength uint64, maxSpliceMatrixSize uint64, eqFn EditDistanceEqualsFn) []Splice {
-	minLength := uint64_min(previousLength, currentLength)
+	minLength := uint64Min(previousLength, currentLength)
 	prefixCount := sharedPrefix(eqFn, minLength)
 	suffixCount := sharedSuffix(eqFn, previousLength, currentLength, minLength-prefixCount)
 
@@ -192,7 +192,7 @@ func calcEditDistances(eqFn EditDistanceEqualsFn, previousStart uint64, previous
 			} else {
 				north := distances[i-1][j] + 1
 				west := distances[i][j-1] + 1
-				distances[i][j] = uint64_min(north, west)
+				distances[i][j] = uint64Min(north, west)
 			}
 		}
 	}
@@ -220,7 +220,7 @@ func operationsFromEditDistances(distances [][]uint64) []uint64 {
 		west := distances[i-1][j]
 		north := distances[i][j-1]
 
-		minValue := uint64_min3(west, north, northWest)
+		minValue := uint64Min3(west, north, northWest)
 
 		if minValue == northWest {
 			if northWest == current {

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -201,20 +201,16 @@ func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint
 	if isIndexedSequence {
 		if childIsMeta {
 			return newIndexedMetaSequence(metaItems, ms.Type(), ms.vr)
-		} else {
-			return newListLeafSequence(ms.vr, valueItems...)
 		}
-	} else {
-		if childIsMeta {
-			return newOrderedMetaSequence(metaItems, ms.Type(), ms.vr)
-		} else {
-			if MapKind == ms.Type().Kind() {
-				return newMapLeafSequence(ms.vr, mapItems...)
-			} else {
-				return newSetLeafSequence(ms.vr, valueItems...)
-			}
-		}
+		return newListLeafSequence(ms.vr, valueItems...)
 	}
+	if childIsMeta {
+		return newOrderedMetaSequence(metaItems, ms.Type(), ms.vr)
+	}
+	if MapKind == ms.Type().Kind() {
+		return newMapLeafSequence(ms.vr, mapItems...)
+	}
+	return newSetLeafSequence(ms.vr, valueItems...)
 }
 
 func isMetaSequence(seq sequence) bool {

--- a/go/types/string.go
+++ b/go/types/string.go
@@ -24,14 +24,14 @@ func (s String) Hash() hash.Hash {
 	return getHash(s)
 }
 
-func (fs String) ChildValues() []Value {
+func (s String) ChildValues() []Value {
 	return nil
 }
 
-func (fs String) Chunks() []Ref {
+func (s String) Chunks() []Ref {
 	return nil
 }
 
-func (fs String) Type() *Type {
+func (s String) Type() *Type {
 	return StringType
 }

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -126,11 +126,11 @@ func (s Struct) Set(n string, v Value) Struct {
 	return Struct{values, s.t, &hash.Hash{}}
 }
 
-func (s1 Struct) Diff(s2 Struct, changes chan<- ValueChanged, closeChan <-chan struct{}) {
-	if s1.Equals(s2) {
+func (s Struct) Diff(last Struct, changes chan<- ValueChanged, closeChan <-chan struct{}) {
+	if s.Equals(last) {
 		return
 	}
-	fs1, fs2 := s1.Type().Desc.(StructDesc).fields, s2.Type().Desc.(StructDesc).fields
+	fs1, fs2 := s.Type().Desc.(StructDesc).fields, last.Type().Desc.(StructDesc).fields
 	i1, i2 := 0, 0
 	for i1 < len(fs1) && i2 < len(fs2) {
 		f1, f2 := fs1[i1], fs2[i2]
@@ -138,7 +138,7 @@ func (s1 Struct) Diff(s2 Struct, changes chan<- ValueChanged, closeChan <-chan s
 
 		var change ValueChanged
 		if fn1 == fn2 {
-			if !s1.values[i1].Equals(s2.values[i2]) {
+			if !s.values[i1].Equals(last.values[i2]) {
 				change = ValueChanged{ChangeType: DiffChangeModified, V: String(fn1)}
 			}
 			i1++

--- a/go/util/orderedparallel/ordered_parallel.go
+++ b/go/util/orderedparallel/ordered_parallel.go
@@ -95,8 +95,8 @@ func (wq *workQueue) Pop() interface{} {
 	return x
 }
 
-func (h workQueue) Empty() bool {
-	return len(h) == 0
+func (wq workQueue) Empty() bool {
+	return len(wq) == 0
 }
 
 func (wq workQueue) Peek() (oi workItem) {

--- a/samples/go/blob-get/blob_get_test.go
+++ b/samples/go/blob-get/blob_get_test.go
@@ -26,19 +26,19 @@ type bgSuite struct {
 }
 
 func (s *bgSuite) TestBlobGet() {
-	blob_bytes := []byte("hello")
-	blob := types.NewBlob(bytes.NewBuffer(blob_bytes))
+	blobBytes := []byte("hello")
+	blob := types.NewBlob(bytes.NewBuffer(blobBytes))
 
 	db, err := spec.GetDatabase(s.TempDir)
 	s.NoError(err)
 	hash := db.WriteValue(blob)
 	db.Close()
 
-	hash_spec := fmt.Sprintf("%s::#%s", s.TempDir, hash.TargetHash().String())
-	file_path := filepath.Join(s.TempDir, "out")
-	s.Run(main, []string{hash_spec, file_path})
+	hashSpec := fmt.Sprintf("%s::#%s", s.TempDir, hash.TargetHash().String())
+	filePath := filepath.Join(s.TempDir, "out")
+	s.Run(main, []string{hashSpec, filePath})
 
-	file_bytes, err := ioutil.ReadFile(file_path)
+	fileBytes, err := ioutil.ReadFile(filePath)
 	s.NoError(err)
-	s.Equal(blob_bytes, file_bytes)
+	s.Equal(blobBytes, fileBytes)
 }

--- a/samples/go/csv/schema.go
+++ b/samples/go/csv/schema.go
@@ -204,9 +204,8 @@ func FindPrimaryKeys(r *csv.Reader, numSamples, maxLenPrimaryKeyList, numFields 
 			key := makeKeyString(row, combination, "$&$")
 			if _, ok := keys[key]; ok {
 				return
-			} else {
-				keys[key] = true
 			}
+			keys[key] = true
 		}
 		// need to copy the combination because it will be changed by caller
 		pksFound = append(pksFound, append([]int{}, combination...))

--- a/samples/go/hr/main.go
+++ b/samples/go/hr/main.go
@@ -109,7 +109,6 @@ func getPersons(ds dataset.Dataset) types.Map {
 	hv, ok := ds.MaybeHeadValue()
 	if ok {
 		return hv.(types.Map)
-	} else {
-		return types.NewMap()
 	}
+	return types.NewMap()
 }

--- a/samples/go/nomdex/query_range.go
+++ b/samples/go/nomdex/query_range.go
@@ -73,18 +73,18 @@ func (b bound) String() string {
 	return fmt.Sprintf("bound{v: %s, include: %t, infinity: %d}", s1, b.include, b.infinity)
 }
 
-func (v bound) minValue(o bound) (res bound) {
-	if v.isLessThan(o) {
-		return v
+func (b bound) minValue(o bound) (res bound) {
+	if b.isLessThan(o) {
+		return b
 	}
 	return o
 }
 
-func (v bound) maxValue(o bound) (res bound) {
-	if v.isLessThan(o) {
+func (b bound) maxValue(o bound) (res bound) {
+	if b.isLessThan(o) {
 		return o
 	}
-	return v
+	return b
 }
 
 type queryRange struct {

--- a/samples/go/noms-merge/main.go
+++ b/samples/go/noms-merge/main.go
@@ -72,7 +72,7 @@ func nomsMerge() error {
 		pc := make(chan struct{}, 128)
 		go func() {
 			count := 0
-			for _ = range pc {
+			for range pc {
 				if !*quiet {
 					count++
 					status.Printf("Applied %d changes...", count)


### PR DESCRIPTION

Fixes are based on Go report card output:
- `gofmt -s` eliminates some duplication in struct/slice initialization
- `golint` found some issues like: `warning: should drop = nil from declaration of var XXX; it is the zero value`
- `golint` found some issues like: `warning: receiver name XXX should be consistent with previous receiver name YYY for ZZZ`
- `golint` says not to use underscores for function/variable names
- `golint` found several issues like: `warning: if block ends with a return statement, so drop this else and outdent its block`

No functional changes are included - just source code quality improvements.