### PR TITLE
JS: Auto-merge concurrent commits to noms datasets

### DIFF
--- a/js/noms/src/database-test.js
+++ b/js/noms/src/database-test.js
@@ -5,7 +5,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 import {suite, test} from 'mocha';
-import {makeTestingRemoteBatchStore, TestingDelegate} from './remote-batch-store.js';
+import makeRemoteBatchStoreFake from './remote-batch-store-fake.js';
+import {TestingDelegate} from './remote-batch-store-fake.js';
 import RemoteBatchStore from './remote-batch-store.js';
 import MemoryStore from './memory-store.js';
 import {assert} from 'chai';
@@ -18,7 +19,7 @@ import NomsSet from './set.js'; // namespace collision with JS Set
 
 suite('Database', () => {
   test('access', async () => {
-    const bs = makeTestingRemoteBatchStore();
+    const bs = makeRemoteBatchStoreFake();
     const ds = new Database(bs);
     const input = 'abc';
 
@@ -35,7 +36,7 @@ suite('Database', () => {
   });
 
   test('commit', async () => {
-    const bs = makeTestingRemoteBatchStore();
+    const bs = makeRemoteBatchStoreFake();
     const db = new Database(bs);
     let ds = await db.getDataset('ds1');
 
@@ -107,7 +108,7 @@ suite('Database', () => {
   });
 
   test('concurrency', async () => {
-    const bs = makeTestingRemoteBatchStore();
+    const bs = makeRemoteBatchStoreFake();
     const db = new Database(bs);
     let ds = await db.getDataset('ds1');
 
@@ -190,14 +191,14 @@ suite('Database', () => {
   });
 
   test('empty datasets', async () => {
-    const ds = new Database(makeTestingRemoteBatchStore());
+    const ds = new Database(makeRemoteBatchStoreFake());
     const datasets = await ds.datasets();
     assert.strictEqual(0, datasets.size);
     await ds.close();
   });
 
   test('height of refs', async () => {
-    const ds = new Database(new makeTestingRemoteBatchStore());
+    const ds = new Database(new makeRemoteBatchStoreFake());
 
     const v1 = ds.writeValue('hello');
     assert.strictEqual(1, v1.height);
@@ -209,7 +210,7 @@ suite('Database', () => {
   });
 
   test('height of collections', async() => {
-    const ds = new Database(new makeTestingRemoteBatchStore());
+    const ds = new Database(new makeRemoteBatchStoreFake());
 
     // Set<String>.
     const v1 = 'hello';

--- a/js/noms/src/dataset-test.js
+++ b/js/noms/src/dataset-test.js
@@ -5,7 +5,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 import {suite, test} from 'mocha';
-import {makeTestingRemoteBatchStore} from './remote-batch-store.js';
+import makeRemoteBatchStoreFake from './remote-batch-store-fake.js';
 import {emptyHash} from './hash.js';
 import {assert} from 'chai';
 import Commit from './commit.js';
@@ -16,7 +16,7 @@ import {equals} from './compare.js';
 
 suite('Dataset', () => {
   test('id validation', () => {
-    const db = new Database(makeTestingRemoteBatchStore());
+    const db = new Database(makeRemoteBatchStoreFake());
 
     const invalidDatasetNames = [' ', '', 'a ', ' a', '$', '#', ':', '\n', '💩'];
     for (const s of invalidDatasetNames) {
@@ -25,7 +25,7 @@ suite('Dataset', () => {
   });
 
   test('head', async () => {
-    const bs = makeTestingRemoteBatchStore();
+    const bs = makeRemoteBatchStoreFake();
     let db = new Database(bs);
 
     const commit = new Commit('foo');

--- a/js/noms/src/remote-batch-store-fake.js
+++ b/js/noms/src/remote-batch-store-fake.js
@@ -1,0 +1,47 @@
+// @flow
+
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+import Chunk from './chunk.js';
+import Hash from './hash.js';
+import MemoryStore from './memory-store.js';
+import RemoteBatchStore from './remote-batch-store.js';
+import type {BatchStore} from './batch-store.js';
+import type {ChunkStore} from './chunk-store.js';
+import type {ChunkStream} from './chunk-serializer.js';
+import type {UnsentReadMap} from './remote-batch-store.js';
+import {notNull} from './assert.js';
+
+export default function makeRemoteBatchStoreFake(): BatchStore {
+  return new RemoteBatchStore(3, new TestingDelegate(new MemoryStore()));
+}
+
+export class TestingDelegate {
+  _cs: ChunkStore;
+  preUpdateRootHook: () => Promise<void>;
+
+  constructor(cs: ChunkStore) {
+    this._cs = cs;
+    this.preUpdateRootHook = () => Promise.resolve();
+  }
+
+  async readBatch(reqs: UnsentReadMap): Promise<void> {
+    Object.keys(reqs).forEach(hashStr => {
+      this._cs.get(notNull(Hash.parse(hashStr))).then(chunk => { reqs[hashStr](chunk); });
+    });
+  }
+
+  async writeBatch(hints: Set<Hash>, chunkStream: ChunkStream): Promise<void> {
+    return chunkStream((chunk: Chunk) => this._cs.put(chunk));
+  }
+
+  async getRoot(): Promise<Hash> {
+    return this._cs.getRoot();
+  }
+
+  async updateRoot(current: Hash, last: Hash): Promise<boolean> {
+    return this.preUpdateRootHook().then(() => this._cs.updateRoot(current, last));
+  }
+}

--- a/js/noms/src/remote-batch-store-test.js
+++ b/js/noms/src/remote-batch-store-test.js
@@ -6,12 +6,12 @@
 
 import {suite, test} from 'mocha';
 import {assert} from 'chai';
-import {makeTestingRemoteBatchStore} from './remote-batch-store.js';
+import makeRemoteBatchStoreFake from './remote-batch-store-fake.js';
 import {encodeValue} from './codec.js';
 
 suite('BatchStore', () => {
   test('get after schedulePut works immediately', async () => {
-    const bs = makeTestingRemoteBatchStore();
+    const bs = makeRemoteBatchStoreFake();
     const input = 'abc';
 
     const c = encodeValue(input);
@@ -23,7 +23,7 @@ suite('BatchStore', () => {
   });
 
   test('get after schedulePut works after flush', async () => {
-    const bs = makeTestingRemoteBatchStore();
+    const bs = makeRemoteBatchStoreFake();
     const input = 'abc';
 
     const c = encodeValue(input);

--- a/js/noms/src/remote-batch-store.js
+++ b/js/noms/src/remote-batch-store.js
@@ -156,11 +156,13 @@ export function makeTestingRemoteBatchStore(): BatchStore {
   return new RemoteBatchStore(3, new TestingDelegate(new MemoryStore()));
 }
 
-class TestingDelegate {
+export class TestingDelegate {
   _cs: ChunkStore;
+  preUpdateRootHook: () => Promise<void>;
 
   constructor(cs: ChunkStore) {
     this._cs = cs;
+    this.preUpdateRootHook = () => Promise.resolve();
   }
 
   async readBatch(reqs: UnsentReadMap): Promise<void> {
@@ -178,6 +180,6 @@ class TestingDelegate {
   }
 
   async updateRoot(current: Hash, last: Hash): Promise<boolean> {
-    return this._cs.updateRoot(current, last);
+    return this.preUpdateRootHook().then(() => this._cs.updateRoot(current, last));
   }
 }

--- a/js/noms/src/remote-batch-store.js
+++ b/js/noms/src/remote-batch-store.js
@@ -6,10 +6,7 @@
 
 import Chunk from './chunk.js';
 import Hash from './hash.js';
-import MemoryStore from './memory-store.js';
 import OrderedPutCache from './put-cache.js';
-import type {BatchStore} from './batch-store.js';
-import type {ChunkStore} from './chunk-store.js';
 import type {ChunkStream} from './chunk-serializer.js';
 import {notNull} from './assert.js';
 
@@ -149,37 +146,5 @@ export default class RemoteBatchStore {
   // requests should be an error on both sides. TBD.
   close(): Promise<void> {
     return this._pendingWrites.destroy();
-  }
-}
-
-export function makeTestingRemoteBatchStore(): BatchStore {
-  return new RemoteBatchStore(3, new TestingDelegate(new MemoryStore()));
-}
-
-export class TestingDelegate {
-  _cs: ChunkStore;
-  preUpdateRootHook: () => Promise<void>;
-
-  constructor(cs: ChunkStore) {
-    this._cs = cs;
-    this.preUpdateRootHook = () => Promise.resolve();
-  }
-
-  async readBatch(reqs: UnsentReadMap): Promise<void> {
-    Object.keys(reqs).forEach(hashStr => {
-      this._cs.get(notNull(Hash.parse(hashStr))).then(chunk => { reqs[hashStr](chunk); });
-    });
-  }
-
-  async writeBatch(hints: Set<Hash>, chunkStream: ChunkStream): Promise<void> {
-    return chunkStream((chunk: Chunk) => this._cs.put(chunk));
-  }
-
-  async getRoot(): Promise<Hash> {
-    return this._cs.getRoot();
-  }
-
-  async updateRoot(current: Hash, last: Hash): Promise<boolean> {
-    return this.preUpdateRootHook().then(() => this._cs.updateRoot(current, last));
   }
 }


### PR DESCRIPTION
This patch brings JS into line with Go's handling of concurrent
commits to separate Datasets.

Fixes issue #2524