### PR TITLE
flickr/slurp: Treat fail as an error

### DIFF
--- a/samples/js/flickr/slurp/src/main.js
+++ b/samples/js/flickr/slurp/src/main.js
@@ -156,7 +156,11 @@ function callFlickr(method: string, params: ?{[key: string]: string}) {
         if (err) {
           rej(err);
         } else {
-          res(data);
+          if (data.stat === 'fail') {
+            rej(new Error(data.message));
+          } else {
+            res(data);
+          }
         }
       },
     });


### PR DESCRIPTION
Reject the promise when we get a fail status.