### PR TITLE
Let Database expose a progress channel

### DIFF
--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -43,6 +43,10 @@ type Database interface {
 	// SetHead sets the Commit that datasetID in this database points at. All Values that have been written to this Database are guaranteed to be persistent after SetHead(). If the update cannot be performed, e.g., because of a conflict, error will be non-nil. The newest snapshot of the database is always returned.
 	SetHead(datasetID string, commit types.Struct) (Database, error)
 
+	// ProgressChannel returns a channel that progress information is sent to. If this is nil then
+	// the underlying database implementation does not report progress.
+	ProgressChannel() chan DatabaseProgress
+
 	has(hash hash.Hash) bool
 	validatingBatchStore() types.BatchStore
 }

--- a/go/datas/database_progress.go
+++ b/go/datas/database_progress.go
@@ -1,0 +1,15 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package datas
+
+// DatabaseProgress provides information about the progress of the database. This is an
+// approximation and it will only give useful information if there is only one client of the
+// underlying chunk store client.
+type DatabaseProgress struct {
+	// DoneBytes is the number of bytes that have been sent so far.
+	DoneBytes uint64
+	// KnownBytes is the total number of bytes that commit needs to send.
+	KnownBytes uint64
+}

--- a/go/datas/local_database.go
+++ b/go/datas/local_database.go
@@ -39,6 +39,10 @@ func (lds *LocalDatabase) SetHead(datasetID string, commit types.Struct) (Databa
 	return &LocalDatabase{newDatabaseCommon(lds.cch, lds.ValueStore, lds.rt), lds.cs}, err
 }
 
+func (lds *LocalDatabase) ProgressChannel() chan DatabaseProgress {
+	return nil
+}
+
 func (lds *LocalDatabase) validatingBatchStore() (bs types.BatchStore) {
 	bs = lds.ValueStore.BatchStore()
 	if !bs.IsValidating() {

--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -86,7 +86,10 @@ func (suite *RemoteToRemoteSuite) SetupTest() {
 
 func makeRemoteDb(cs chunks.ChunkStore) Database {
 	hbs := newHTTPBatchStoreForTest(cs)
-	return &RemoteDatabaseClient{newDatabaseCommon(newCachingChunkHaver(hbs), types.NewValueStore(hbs), hbs)}
+	return &RemoteDatabaseClient{
+		newDatabaseCommon(newCachingChunkHaver(hbs), types.NewValueStore(hbs), hbs),
+		hbs,
+	}
 }
 
 func (suite *PullSuite) sinkIsLocal() bool {


### PR DESCRIPTION
The underlying HTTP batch store posts progress reports to this channel
during commit. At this point the numbers only makes sense if there is a
single commit going on.

Towards #2037