### PR TITLE
Refactors code to bubble csv parse errors up

### DIFF
--- a/cmd/noms/noms.go
+++ b/cmd/noms/noms.go
@@ -16,6 +16,7 @@ import (
 )
 
 var commands = []*util.Command{
+	nomsCommit,
 	nomsDiff,
 	nomsDs,
 	nomsLog,

--- a/cmd/noms/noms_commit.go
+++ b/cmd/noms/noms_commit.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/attic-labs/noms/cmd/util"
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/dataset"
+	"github.com/attic-labs/noms/go/spec"
+	flag "github.com/juju/gnuflag"
+)
+
+var allowDupe bool
+
+var nomsCommit = &util.Command{
+	Run:       runCommit,
+	UsageLine: "commit [options] [absolute-path] <dataset>",
+	Short:     "Commits a specified value as head of the dataset",
+	Long:      "If absolute-path is not provided, then it is read from stdin. See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the dataset and absolute-path arguments.",
+	Flags:     setupCommitFlags,
+	Nargs:     1, // if absolute-path not present we read it from stdin
+}
+
+func setupCommitFlags() *flag.FlagSet {
+	commitFlagSet := flag.NewFlagSet("commit", flag.ExitOnError)
+	commitFlagSet.BoolVar(&allowDupe, "allow-dupe", false, "creates a new commit, even if it would be identical (modulo metadata and parents) to the existing HEAD.")
+	spec.RegisterCommitMetaFlags(commitFlagSet)
+	return commitFlagSet
+}
+
+func runCommit(args []string) int {
+	ds, err := spec.GetDataset(args[len(args)-1])
+	d.CheckError(err)
+	defer ds.Database().Close()
+
+	var path string
+	if len(args) == 2 {
+		path = args[0]
+	} else {
+		readPath, _, err := bufio.NewReader(os.Stdin).ReadLine()
+		d.CheckError(err)
+		path = string(readPath)
+	}
+	absPath, err := spec.NewAbsolutePath(path)
+	d.CheckError(err)
+
+	value := absPath.Resolve(ds.Database())
+	if value == nil {
+		d.CheckErrorNoUsage(errors.New(fmt.Sprintf("Error resolving value: %s", path)))
+	}
+
+	oldCommitRef, oldCommitExists := ds.MaybeHeadRef()
+	if oldCommitExists {
+		head := ds.HeadValue()
+		if head.Hash() == value.Hash() && !allowDupe {
+			fmt.Fprintf(os.Stdout, "Commit aborted - allow-dupe is set to off and this commit would create a duplicate\n")
+			return 0
+		}
+	}
+
+	meta, err := spec.CreateCommitMetaStruct(ds.Database(), "", "", nil, nil)
+	d.CheckErrorNoUsage(err)
+
+	ds, err = ds.Commit(value, dataset.CommitOptions{Meta: meta})
+	d.CheckErrorNoUsage(err)
+
+	if oldCommitExists {
+		fmt.Fprintf(os.Stdout, "New head #%v (was #%v)\n", ds.HeadRef().TargetHash().String(), oldCommitRef.TargetHash().String())
+	} else {
+		fmt.Fprintf(os.Stdout, "New head #%v\n", ds.HeadRef().TargetHash().String())
+	}
+	return 0
+}

--- a/cmd/noms/noms_commit_test.go
+++ b/cmd/noms/noms_commit_test.go
@@ -1,0 +1,200 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/dataset"
+	"github.com/attic-labs/noms/go/spec"
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/clienttest"
+	"github.com/attic-labs/testify/suite"
+)
+
+type nomsCommitTestSuite struct {
+	clienttest.ClientTestSuite
+}
+
+func TestNomsCommit(t *testing.T) {
+	suite.Run(t, &nomsCommitTestSuite{})
+}
+
+func (s *nomsCommitTestSuite) setupDataset(name string, doCommit bool) (ds dataset.Dataset, dsStr string, ref types.Ref) {
+	dsStr = spec.CreateValueSpecString("ldb", s.LdbDir, name)
+	ds, err := spec.GetDataset(dsStr)
+	s.NoError(err)
+
+	v := types.String("testcommit")
+	ref = ds.Database().WriteValue(v)
+	if doCommit {
+		ds, err = ds.CommitValue(v)
+		s.NoError(err)
+	}
+	return
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitReadPathFromStdin() {
+	ds, dsStr, ref := s.setupDataset("commitTestStdin", false)
+	defer ds.Database().Close()
+
+	_, ok := ds.MaybeHead()
+	s.False(ok, "should not have a commit")
+
+	oldStdin := os.Stdin
+	newStdin, stdinWriter, err := os.Pipe()
+	s.NoError(err)
+
+	os.Stdin = newStdin
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
+	go func() {
+		stdinWriter.Write([]byte("#" + ref.TargetHash().String() + "\n"))
+		stdinWriter.Close()
+	}()
+	stdoutString, stderrString := s.MustRun(main, []string{"commit", dsStr})
+	s.Empty(stderrString)
+	s.Contains(stdoutString, "New head #")
+
+	ds, err = spec.GetDataset(dsStr)
+	s.NoError(err)
+	commit, ok := ds.MaybeHead()
+	s.True(ok, "should have a commit now")
+	value := commit.Get(datas.ValueField)
+	s.True(value.Hash() == ref.TargetHash(), "commit.value hash == writevalue hash")
+
+	meta := commit.Get(datas.MetaField).(types.Struct)
+	s.NotEmpty(meta.Get("date"))
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitToDatasetWithoutHead() {
+	ds, dsStr, ref := s.setupDataset("commitTest", false)
+	defer ds.Database().Close()
+
+	_, ok := ds.MaybeHead()
+	s.False(ok, "should not have a commit")
+
+	stdoutString, stderrString := s.MustRun(main, []string{"commit", "#" + ref.TargetHash().String(), dsStr})
+	s.Empty(stderrString)
+	s.Contains(stdoutString, "New head #")
+
+	ds, err := spec.GetDataset(dsStr)
+	s.NoError(err)
+	commit, ok := ds.MaybeHead()
+	s.True(ok, "should have a commit now")
+	value := commit.Get(datas.ValueField)
+	s.True(value.Hash() == ref.TargetHash(), "commit.value hash == writevalue hash")
+
+	meta := commit.Get(datas.MetaField).(types.Struct)
+	s.NotEmpty(meta.Get("date"))
+}
+
+func structFieldEqual(old, now types.Struct, field string) bool {
+	oldValue, oldOk := old.MaybeGet(field)
+	nowValue, nowOk := now.MaybeGet(field)
+	return oldOk && nowOk && nowValue.Equals(oldValue)
+}
+
+func (s *nomsCommitTestSuite) runDuplicateTest(allowDuplicate bool) {
+	ds, dsStr, ref := s.setupDataset("commitTestDuplicate", true)
+	defer ds.Database().Close()
+
+	_, ok := ds.MaybeHeadValue()
+	s.True(ok, "should have a commit")
+
+	cliOptions := []string{"commit"}
+	if allowDuplicate {
+		cliOptions = append(cliOptions, "--allow-dupe=1")
+	}
+	cliOptions = append(cliOptions, "#"+ref.TargetHash().String(), dsStr)
+
+	stdoutString, stderrString := s.MustRun(main, cliOptions)
+	s.Empty(stderrString)
+	if allowDuplicate {
+		s.NotContains(stdoutString, "Commit aborted")
+		s.Contains(stdoutString, "New head #")
+	} else {
+		s.Contains(stdoutString, "Commit aborted")
+	}
+
+	ds, err := spec.GetDataset(dsStr)
+	s.NoError(err)
+	value, ok := ds.MaybeHeadValue()
+	s.True(ok, "should still have a commit")
+	s.True(value.Hash() == ref.TargetHash(), "commit.value hash == previous commit hash")
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitDuplicate() {
+	s.runDuplicateTest(false)
+	s.runDuplicateTest(true)
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitMetadata() {
+	ds, dsStr, ref := s.setupDataset("commitTestMetadata", true)
+	metaOld := ds.Head().Get(datas.MetaField).(types.Struct)
+
+	stdoutString, stderrString := s.MustRun(main, []string{"commit", "--allow-dupe=1", "--message=foo", "#" + ref.TargetHash().String(), dsStr})
+	s.Empty(stderrString)
+	s.Contains(stdoutString, "New head #")
+
+	ds, err := spec.GetDataset(dsStr)
+	s.NoError(err)
+	metaNew := ds.Head().Get(datas.MetaField).(types.Struct)
+
+	s.False(metaOld.Equals(metaNew), "meta didn't change")
+	s.False(structFieldEqual(metaOld, metaNew, "date"), "date didn't change")
+	s.False(structFieldEqual(metaOld, metaNew, "message"), "message didn't change")
+	s.True(metaNew.Get("message").Equals(types.String("foo")), "message wasn't set")
+
+	metaOld = metaNew
+	stdoutString, stderrString = s.MustRun(main, []string{"commit", "--allow-dupe=1", "--meta=message=bar", "--date=" + spec.CommitMetaDateFormat, "#" + ref.TargetHash().String(), dsStr})
+	s.Empty(stderrString)
+	s.Contains(stdoutString, "New head #")
+
+	ds, err = spec.GetDataset(dsStr)
+	s.NoError(err)
+	metaNew = ds.Head().Get(datas.MetaField).(types.Struct)
+	s.False(metaOld.Equals(metaNew), "meta didn't change")
+	s.False(structFieldEqual(metaOld, metaNew, "date"), "date didn't change")
+	s.False(structFieldEqual(metaOld, metaNew, "message"), "message didn't change")
+	s.True(metaNew.Get("message").Equals(types.String("bar")), "message wasn't set")
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitHashNotFound() {
+	s.Panics(func() {
+		s.MustRun(main, []string{"commit", "#9ei6fbrs0ujo51vifd3f2eebufo4lgdu", "f::b"})
+	})
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitMetadataBadDateFormat() {
+	ds, dsStr, ref := s.setupDataset("commitTestMetadata", true)
+	defer ds.Database().Close()
+
+	s.Panics(func() {
+		s.MustRun(main, []string{"commit", "--allow-dupe=1", "--date=a", "#" + ref.TargetHash().String(), dsStr})
+	})
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitInvalidMetadataPaths() {
+	ds, dsStr, ref := s.setupDataset("commitTestMetadataPaths", true)
+	defer ds.Database().Close()
+
+	s.Panics(func() {
+		s.MustRun(main, []string{"commit", "--allow-dupe=1", "--meta-p=#beef", "#" + ref.TargetHash().String(), dsStr})
+	})
+}
+
+func (s *nomsCommitTestSuite) TestNomsCommitInvalidMetadataFieldName() {
+	ds, dsStr, ref := s.setupDataset("commitTestMetadataFields", true)
+	defer ds.Database().Close()
+
+	s.Panics(func() {
+		s.MustRun(main, []string{"commit", "--allow-dupe=1", "--meta=_foo=bar", "#" + ref.TargetHash().String(), dsStr})
+	})
+}

--- a/go/spec/commit_meta.go
+++ b/go/spec/commit_meta.go
@@ -1,0 +1,115 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/types"
+	flag "github.com/juju/gnuflag"
+)
+
+const CommitMetaDateFormat = "2006-01-02T15:04:05-0700"
+
+var (
+	commitMetaDate            string
+	commitMetaMessage         string
+	commitMetaKeyValueStrings string
+	commitMetaKeyValuePaths   string
+)
+
+// RegisterCommitMetaFlags registers command line flags used for creating commit meta structs.
+func RegisterCommitMetaFlags(flags *flag.FlagSet) {
+	flags.StringVar(&commitMetaDate, "date", "", "alias for -meta 'date=<date>'. '<date>' must be iso8601-formatted. If '<date>' is empty, it defaults to the current date.")
+	flags.StringVar(&commitMetaMessage, "message", "", "alias for -meta 'message=<message>'")
+	flags.StringVar(&commitMetaKeyValueStrings, "meta", "", "'<key>=<value>' - creates a metadata field called 'key' set to 'value'. Value should be human-readable encoded.")
+	flags.StringVar(&commitMetaKeyValuePaths, "meta-p", "", "'<key>=<path>' - creates a metadata field called 'key' set to the value at <path>")
+}
+
+// CreateCommitMetaStruct creates and returns a Noms struct suitable for use in CommitOptions.Meta.
+// It returns types.EmptyStruct and an error if any issues are encountered.
+// Database is used only if commitMetaKeyValuePaths are provided on the command line and values need to be resolved.
+// Date should be ISO 8601 format (see CommitMetaDateFormat), if empty the current date is used.
+// The values passed as command line arguments (if any) are merged with the values provided as function arguments.
+func CreateCommitMetaStruct(db datas.Database, date, message string, keyValueStrings map[string]string, keyValuePaths map[string]types.Value) (types.Struct, error) {
+	metaValues := types.StructData{}
+
+	resolvePathFunc := func(path string) (types.Value, error) {
+		absPath, err := NewAbsolutePath(path)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Bad path for meta-p: %s", path))
+		}
+		return absPath.Resolve(db), nil
+	}
+	parseMetaStrings := func(param string, resolveAsPaths bool) error {
+		if param == "" {
+			return nil
+		}
+		ms := strings.Split(param, ",")
+		for _, m := range ms {
+			kv := strings.Split(m, "=")
+			if len(kv) != 2 {
+				return errors.New(fmt.Sprintf("Unable to parse meta value: %s", m))
+			}
+			if !types.IsValidStructFieldName(kv[0]) {
+				return errors.New(fmt.Sprintf("Invalid meta key: %s", kv[0]))
+			}
+			if resolveAsPaths {
+				v, err := resolvePathFunc(kv[1])
+				if err != nil {
+					return err
+				}
+				metaValues[kv[0]] = v
+			} else {
+				metaValues[kv[0]] = types.String(kv[1])
+			}
+		}
+		return nil
+	}
+
+	if err := parseMetaStrings(commitMetaKeyValueStrings, false); err != nil {
+		return types.EmptyStruct, err
+	}
+	if err := parseMetaStrings(commitMetaKeyValuePaths, true); err != nil {
+		return types.EmptyStruct, err
+	}
+
+	for k, v := range keyValueStrings {
+		if !types.IsValidStructFieldName(k) {
+			return types.EmptyStruct, errors.New(fmt.Sprintf("Invalid meta key: %s", k))
+		}
+		metaValues[k] = types.String(v)
+	}
+	for k, v := range keyValuePaths {
+		if !types.IsValidStructFieldName(k) {
+			return types.EmptyStruct, errors.New(fmt.Sprintf("Invalid meta key: %s", k))
+		}
+		metaValues[k] = v
+	}
+
+	if date == "" {
+		date = commitMetaDate
+	}
+	if date == "" {
+		date = time.Now().UTC().Format(CommitMetaDateFormat)
+	} else {
+		_, err := time.Parse(CommitMetaDateFormat, date)
+		if err != nil {
+			return types.EmptyStruct, errors.New(fmt.Sprintf("Unable to parse date: %s", date))
+		}
+	}
+	metaValues["date"] = types.String(date)
+
+	if message != "" {
+		metaValues["message"] = types.String(message)
+	} else if commitMetaMessage != "" {
+		metaValues["message"] = types.String(commitMetaMessage)
+	}
+	return types.NewStruct("Meta", metaValues), nil
+}

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -34,7 +34,7 @@
     "chai": "^3.5.0",
     "chokidar": "^1.6.0",
     "commander": "^2.9.0",
-    "documentation": "^4.0.0-beta10",
+    "documentation": "documentationjs/documentation#e11c1ab3b5a7b366131d335f707d0b4641f950ac",
     "flow-bin": "0.30.0",
     "fs-extra": "^0.30.0",
     "mocha": "^2.5.3"
@@ -49,7 +49,7 @@
     "copy-flow-files": "npm run copy-flow-files-commonjs",
     "copy-flow-files-commonjs": "node build/copy-flow-files.js -d dist/commonjs/ src/",
     "make-index-html": "node build/make-index-html.js",
-    "build-docs": "documentation build --name Noms --project-version $npm_package_version --document-exported --infer-private ^_ --github --format html --output generated-docs/$npm_package_version/ src/noms.js && npm run make-index-html"
+    "build-docs": "documentation build --name Noms --project-version $npm_package_version --document-exported --infer-private ^_ --github --format html --sort-order alpha --output generated-docs/$npm_package_version/ src/noms.js && npm run make-index-html"
   },
   "browser": {
     "./src/bytes.js": "./src/browser/bytes.js",

--- a/js/noms/src/struct.js
+++ b/js/noms/src/struct.js
@@ -42,6 +42,7 @@ export const fieldNameRe = new RegExp(fieldNameComponentRe.source + '$');
  *   get s(): string;
  *   setS(value: string): MyStruct;
  * }
+ * ```
  *
  * With one major exception: if the field name conflicts with any of the properties in ValueBase (or
  * Object), such as `chunks`, `hash` or `type` (or `toString`, `hasOwnProperty` etc.), then these

--- a/js/noms/src/walk.js
+++ b/js/noms/src/walk.js
@@ -17,12 +17,12 @@ import type Value from './value.js';
 type walkCb = (v: Value) => ?boolean | Promise<?boolean>;
 
 /**
- * Invokes `cb` once for `v` and each of its descendants. The returned `Promise` is resolved when all
- * invocations to `cb` have been resolved.
+ * Invokes `cb` once for `v` and each of its descendants. The returned `Promise` is resolved when
+ * all invocations to `cb` have been resolved.
  *
  * The return value of `cb` indicates whether to recurse further into the tree. Return false or
- * `Promise.resolve(false)` to continue recursing. Return `true` or `Promise.resolve(true)` to skip this
- * node's children.
+ * `Promise.resolve(false)` to continue recursing. Return `true` or `Promise.resolve(true)` to skip
+ * this node's children.
  *
  * If `cb` returns undefined or `Promise.resolve()`, the default is to continue recursing (`false`).
  */

--- a/js/noms/src/walk.js
+++ b/js/noms/src/walk.js
@@ -17,14 +17,14 @@ import type Value from './value.js';
 type walkCb = (v: Value) => ?boolean | Promise<?boolean>;
 
 /**
- * Invokes |cb| once for |v| and each of its descendants. The returned Promise is resolved when all
- * invocations to |cb| have been resolved.
+ * Invokes `cb` once for `v` and each of its descendants. The returned `Promise` is resolved when all
+ * invocations to `cb` have been resolved.
  *
- * The return value of |cb| indicates whether to recurse further into the tree. Return false or
- * Promise.resolve(false) to continue recursing. Return true or Promise.resolve(true) to skip this
+ * The return value of `cb` indicates whether to recurse further into the tree. Return false or
+ * `Promise.resolve(false)` to continue recursing. Return `true` or `Promise.resolve(true)` to skip this
  * node's children.
  *
- * If |cb| returns undefined or Promise.resolve(), the default is to continue recursing (false).
+ * If `cb` returns undefined or `Promise.resolve()`, the default is to continue recursing (`false`).
  */
 export default async function walk(v: Value, ds: Database, cb: walkCb): Promise<void> {
   let skip = cb(v);

--- a/js/perf/viewer/build.py
+++ b/js/perf/viewer/build.py
@@ -18,5 +18,5 @@ def main():
 
     subprocess.check_call(['npm', 'install'], shell=False)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -161,9 +161,15 @@ func main() {
 
 	var value types.Value
 	if dest == destList {
-		value, _ = csv.ReadToList(cr, *name, headers, kinds, ds.Database())
+		value, _, err = csv.ReadToList(cr, *name, headers, kinds, ds.Database())
+		if err != nil {
+			d.CheckErrorNoUsage(fmt.Errorf("Could not parse csv to list, encountered the following issue: %s", err))
+		}
 	} else {
-		value = csv.ReadToMap(cr, *name, headers, strPks, kinds, ds.Database())
+		value, err = csv.ReadToMap(cr, *name, headers, strPks, kinds, ds.Database())
+		if err != nil {
+			d.CheckErrorNoUsage(fmt.Errorf("Could not parse csv to map, encountered the following issue: %s", err))
+		}
 	}
 
 	if *performCommit {

--- a/samples/go/csv/csv-import/importer_test.go
+++ b/samples/go/csv/csv-import/importer_test.go
@@ -169,6 +169,17 @@ func (s *testSuite) TestCSVImporterToMap() {
 	validateMap(s, m)
 }
 
+func (s *testSuite) TestCSVImporterToMapInvalidPk() {
+	setName := "csv"
+	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)
+	stdout, stderr, err := s.Run(main, []string{"--no-progress", "--column-types", TEST_FIELDS, "--dest-type", "map:5", s.tmpFileName, dataspec})
+	s.Equal("", stdout)
+	s.Equal("error: Could not parse csv to map, encountered the following issue: Invalid pk: 5\n", stderr)
+	s.Equal(clienttest.ExitError{-1}, err)
+
+	defer os.RemoveAll(s.LdbDir)
+}
+
 func (s *testSuite) TestCSVImporterToNestedMap() {
 	setName := "csv"
 	dataspec := spec.CreateValueSpecString("ldb", s.LdbDir, setName)

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -26,8 +26,9 @@ b,2,false
 
 	headers := []string{"A", "B", "C"}
 	kinds := KindSlice{types.StringKind, types.NumberKind, types.BoolKind}
-	l, typ := ReadToList(r, "test", headers, kinds, ds)
+	l, typ, err := ReadToList(r, "test", headers, kinds, ds)
 
+	assert.NoError(err)
 	assert.Equal(uint64(2), l.Len())
 
 	assert.Equal(types.StructKind, typ.Kind())
@@ -60,8 +61,9 @@ b,2,false
 
 	headers := []string{"A", "B", "C"}
 	kinds := KindSlice{types.StringKind, types.NumberKind, types.BoolKind}
-	m := ReadToMap(r, "test", headers, []string{"0"}, kinds, ds)
+	m, err := ReadToMap(r, "test", headers, []string{"0"}, kinds, ds)
 
+	assert.NoError(err)
 	assert.Equal(uint64(2), m.Len())
 	assert.True(m.Type().Equals(
 		types.MakeMapType(types.StringType, types.MakeStructType("test",
@@ -93,9 +95,10 @@ func testTrailingHelper(t *testing.T, dataString string) {
 
 	headers := []string{"A", "B"}
 	kinds := KindSlice{types.StringKind, types.StringKind}
-	l, typ := ReadToList(r, "test", headers, kinds, ds1)
+	l, typ, err := ReadToList(r, "test", headers, kinds, ds1)
 	assert.Equal(uint64(3), l.Len())
 	assert.Equal(types.StructKind, typ.Kind())
+	assert.NoError(err)
 
 	desc, ok := typ.Desc.(types.StructDesc)
 	assert.True(ok)
@@ -106,7 +109,10 @@ func testTrailingHelper(t *testing.T, dataString string) {
 	ds2 := datas.NewDatabase(chunks.NewMemoryStore())
 	defer ds2.Close()
 	r = NewCSVReader(bytes.NewBufferString(dataString), ',')
-	m := ReadToMap(r, "test", headers, []string{"0"}, kinds, ds2)
+
+	m, err := ReadToMap(r, "test", headers, []string{"0"}, kinds, ds2)
+	assert.NoError(err)
+
 	assert.Equal(uint64(3), m.Len())
 }
 
@@ -197,12 +203,14 @@ func TestEscapeFieldNames(t *testing.T) {
 	headers := []string{"A A", "B"}
 	kinds := KindSlice{types.NumberKind, types.NumberKind}
 
-	l, _ := ReadToList(r, "test", headers, kinds, ds)
+	l, _, err := ReadToList(r, "test", headers, kinds, ds)
+	assert.NoError(err)
 	assert.Equal(uint64(1), l.Len())
 	assert.Equal(types.Number(1), l.Get(0).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 
 	r = NewCSVReader(bytes.NewBufferString(dataString), ',')
-	m := ReadToMap(r, "test", headers, []string{"1"}, kinds, ds)
+	m, err := ReadToMap(r, "test", headers, []string{"1"}, kinds, ds)
+	assert.NoError(err)
 	assert.Equal(uint64(1), l.Len())
 	assert.Equal(types.Number(1), m.Get(types.Number(2)).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 }
@@ -215,7 +223,8 @@ func TestDefaults(t *testing.T) {
 	headers := []string{"A", "B", "C", "D"}
 	kinds := KindSlice{types.NumberKind, types.NumberKind, types.BoolKind, types.StringKind}
 
-	l, _ := ReadToList(r, "test", headers, kinds, ds)
+	l, _, err := ReadToList(r, "test", headers, kinds, ds)
+	assert.NoError(err)
 	assert.Equal(uint64(1), l.Len())
 	row := l.Get(0).(types.Struct)
 	assert.Equal(types.Number(42), row.Get("A"))
@@ -232,7 +241,8 @@ func TestBooleanStrings(t *testing.T) {
 	headers := []string{"T", "F"}
 	kinds := KindSlice{types.BoolKind, types.BoolKind}
 
-	l, _ := ReadToList(r, "test", headers, kinds, ds)
+	l, _, err := ReadToList(r, "test", headers, kinds, ds)
+	assert.NoError(err)
 	assert.Equal(uint64(5), l.Len())
 	for i := uint64(0); i < l.Len(); i++ {
 		row := l.Get(i).(types.Struct)

--- a/samples/go/csv/write_test.go
+++ b/samples/go/csv/write_test.go
@@ -87,20 +87,20 @@ func startReadingCsvTestExpectationFile(s *csvWriteTestSuite) (cr *csv.Reader, h
 	return
 }
 
-func createTestList(s *csvWriteTestSuite) types.List {
+func createTestList(s *csvWriteTestSuite) (types.List, error) {
 	ds := datas.NewDatabase(chunks.NewMemoryStore())
 	cr, headers := startReadingCsvTestExpectationFile(s)
-	l, _ := ReadToList(cr, TEST_ROW_STRUCT_NAME, headers, typesToKinds(s.fieldTypes), ds)
-	return l
+	l, _, err := ReadToList(cr, TEST_ROW_STRUCT_NAME, headers, typesToKinds(s.fieldTypes), ds)
+	return l, err
 }
 
-func createTestMap(s *csvWriteTestSuite) types.Map {
+func createTestMap(s *csvWriteTestSuite) (types.Map, error) {
 	ds := datas.NewDatabase(chunks.NewMemoryStore())
 	cr, headers := startReadingCsvTestExpectationFile(s)
 	return ReadToMap(cr, TEST_ROW_STRUCT_NAME, headers, []string{"anid"}, typesToKinds(s.fieldTypes), ds)
 }
 
-func createTestNestedMap(s *csvWriteTestSuite) types.Map {
+func createTestNestedMap(s *csvWriteTestSuite) (types.Map, error) {
 	ds := datas.NewDatabase(chunks.NewMemoryStore())
 	cr, headers := startReadingCsvTestExpectationFile(s)
 	return ReadToMap(cr, TEST_ROW_STRUCT_NAME, headers, []string{"anid", "year"}, typesToKinds(s.fieldTypes), ds)
@@ -117,24 +117,27 @@ func verifyOutput(s *csvWriteTestSuite, r io.Reader) {
 }
 
 func (s *csvWriteTestSuite) TestCSVWriteList() {
-	l := createTestList(s)
+	l, err := createTestList(s)
 	w := new(bytes.Buffer)
+	s.NoError(err)
 	s.True(TEST_DATA_SIZE == l.Len(), "list length")
 	WriteList(l, s.rowStructDesc, s.comma, w)
 	verifyOutput(s, w)
 }
 
 func (s *csvWriteTestSuite) TestCSVWriteMap() {
-	m := createTestMap(s)
+	m, err := createTestMap(s)
 	w := new(bytes.Buffer)
 	s.True(TEST_DATA_SIZE == m.Len(), "map length")
+	s.NoError(err)
 	WriteMap(m, s.rowStructDesc, s.comma, w)
 	verifyOutput(s, w)
 }
 
 func (s *csvWriteTestSuite) TestCSVWriteNestedMap() {
-	m := createTestNestedMap(s)
+	m, err := createTestNestedMap(s)
 	w := new(bytes.Buffer)
+	s.NoError(err)
 	s.True(TEST_DATA_SIZE == m.Len(), "nested map length")
 	WriteMap(m, s.rowStructDesc, s.comma, w)
 	verifyOutput(s, w)

--- a/samples/go/url-fetch/fetch_test.go
+++ b/samples/go/url-fetch/fetch_test.go
@@ -48,6 +48,7 @@ func (s *testSuite) TestImportFromStdin() {
 
 	db, blob, err := spec.GetPath(dsName + ".value")
 	assert.NoError(err)
+	defer db.Close()
 
 	expected := types.NewBlob(bytes.NewBufferString("abcdef"))
 	assert.True(expected.Equals(blob))
@@ -57,8 +58,6 @@ func (s *testSuite) TestImportFromStdin() {
 	metaDesc := meta.Type().Desc.(types.StructDesc)
 	assert.Equal(1, metaDesc.Len())
 	assert.NotNil(metaDesc.Field("date"))
-
-	db.Close()
 }
 
 func (s *testSuite) TestImportFromFile() {
@@ -75,6 +74,7 @@ func (s *testSuite) TestImportFromFile() {
 
 	db, blob, err := spec.GetPath(dsName + ".value")
 	assert.NoError(err)
+	defer db.Close()
 
 	expected := types.NewBlob(bytes.NewBufferString("abcdef"))
 	assert.True(expected.Equals(blob))
@@ -84,8 +84,6 @@ func (s *testSuite) TestImportFromFile() {
 	assert.Equal(2, metaDesc.Len())
 	assert.NotNil(metaDesc.Field("date"))
 	assert.Equal(f.Name(), string(meta.Get("file").(types.String)))
-
-	db.Close()
 }
 
 // TODO: TestImportFromURL

--- a/samples/js/splore/.gitignore
+++ b/samples/js/splore/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 out.js
+generated-files

--- a/samples/js/splore/index.html
+++ b/samples/js/splore/index.html
@@ -1,14 +1,12 @@
+<!doctype html>
 <!--
   Copyright 2016 Attic Labs, Inc. All rights reserved.
   Licensed under the Apache License, version 2.0:
   http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-<!doctype html>
-<head>
 <title>'Splore</title>
 <meta charset="UTF-8">
 <script src="out.js"></script>
 <link rel="stylesheet" href="styles.css">
-</head>
-<body><div id="splore"></div></body>
+<div id="splore"></div>

--- a/samples/js/splore/stage.py
+++ b/samples/js/splore/stage.py
@@ -11,4 +11,5 @@ sys.path.append(os.path.abspath('../../../tools'))
 import noms.staging as staging
 
 if __name__ == '__main__':
-	staging.Main('splore', staging.GlobCopier('out.js', 'index.html', 'styles.css'))
+    staging.Main('splore', staging.GlobCopier('out.js', 'styles.css',
+        index_file='index.html', rename=True))


### PR DESCRIPTION
Refactors code to expose parse errors so components upstream can react
accordingly. This subsequently fixes panic state for invalid primary
key when importing csv to map

Initial issue 
https://github.com/attic-labs/noms/issues/2455
