### PR TITLE
Fixes bug where delimiter applied to header arguments

### DIFF
--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -114,7 +114,7 @@ func main() {
 		r = progressreader.New(r, getStatusPrinter(size))
 	}
 
-	comma, err := csv.StringToRune(*delimiter)
+	parsedDelimiter, err := csv.StringToRune(*delimiter)
 	d.CheckErrorNoUsage(err)
 
 	var dest int
@@ -133,7 +133,7 @@ func main() {
 		return
 	}
 
-	cr := csv.NewCSVReader(r, comma)
+	cr := csv.NewCSVReader(r, parsedDelimiter)
 	csv.SkipRecords(cr, *skipRecords)
 
 	var headers []string

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -114,7 +114,7 @@ func main() {
 		r = progressreader.New(r, getStatusPrinter(size))
 	}
 
-	parsedDelimiter, err := csv.StringToRune(*delimiter)
+	delim, err := csv.StringToRune(*delimiter)
 	d.CheckErrorNoUsage(err)
 
 	var dest int
@@ -133,7 +133,7 @@ func main() {
 		return
 	}
 
-	cr := csv.NewCSVReader(r, parsedDelimiter)
+	cr := csv.NewCSVReader(r, delim)
 	csv.SkipRecords(cr, *skipRecords)
 
 	var headers []string

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -141,7 +141,7 @@ func main() {
 		headers, err = cr.Read()
 		d.PanicIfError(err)
 	} else {
-		headers = strings.Split(*header, string(comma))
+		headers = strings.Split(*header, string(","))
 	}
 
 	kinds := []types.NomsKind{}

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -141,7 +141,7 @@ func main() {
 		headers, err = cr.Read()
 		d.PanicIfError(err)
 	} else {
-		headers = strings.Split(*header, string(","))
+		headers = strings.Split(*header, ",")
 	}
 
 	kinds := []types.NomsKind{}


### PR DESCRIPTION
Small fix that changes the logic from using the delimiter specified delimiter to parse header arguments.

https://github.com/attic-labs/noms/issues/2456