### PR TITLE
Add --force to run-all-js-tests.py

### DIFF
--- a/tools/run-all-js-tests.py
+++ b/tools/run-all-js-tests.py
@@ -6,6 +6,7 @@
 
 # This tool finds all package.json files and runs npm install and npm test in those directories.
 
+import argparse
 import os
 import subprocess
 from contextlib import contextmanager
@@ -18,6 +19,10 @@ def pushd(path):
   os.chdir(currentDir)
 
 def main():
+  parser = argparse.ArgumentParser(description='Runs all Node.js tests')
+  parser.add_argument('--force', action='store_true', help='Force updating @attic/noms')
+  args = parser.parse_args()
+
   lsfiles = subprocess.check_output(['git', 'ls-files']).split('\n')
   lsfiles.sort(key = len) # Sort by shortest first to make sure we deal with parents first
   for f in lsfiles:
@@ -25,6 +30,8 @@ def main():
     if name == 'package.json':
       with pushd(path):
         subprocess.check_call(['npm', 'install'])
+        if args.force and not path.endswith('js/noms'):
+            subprocess.check_call(['npm', 'install', '@attic/noms'])
         subprocess.check_call(['npm', 'test'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
When the flag is present we force update @attic/noms. This is useful
since a lot of the samples use file: dependencies which lack a version
so they do not get updated as normal dependencies do.