### PR TITLE
Make jsonToNoms handle some null values

### DIFF
--- a/js/noms/src/json-convert-test.js
+++ b/js/noms/src/json-convert-test.js
@@ -23,6 +23,10 @@ suite('jsonToNoms', () => {
     assert.isTrue(equals(new List([true]), jsonToNoms([true])));
     assert.isTrue(equals(new List([true, 42]), jsonToNoms([true, 42])));
     assert.isTrue(equals(new List([new List([88.8])]), jsonToNoms([[88.8]])));
+    const l1 = [88.8, 'a string', false];
+    assert.isTrue(equals(new List(l1), jsonToNoms(l1)));
+    const l2 = [88.8, null, false];
+    assert.throws(() => { jsonToNoms(l2); });
   });
 
   test('object', () => {
@@ -33,13 +37,28 @@ suite('jsonToNoms', () => {
         bool: true,
         num: 42,
         string: 'monkey',
-        list: [],
+        list: ['one', 'two', 'three'],
         struct: {key: 'val'},
       },
       newStruct('', {
         bool: true,
         num: 42,
         string: 'monkey',
+        list: new List(['one', 'two', 'three']),
+        struct: newStruct('', {
+          key: 'val',
+        }),
+      }),
+      {
+        bool: true,
+        num: 42,
+        string: null,
+        list: [],
+        struct: {key: 'val'},
+      },
+      newStruct('', {
+        bool: true,
+        num: 42,
         list: new List([]),
         struct: newStruct('', {
           key: 'val',

--- a/js/noms/src/json-convert.js
+++ b/js/noms/src/json-convert.js
@@ -16,8 +16,21 @@ type JSON = string | number | boolean | null | JSONObject | JSONArray;
 type JSONObject = { [key:string]: JSON };
 type JSONArray = Array<JSON>;
 
+type NullableValue = Value | null;
+
+// Values in json can sometimes by null. If a field in a struct is null we
+// skip over it. If an element in an array is null, we throw an error.
 // TODO: Can we return a more specific type?
 export default function jsonToNoms(v: JSON): Value {
+  const nv = jsonToNullableValue(v);
+  invariant(nv !== null);
+  return nv;
+}
+
+function jsonToNullableValue(v: JSON): NullableValue {
+  if (v === null) {
+    return null;
+  }
   switch (typeof v) {
     case 'boolean':
     case 'number':
@@ -33,7 +46,10 @@ export default function jsonToNoms(v: JSON): Value {
     const props = {};
     Object.keys(v).forEach(k => {
       invariant(v instanceof Object);
-      props[escapeStructField(k)] = jsonToNoms(v[k]);
+      const v1 = jsonToNullableValue(v[k]);
+      if (v1 !== null) {
+        props[escapeStructField(k)] = v1;
+      }
     });
     return newStruct('', props);
   }


### PR DESCRIPTION
Null values in struct field are handled by not skipping that field in
the noms type. Null values as elements in array cause an exception.