### PR TITLE
Remove the orderedSequence interface, move getKey to sequence

### DIFF
--- a/go/types/graph_builder.go
+++ b/go/types/graph_builder.go
@@ -272,9 +272,9 @@ func (s graphStack) String() string {
 func (e *graphStackElem) done() Collection {
 	switch e.kind {
 	case MapKind:
-		return newMap(e.ch.Done().(orderedSequence))
+		return newMap(e.ch.Done())
 	case SetKind:
-		return newSet(e.ch.Done().(orderedSequence))
+		return newSet(e.ch.Done())
 	case ListKind:
 		return newList(e.ch.Done())
 	}

--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -29,3 +29,8 @@ func (seq leafSequence) Type() *Type {
 func (seq leafSequence) getChildSequence(idx int) sequence {
 	return nil
 }
+
+func (sl leafSequence) getKey(idx int) orderedKey {
+	// Ordered sequences should implement this.
+	panic("not implemented")
+}

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -12,11 +12,11 @@ import (
 )
 
 type Map struct {
-	seq orderedSequence
+	seq sequence
 	h   *hash.Hash
 }
 
-func newMap(seq orderedSequence) Map {
+func newMap(seq sequence) Map {
 	return Map{seq, &hash.Hash{}}
 }
 
@@ -34,7 +34,7 @@ func NewMap(kv ...Value) Map {
 		ch.Append(entry)
 	}
 
-	return newMap(ch.Done().(orderedSequence))
+	return newMap(ch.Done())
 }
 
 func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
@@ -190,7 +190,7 @@ func (m Map) splice(cur *sequenceCursor, deleteCount uint64, vs ...mapEntry) Map
 	for _, v := range vs {
 		ch.Append(v)
 	}
-	return newMap(ch.Done().(orderedSequence))
+	return newMap(ch.Done())
 }
 
 func (m Map) getCursorAtValue(v Value) (cur *sequenceCursor, found bool) {

--- a/go/types/mapMutator.go
+++ b/go/types/mapMutator.go
@@ -38,5 +38,5 @@ func (mx *mapMutator) Finish() Map {
 		d.PanicIfFalse(MapKind == kind)
 		seq.Append(item)
 	}
-	return newMap(seq.Done().(orderedSequence))
+	return newMap(seq.Done())
 }

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -33,7 +33,7 @@ func (mes mapEntrySlice) Equals(other mapEntrySlice) bool {
 	return true
 }
 
-func newMapLeafSequence(vr ValueReader, data ...mapEntry) orderedSequence {
+func newMapLeafSequence(vr ValueReader, data ...mapEntry) sequence {
 	kts := make([]*Type, len(data))
 	vts := make([]*Type, len(data))
 	for i, e := range data {
@@ -65,8 +65,6 @@ func (ml mapLeafSequence) getCompareFn(other sequence) compareFn {
 		return entry.key.Equals(otherEntry.key) && entry.value.Equals(otherEntry.value)
 	}
 }
-
-// orderedSequence interface
 
 func (ml mapLeafSequence) getKey(idx int) orderedKey {
 	return newOrderedKey(ml.data[idx].key)

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -15,7 +15,7 @@ const (
 	lengthOfNumbersTest = 1000
 )
 
-type diffFn func(last orderedSequence, current orderedSequence, changes chan<- ValueChanged, closeChan <-chan struct{}) bool
+type diffFn func(last sequence, current sequence, changes chan<- ValueChanged, closeChan <-chan struct{}) bool
 
 type diffTestSuite struct {
 	suite.Suite
@@ -39,7 +39,7 @@ func newDiffTestSuite(from1, to1, by1, from2, to2, by2, numAddsExpected, numRemo
 	}
 }
 
-func accumulateOrderedSequenceDiffChanges(o1, o2 orderedSequence, df diffFn) (added []Value, removed []Value, modified []Value) {
+func accumulateOrderedSequenceDiffChanges(o1, o2 sequence, df diffFn) (added []Value, removed []Value, modified []Value) {
 	changes := make(chan ValueChanged)
 	closeChan := make(chan struct{})
 	go func() {
@@ -75,8 +75,8 @@ func (suite *diffTestSuite) TestDiff() {
 		col1 := cf(vf(suite.from1, suite.to1, suite.by1))
 		col2 := cf(vf(suite.from2, suite.to2, suite.by2))
 		suite.added, suite.removed, suite.modified = accumulateOrderedSequenceDiffChanges(
-			col1.sequence().(orderedSequence),
-			col2.sequence().(orderedSequence),
+			col1.sequence(),
+			col2.sequence(),
 			df)
 		suite.Equal(suite.numAddsExpected, len(suite.added), "test %s: num added is not as expected", name)
 		suite.Equal(suite.numRemovesExpected, len(suite.removed), "test %s: num removed is not as expected", name)

--- a/go/types/path.go
+++ b/go/types/path.go
@@ -226,7 +226,7 @@ func newHashIndexPath(h hash.Hash, intoKey bool) HashIndexPath {
 }
 
 func (hip HashIndexPath) Resolve(v Value) (res Value) {
-	var seq orderedSequence
+	var seq sequence
 	var getCurrentValue func(cur *sequenceCursor) Value
 
 	switch v := v.(type) {

--- a/go/types/sequence.go
+++ b/go/types/sequence.go
@@ -17,4 +17,5 @@ type sequence interface {
 	Type() *Type
 	getCompareFn(other sequence) compareFn
 	getChildSequence(idx int) sequence
+	getKey(idx int) orderedKey
 }

--- a/go/types/sequence_cursor_test.go
+++ b/go/types/sequence_cursor_test.go
@@ -16,6 +16,7 @@ type testSequence struct {
 }
 
 // sequence interface
+
 func (ts testSequence) getItem(idx int) sequenceItem {
 	return ts.items[idx]
 }
@@ -44,7 +45,12 @@ func (ts testSequence) getChildSequence(idx int) sequence {
 	return testSequence{child.([]interface{})}
 }
 
+func (ts testSequence) getKey(idx int) orderedKey {
+	panic("not reached")
+}
+
 // Value interface
+
 func (ts testSequence) Equals(other Value) bool {
 	panic("not reached")
 }

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Set struct {
-	seq orderedSequence
+	seq sequence
 	h   *hash.Hash
 }
 
-func newSet(seq orderedSequence) Set {
+func newSet(seq sequence) Set {
 	return Set{seq, &hash.Hash{}}
 }
 
@@ -27,7 +27,7 @@ func NewSet(v ...Value) Set {
 		ch.Append(v)
 	}
 
-	return newSet(ch.Done().(orderedSequence))
+	return newSet(ch.Done())
 }
 
 func NewStreamingSet(vrw ValueReadWriter, vals <-chan Value) <-chan Set {
@@ -159,7 +159,7 @@ func (s Set) splice(cur *sequenceCursor, deleteCount uint64, vs ...Value) Set {
 		ch.Append(v)
 	}
 
-	ns := newSet(ch.Done().(orderedSequence))
+	ns := newSet(ch.Done())
 	return ns
 }
 

--- a/go/types/setMutator.go
+++ b/go/types/setMutator.go
@@ -38,5 +38,5 @@ func (mx *setMutator) Finish() Set {
 		d.PanicIfFalse(SetKind == kind)
 		seq.Append(item)
 	}
-	return newSet(seq.Done().(orderedSequence))
+	return newSet(seq.Done())
 }

--- a/go/types/set_leaf_sequence.go
+++ b/go/types/set_leaf_sequence.go
@@ -9,7 +9,7 @@ type setLeafSequence struct {
 	data []Value // sorted by Hash()
 }
 
-func newSetLeafSequence(vr ValueReader, v ...Value) orderedSequence {
+func newSetLeafSequence(vr ValueReader, v ...Value) sequence {
 	ts := make([]*Type, len(v))
 	for i, v := range v {
 		ts[i] = v.Type()
@@ -37,8 +37,6 @@ func (sl setLeafSequence) getCompareFn(other sequence) compareFn {
 		return entry.Equals(osl.data[otherIdx])
 	}
 }
-
-// orderedSequence interface
 
 func (sl setLeafSequence) getKey(idx int) orderedKey {
 	return newOrderedKey(sl.data[idx])

--- a/go/types/value_decoder.go
+++ b/go/types/value_decoder.go
@@ -77,12 +77,12 @@ func (r *valueDecoder) readListLeafSequence(t *Type) sequence {
 	return listLeafSequence{leafSequence{r.vr, len(data), t}, data}
 }
 
-func (r *valueDecoder) readSetLeafSequence(t *Type) orderedSequence {
+func (r *valueDecoder) readSetLeafSequence(t *Type) sequence {
 	data := r.readValueSequence()
 	return setLeafSequence{leafSequence{r.vr, len(data), t}, data}
 }
 
-func (r *valueDecoder) readMapLeafSequence(t *Type) orderedSequence {
+func (r *valueDecoder) readMapLeafSequence(t *Type) sequence {
 	count := r.readUint32()
 	data := []mapEntry{}
 	for i := uint32(0); i < count; i++ {


### PR DESCRIPTION
It makes the JS port easier. It's slightly less compile time typesafe,
but the hoops aren't really worth it.
