### PR TITLE
Allow struct set to cause a type change

### DIFF
--- a/go/types/struct_test.go
+++ b/go/types/struct_test.go
@@ -73,11 +73,21 @@ func TestGenericStructSet(t *testing.T) {
 	s := NewStruct("S3", StructData{"b": Bool(true), "o": String("hi")})
 	s2 := s.Set("b", Bool(false))
 
-	assert.Panics(func() { s.Set("b", Number(1)) })
-	assert.Panics(func() { s.Set("x", Number(1)) })
-
 	s3 := s2.Set("b", Bool(true))
 	assert.True(s.Equals(s3))
+
+	// Changes the type
+	s4 := s.Set("b", Number(42))
+	assert.True(MakeStructType("S3", []string{"b", "o"}, []*Type{NumberType, StringType}).Equals(s4.Type()))
+
+	// Adds a new field
+	s5 := s.Set("x", Number(42))
+	assert.True(MakeStructType("S3", []string{"b", "o", "x"}, []*Type{BoolType, StringType, NumberType}).Equals(s5.Type()))
+
+	// Subtype
+	s6 := NewStruct("", StructData{"l": NewList(Number(0), Number(1), Bool(false), Bool(true))})
+	s7 := s6.Set("l", NewList(Number(2), Number(3)))
+	assert.True(s6.Type().Equals(s7.Type()))
 }
 
 func TestStructDiff(t *testing.T) {

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "63.0.1",
+  "version": "63.1.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/struct-test.js
+++ b/js/noms/src/struct-test.js
@@ -84,12 +84,18 @@ suite('Struct', () => {
 
     // Changes the type
     const s7 = new StructMirror(s1).set('b', 42);
-    assert.isTrue(equals(s7.type, makeStructType('S3', ['b', 'o'], [numberType, stringType])));
+    assert.isTrue(equals(s7.type, makeStructType('S3', {
+      b: numberType,
+      o: stringType,
+    })));
 
     // Adds a new field
     const s8 = new StructMirror(s1).set('x', 42);
-    assert.isTrue(equals(s8.type, makeStructType('S3', ['b', 'o', 'x'],
-      [boolType, stringType, numberType])));
+    assert.isTrue(equals(s8.type, makeStructType('S3', {
+      b: boolType,
+      o: stringType,
+      x: numberType,
+    })));
 
     // Subtype
     const s9 = newStruct('', {l: new List([0, 1, false, true])});

--- a/js/noms/src/struct-test.js
+++ b/js/noms/src/struct-test.js
@@ -81,6 +81,20 @@ suite('Struct', () => {
     const s5 = s3.setO('bye');
     const s6 = new StructMirror(s3).set('o', 'bye');
     assert.isTrue(equals(s5, s6));
+
+    // Changes the type
+    const s7 = new StructMirror(s1).set('b', 42);
+    assert.isTrue(equals(s7.type, makeStructType('S3', ['b', 'o'], [numberType, stringType])));
+
+    // Adds a new field
+    const s8 = new StructMirror(s1).set('x', 42);
+    assert.isTrue(equals(s8.type, makeStructType('S3', ['b', 'o', 'x'],
+      [boolType, stringType, numberType])));
+
+    // Subtype
+    const s9 = newStruct('', {l: new List([0, 1, false, true])});
+    const s10 = new StructMirror(s9).set('l', new List([2, 3]));
+    assert.isTrue(equals(s9.type, s10.type));
   });
 
   test('createStructClass', () => {


### PR DESCRIPTION
This allows setting a field in a struct to a new type or to set a
non-existig field in a struct.

In JS this is done through the StructMirror.p.set and in Go this is
done through Struct Set.

Fixes #2181