### PR TITLE
Remove TypeDesc equals

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "59.0.2",
+  "version": "60.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/encoding-test.js
+++ b/js/noms/src/encoding-test.js
@@ -34,8 +34,8 @@ import {
   newSetMetaSequence,
 } from './meta-sequence.js';
 import {
-  boolType,
   blobType,
+  boolType,
   makeCycleType,
   makeListType,
   makeMapType,
@@ -45,6 +45,7 @@ import {
   numberType,
   stringType,
   typeType,
+  valueType,
 } from './type.js';
 import type {Type} from './type.js';
 import {staticTypeCache} from './type-cache.js';
@@ -291,6 +292,7 @@ suite('Encoding', () => {
   const SetKind = Kind.Set;
   const StructKind = Kind.Struct;
   const TypeKind = Kind.Type;
+  const ValueKind = Kind.Value;
   const CycleKind = Kind.Cycle;
   const UnionKind = Kind.Union;
 
@@ -319,6 +321,7 @@ suite('Encoding', () => {
   test('types', () => {
     assertEncoding([uint8(TypeKind), uint8(BoolKind)], boolType);
     assertEncoding([uint8(TypeKind), uint8(TypeKind)], typeType);
+    assertEncoding([uint8(TypeKind), uint8(ValueKind)], valueType);
     assertEncoding([uint8(TypeKind), uint8(ListKind), uint8(BoolKind)], makeListType(boolType));
     assertEncoding([uint8(TypeKind), uint8(SetKind), uint8(StringKind)], makeSetType(stringType));
     assertEncoding([uint8(TypeKind), uint8(MapKind), uint8(StringKind), uint8(NumberKind)], makeMapType(stringType, numberType));

--- a/js/noms/src/struct.js
+++ b/js/noms/src/struct.js
@@ -279,9 +279,8 @@ function computeTypeForStruct(name: string, data: StructData): Type<StructDesc> 
  * Returns the field names which have different values in the respective structs.
  */
 export function structDiff(s1: Struct, s2: Struct): string[] {
+  invariant(equals(s1.type, s2.type));
   const desc1: StructDesc = s1.type.desc;
-  const desc2: StructDesc = s2.type.desc;
-  invariant(desc1.equals(desc2));
 
   const changed = [];
   desc1.fields.forEach((f: Field, i: number) => {


### PR DESCRIPTION
This method was not being used.

Major Version Change: equals was part of exposed public API of *Desc