### PR TITLE
JS: Make Database a mutable API that vends immutable Datasets

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "61.0.0",
+  "version": "62.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/absolute-path-test.js
+++ b/js/noms/src/absolute-path-test.js
@@ -10,7 +10,6 @@ import {equals} from './compare.js';
 
 import {invariant, notNull} from './assert.js';
 import AbsolutePath from './absolute-path.js';
-import Commit from './commit.js';
 import {getHash} from './get-hash.js';
 import {stringLength} from './hash.js';
 import List from './list.js';
@@ -35,14 +34,15 @@ suite('AbsolutePath', () => {
     const list = new List([s0, s1]);
     const emptySet = new Set();
 
-    let db = new TestDatabase();
+    const db = new TestDatabase();
     db.writeValue(s0);
     db.writeValue(s1);
     db.writeValue(list);
     db.writeValue(emptySet);
 
-    db = await db.commit('ds', new Commit(list));
-    const head = await db.head('ds');
+    let ds = db.getDataset('ds');
+    ds = await db.commit(ds, list);
+    const head = await ds.head();
     invariant(head);
 
     const resolvesTo = async (exp: Value | null, str: string) => {

--- a/js/noms/src/absolute-path.js
+++ b/js/noms/src/absolute-path.js
@@ -84,7 +84,7 @@ export default class AbsolutePath {
   async resolve(db: Database): Promise<Value | null> {
     let val = null;
     if (this.dataset !== '') {
-      val = await db.head(this.dataset);
+      val = await db.getDataset(this.dataset).head();
     } else if (this.hash !== null) {
       val = await db.readValue(this.hash);
     } else {

--- a/js/noms/src/database.js
+++ b/js/noms/src/database.js
@@ -108,7 +108,9 @@ export default class Database {
     }
     const commit = new Commit(v, new Set(parents));
     try {
-      return this._doCommit(ds.id, commit).then(r => new Dataset(this, ds.id, Promise.resolve(r)));
+      const commitRefPromise = this._doCommit(ds.id, commit);
+      await commitRefPromise;
+      return new Dataset(this, ds.id, commitRefPromise);
     } finally {
       this._datasets = this._datasetsFromRootRef(this._rt.getRoot());
     }

--- a/js/noms/src/dataset.js
+++ b/js/noms/src/dataset.js
@@ -44,6 +44,8 @@ export default class Dataset {
   /**
    * HeadRef returns the Ref of the current head Commit, which contains the
    * current root of the Dataset's value tree.
+   * If the named Dataset doesn't exist in this._database, the returned Promise may resolve to null.
+   * The returned Promise may be rejected if errors occur while getting the Ref.
    */
   headRef(): Promise<?Ref<Commit<any>>> {
     return this._headRef;
@@ -53,12 +55,18 @@ export default class Dataset {
   /**
    * Head returns the current head Commit, which contains the current root of
    * the Dataset's value tree.
+   * If the named Dataset doesn't exist in this._database, the returned Promise may resolve to null.
+   * The returned Promise may be rejected if errors occur while getting the Head.
    */
   head(): Promise<?Commit<any>> {
     return this._headRef.then(hr => hr ? hr.targetValue(this._database) : null);
   }
 
-  /** HeadValue returns the Value field of the current head Commit. */
+  /**
+   * HeadValue returns the Value field of the current head Commit.
+   * If the named Dataset doesn't exist in this._database, the returned Promise may resolve to null.
+   * The returned Promise may be rejected if errors occur while getting the Head.
+   */
   headValue(): Promise<?Value> {
     return this.head().then(commit => commit && commit.value);
   }

--- a/js/noms/src/dataset.js
+++ b/js/noms/src/dataset.js
@@ -35,16 +35,17 @@ export default class Dataset {
     return this._database;
   }
 
-  /** ID returns the name of this Dataset. */
+  /** id() returns the name of this Dataset. */
   get id(): string {
     return this._id;
   }
 
   // TODO: This should return Promise<Ref<Commit> | null>.
   /**
-   * HeadRef returns the Ref of the current head Commit, which contains the
+   * headRef returns the Ref of the current head Commit, which contains the
    * current root of the Dataset's value tree.
-   * If the named Dataset doesn't exist in this._database, the returned Promise may resolve to null.
+   * If the named Dataset doesn't exist in the underlying Database, the returned
+   * Promise may resolve to null.
    * The returned Promise may be rejected if errors occur while getting the Ref.
    */
   headRef(): Promise<?Ref<Commit<any>>> {
@@ -53,9 +54,10 @@ export default class Dataset {
 
   // TODO: This should return Promise<Commit | null>
   /**
-   * Head returns the current head Commit, which contains the current root of
+   * head returns the current head Commit, which contains the current root of
    * the Dataset's value tree.
-   * If the named Dataset doesn't exist in this._database, the returned Promise may resolve to null.
+   * If the named Dataset doesn't exist in the underlying Database, the returned
+   * Promise may resolve to null.
    * The returned Promise may be rejected if errors occur while getting the Head.
    */
   head(): Promise<?Commit<any>> {
@@ -63,8 +65,9 @@ export default class Dataset {
   }
 
   /**
-   * HeadValue returns the Value field of the current head Commit.
-   * If the named Dataset doesn't exist in this._database, the returned Promise may resolve to null.
+   * headValue returns the Value field of the current head Commit.
+   * If the named Dataset doesn't exist in underlying Database, the returned
+   * Promise may resolve to null.
    * The returned Promise may be rejected if errors occur while getting the Head.
    */
   headValue(): Promise<?Value> {

--- a/js/noms/src/dataset.js
+++ b/js/noms/src/dataset.js
@@ -8,7 +8,6 @@ import Commit from './commit.js';
 import type Value from './value.js';
 import type Database from './database.js';
 import Ref from './ref.js';
-import Set from './set.js';
 
 /** Matches any valid dataset name in a string. */
 export const datasetRe = /^[a-zA-Z0-9\-_/]+/;
@@ -19,15 +18,18 @@ const idRe = new RegExp('^' + datasetRe.source + '$');
 export default class Dataset {
   _database: Database;
   _id: string;
+  _headRef: Promise<?Ref<Commit<any>>>;
 
-  constructor(database: Database, id: string) {
+  constructor(database: Database, id: string, headRef: Promise<?Ref<Commit<any>>>) {
     if (!idRe.test(id)) {
       throw new TypeError(`Invalid dataset ID: ${id}`);
     }
     this._database = database;
     this._id = id;
+    this._headRef = headRef;
   }
 
+  // WARNING: database() is under consideration for deprecation.
   get database(): Database {
     return this._database;
   }
@@ -36,27 +38,17 @@ export default class Dataset {
     return this._id;
   }
 
+  // TODO: This should return Promise<Ref<Commit> | null>.
   headRef(): Promise<?Ref<Commit<any>>> {
-    return this._database.headRef(this._id);
+    return this._headRef;
   }
 
+  // TODO: This should return Promise<Commit | null>
   head(): Promise<?Commit<any>> {
-    return this._database.head(this._id);
+    return this._headRef.then(hr => hr ? hr.targetValue(this._database) : null);
   }
 
   headValue(): Promise<?Value> {
     return this.head().then(commit => commit && commit.value);
-  }
-
-  // Commit updates the commit that a dataset points at. If parents is provided then an the promise
-  // is rejected if the commit does not descend from the parents.
-  async commit(v: Value, parents: ?Array<Ref<Commit<any>>> = undefined): Promise<Dataset> {
-    if (!parents) {
-      const headRef = await this.headRef();
-      parents = headRef ? [headRef] : [];
-    }
-    const commit = new Commit(v, new Set(parents));
-    const database = await this._database.commit(this._id, commit);
-    return new Dataset(database, this._id);
   }
 }

--- a/js/noms/src/dataset.js
+++ b/js/noms/src/dataset.js
@@ -15,6 +15,7 @@ export const datasetRe = /^[a-zA-Z0-9\-_/]+/;
 /** Matches if an entire string is a valid dataset name. */
 const idRe = new RegExp('^' + datasetRe.source + '$');
 
+/** Dataset is a named Commit within a Database. */
 export default class Dataset {
   _database: Database;
   _id: string;
@@ -34,20 +35,30 @@ export default class Dataset {
     return this._database;
   }
 
+  /** ID returns the name of this Dataset. */
   get id(): string {
     return this._id;
   }
 
   // TODO: This should return Promise<Ref<Commit> | null>.
+  /**
+   * HeadRef returns the Ref of the current head Commit, which contains the
+   * current root of the Dataset's value tree.
+   */
   headRef(): Promise<?Ref<Commit<any>>> {
     return this._headRef;
   }
 
   // TODO: This should return Promise<Commit | null>
+  /**
+   * Head returns the current head Commit, which contains the current root of
+   * the Dataset's value tree.
+   */
   head(): Promise<?Commit<any>> {
     return this._headRef.then(hr => hr ? hr.targetValue(this._database) : null);
   }
 
+  /** HeadValue returns the Value field of the current head Commit. */
   headValue(): Promise<?Value> {
     return this.head().then(commit => commit && commit.value);
   }

--- a/js/noms/src/specs-test.js
+++ b/js/noms/src/specs-test.js
@@ -6,8 +6,6 @@
 
 import {assert} from 'chai';
 import {suite, test} from 'mocha';
-
-import Dataset from './dataset.js';
 import {getHash} from './get-hash.js';
 import List from './list.js';
 import {DatabaseSpec, DatasetSpec, PathSpec} from './specs.js';
@@ -42,7 +40,8 @@ suite('Specs', () => {
     let [, head] = await spec.value();
     assert.strictEqual(null, head);
 
-    await spec.dataset().commit('Commit Value');
+    const [db, ds] = await spec.dataset();
+    await db.commit(ds, 'Commit Value');
     [, head] = await spec.value();
     assert.strictEqual('Commit Value', head);
   });
@@ -65,8 +64,8 @@ suite('Specs', () => {
     let [db, value] = await spec.value();
     assert.strictEqual(null, value);
 
-    const ds = new Dataset(db, 'test');
-    await ds.commit(new List([42]));
+    const ds = await db.getDataset('test');
+    await db.commit(ds, new List([42]));
     [db, value] = await spec.value();
     assert.strictEqual(42, value);
   });

--- a/js/noms/src/specs.js
+++ b/js/noms/src/specs.js
@@ -115,8 +115,9 @@ export class DatasetSpec {
   /**
    * Returns a new Dataset based on this DatasetSpec.
    */
-  dataset(): Dataset {
-    return new Dataset(this.database.database(), this.name);
+  dataset(): [Database, Dataset] {
+    const db = this.database.database();
+    return [db, db.getDataset(this.name)];
   }
 
   /**
@@ -126,8 +127,8 @@ export class DatasetSpec {
    * The caller should always call `close()` when done.
    */
   value(): Promise<[Database, Value | null]> {
-    const db = this.database.database();
-    return this.dataset().head().then(commit => [db, commit ? commit.value : null]);
+    const [db, ds] = this.dataset();
+    return ds.head().then(commit => [db, commit ? commit.value : null]);
   }
 }
 

--- a/js/perf/codec-perf-rig/src/main.js
+++ b/js/perf/codec-perf-rig/src/main.js
@@ -73,11 +73,11 @@ async function main(): Promise<void> {
       const valueFn = valueFns[j];
 
       // Build One-Time
-      let ds = notNull(DatasetSpec.parse('mem::csv')).dataset();
+      let [db, ds] = notNull(DatasetSpec.parse('mem::csv')).dataset();
 
       let t1 = Date.now();
       let col = buildFns[i](buildCount, valueFn);
-      ds = await ds.commit(col);
+      ds = await db.commit(ds, col);
       const buildDuration = Date.now() - t1;
 
       // Read
@@ -87,10 +87,10 @@ async function main(): Promise<void> {
       const readDuration = Date.now() - t1;
 
       // Build Incrementally
-      ds = notNull(DatasetSpec.parse('mem::csv')).dataset();
+      [db, ds] = notNull(DatasetSpec.parse('mem::csv')).dataset();
       t1 = Date.now();
       col = await buildIncrFns[i](insertCount, valueFn);
-      ds = await ds.commit(col);
+      ds = await db.commit(ds, col);
       const incrDuration = Date.now() - t1;
 
       const elementSize = elementSizes[j];
@@ -106,12 +106,12 @@ async function main(): Promise<void> {
   const blobSizeStr = humanize.numberFormat(blobSize / 1000000);
   console.log(`Testing Blob: \t\tbuild ${blobSizeStr} MB\t\t\tscan ${blobSizeStr} MB`);
 
-  let ds = notNull(DatasetSpec.parse('mem::csv')).dataset();
+  const [db, ds] = notNull(DatasetSpec.parse('mem::csv')).dataset();
   const blobBytes = makeBlobBytes(blobSize);
 
   let t1 = Date.now();
   let blob = new Blob(blobBytes);
-  ds = await ds.commit(blob);
+  await db.commit(ds, blob);
   const buildDuration = Date.now() - t1;
 
   t1 = Date.now();

--- a/js/perf/viewer/src/main.js
+++ b/js/perf/viewer/src/main.js
@@ -62,9 +62,10 @@ function load() {
   loadDataset(datasets[0]);
 }
 
-async function loadDataset(ds: string) {
-  const dsSpec = DatasetSpec.parse(ds);
-  const [perfData, gitRevs] = await getPerfHistory(dsSpec.dataset());
+async function loadDataset(dsID: string) {
+  const dsSpec = DatasetSpec.parse(dsID);
+  const [, ds] = dsSpec.dataset();
+  const [perfData, gitRevs] = await getPerfHistory(ds);
 
   // git describe --always uses the first 7 characters.
   const labels = gitRevs.map(rev => rev.slice(0, 7));
@@ -103,7 +104,7 @@ async function loadDataset(ds: string) {
     datapoints.set(testNames[i], testChartData[i]);
   }
 
-  render(ds, labels, datapoints);
+  render(dsID, labels, datapoints);
 }
 
 // Returns the history of perf data with their git revisions, from oldest to newest.

--- a/samples/js/aggregate/src/main.js
+++ b/samples/js/aggregate/src/main.js
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   const outSpec = DatasetSpec.parse(args._[1]);
   invariant(outSpec, quit('invalid input dataset spec'));
 
-  const input = inSpec.dataset();
+  const [, input] = inSpec.dataset();
   const rv = await input.headRef();
   if (!rv) {
     process.stderr.write(`{args._[0]} does not exist}\n`);
@@ -82,7 +82,8 @@ async function main(): Promise<void> {
     return true;
   });
 
-  await outSpec.dataset().commit(await out);
+  const [db, output] = outSpec.dataset();
+  await db.commit(output, await out);
 }
 
 function quit(err: string): Function {

--- a/samples/js/counter/src/main.js
+++ b/samples/js/counter/src/main.js
@@ -6,6 +6,7 @@
 
 import argv from 'yargs';
 import {
+  Database,
   Dataset,
   DatasetSpec,
 } from '@attic/noms';
@@ -29,11 +30,11 @@ async function main(): Promise<void> {
     return;
   }
 
-  const ds = spec.dataset();
-  await increment(ds);
+  const [db, ds] = spec.dataset();
+  await increment(db, ds);
 }
 
-async function increment(ds: Dataset): Promise<Dataset> {
+async function increment(db: Database, ds: Dataset): Promise<Dataset> {
   let lastVal = 0;
 
   const value = await ds.headValue();
@@ -42,7 +43,7 @@ async function increment(ds: Dataset): Promise<Dataset> {
   }
 
   const newVal = lastVal + 1;
-  ds = await ds.commit(newVal);
+  ds = await db.commit(ds, newVal);
   process.stdout.write(`${ newVal }\n`);
   return ds;
 }

--- a/samples/js/fb/find-photos/src/main.js
+++ b/samples/js/fb/find-photos/src/main.js
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     return db.close();
   }
   const outSpec = DatasetSpec.parse(args._[1]);
-  const output = outSpec.dataset();
+  const [outDB, output] = outSpec.dataset();
   let result = Promise.resolve(new Set());
 
   // TODO: progress
@@ -77,7 +77,9 @@ async function main(): Promise<void> {
     }
   });
 
-  return output.commit(await result).then(() => db.close());
+  return outDB.commit(output, await result)
+    .then(() => db.close())
+    .then(() => outDB.close());
 }
 
 function getGeo(input): Struct {

--- a/samples/js/fb/slurp/src/main.js
+++ b/samples/js/fb/slurp/src/main.js
@@ -49,13 +49,13 @@ async function main(): Promise<void> {
     throw 'invalid destination dataset spec';
   }
 
-  const out = outSpec.dataset();
+  const [db, out] = outSpec.dataset();
   const [user, photos] = await Promise.all([
     getUser(),
     getPhotos(),
     // TODO: Add more object types here
   ]);
-  await out.commit(newStruct('', {user, photos}));
+  await db.commit(out, newStruct('', {user, photos}));
   process.stdout.write(clearLine);
   return;
 }

--- a/samples/js/flickr/find-photos/src/main.js
+++ b/samples/js/flickr/find-photos/src/main.js
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
     return db.close();
   }
   const outSpec = DatasetSpec.parse(args._[1]);
-  const output = outSpec.dataset();
+  const [outDB, output] = outSpec.dataset();
   let result = Promise.resolve(new Set());
 
   // TODO: How to report progress?
@@ -112,7 +112,9 @@ async function main(): Promise<void> {
     return false;
   });
 
-  return output.commit(await result).then(() => db.close());
+  return outDB.commit(output, await result)
+    .then(() => db.close())
+    .then(() => outDB.close());
 }
 
 function getGeo(input: Object): Struct {

--- a/samples/js/flickr/slurp/src/main.js
+++ b/samples/js/flickr/slurp/src/main.js
@@ -8,7 +8,6 @@ import argv from 'yargs';
 import flickrAPI from 'flickr-oauth-and-upload';
 import readline from 'readline';
 import {
-  Dataset,
   DatasetSpec,
   invariant,
   jsonToNoms,
@@ -57,7 +56,6 @@ main().catch(ex => {
 var authToken: ?string;  // eslint-disable-line no-var
 var authSecret: ?string;  // eslint-disable-line no-var
 var authURL: ?string;  // eslint-disable-line no-var
-var out: Dataset;  // eslint-disable-line no-var
 
 async function main(): Promise<void> {
   const outSpec = DatasetSpec.parse(args._[0]);
@@ -65,7 +63,7 @@ async function main(): Promise<void> {
     throw 'invalid destination dataset spec';
   }
 
-  out = outSpec.dataset();
+  const [db, out] = outSpec.dataset();
 
   if (args['auth-token'] && args['auth-secret']) {
     authToken = args['auth-token'];
@@ -85,10 +83,10 @@ async function main(): Promise<void> {
   }))).then(sets => new Set(sets));
 
   process.stdout.write(clearLine);
-  return out.commit(newStruct('', {
+  return db.commit(out, newStruct('', {
     photosetsMeta: jsonToNoms(photosetsJSON),
     photosets: await photosets,
-  })).then();
+  })).then(() => db.close());
 }
 
 async function getPhotosetsJSON(): Promise<any> {

--- a/samples/js/fs/src/main.js
+++ b/samples/js/fs/src/main.js
@@ -78,10 +78,10 @@ async function main(): Promise<void> {
 
   startTime = Date.now();
 
-  const ds = spec.dataset();
-  const de = await processPath(path, ds.database);
+  const [db, ds] = spec.dataset();
+  const de = await processPath(path, db);
   if (de) {
-    await ds.commit(de);
+    await db.commit(ds, de);
     process.stdout.write('\ndone\n');
   }
 

--- a/samples/js/url_fetch/src/main.js
+++ b/samples/js/url_fetch/src/main.js
@@ -42,9 +42,9 @@ function main(): Promise<void> {
     return Promise.resolve();
   }
 
-  const set = spec.dataset();
+  const [db, set] = spec.dataset();
   return getBlob(url)
-    .then(b => set.commit(b))
+    .then(b => db.commit(set, b))
     .then(() => {
       process.stderr.write(clearLine + 'Done\n');
     });


### PR DESCRIPTION
Noms SDK users frequently shoot themselves in the foot because they're
holding onto an "old" Database object. That is, they have a Database
tucked away in some internal state, they call Commit() on it, and
don't replace the object in their internal state with the new Database
returned from Commit.

This PR fixes #2589 by changing the Database and Dataset JS API to be
in line with the proposal there.