### PR TITLE
Adds checks for bad column-type and header csv-import flag values

### DIFF
--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -144,9 +144,20 @@ func main() {
 		headers = strings.Split(*header, string(comma))
 	}
 
+	uniqueHeaders := make(map[string]bool)
+	for _, header := range headers {
+		uniqueHeaders[header] = true
+	}
+	if len(uniqueHeaders) != len(headers) {
+		d.CheckErrorNoUsage(fmt.Errorf("Invalid headers specified, headers must be unique"))
+	}
+
 	kinds := []types.NomsKind{}
 	if *columnTypes != "" {
 		kinds = csv.StringsToKinds(strings.Split(*columnTypes, ","))
+		if len(kinds) != len(uniqueHeaders) {
+			d.CheckErrorNoUsage(fmt.Errorf("Invalid column-types specified, column types do not correspond to number of headers"))
+		}
 	}
 
 	ds, err := spec.GetDataset(flag.Arg(dataSetArgN))

--- a/samples/go/csv/csv-import/importer_test.go
+++ b/samples/go/csv/csv-import/importer_test.go
@@ -228,6 +228,7 @@ func (s *testSuite) TestCSVImporterWithPipe() {
 	s.Equal(types.String("1"), st.Get("a"))
 	s.Equal(types.Number(2), st.Get("b"))
 }
+
 func (s *testSuite) TestCSVImporterWithExternalHeader() {
 	input, err := ioutil.TempFile(s.TempDir, "")
 	d.Chk.NoError(err)
@@ -288,7 +289,6 @@ func (s *testSuite) TestCSVImporterWithInvalidNumColumnTypeSpec() {
 	s.Equal("", stdout)
 	s.Equal("error: Invalid column-types specified, column types do not correspond to number of headers\n", stderr)
 	s.Equal(clienttest.ExitError{-1}, exitErr)
-
 }
 
 func (s *testSuite) TestCSVImportSkipRecords() {


### PR DESCRIPTION
Adds checks to ensure column types correspond to the number of header types, makes partial specification invalid and ensures header values are unique.