### PR TITLE
Add FindCommonAncestor for Commits

### DIFF
--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -5,6 +5,8 @@
 package datas
 
 import (
+	"sort"
+
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
 )
@@ -64,6 +66,50 @@ func CommitDescendsFrom(commit types.Struct, ancestor types.Ref, vr types.ValueR
 		ancestors = getAncestors(ancestors, ancestor.Height(), vr)
 	}
 	return true
+}
+
+// FindCommonAncestor returns the most recent common ancestor of c1 and c2, if
+// one exists, setting ok to true. If there is no common ancestor, ok is set to false.
+func FindCommonAncestor(c1, c2 types.Struct, vr types.ValueReader) (a types.Struct, ok bool) {
+	c1Q, c2Q := &types.RefByHeight{types.NewRef(c1)}, &types.RefByHeight{types.NewRef(c2)}
+
+	makeSet := func(refs types.RefSlice) types.Set {
+		vals := make(types.ValueSlice, refs.Len())
+		for i, r := range refs {
+			vals[i] = r
+		}
+		return types.NewSet(vals...)
+	}
+
+	for !c1Q.Empty() && !c2Q.Empty() {
+		c1Ht, c2Ht := c1Q.MaxHeight(), c2Q.MaxHeight()
+		if c1Ht == c2Ht {
+			c1Parents, c2Parents := c1Q.PopRefsOfHeight(c1Ht), c2Q.PopRefsOfHeight(c2Ht)
+			intersection := types.NewIntersectionIterator(makeSet(c1Parents).Iterator(), makeSet(c2Parents).Iterator())
+			if common := intersection.Next(); common != nil {
+				return common.(types.Ref).TargetValue(vr).(types.Struct), true
+			}
+
+			parentsToQueue(c1Parents, c1Q, vr)
+			parentsToQueue(c2Parents, c2Q, vr)
+		} else if c1Ht > c2Ht {
+			parentsToQueue(c1Q.PopRefsOfHeight(c1Ht), c1Q, vr)
+		} else {
+			parentsToQueue(c2Q.PopRefsOfHeight(c2Ht), c2Q, vr)
+		}
+	}
+	return
+}
+
+func parentsToQueue(refs types.RefSlice, q *types.RefByHeight, vr types.ValueReader) {
+	for _, r := range refs {
+		c := r.TargetValue(vr).(types.Struct)
+		p := c.Get(ParentsField).(types.Set)
+		p.IterAll(func(v types.Value) {
+			q.PushBack(v.(types.Ref))
+		})
+	}
+	sort.Sort(q)
 }
 
 // getAncestors returns set of direct ancestors with height >= minHeight

--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -70,10 +70,13 @@ func CommitDescendsFrom(commit types.Struct, ancestor types.Ref, vr types.ValueR
 }
 
 // FindCommonAncestor returns the most recent common ancestor of c1 and c2, if
-// one exists, setting ok to true. If there is no common ancestor, ok is set to false.
+// one exists, setting ok to true. If there is no common ancestor, ok is set
+// to false.
 func FindCommonAncestor(c1, c2 types.Struct, vr types.ValueReader) (a types.Struct, ok bool) {
-	c1Q, c2Q := &types.RefByHeight{types.NewRef(c1)}, &types.RefByHeight{types.NewRef(c2)}
+	d.PanicIfFalse(IsCommitType(c1.Type()), "FindCommonAncestor() called on %s", c1.Type().Describe())
+	d.PanicIfFalse(IsCommitType(c2.Type()), "FindCommonAncestor() called on %s", c2.Type().Describe())
 
+	c1Q, c2Q := &types.RefByHeight{types.NewRef(c1)}, &types.RefByHeight{types.NewRef(c2)}
 	for !c1Q.Empty() && !c2Q.Empty() {
 		c1Ht, c2Ht := c1Q.MaxHeight(), c2Q.MaxHeight()
 		if c1Ht == c2Ht {
@@ -81,7 +84,6 @@ func FindCommonAncestor(c1, c2 types.Struct, vr types.ValueReader) (a types.Stru
 			if common := findCommonRef(c1Parents, c2Parents); (common != types.Ref{}) {
 				return common.TargetValue(vr).(types.Struct), true
 			}
-
 			parentsToQueue(c1Parents, c1Q, vr)
 			parentsToQueue(c2Parents, c2Q, vr)
 		} else if c1Ht > c2Ht {

--- a/go/types/ref_heap.go
+++ b/go/types/ref_heap.go
@@ -69,6 +69,20 @@ func (h *RefByHeight) Unique() {
 	*h = result
 }
 
+// PopRefsOfHeight pops off and returns all refs r in h for which r.Height() == height.
+func (h *RefByHeight) PopRefsOfHeight(height uint64) (refs RefSlice) {
+	for h.MaxHeight() == height {
+		r := h.PopBack()
+		refs = append(refs, r)
+	}
+	return
+}
+
+// MaxHeight returns the height of the 'tallest' Ref in h.
+func (h RefByHeight) MaxHeight() uint64 {
+	return h.PeekEnd().Height()
+}
+
 func (h RefByHeight) Empty() bool {
 	return h.Len() == 0
 }

--- a/go/types/ref_heap_test.go
+++ b/go/types/ref_heap_test.go
@@ -86,3 +86,21 @@ func TestDropIndices(t *testing.T) {
 		assert.NotContains(t, *h, dropped, "Should not contain %d", toDrop[i])
 	}
 }
+
+func TestPopRefsOfHeight(t *testing.T) {
+	h := &RefByHeight{}
+	for i, n := range []int{6, 3, 6, 6, 2} {
+		r := NewRef(Number(i))
+		r.height = uint64(n)
+		h.PushBack(r)
+	}
+	sort.Sort(h)
+
+	expected := RefSlice{h.PeekAt(4), h.PeekAt(3), h.PeekAt(2)}
+	refs := h.PopRefsOfHeight(h.MaxHeight())
+	assert.Len(t, *h, 2)
+	assert.Len(t, refs, 3)
+	for _, popped := range expected {
+		assert.NotContains(t, *h, popped, "Should not contain ref of height 6")
+	}
+}


### PR DESCRIPTION
Once we integrate noms-merge into the `noms commit` command, this
function will allow us to stop requiring users to pass in the common
ancestor to be used when merging. The code can just find it and merge
away.

Toward #2535