### PR TITLE
Introduce List.Concat to the Go API

### DIFF
--- a/go/perf/suite/suite.go
+++ b/go/perf/suite/suite.go
@@ -83,6 +83,7 @@ import (
 	"time"
 
 	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/dataset"
 	"github.com/attic-labs/noms/go/marshal"
@@ -339,16 +340,14 @@ func (suite *PerfSuite) Pause(fn func()) {
 	suite.paused += time.Since(start)
 }
 
-func callSafe(name string, fun reflect.Value, args ...interface{}) (err interface{}) {
-	defer func() {
-		err = recover()
-	}()
+func callSafe(name string, fun reflect.Value, args ...interface{}) error {
 	funArgs := make([]reflect.Value, len(args))
 	for i, arg := range args {
 		funArgs[i] = reflect.ValueOf(arg)
 	}
-	fun.Call(funArgs)
-	return
+	return d.Try(func() {
+		fun.Call(funArgs)
+	})
 }
 
 func (suite *PerfSuite) getEnvironment() types.Value {

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -59,22 +59,6 @@ func (ims indexedMetaSequence) getCompareFn(other sequence) compareFn {
 	}
 }
 
-func newCursorAtIndex(seq indexedSequence, idx uint64) *sequenceCursor {
-	var cur *sequenceCursor
-	for {
-		cur = newSequenceCursor(cur, seq, 0)
-		idx = idx - advanceCursorToOffset(cur, idx)
-		cs := cur.getChildSequence()
-		if cs == nil {
-			break
-		}
-		seq = cs.(indexedSequence)
-	}
-
-	d.Chk.True(cur != nil)
-	return cur
-}
-
 func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 	seq := cur.seq.(indexedSequence)
 	cur.idx = sort.Search(seq.seqLen(), func(i int) bool {

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -155,14 +155,6 @@ func (l List) Insert(idx uint64, vs ...Value) List {
 // visit the rightmost prolly tree chunks of this list, and the leftmost prolly
 // tree chunks of other.
 func (l List) Concat(other List) List {
-	if l.Empty() {
-		return other
-	}
-	if other.Empty() {
-		return l
-	}
-	d.Chk.True(l.seq.valueReader() == other.seq.valueReader())
-
 	seq := concat(l.seq, other.seq, func(cur *sequenceCursor, vr ValueReader) *sequenceChunker {
 		return l.newChunker(cur, vr)
 	})

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -161,7 +161,7 @@ func (l List) Concat(other List) List {
 	if other.Empty() {
 		return l
 	}
-	d.Chk.Equal(l.seq.valueReader(), other.seq.valueReader())
+	d.Chk.True(l.seq.valueReader() == other.seq.valueReader())
 
 	seq := concat(l.seq, other.seq, func(cur *sequenceCursor) *sequenceChunker {
 		return l.newChunker(cur)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -1060,3 +1060,51 @@ func TestListRemoveLastWhenNotLoaded(t *testing.T) {
 		assert.True(tl.toList().Equals(nl))
 	}
 }
+
+func TestListConcat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	assert := assert.New(t)
+
+	smallTestChunks()
+	chunkPattern = defaultChunkPattern
+	defer normalProductionChunks()
+
+	vs := NewTestValueStore()
+	reload := func(vs *ValueStore, l List) List {
+		return vs.ReadValue(vs.WriteValue(l).TargetHash()).(List)
+	}
+
+	run := func(seed int64, size, from, to, by int) {
+		r := rand.New(rand.NewSource(seed))
+
+		listSlice := make(testList, size)
+		for i := range listSlice {
+			listSlice[i] = Number(r.Intn(size))
+		}
+
+		list := listSlice.toList()
+
+		for i := from; i < to; i += by {
+			fst := reload(vs, listSlice[:i].toList())
+			snd := reload(vs, listSlice[i:].toList())
+			actual := fst.Concat(snd)
+			assert.True(list.Equals(actual),
+				"fail at %d/%d (with expected length %d, actual %d)", i, size, list.Len(), actual.Len())
+		}
+	}
+
+	run(0, 10, 0, 10, 1)
+
+	run(1, 100, 0, 100, 1)
+
+	run(2, 1000, 0, 1000, 10)
+	run(3, 1000, 0, 100, 1)
+	run(4, 1000, 900, 1000, 1)
+
+	run(5, 1e4, 0, 1e4, 100)
+	run(6, 1e4, 0, 1000, 10)
+	run(7, 1e4, 1e4-1000, 1e4, 10)
+}

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -1069,7 +1069,6 @@ func TestListConcat(t *testing.T) {
 	assert := assert.New(t)
 
 	smallTestChunks()
-	chunkPattern = defaultChunkPattern
 	defer normalProductionChunks()
 
 	vs := NewTestValueStore()

--- a/go/types/perf/dummy.go
+++ b/go/types/perf/dummy.go
@@ -1,0 +1,7 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package perf
+
+// go build fails if there are _test.go but no other go files in a directory.

--- a/go/types/perf/perf_test.go
+++ b/go/types/perf/perf_test.go
@@ -1,0 +1,99 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package perf
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/attic-labs/noms/go/dataset"
+	"github.com/attic-labs/noms/go/perf/suite"
+	"github.com/attic-labs/noms/go/types"
+)
+
+type perfSuite struct {
+	suite.PerfSuite
+	r  *rand.Rand
+	ds string
+}
+
+func (s *perfSuite) SetupSuite() {
+	s.r = rand.New(rand.NewSource(0))
+}
+
+func (s *perfSuite) Test01BuildList10mNumbers() {
+	assert := s.NewAssert()
+	in := make(chan types.Value, 16)
+	out := types.NewStreamingList(s.Database, in)
+
+	for i := 0; i < 1e7; i++ {
+		in <- types.Number(s.r.Int63())
+	}
+	close(in)
+
+	ds := dataset.NewDataset(s.Database, "BuildList10mNumbers")
+
+	var err error
+	ds, err = ds.CommitValue(<-out)
+
+	assert.NoError(err)
+	s.Database = ds.Database()
+}
+
+func (s *perfSuite) Test02BuildList10mStructs() {
+	assert := s.NewAssert()
+	in := make(chan types.Value, 16)
+	out := types.NewStreamingList(s.Database, in)
+
+	for i := 0; i < 1e7; i++ {
+		in <- types.NewStruct("", types.StructData{
+			"number": types.Number(s.r.Int63()),
+		})
+	}
+	close(in)
+
+	ds := dataset.NewDataset(s.Database, "BuildList10mStructs")
+
+	var err error
+	ds, err = ds.CommitValue(<-out)
+
+	assert.NoError(err)
+	s.Database = ds.Database()
+}
+
+func (s *perfSuite) Test03Read10mNumbers() {
+	s.headList("BuildList10mNumbers").IterAll(func(v types.Value, index uint64) {})
+}
+
+func (s *perfSuite) Test04Read10mStructs() {
+	s.headList("BuildList10mStructs").IterAll(func(v types.Value, index uint64) {})
+}
+
+func (s *perfSuite) Test05Concat10mValues2kTimes() {
+	assert := s.NewAssert()
+	l1 := s.headList("BuildList10mNumbers")
+	l2 := s.headList("BuildList10mStructs")
+
+	l3 := types.NewList()
+	for i := 0; i < 1e3; i++ {
+		l3 = l3.Concat(l1).Concat(l2)
+	}
+
+	ds := dataset.NewDataset(s.Database, "Concat10mValues2000Times")
+	var err error
+	ds, err = ds.CommitValue(l3)
+
+	assert.NoError(err)
+	s.Database = ds.Database()
+}
+
+func (s *perfSuite) headList(dsName string) types.List {
+	ds := dataset.NewDataset(s.Database, dsName)
+	return ds.HeadValue().(types.List)
+}
+
+func TestPerf(t *testing.T) {
+	suite.Run("types", t, &perfSuite{})
+}

--- a/go/types/sequence_chunker.go
+++ b/go/types/sequence_chunker.go
@@ -128,17 +128,14 @@ func (sc *sequenceChunker) resume() {
 	}
 }
 
-// Append appends an item to chunker, and returns the size of the item in bytes.
-func (sc *sequenceChunker) Append(item sequenceItem) (bytesHashed uint32) {
+func (sc *sequenceChunker) Append(item sequenceItem) {
 	d.Chk.True(item != nil)
 	sc.current = append(sc.current, item)
 	sc.rv.ClearLastBoundary()
 	sc.hashValueBytes(item, sc.rv)
-	bytesHashed = sc.rv.bytesHashed
 	if sc.rv.crossedBoundary {
 		sc.handleChunkBoundary()
 	}
-	return
 }
 
 func (sc *sequenceChunker) Skip() {

--- a/go/types/sequence_chunker.go
+++ b/go/types/sequence_chunker.go
@@ -128,14 +128,17 @@ func (sc *sequenceChunker) resume() {
 	}
 }
 
-func (sc *sequenceChunker) Append(item sequenceItem) {
+// Append appends an item to chunker, and returns the size of the item in bytes.
+func (sc *sequenceChunker) Append(item sequenceItem) (bytesHashed uint32) {
 	d.Chk.True(item != nil)
 	sc.current = append(sc.current, item)
 	sc.rv.ClearLastBoundary()
 	sc.hashValueBytes(item, sc.rv)
+	bytesHashed = sc.rv.bytesHashed
 	if sc.rv.crossedBoundary {
 		sc.handleChunkBoundary()
 	}
+	return
 }
 
 func (sc *sequenceChunker) Skip() {

--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -70,12 +70,12 @@ func appendCursorToChunker(chunker *sequenceChunker, cur *sequenceCursor) {
 		return
 	}
 
-	d.Chk.True(len(chunker.current) == 0)
+	d.PanicIfTrue(len(chunker.current) > 0, "there were unchunked items")
 
 	// sequenceChunker's implementation will create parent chunkers while the
 	// cursor has a parent, and only trim then when Done is called.
-	d.Chk.NotNil(cur.parent)
-	d.Chk.NotNil(chunker.parent)
+	d.PanicIfTrue(cur.parent == nil, "parent is nil")
+	d.PanicIfTrue(chunker.parent == nil, "chunker.parent is nil")
 
 	appendCursorToChunker(chunker.parent, cur.parent)
 }

--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -59,12 +59,13 @@ func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence
 func appendCursorToChunker(chunker *sequenceChunker, cur *sequenceCursor) {
 	// Append beyond the chunk window, then through to the next definite chunk
 	// boundary.
-	for i := uint32(0); cur.valid() && (i < chunkWindow || cur.indexInChunk() != 0); i++ {
-		chunker.Append(cur.current())
+	hashWindow := chunkWindow
+	for cur.valid() && (hashWindow > 0 || cur.indexInChunk() != 0) {
+		hashWindow -= chunker.Append(cur.current())
 		cur.advance()
 	}
 
-	// There may not be a chunk bounary beyond the chunk window - terminate.
+	// There may not be a chunk boundary beyond the chunk window - terminate.
 	if !cur.valid() {
 		return
 	}

--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -4,78 +4,26 @@
 
 package types
 
-import "github.com/attic-labs/noms/go/d"
-
 type newSequenceChunkerFn func(cur *sequenceCursor) *sequenceChunker
 
 func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence {
-	// To understand how concat (along with appendCursorToChunker) works, imagine
-	// *incorrectly* implementing concat using the simplest possible method:
-	// simply concatenate the sequences at each level.
-	//
-	//    [FF]
-	//  [AA] [BB]
-	//
-	//  +
-	//
-	//    [SS]
-	//  [CC] [DD]
-	//
-	//  =
-	//
-	//    [FF]       [SS]
-	//  [AA] [BB] [CC] [DD]
-	//
-	// which requires adding another level to the prolly tree to reference the
-	// roots of each tree:
-	//
-	//         [RR]
-	//    [FF]       [SS]
-	//  [AA] [BB] [CC] [DD]
-	//
-	// This is probably incorrect for 2 reasons:
-	//
-	//  1. It assumes that [BB] and [FF] each end on a chunk boundary, which has a
-	//     small chance of being true, specificaly (1 / target chunk size).
-	//  2. It assumes that the rolling hash window doesn't change the chunk
-	//     boundaries. In snd, the chunk boundary after [CC] is calculated with a
-	//     rolling hash primed with no values. In the new tree, it would be primed
-	//     with AABB.
-	//
-	// concat/appendCursorToChunker fixes this by starting the chunking at the
-	// beginning of the rightmost chunk of fst, then continuing through snd (a)
-	// beyond the chunk window, to solve Incorrect Reason 2, then (b) through to
-	// the next definite chunk boundary of snd, to solve Reason 1.
-	//
-	// Implementation-wise wise we can simply reuse sequenceChunker re-chunking
-	// logic, which automatically steps back to the start of the previous chunk
-	// (and can correctly prime the chunk window, etc), plus how to construct that
-	// resulting concatenated sequence.
+	// concat works by tricking the sequenceChunker into resuming chunking at a
+	// cursor to the end of fst, then finalizing chunking to the start of snd - by
+	// swapping fst cursors for snd cursors in the middle of chunking.
 	chunker := newSequenceChunker(newCursorAtIndex(fst, fst.numLeaves()))
-	appendCursorToChunker(chunker, newCursorAtIndex(snd, 0))
+
+	for cur, ch := newCursorAtIndex(snd, 0), chunker; cur != nil; cur = cur.parent {
+		// If fst is shallower than snd, its cur will have a parent whereas the
+		// chunker to snd won't. In that case, create a parent for fst.
+		// Note that if the inverse is true - snd is shallower than fst - this just
+		// means higher chunker levels will still have cursors from fst... which
+		// point to the end, so finalisation won't do anything. This is correct.
+		if ch.parent == nil {
+			ch.createParent()
+		}
+		ch.cur = cur
+		ch = ch.parent
+	}
+
 	return chunker.Done()
-}
-
-func appendCursorToChunker(chunker *sequenceChunker, cur *sequenceCursor) {
-	// Append beyond the chunk window, then through to the next definite chunk
-	// boundary.
-	hashWindow := chunkWindow
-	for cur.valid() && (hashWindow > 0 || cur.indexInChunk() != 0) {
-		hashWindow -= chunker.Append(cur.current())
-		cur.advance()
-	}
-
-	// There may not be a chunk boundary beyond the chunk window - terminate.
-	if !cur.valid() {
-		return
-	}
-
-	d.PanicIfTrue(len(chunker.current) > 0, "there were unchunked items")
-
-	// sequenceChunker's implementation will create parent chunkers while the
-	// cursor has a parent, and only trim then when Done is called.
-	d.PanicIfTrue(cur.parent == nil, "parent is nil")
-	d.PanicIfTrue(chunker.parent == nil, "chunker.parent is nil")
-
-	appendCursorToChunker(chunker.parent, cur.parent)
 }

--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import "github.com/attic-labs/noms/go/d"
+
+type newSequenceChunkerFn func(cur *sequenceCursor) *sequenceChunker
+
+func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence {
+	// To understand how concat (along with appendCursorToChunker) works, imagine
+	// *incorrectly* implementing concat using the simplest possible method:
+	// simply concatenate the sequences at each level.
+	//
+	//    [FF]
+	//  [AA] [BB]
+	//
+	//  +
+	//
+	//    [SS]
+	//  [CC] [DD]
+	//
+	//  =
+	//
+	//    [FF]       [SS]
+	//  [AA] [BB] [CC] [DD]
+	//
+	// which requires adding another level to the prolly tree to reference the
+	// roots of each tree:
+	//
+	//         [RR]
+	//    [FF]       [SS]
+	//  [AA] [BB] [CC] [DD]
+	//
+	// This is probably incorrect for 2 reasons:
+	//
+	//  1. It assumes that [BB] and [FF] each end on a chunk boundary, which has a
+	//     small chance of being true, specificaly (1 / target chunk size).
+	//  2. It assumes that the rolling hash window doesn't change the chunk
+	//     boundaries. In snd, the chunk boundary after [CC] is calculated with a
+	//     rolling hash primed with no values. In the new tree, it would be primed
+	//     with AABB.
+	//
+	// concat/appendCursorToChunker fixes this by starting the chunking at the
+	// beginning of the rightmost chunk of fst, then continuing through snd (a)
+	// beyond the chunk window, to solve Incorrect Reason 2, then (b) through to
+	// the next definite chunk boundary of snd, to solve Reason 1.
+	//
+	// Implementation-wise wise we can simply reuse sequenceChunker re-chunking
+	// logic, which automatically steps back to the start of the previous chunk
+	// (and can correctly prime the chunk window, etc), plus how to construct that
+	// resulting concatenated sequence.
+	chunker := newSequenceChunker(newCursorAtIndex(fst, fst.numLeaves()))
+	appendCursorToChunker(chunker, newCursorAtIndex(snd, 0))
+	return chunker.Done()
+}
+
+func appendCursorToChunker(chunker *sequenceChunker, cur *sequenceCursor) {
+	// Append beyond the chunk window, then through to the next definite chunk
+	// boundary.
+	for i := uint32(0); cur.valid() && (i < chunkWindow || cur.indexInChunk() != 0); i++ {
+		chunker.Append(cur.current())
+		cur.advance()
+	}
+
+	// There may not be a chunk bounary beyond the chunk window - terminate.
+	if !cur.valid() {
+		return
+	}
+
+	d.Chk.True(len(chunker.current) == 0)
+
+	// sequenceChunker's implementation will create parent chunkers while the
+	// cursor has a parent, and only trim then when Done is called.
+	d.Chk.NotNil(cur.parent)
+	d.Chk.NotNil(chunker.parent)
+
+	appendCursorToChunker(chunker.parent, cur.parent)
+}

--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -9,10 +9,10 @@ import "github.com/attic-labs/noms/go/d"
 type newSequenceChunkerFn func(cur *sequenceCursor, vr ValueReader) *sequenceChunker
 
 func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence {
-	if _, ok := fst.(emptySequence); ok {
+	if fst.numLeaves() == 0 {
 		return snd
 	}
-	if _, ok := snd.(emptySequence); ok {
+	if snd.numLeaves() == 0 {
 		return fst
 	}
 
@@ -32,7 +32,7 @@ func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence
 		if ch.parent == nil {
 			ch.createParent()
 		}
-		ch.cur = cur
+		ch.cur = cur.clone()
 		ch = ch.parent
 	}
 

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -138,6 +138,6 @@ func newCursorAtIndex(seq sequence, idx uint64) *sequenceCursor {
 		seq = cs
 	}
 
-	d.Chk.True(cur != nil)
+	d.PanicIfTrue(cur == nil)
 	return cur
 }

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -125,3 +125,19 @@ func (cur *sequenceCursor) iter(cb cursorIterCallback) {
 		cur.advance()
 	}
 }
+
+func newCursorAtIndex(seq sequence, idx uint64) *sequenceCursor {
+	var cur *sequenceCursor
+	for {
+		cur = newSequenceCursor(cur, seq, 0)
+		idx = idx - advanceCursorToOffset(cur, idx)
+		cs := cur.getChildSequence()
+		if cs == nil {
+			break
+		}
+		seq = cs
+	}
+
+	d.Chk.True(cur != nil)
+	return cur
+}

--- a/go/types/util_test.go
+++ b/go/types/util_test.go
@@ -34,17 +34,15 @@ func intsToValueSlice(ints ...int) ValueSlice {
 }
 
 func generateNumbersAsValues(n int) []Value {
-	d.Chk.True(n > 0, "must be an integer greater than zero")
 	return generateNumbersAsValuesFromToBy(0, n, 1)
 }
 
 func generateNumbersAsValueSlice(n int) ValueSlice {
-	d.Chk.True(n > 0, "must be an integer greater than zero")
 	return generateNumbersAsValuesFromToBy(0, n, 1)
 }
 
 func generateNumbersAsValuesFromToBy(from, to, by int) ValueSlice {
-	d.Chk.True(to > from, "to must be greater than from")
+	d.Chk.True(to >= from, "to must be greater than or equal to from")
 	d.Chk.True(by > 0, "must be an integer greater than zero")
 	nums := []Value{}
 	for i := from; i < to; i += by {
@@ -58,7 +56,7 @@ func generateNumbersAsStructs(n int) ValueSlice {
 }
 
 func generateNumbersAsStructsFromToBy(from, to, by int) ValueSlice {
-	d.Chk.True(to > from, "to must be greater than from")
+	d.Chk.True(to >= from, "to must be greater than or equal to from")
 	d.Chk.True(by > 0, "must be an integer greater than zero")
 	nums := []Value{}
 	for i := from; i < to; i += by {
@@ -68,7 +66,6 @@ func generateNumbersAsStructsFromToBy(from, to, by int) ValueSlice {
 }
 
 func generateNumbersAsRefOfStructs(n int) []Value {
-	d.Chk.True(n > 0, "must be an integer greater than zero")
 	vs := NewTestValueStore()
 	nums := []Value{}
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
It exploits the chunked structure of Lists to allow concatenating
arbitrarily large Lists.

I've added both functional and perf tests for Concat, and the perf tests
only made sense with tests for building and reading Lists, so now we
have those too.
