### PR TITLE
Allow changes to different Datasets to proceed concurrently

### DIFF
--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -227,6 +227,7 @@ func (suite *HTTPBatchStoreSuite) TestRoot() {
 func (suite *HTTPBatchStoreSuite) TestVersionMismatch() {
 	store := newBadVersionHTTPBatchStoreForTest(suite)
 	c := chunks.NewChunk([]byte("abc"))
+	suite.cs.Put(c)
 	suite.Panics(func() { store.UpdateRoot(c.Hash(), hash.Hash{}) })
 }
 

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -72,8 +72,8 @@ func versionCheck(hndlr Handler) Handler {
 
 		err := d.Try(func() { hndlr(w, req, ps, cs) })
 		if err != nil {
-			fmt.Printf("Returning bad request: %v\n", err)
-			http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
+			fmt.Printf("Returning bad request:\n%v\n", err)
+			http.Error(w, fmt.Sprintf("Error: %v", d.Unwrap(err)), http.StatusBadRequest)
 			return
 		}
 	}

--- a/go/dataset/dataset.go
+++ b/go/dataset/dataset.go
@@ -112,17 +112,17 @@ func (ds *Dataset) Pull(sourceDB datas.Database, sourceRef types.Ref, concurrenc
 }
 
 // FastForward takes a types.Ref to a Commit object and makes it the new Head of ds iff it is a descendant of the current Head. Intended to be used e.g. after a call to Pull(). If the update cannot be performed, e.g., because another process moved the current Head out from under you, err will be non-nil. The newest snapshot of the Dataset is always returned, so the caller an easily retry using the latest.
-func (ds *Dataset) FastForward(newHeadRef types.Ref) (sink Dataset, err error) {
-	sink = *ds
+func (ds *Dataset) FastForward(newHeadRef types.Ref) (Dataset, error) {
+	sink := *ds
 	if currentHeadRef, ok := sink.MaybeHeadRef(); ok && newHeadRef == currentHeadRef {
-		return
+		return sink, nil
 	} else if newHeadRef.Height() <= currentHeadRef.Height() {
 		return sink, datas.ErrMergeNeeded
 	}
 
-	for err = datas.ErrOptimisticLockFailed; err == datas.ErrOptimisticLockFailed; sink, err = sink.commitNewHead(newHeadRef) {
-	}
-	return
+	commit := ds.validateRefAsCommit(newHeadRef)
+	store, err := ds.Database().Commit(ds.id, commit)
+	return Dataset{store, ds.id}, err
 }
 
 // SetHead takes a types.Ref to a Commit object and makes it the new Head of ds. Intended to be used e.g. when rewinding in ds' Commit history. If the update cannot be performed, e.g., because the state of ds.Database() changed out from under you, err will be non-nil. The newest snapshot of the Dataset is always returned, so the caller an easily retry using the latest.
@@ -147,11 +147,4 @@ func (ds *Dataset) validateRefAsCommit(r types.Ref) types.Struct {
 		panic("Not a commit: " + types.EncodedValue(v))
 	}
 	return v.(types.Struct)
-}
-
-// commitNewHead attempts to make the object pointed to by newHeadRef the new Head of ds. First, it checks that the object exists in ds and validates that it decodes to the correct type of value. Next, it attempts to commit the object to ds.Database(). This may fail if, for instance, the Head of ds has been changed by another goroutine or process. In the event that the commit fails, the error from Database().Commit() is returned along with a new Dataset that's at it's proper, current Head. The caller should take any necessary corrective action and try again using this new Dataset.
-func (ds *Dataset) commitNewHead(newHeadRef types.Ref) (Dataset, error) {
-	commit := ds.validateRefAsCommit(newHeadRef)
-	store, err := ds.Database().Commit(ds.id, commit)
-	return Dataset{store, ds.id}, err
 }


### PR DESCRIPTION
Prior to this change, concurrent modification of two different
Datasets in a given Database would result in an
ErrOptimisticLockFailed for whichever process lost the race. As of
this patch, concurrent changes to the _same_ Dataset will result in an
ErrMergeNeeded for the loser, but concurrent changes to different
Datasets will succeed.

Fixes #2524