### PR TITLE
Run url-fetch perf tests against a fresh database each time

### DIFF
--- a/go/perf/suite/suite.go
+++ b/go/perf/suite/suite.go
@@ -269,7 +269,24 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 	for repIdx := 0; repIdx < *perfRepeatFlag; repIdx++ {
 		testReps[repIdx] = testRep{}
 
-		serverHost, stopServerFn := suite.startServer()
+		// This is the temporary database for tests to use.
+		//
+		// === Why not use a local database + memory store?
+		// Firstly, because the spec would be "mem", and the spec library doesn't
+		// know how to reuse stores.
+		// Secondly, because it's an unrealistic performance measurement.
+		//
+		// === Why use a remote (HTTP) database?
+		// It's more realistic to exercise the HTTP stack, even if it's just talking
+		// over localhost.
+		//
+		// === Why provide an option for leveldb vs memory underlying store?
+		// Again, leveldb is more realistic than memory, and in common cases disk
+		// space > memory space.
+		// However, on this developer's laptop, there is
+		// actually very little disk space, and a lot of memory; plus making the
+		// test run a little bit faster locally is nice.
+		serverHost, stopServerFn := suite.StartRemoteDatabase()
 		suite.DatabaseSpec = serverHost
 		suite.Database = datas.NewRemoteDatabase(serverHost, "")
 
@@ -464,20 +481,13 @@ func (suite *PerfSuite) getGitHead(dir string) string {
 	return strings.TrimSpace(stdout.String())
 }
 
-func (suite *PerfSuite) startServer() (host string, stopFn func()) {
-	// This is the temporary database for tests to use.
-	//
-	// * Why not use a local database + memory store?
-	// Firstly, because the spec would be "mem", and the spec library doesn't know how to reuse stores.
-	// Secondly, because it's an unrealistic performance measurement.
-	//
-	// * Why use a remote (HTTP) database?
-	// It's more realistic to exercise the HTTP stack, even if it's just talking over localhost.
-	//
-	// * Why provide an option for leveldb vs memory underlying store?
-	// Again, leveldb is more realistic than memory, and in common cases disk space > memory space.
-	// However, on this developer's laptop, there is actually very little disk space, and a lot of memory;
-	// plus making the test run a little bit faster locally is nice.
+// StartRemoteDatabase creates a new remote database on an arbitrary free port,
+// running on a separate goroutine. Returns the hostname that that database was
+// started on, and a callback to run to shut down the server.
+//
+// If the -perf.mem flag is specified, the remote database is hosted in memory,
+// not on disk (in a temporary leveldb directory).
+func (suite *PerfSuite) StartRemoteDatabase() (host string, stopFn func()) {
 	var chunkStore chunks.ChunkStore
 	if *perfMemFlag {
 		chunkStore = chunks.NewMemoryStore()

--- a/go/perf/suite/suite.go
+++ b/go/perf/suite/suite.go
@@ -269,23 +269,6 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 	for repIdx := 0; repIdx < *perfRepeatFlag; repIdx++ {
 		testReps[repIdx] = testRep{}
 
-		// This is the temporary database for tests to use.
-		//
-		// === Why not use a local database + memory store?
-		// Firstly, because the spec would be "mem", and the spec library doesn't
-		// know how to reuse stores.
-		// Secondly, because it's an unrealistic performance measurement.
-		//
-		// === Why use a remote (HTTP) database?
-		// It's more realistic to exercise the HTTP stack, even if it's just talking
-		// over localhost.
-		//
-		// === Why provide an option for leveldb vs memory underlying store?
-		// Again, leveldb is more realistic than memory, and in common cases disk
-		// space > memory space.
-		// However, on this developer's laptop, there is
-		// actually very little disk space, and a lot of memory; plus making the
-		// test run a little bit faster locally is nice.
 		serverHost, stopServerFn := suite.StartRemoteDatabase()
 		suite.DatabaseSpec = serverHost
 		suite.Database = datas.NewRemoteDatabase(serverHost, "")
@@ -487,6 +470,22 @@ func (suite *PerfSuite) getGitHead(dir string) string {
 //
 // If the -perf.mem flag is specified, the remote database is hosted in memory,
 // not on disk (in a temporary leveldb directory).
+//
+// - Why not use a local database + memory store?
+// Firstly, because the spec would be "mem", and the spec library doesn't
+// know how to reuse stores.
+// Secondly, because it's an unrealistic performance measurement.
+//
+// - Why use a remote (HTTP) database?
+// It's more realistic to exercise the HTTP stack, even if it's just talking
+// over localhost.
+//
+// - Why provide an option for leveldb vs memory underlying store?
+// Again, leveldb is more realistic than memory, and in common cases disk
+// space > memory space.
+// However, on this developer's laptop, there is
+// actually very little disk space, and a lot of memory; plus making the
+// test run a little bit faster locally is nice.
 func (suite *PerfSuite) StartRemoteDatabase() (host string, stopFn func()) {
 	var chunkStore chunks.ChunkStore
 	if *perfMemFlag {

--- a/go/perf/suite/suite_test.go
+++ b/go/perf/suite/suite_test.go
@@ -226,8 +226,9 @@ func runTestSuite(t *testing.T, mem bool) {
 		i := 0
 
 		rep.(types.Map).IterAll(func(k, timesVal types.Value) {
-			assert.True(i < len(expectedTests))
-			assert.Equal(expectedTests[i], string(k.(types.String)))
+			if assert.True(i < len(expectedTests)) {
+				assert.Equal(expectedTests[i], string(k.(types.String)))
+			}
 
 			times := timesVal.(types.Struct)
 			assert.True(getOrFail(times, "elapsed").(types.Number) > 0)

--- a/samples/go/url-fetch/perf/perf_test.go
+++ b/samples/go/url-fetch/perf/perf_test.go
@@ -68,8 +68,11 @@ func (s *perfSuite) TestFetchURL() {
 }
 
 func (s *perfSuite) importPath(tag, path string) {
+	host, stopFn := s.StartRemoteDatabase()
+	defer stopFn()
+
 	assert := s.NewAssert()
-	cmd := exec.Command(s.urlFetchExe, path, fmt.Sprintf("%s::url-fetch-%s", s.DatabaseSpec, tag))
+	cmd := exec.Command(s.urlFetchExe, path, fmt.Sprintf("%s::url-fetch-%s", host, tag))
 	cmd.Stdout = s.W
 	cmd.Stderr = os.Stderr
 	assert.NoError(cmd.Run())


### PR DESCRIPTION
The subsequent runs of url-fetch on jenkins are way faster, and this
appears to be because commiting is much faster on subsequent runs. The
perf tests now use a new database each time.