### PR TITLE
Go sequence interface/struct hierarchy refactor

### DIFF
--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -16,11 +16,11 @@ import (
 
 // Blob represents a list of Blobs.
 type Blob struct {
-	seq indexedSequence
+	seq sequence
 	h   *hash.Hash
 }
 
-func newBlob(seq indexedSequence) Blob {
+func newBlob(seq sequence) Blob {
 	return Blob{seq, &hash.Hash{}}
 }
 
@@ -52,7 +52,7 @@ func (b Blob) Splice(idx uint64, deleteCount uint64, data []byte) Blob {
 	for _, v := range data {
 		ch.Append(v)
 	}
-	return newBlob(ch.Done().(indexedSequence))
+	return newBlob(ch.Done())
 }
 
 // Collection interface
@@ -102,7 +102,7 @@ func (b Blob) Type() *Type {
 }
 
 type BlobReader struct {
-	seq           indexedSequence
+	seq           sequence
 	cursor        *sequenceCursor
 	currentReader io.ReadSeeker
 	pos           uint64
@@ -247,5 +247,5 @@ func NewStreamingBlob(r io.Reader, vrw ValueReadWriter) Blob {
 		sc.parent.Append(b.(metaTuple))
 	}
 
-	return newBlob(sc.Done().(indexedSequence))
+	return newBlob(sc.Done())
 }

--- a/go/types/blob_leaf_sequence.go
+++ b/go/types/blob_leaf_sequence.go
@@ -5,18 +5,15 @@
 package types
 
 type blobLeafSequence struct {
+	leafSequence
 	data []byte
-	vr   ValueReader
 }
 
-func newBlobLeafSequence(vr ValueReader, data []byte) indexedSequence {
-	return blobLeafSequence{data, vr}
+func newBlobLeafSequence(vr ValueReader, data []byte) sequence {
+	return blobLeafSequence{leafSequence{vr, len(data), BlobType}, data}
 }
 
-// indexedSequence interface
-func (bl blobLeafSequence) cumulativeNumberOfLeaves(idx int) uint64 {
-	return uint64(idx) + 1
-}
+// sequence interface
 
 func (bl blobLeafSequence) getCompareFn(other sequence) compareFn {
 	otherbl := other.(blobLeafSequence)
@@ -25,27 +22,10 @@ func (bl blobLeafSequence) getCompareFn(other sequence) compareFn {
 	}
 }
 
-// sequence interface
 func (bl blobLeafSequence) getItem(idx int) sequenceItem {
 	return bl.data[idx]
 }
 
-func (bl blobLeafSequence) seqLen() int {
-	return len(bl.data)
-}
-
-func (bl blobLeafSequence) numLeaves() uint64 {
-	return uint64(len(bl.data))
-}
-
-func (bl blobLeafSequence) valueReader() ValueReader {
-	return bl.vr
-}
-
 func (bl blobLeafSequence) Chunks() []Ref {
 	return []Ref{}
-}
-
-func (bl blobLeafSequence) Type() *Type {
-	return BlobType
 }

--- a/go/types/get_hash_test.go
+++ b/go/types/get_hash_test.go
@@ -39,17 +39,17 @@ func TestEnsureHash(t *testing.T) {
 
 	ll := newList(newListLeafSequence(nil, String("foo")))
 	lt := MakeListType(StringType)
-	cl := newList(newIndexedMetaSequence([]metaTuple{{Ref{}, newOrderedKey(Number(1)), 1, ll}}, lt, vs))
+	cl := newList(newMetaSequence([]metaTuple{{Ref{}, newOrderedKey(Number(1)), 1, ll}}, lt, vs))
 
 	newStringOrderedKey := func(s string) orderedKey {
 		return newOrderedKey(String(s))
 	}
 
 	ml := newMap(newMapLeafSequence(nil, mapEntry{String("foo"), String("bar")}))
-	cm := newMap(newOrderedMetaSequence([]metaTuple{{Ref{}, newStringOrderedKey("foo"), 1, ml}}, MakeMapType(StringType, StringType), vs))
+	cm := newMap(newMetaSequence([]metaTuple{{Ref{}, newStringOrderedKey("foo"), 1, ml}}, MakeMapType(StringType, StringType), vs))
 
 	sl := newSet(newSetLeafSequence(nil, String("foo")))
-	cps := newSet(newOrderedMetaSequence([]metaTuple{{Ref{}, newStringOrderedKey("foo"), 1, sl}}, MakeSetType(StringType), vs))
+	cps := newSet(newMetaSequence([]metaTuple{{Ref{}, newStringOrderedKey("foo"), 1, sl}}, MakeSetType(StringType), vs))
 
 	count = byte(1)
 	values := []Value{

--- a/go/types/indexed_sequence_diff.go
+++ b/go/types/indexed_sequence_diff.go
@@ -13,14 +13,14 @@ func sendSpliceChange(changes chan<- Splice, closeChan <-chan struct{}, splice S
 	return true
 }
 
-func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64, current indexedSequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) bool {
+func indexedSequenceDiff(last sequence, lastHeight int, lastOffset uint64, current sequence, currentHeight int, currentOffset uint64, changes chan<- Splice, closeChan <-chan struct{}, maxSpliceMatrixSize uint64) bool {
 	if lastHeight > currentHeight {
-		lastChild := last.(indexedMetaSequence).getCompositeChildSequence(0, uint64(last.seqLen())).(indexedSequence)
+		lastChild := last.(metaSequence).getCompositeChildSequence(0, uint64(last.seqLen()))
 		return indexedSequenceDiff(lastChild, lastHeight-1, lastOffset, current, currentHeight, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
 	if currentHeight > lastHeight {
-		currentChild := current.(indexedMetaSequence).getCompositeChildSequence(0, uint64(current.seqLen())).(indexedSequence)
+		currentChild := current.(metaSequence).getCompositeChildSequence(0, uint64(current.seqLen()))
 		return indexedSequenceDiff(last, lastHeight, lastOffset, currentChild, currentHeight-1, currentOffset, changes, closeChan, maxSpliceMatrixSize)
 	}
 
@@ -42,23 +42,26 @@ func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64
 			continue
 		}
 
+		lastMeta := last.(metaSequence)
+		currentMeta := current.(metaSequence)
+
 		if splice.SpRemoved == 0 || splice.SpAdded == 0 {
 			// An entire subtree was removed at a meta level. We must do some math to map the splice from the meta level into the leaf coordinates.
 			beginRemoveIndex := uint64(0)
 			if splice.SpAt > 0 {
-				beginRemoveIndex = last.cumulativeNumberOfLeaves(int(splice.SpAt) - 1)
+				beginRemoveIndex = lastMeta.cumulativeNumberOfLeaves(int(splice.SpAt) - 1)
 			}
 			endRemoveIndex := uint64(0)
 			if splice.SpAt+splice.SpRemoved > 0 {
-				endRemoveIndex = last.cumulativeNumberOfLeaves(int(splice.SpAt+splice.SpRemoved) - 1)
+				endRemoveIndex = lastMeta.cumulativeNumberOfLeaves(int(splice.SpAt+splice.SpRemoved) - 1)
 			}
 			beginAddIndex := uint64(0)
 			if splice.SpFrom > 0 {
-				beginAddIndex = current.cumulativeNumberOfLeaves(int(splice.SpFrom) - 1)
+				beginAddIndex = currentMeta.cumulativeNumberOfLeaves(int(splice.SpFrom) - 1)
 			}
 			endAddIndex := uint64(0)
 			if splice.SpFrom+splice.SpAdded > 0 {
-				endAddIndex = current.cumulativeNumberOfLeaves(int(splice.SpFrom+splice.SpAdded) - 1)
+				endAddIndex = currentMeta.cumulativeNumberOfLeaves(int(splice.SpFrom+splice.SpAdded) - 1)
 			}
 
 			splice.SpAt = lastOffset + beginRemoveIndex
@@ -76,15 +79,15 @@ func indexedSequenceDiff(last indexedSequence, lastHeight int, lastOffset uint64
 		}
 
 		// Meta sequence splice which includes removed & added sub-sequences. Must recurse down.
-		lastChild := last.(indexedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(indexedSequence)
-		currentChild := current.(indexedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(indexedSequence)
+		lastChild := lastMeta.getCompositeChildSequence(splice.SpAt, splice.SpRemoved)
+		currentChild := currentMeta.getCompositeChildSequence(splice.SpFrom, splice.SpAdded)
 		lastChildOffset := lastOffset
 		if splice.SpAt > 0 {
-			lastChildOffset += last.cumulativeNumberOfLeaves(int(splice.SpAt) - 1)
+			lastChildOffset += lastMeta.cumulativeNumberOfLeaves(int(splice.SpAt) - 1)
 		}
 		currentChildOffset := currentOffset
 		if splice.SpFrom > 0 {
-			currentChildOffset += current.cumulativeNumberOfLeaves(int(splice.SpFrom) - 1)
+			currentChildOffset += currentMeta.cumulativeNumberOfLeaves(int(splice.SpFrom) - 1)
 		}
 		if ok := indexedSequenceDiff(lastChild, lastHeight-1, lastChildOffset, currentChild, currentHeight-1, currentChildOffset, changes, closeChan, maxSpliceMatrixSize); !ok {
 			return false

--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+type leafSequence struct {
+	vr     ValueReader
+	length int
+	t      *Type
+}
+
+func (seq leafSequence) seqLen() int {
+	return seq.length
+}
+
+func (seq leafSequence) numLeaves() uint64 {
+	return uint64(seq.length)
+}
+
+func (seq leafSequence) valueReader() ValueReader {
+	return seq.vr
+}
+
+func (seq leafSequence) Type() *Type {
+	return seq.t
+}
+
+func (seq leafSequence) getChildSequence(idx int) sequence {
+	return nil
+}

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -19,11 +19,11 @@ import (
 //
 // Lists, like all Noms values are immutable so the "mutation" methods return a new list.
 type List struct {
-	seq indexedSequence
+	seq sequence
 	h   *hash.Hash
 }
 
-func newList(seq indexedSequence) List {
+func newList(seq sequence) List {
 	return List{seq, &hash.Hash{}}
 }
 
@@ -34,7 +34,7 @@ func NewList(values ...Value) List {
 	for _, v := range values {
 		seq.Append(v)
 	}
-	return newList(seq.Done().(indexedSequence))
+	return newList(seq.Done())
 }
 
 // NewStreamingList creates a new List, populated with values, chunking if and when needed. As
@@ -47,7 +47,7 @@ func NewStreamingList(vrw ValueReadWriter, values <-chan Value) <-chan List {
 		for v := range values {
 			seq.Append(v)
 		}
-		out <- newList(seq.Done().(indexedSequence))
+		out <- newList(seq.Done())
 		close(out)
 	}()
 	return out
@@ -171,7 +171,7 @@ func (l List) Splice(idx uint64, deleteCount uint64, vs ...Value) List {
 	for _, v := range vs {
 		ch.Append(v)
 	}
-	return newList(ch.Done().(indexedSequence))
+	return newList(ch.Done())
 }
 
 // Insert returns a new list where vs values have been inserted at idx.
@@ -186,7 +186,7 @@ func (l List) Concat(other List) List {
 	seq := concat(l.seq, other.seq, func(cur *sequenceCursor, vr ValueReader) *sequenceChunker {
 		return l.newChunker(cur, vr)
 	})
-	return newList(seq.(indexedSequence))
+	return newList(seq)
 }
 
 // Remove returns a new list where the items at index start (inclusive) through end (exclusive) have

--- a/go/types/list_leaf_sequence.go
+++ b/go/types/list_leaf_sequence.go
@@ -5,24 +5,20 @@
 package types
 
 type listLeafSequence struct {
+	leafSequence
 	values []Value
-	t      *Type
-	vr     ValueReader
 }
 
-func newListLeafSequence(vr ValueReader, v ...Value) indexedSequence {
+func newListLeafSequence(vr ValueReader, v ...Value) sequence {
 	ts := make([]*Type, len(v))
 	for i, v := range v {
 		ts[i] = v.Type()
 	}
 	t := MakeListType(MakeUnionType(ts...))
-	return listLeafSequence{v, t, vr}
+	return listLeafSequence{leafSequence{vr, len(v), t}, v}
 }
 
-// indexedSequence interface
-func (ll listLeafSequence) cumulativeNumberOfLeaves(idx int) uint64 {
-	return uint64(idx) + 1
-}
+// sequence interface
 
 func (ll listLeafSequence) getCompareFn(other sequence) compareFn {
 	oll := other.(listLeafSequence)
@@ -31,21 +27,8 @@ func (ll listLeafSequence) getCompareFn(other sequence) compareFn {
 	}
 }
 
-// sequence interface
 func (ll listLeafSequence) getItem(idx int) sequenceItem {
 	return ll.values[idx]
-}
-
-func (ll listLeafSequence) seqLen() int {
-	return len(ll.values)
-}
-
-func (ll listLeafSequence) numLeaves() uint64 {
-	return uint64(len(ll.values))
-}
-
-func (ll listLeafSequence) valueReader() ValueReader {
-	return ll.vr
 }
 
 func (ll listLeafSequence) Chunks() (chunks []Ref) {
@@ -53,8 +36,4 @@ func (ll listLeafSequence) Chunks() (chunks []Ref) {
 		chunks = append(chunks, v.Chunks()...)
 	}
 	return
-}
-
-func (ll listLeafSequence) Type() *Type {
-	return ll.t
 }

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -1037,7 +1037,7 @@ func TestListTypeAfterMutations(t *testing.T) {
 	}
 
 	test(15, listLeafSequence{})
-	test(1500, indexedMetaSequence{})
+	test(1500, metaSequence{})
 }
 
 func TestListRemoveLastWhenNotLoaded(t *testing.T) {

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -5,9 +5,8 @@
 package types
 
 type mapLeafSequence struct {
+	leafSequence
 	data []mapEntry // sorted by entry.key.Hash()
-	t    *Type
-	vr   ValueReader
 }
 
 type mapEntry struct {
@@ -42,24 +41,13 @@ func newMapLeafSequence(vr ValueReader, data ...mapEntry) orderedSequence {
 		vts[i] = e.value.Type()
 	}
 	t := MakeMapType(MakeUnionType(kts...), MakeUnionType(vts...))
-	return mapLeafSequence{data, t, vr}
+	return mapLeafSequence{leafSequence{vr, len(data), t}, data}
 }
 
 // sequence interface
+
 func (ml mapLeafSequence) getItem(idx int) sequenceItem {
 	return ml.data[idx]
-}
-
-func (ml mapLeafSequence) seqLen() int {
-	return len(ml.data)
-}
-
-func (ml mapLeafSequence) numLeaves() uint64 {
-	return uint64(len(ml.data))
-}
-
-func (ml mapLeafSequence) valueReader() ValueReader {
-	return ml.vr
 }
 
 func (ml mapLeafSequence) Chunks() (chunks []Ref) {
@@ -70,15 +58,6 @@ func (ml mapLeafSequence) Chunks() (chunks []Ref) {
 	return
 }
 
-func (ml mapLeafSequence) Type() *Type {
-	return ml.t
-}
-
-// orderedSequence interface
-func (ml mapLeafSequence) getKey(idx int) orderedKey {
-	return newOrderedKey(ml.data[idx].key)
-}
-
 func (ml mapLeafSequence) getCompareFn(other sequence) compareFn {
 	oml := other.(mapLeafSequence)
 	return func(idx, otherIdx int) bool {
@@ -86,6 +65,12 @@ func (ml mapLeafSequence) getCompareFn(other sequence) compareFn {
 		otherEntry := oml.data[otherIdx]
 		return entry.key.Equals(otherEntry.key) && entry.value.Equals(otherEntry.value)
 	}
+}
+
+// orderedSequence interface
+
+func (ml mapLeafSequence) getKey(idx int) orderedKey {
+	return newOrderedKey(ml.data[idx].key)
 }
 
 // Collection interface

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -1145,7 +1145,7 @@ func TestMapTypeAfterMutations(t *testing.T) {
 	}
 
 	test(10, mapLeafSequence{})
-	test(1000, orderedMetaSequence{})
+	test(1000, metaSequence{})
 }
 
 func TestCompoundMapWithValuesOfEveryType(t *testing.T) {

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -18,12 +18,6 @@ const (
 
 var emptyKey = orderedKey{}
 
-// metaSequence is a logical abstraction, but has no concrete "base" implementation. A Meta Sequence is a non-leaf (internal) node of a Prolly Tree, which results from the chunking of an ordered or unordered sequence of values.
-type metaSequence interface {
-	sequence
-	getChildSequence(idx int) sequence
-}
-
 func newMetaTuple(ref Ref, key orderedKey, numLeaves uint64, child Collection) metaTuple {
 	d.PanicIfFalse(Ref{} != ref)
 	return metaTuple{ref, key, numLeaves, child}
@@ -72,10 +66,6 @@ func orderedKeyFromUint64(n uint64) orderedKey {
 	return newOrderedKey(Number(n))
 }
 
-func (key orderedKey) uint64Value() uint64 {
-	return uint64(key.v.(Number))
-}
-
 func (key orderedKey) Less(mk2 orderedKey) bool {
 	switch {
 	case key.isOrderedByValue && mk2.isOrderedByValue:
@@ -90,37 +80,53 @@ func (key orderedKey) Less(mk2 orderedKey) bool {
 	}
 }
 
-type metaSequenceData []metaTuple
-
-func (msd metaSequenceData) last() metaTuple {
-	return msd[len(msd)-1]
+type metaSequence struct {
+	tuples []metaTuple
+	t      *Type
+	vr     ValueReader
 }
 
-type metaSequenceObject struct {
-	tuples    metaSequenceData
-	t         *Type
-	vr        ValueReader
-	leafCount uint64
+func newMetaSequence(tuples []metaTuple, t *Type, vr ValueReader) metaSequence {
+	return metaSequence{tuples, t, vr}
 }
 
-func (ms metaSequenceObject) data() metaSequenceData {
+func (ms metaSequence) data() []metaTuple {
 	return ms.tuples
 }
 
+func (ms metaSequence) getKey(idx int) orderedKey {
+	return ms.tuples[idx].key
+}
+
+func (ms metaSequence) cumulativeNumberOfLeaves(idx int) uint64 {
+	cum := uint64(0)
+	for i := 0; i <= idx; i++ {
+		cum += ms.tuples[i].numLeaves
+	}
+	return cum
+}
+
+func (ms metaSequence) getCompareFn(other sequence) compareFn {
+	oms := other.(metaSequence)
+	return func(idx, otherIdx int) bool {
+		return ms.tuples[idx].ref.TargetHash() == oms.tuples[otherIdx].ref.TargetHash()
+	}
+}
+
 // sequence interface
-func (ms metaSequenceObject) getItem(idx int) sequenceItem {
+func (ms metaSequence) getItem(idx int) sequenceItem {
 	return ms.tuples[idx]
 }
 
-func (ms metaSequenceObject) seqLen() int {
+func (ms metaSequence) seqLen() int {
 	return len(ms.tuples)
 }
 
-func (ms metaSequenceObject) valueReader() ValueReader {
+func (ms metaSequence) valueReader() ValueReader {
 	return ms.vr
 }
 
-func (ms metaSequenceObject) Chunks() []Ref {
+func (ms metaSequence) Chunks() []Ref {
 	chunks := make([]Ref, len(ms.tuples))
 	for i, tuple := range ms.tuples {
 		chunks[i] = tuple.ref
@@ -128,21 +134,21 @@ func (ms metaSequenceObject) Chunks() []Ref {
 	return chunks
 }
 
-func (ms metaSequenceObject) Type() *Type {
+func (ms metaSequence) Type() *Type {
 	return ms.t
 }
 
-func (ms metaSequenceObject) numLeaves() uint64 {
-	return ms.leafCount
+func (ms metaSequence) numLeaves() uint64 {
+	return ms.cumulativeNumberOfLeaves(len(ms.tuples) - 1)
 }
 
 // metaSequence interface
-func (ms metaSequenceObject) getChildSequence(idx int) sequence {
+func (ms metaSequence) getChildSequence(idx int) sequence {
 	mt := ms.tuples[idx]
 	return mt.getChildSequence(ms.vr)
 }
 
-func (ms metaSequenceObject) beginFetchingChildSequences(start, length uint64) chan interface{} {
+func (ms metaSequence) beginFetchingChildSequences(start, length uint64) chan interface{} {
 	input := make(chan interface{})
 	output := orderedparallel.New(input, func(item interface{}) interface{} {
 		i := item.(int)
@@ -161,7 +167,7 @@ func (ms metaSequenceObject) beginFetchingChildSequences(start, length uint64) c
 
 // Returns the sequences pointed to by all items[i], s.t. start <= i < end, and returns the
 // concatentation as one long composite sequence
-func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint64) sequence {
+func (ms metaSequence) getCompositeChildSequence(start uint64, length uint64) sequence {
 	if length == 0 {
 		return emptySequence{}
 	}
@@ -181,12 +187,9 @@ func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint
 		seq := item.(sequence)
 
 		switch t := seq.(type) {
-		case indexedMetaSequence:
+		case metaSequence:
 			childIsMeta = true
-			metaItems = append(metaItems, t.metaSequenceObject.tuples...)
-		case orderedMetaSequence:
-			childIsMeta = true
-			metaItems = append(metaItems, t.metaSequenceObject.tuples...)
+			metaItems = append(metaItems, t.tuples...)
 		case mapLeafSequence:
 			mapItems = append(mapItems, t.data...)
 		case setLeafSequence:
@@ -198,18 +201,18 @@ func (ms metaSequenceObject) getCompositeChildSequence(start uint64, length uint
 		}
 	}
 
+	if childIsMeta {
+		return newMetaSequence(metaItems, ms.Type(), ms.vr)
+	}
+
 	if isIndexedSequence {
-		if childIsMeta {
-			return newIndexedMetaSequence(metaItems, ms.Type(), ms.vr)
-		}
 		return newListLeafSequence(ms.vr, valueItems...)
 	}
-	if childIsMeta {
-		return newOrderedMetaSequence(metaItems, ms.Type(), ms.vr)
-	}
+
 	if MapKind == ms.Type().Kind() {
 		return newMapLeafSequence(ms.vr, mapItems...)
 	}
+
 	return newSetLeafSequence(ms.vr, valueItems...)
 }
 
@@ -278,4 +281,8 @@ func (es emptySequence) getKey(idx int) orderedKey {
 
 func (es emptySequence) cumulativeNumberOfLeaves(idx int) uint64 {
 	panic("empty sequence")
+}
+
+func (es emptySequence) getChildSequence(i int) sequence {
+	return nil
 }

--- a/go/types/ordered_sequences_diff.go
+++ b/go/types/ordered_sequences_diff.go
@@ -121,12 +121,12 @@ func orderedSequenceDiffTopDown(last orderedSequence, current orderedSequence, c
 // TODO - something other than the literal edit-distance, which is way too much cpu work for this case - https://github.com/attic-labs/noms/issues/2027
 func orderedSequenceDiffInternalNodes(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, stopChan <-chan struct{}, lastHeight, currentHeight int) bool {
 	if lastHeight > currentHeight {
-		lastChild := last.(orderedMetaSequence).getCompositeChildSequence(0, uint64(last.seqLen())).(orderedSequence)
+		lastChild := last.(metaSequence).getCompositeChildSequence(0, uint64(last.seqLen())).(orderedSequence)
 		return orderedSequenceDiffInternalNodes(lastChild, current, changes, stopChan, lastHeight-1, currentHeight)
 	}
 
 	if currentHeight > lastHeight {
-		currentChild := current.(orderedMetaSequence).getCompositeChildSequence(0, uint64(current.seqLen())).(orderedSequence)
+		currentChild := current.(metaSequence).getCompositeChildSequence(0, uint64(current.seqLen())).(orderedSequence)
 		return orderedSequenceDiffInternalNodes(last, currentChild, changes, stopChan, lastHeight, currentHeight-1)
 	}
 
@@ -142,10 +142,10 @@ func orderedSequenceDiffInternalNodes(last orderedSequence, current orderedSeque
 		var lastChild, currentChild orderedSequence
 		functions.All(
 			func() {
-				lastChild = last.(orderedMetaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
+				lastChild = last.(metaSequence).getCompositeChildSequence(splice.SpAt, splice.SpRemoved).(orderedSequence)
 			},
 			func() {
-				currentChild = current.(orderedMetaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
+				currentChild = current.(metaSequence).getCompositeChildSequence(splice.SpFrom, splice.SpAdded).(orderedSequence)
 			},
 		)
 		if ok := orderedSequenceDiffInternalNodes(lastChild, currentChild, changes, stopChan, lastHeight-1, currentHeight-1); !ok {

--- a/go/types/sequence.go
+++ b/go/types/sequence.go
@@ -16,4 +16,5 @@ type sequence interface {
 	Chunks() []Ref
 	Type() *Type
 	getCompareFn(other sequence) compareFn
+	getChildSequence(idx int) sequence
 }

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -14,12 +14,14 @@ type sequenceCursor struct {
 }
 
 func newSequenceCursor(parent *sequenceCursor, seq sequence, idx int) *sequenceCursor {
+	d.PanicIfTrue(seq == nil)
 	if idx < 0 {
 		idx += seq.seqLen()
 		d.PanicIfFalse(idx >= 0)
 	}
 
-	return &sequenceCursor{parent, seq, idx}
+	cur := &sequenceCursor{parent, seq, idx}
+	return cur
 }
 
 func (cur *sequenceCursor) length() int {
@@ -36,10 +38,7 @@ func (cur *sequenceCursor) sync() {
 }
 
 func (cur *sequenceCursor) getChildSequence() sequence {
-	if ms, ok := cur.seq.(metaSequence); ok {
-		return ms.getChildSequence(cur.idx)
-	}
-	return nil
+	return cur.seq.getChildSequence(cur.idx)
 }
 
 // Returns the value the cursor refers to. Fails an assertion if the cursor doesn't point to a value.

--- a/go/types/sequence_cursor_test.go
+++ b/go/types/sequence_cursor_test.go
@@ -39,7 +39,6 @@ func (ts testSequence) valueReader() ValueReader {
 	panic("not reached")
 }
 
-// metaSequence interface
 func (ts testSequence) getChildSequence(idx int) sequence {
 	child := ts.items[idx]
 	return testSequence{child.([]interface{})}

--- a/go/types/set_leaf_sequence.go
+++ b/go/types/set_leaf_sequence.go
@@ -5,9 +5,8 @@
 package types
 
 type setLeafSequence struct {
+	leafSequence
 	data []Value // sorted by Hash()
-	t    *Type
-	vr   ValueReader
 }
 
 func newSetLeafSequence(vr ValueReader, v ...Value) orderedSequence {
@@ -16,24 +15,13 @@ func newSetLeafSequence(vr ValueReader, v ...Value) orderedSequence {
 		ts[i] = v.Type()
 	}
 	t := MakeSetType(MakeUnionType(ts...))
-	return setLeafSequence{v, t, vr}
+	return setLeafSequence{leafSequence{vr, len(v), t}, v}
 }
 
 // sequence interface
+
 func (sl setLeafSequence) getItem(idx int) sequenceItem {
 	return sl.data[idx]
-}
-
-func (sl setLeafSequence) seqLen() int {
-	return len(sl.data)
-}
-
-func (sl setLeafSequence) numLeaves() uint64 {
-	return uint64(len(sl.data))
-}
-
-func (sl setLeafSequence) valueReader() ValueReader {
-	return sl.vr
 }
 
 func (sl setLeafSequence) Chunks() (chunks []Ref) {
@@ -43,19 +31,16 @@ func (sl setLeafSequence) Chunks() (chunks []Ref) {
 	return
 }
 
-func (sl setLeafSequence) Type() *Type {
-	return sl.t
-}
-
-// orderedSequence interface
-func (sl setLeafSequence) getKey(idx int) orderedKey {
-	return newOrderedKey(sl.data[idx])
-}
-
 func (sl setLeafSequence) getCompareFn(other sequence) compareFn {
 	osl := other.(setLeafSequence)
 	return func(idx, otherIdx int) bool {
 		entry := sl.data[idx]
 		return entry.Equals(osl.data[otherIdx])
 	}
+}
+
+// orderedSequence interface
+
+func (sl setLeafSequence) getKey(idx int) orderedKey {
+	return newOrderedKey(sl.data[idx])
 }

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -912,7 +912,7 @@ func TestSetTypeAfterMutations(t *testing.T) {
 	}
 
 	test(10, setLeafSequence{})
-	test(2000, orderedMetaSequence{})
+	test(2000, metaSequence{})
 }
 
 func TestChunkedSetWithValuesOfEveryType(t *testing.T) {


### PR DESCRIPTION
This makes a number of changes to simplify code:
- metaSequence is now a struct, not an interface
- orderedMetaSequence and indexedMetaSequence is gone
- metaSequenceObject is gone
- indexedSequence is gone
- add leafSequence struct for leaf sequences to embed
