### PR TITLE
JS: Add CommitOptions to commit method

### DIFF
--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -41,10 +41,10 @@ type Database interface {
 	// Commit updates the Commit that ds.ID() in this database points at. All
 	// Values that have been written to this Database are guaranteed to be
 	// persistent after Commit() returns.
-	// The new Commit struct is constructed using `v`, `opts.Parents`, and
-	// `opts.Meta`. If `opts.Parents` is the zero value (`types.Set{}`) then
-	// the current head is used. If `opts.Meta is the zero value
-	// (`types.Struct{}`) then a fully initialized empty Struct is passed to
+	// The new Commit struct is constructed using v, opts.Parents, and
+	// opts.Meta. If opts.Parents is the zero value (types.Set{}) then
+	// the current head is used. If opts.Meta is the zero value
+	// (types.Struct{}) then a fully initialized empty Struct is passed to
 	// NewCommit.
 	// The returned Dataset is always the newest snapshot, regardless of
 	// success or failure, and Datasets() is updated to match backing storage

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -471,6 +471,5 @@ func (suite *DatabaseSuite) TestMetaOption() {
 	ds, err := suite.db.Commit(ds, types.String("a"), CommitOptions{Meta: m})
 	suite.NoError(err)
 	c := ds.Head()
-	suite.NoError(err)
 	suite.Equal(types.String("arv"), c.Get("meta").(types.Struct).Get("author"))
 }

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -461,3 +461,16 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
 
 	suite.db.WriteValue(types.NewList(andMore...))
 }
+
+func (suite *DatabaseSuite) TestMetaOption() {
+	ds := suite.db.GetDataset("ds1")
+	m := types.NewStruct("M", types.StructData{
+		"author": types.String("arv"),
+	})
+
+	ds, err := suite.db.Commit(ds, types.String("a"), CommitOptions{Meta: m})
+	suite.NoError(err)
+	c := ds.Head()
+	suite.NoError(err)
+	suite.Equal(types.String("arv"), c.Get("meta").(types.Struct).Get("author"))
+}

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "62.1.0",
+  "version": "63.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",


### PR DESCRIPTION
This allows setting the meta field when you commit.

This is a version change because the signature of Database commit
changed in a non backwards compatible way. It now takes an optional
third options object instead of an optional array.