### PR TITLE
Improve sequence read performance using read-ahead

### DIFF
--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -20,6 +20,14 @@ func newBlobMetaSequence(tuples []metaTuple, vr ValueReader) metaSequence {
 	return newMetaSequence(tuples, BlobType, vr)
 }
 
+// advanceCursorToOffset advances the cursor as close as possible to idx
+//
+// If the cursor references a leaf sequence,
+// 	advance to idx,
+// 	and return the number of values preceding and including idx
+// If it references a meta-sequence,
+// 	advance to the tuple containing idx,
+//      and return the number of leaf values preceding this tuple
 func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 	seq := cur.seq
 
@@ -28,6 +36,7 @@ func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 		cur.idx = 0
 		cum := uint64(0)
 
+		// Advance the cursor to the meta-sequence tuple containing idx
 		for cur.idx < ms.seqLen()-1 && uint64(idx) >= cum+ms.tuples[cur.idx].numLeaves {
 			cum += ms.tuples[cur.idx].numLeaves
 			cur.idx++
@@ -40,7 +49,8 @@ func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 	if cur.idx > seq.seqLen() {
 		cur.idx = seq.seqLen()
 	}
-
+	// TODO: Why +1 here? This is inconsistent with the metaSeqence case and it's
+	// not clear why
 	return uint64(cur.idx) + 1
 }
 

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -24,10 +24,10 @@ func newBlobMetaSequence(tuples []metaTuple, vr ValueReader) metaSequence {
 //
 // If the cursor references a leaf sequence,
 // 	advance to idx,
-// 	and return the number of values preceding and including idx
+// 	and return the number of values preceding the idx
 // If it references a meta-sequence,
 // 	advance to the tuple containing idx,
-//      and return the number of leaf values preceding this tuple
+// 	and return the number of leaf values preceding this tuple
 func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 	seq := cur.seq
 
@@ -49,9 +49,7 @@ func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 	if cur.idx > seq.seqLen() {
 		cur.idx = seq.seqLen()
 	}
-	// TODO: Why +1 here? This is inconsistent with the metaSeqence case and it's
-	// not clear why
-	return uint64(cur.idx) + 1
+	return uint64(cur.idx)
 }
 
 // If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -5,7 +5,6 @@
 package types
 
 import (
-	"fmt"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/util/orderedparallel"
@@ -37,10 +36,6 @@ func (mt metaTuple) getChildSequence(vr ValueReader) sequence {
 		return mt.child.sequence()
 	}
 	return mt.ref.TargetValue(vr).(Collection).sequence()
-}
-
-func (mt *metaTuple) String() string {
-	return fmt.Sprintf("Type: %T, Ref: %s, %d , Leaves: %d, Key: %v", mt, EncodedValue(mt.ref), mt.ref.height, mt.numLeaves, mt.key.v)
 }
 
 // orderedKey is a key in a Prolly Tree level, which is a metaTuple in a metaSequence, or a value in a leaf sequence.

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -139,6 +139,7 @@ func (ms metaSequence) numLeaves() uint64 {
 	return ms.cumulativeNumberOfLeaves(len(ms.tuples) - 1)
 }
 
+
 // metaSequence interface
 func (ms metaSequence) getChildSequence(idx int) sequence {
 	mt := ms.tuples[idx]

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -139,7 +139,6 @@ func (ms metaSequence) numLeaves() uint64 {
 	return ms.cumulativeNumberOfLeaves(len(ms.tuples) - 1)
 }
 
-
 // metaSequence interface
 func (ms metaSequence) getChildSequence(idx int) sequence {
 	mt := ms.tuples[idx]

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -5,6 +5,7 @@
 package types
 
 import (
+	"fmt"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/util/orderedparallel"
@@ -35,8 +36,11 @@ func (mt metaTuple) getChildSequence(vr ValueReader) sequence {
 	if mt.child != nil {
 		return mt.child.sequence()
 	}
-
 	return mt.ref.TargetValue(vr).(Collection).sequence()
+}
+
+func (mt *metaTuple) String() string {
+	return fmt.Sprintf("Type: %T, Ref: %s, %d , Leaves: %d, Key: %v", mt, EncodedValue(mt.ref), mt.ref.height, mt.numLeaves, mt.key.v)
 }
 
 // orderedKey is a key in a Prolly Tree level, which is a metaTuple in a metaSequence, or a value in a leaf sequence.

--- a/go/types/ordered_sequences.go
+++ b/go/types/ordered_sequences.go
@@ -67,7 +67,6 @@ func newCursorAt(seq orderedSequence, key orderedKey, forInsertion bool, last bo
 		}
 		seq = cs.(orderedSequence)
 	}
-
 	d.PanicIfFalse(cur != nil)
 	return cur
 }

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -34,7 +34,6 @@ func newSequenceCursor(parent *sequenceCursor, seq sequence, idx int) *sequenceC
 	return &sequenceCursor{parent, seq, idx, nil}
 }
 
-
 func (cur *sequenceCursor) length() int {
 	return cur.seq.seqLen()
 }
@@ -169,17 +168,15 @@ func newCursorAtIndex(seq sequence, idx uint64) *sequenceCursor {
 	return cur
 }
 
-// enableReadAhead turns on chunk read-ahead for this cursor.
+// enableReadAhead turns on chunk read-ahead for a leaf sequence cursor.
+// It is only intended to be called by sequenceIterator.
 //
 // Read-ahead should only be used in cases where the caller is iterating sequentially
 // forward through all chunks starting at the current position.
-//
-// should only be call by sequenceIterator
 func (cur *sequenceCursor) enableReadAhead() {
 	_, meta := cur.seq.(metaSequence)
 	d.PanicIfTrue(meta)
-	if cur.parent != nil { // ignore if there are multiple chunks
+	if cur.parent != nil { // only operative if sequence is chunked
 		cur.readAhead = newSequenceReadAhead(cur.parent, readAheadParallelism)
 	}
-
 }

--- a/go/types/sequence_iterator.go
+++ b/go/types/sequence_iterator.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+// iterSequence efficiently iterates through a sequence calling cb for
+// each item.
+//
+// This is preferred to sequenceCursor.iter()
+func iterSequence(sc *sequenceCursor, cb cursorIterCallback) {
+	cur := sc.clone()
+	cur.enableReadAhead()
+	it := &sequenceIterator{cur}
+	for it.hasMore() && !cb(it.item()) {
+		it.advance(1)
+	}
+}
+
+// sequenceIterator iterates forward through a sequence.
+//
+// Since it can assume the sequence is being read forward, it reads
+// upcoming chunks ahead of their access to optimize throughput
+type sequenceIterator struct {
+	cursor *sequenceCursor
+}
+
+// newSequenceIterator creates an iterator for reading a sequence
+func newSequenceIterator(seq sequence, idx uint64) *sequenceIterator {
+	sc := newCursorAtIndex(seq, idx)
+	sc.enableReadAhead()
+	return &sequenceIterator{sc}
+}
+
+
+// hasMore return true if there's more to iterate
+func (si sequenceIterator) hasMore() bool {
+	return si.cursor.valid()
+}
+
+// advance advances the iterator by n items
+func (si sequenceIterator) advance(n int) bool {
+	for i := 0; i < n; i++ {
+		si.cursor.advance()
+	}
+	return si.cursor.valid()
+}
+
+// item returns the value at the current position
+func (si sequenceIterator) item() sequenceItem {
+	return si.cursor.current()
+}
+
+// chunkAndIndex returns the current leaf chunk and the index in that chunk referring to Item()
+func (si sequenceIterator) chunkAndIndex() (sequence, int) {
+	return si.cursor.seq, si.cursor.idx
+}
+
+// hitRate returns the read-ahead cache hit rate
+func (si sequenceIterator) readAheadHitRate() float32 {
+	if ra := si.cursor.readAhead; ra != nil {
+		return ra.hitRate()
+	}
+	return 0.0
+}
+
+
+

--- a/go/types/sequence_iterator_test.go
+++ b/go/types/sequence_iterator_test.go
@@ -1,0 +1,89 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+var seedData = []string{
+	"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+}
+
+const testCollectionSize = 100000
+
+func genTestBlob() (Blob, []byte) {
+	var buffer bytes.Buffer
+	for i := 0; i < testCollectionSize; i += 1 {
+		for _, v := range seedData {
+			buffer.WriteString(fmt.Sprintf("%d%s", i, v))
+		}
+	}
+	blob := NewBlob(bytes.NewReader(buffer.Bytes()))
+	return blob, buffer.Bytes()
+}
+
+func TestIterBlob(t *testing.T) {
+	testIter := func(t *testing.T, blob Blob, expected []byte, start int) {
+		assert := assert.New(t)
+		expected = expected[start:]
+		iter := newSequenceIterator(blob.seq, uint64(start))
+		actual := []byte{}
+		for iter.hasMore() {
+			actual = append(actual, iter.item().(byte))
+			iter.advance(1)
+		}
+		assert.Equal(len(expected), len(actual))
+		assert.Equal(expected, actual)
+		// delta normally 0 but may be more in rare case where the same
+		// (chunkIdx, hash) pair is repeated in different chunks. A lower
+		// hit rate likely indicates a bug.
+		assert.InDelta(1.0, iter.readAheadHitRate(), 0.01)
+	}
+
+	blob, expected := genTestBlob()
+
+	testIter(t, blob, expected, 0)
+	testIter(t, blob, expected, len(expected)/2)
+}
+
+func TestIterList(t *testing.T) {
+	genList := func() (List, []string) {
+		var buffer []string
+		var lbuffer []Value
+
+		list := NewList()
+
+		for i := 0; i < testCollectionSize; i += 1 {
+			for _, v := range seedData {
+				s := fmt.Sprintf("%d%s", i, v)
+				buffer = append(buffer, s)
+				lbuffer = append(lbuffer, String(s))
+			}
+		}
+		list = list.Append(lbuffer...)
+		return list, buffer
+
+	}
+	testIter := func(t *testing.T, list List, expected []string, start int) {
+		assert := assert.New(t)
+		expected = expected[start:]
+		iter := newSequenceIterator(list.seq, uint64(start))
+		actual := []string{}
+		for iter.hasMore() {
+			actual = append(actual, string(iter.item().(String)))
+			iter.advance(1)
+		}
+		assert.Equal(len(expected), len(actual))
+		assert.Equal(expected, actual)
+	}
+	list, expected := genList()
+	testIter(t, list, expected, 0)
+	testIter(t, list, expected, len(expected)/2)
+}

--- a/go/types/sequence_iterator_test.go
+++ b/go/types/sequence_iterator_test.go
@@ -25,7 +25,7 @@ func genTestBlob() (Blob, []byte) {
 			buffer.WriteString(fmt.Sprintf("%d%s", i, v))
 		}
 	}
-	blob := NewBlob(bytes.NewReader(buffer.Bytes()))
+	blob := NewBlob(&buffer)
 	return blob, buffer.Bytes()
 }
 
@@ -34,7 +34,7 @@ func TestIterBlob(t *testing.T) {
 		assert := assert.New(t)
 		expected = expected[start:]
 		iter := newSequenceIterator(blob.seq, uint64(start))
-		actual := []byte{}
+		var actual []byte
 		for iter.hasMore() {
 			actual = append(actual, iter.item().(byte))
 			iter.advance(1)

--- a/go/types/sequence_readahead.go
+++ b/go/types/sequence_readahead.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"github.com/attic-labs/noms/go/hash"
+)
+
+// sequenceReadAhead implements read-ahead by mapping a hash to a channel returning
+// the corresponding sequence.
+//
+// It reads ahead by firing off a set of short-lived go routines. Each go
+// routine (1) reads a sequence, (2) inserts it into a channel, (3) adds the
+// channel to the map keyed by sequence hash, and (4) exits.
+//
+// The caller retrieves the sequence by looking up the channel by hash and
+// reading from it.
+//
+// It maintains parallelism |p| by initially firing off |p| go routines
+// to read the next |p| sequences. When a sequence is retreived from the cache,
+// It fires off a new go-routine to read the next sequence. This ensures that
+// there are always |p| outstanding channels to read from the cache.
+//
+// This approach has one major advantage over a channel based approach:
+// there are no go-routines to shutdown when finished with the cursor. This
+// avoids requiring caller to call a Close() method.
+type sequenceReadAhead struct {
+	cursor      *sequenceCursor
+	cache       map[raKey]chan sequence
+	parallelism int
+	outstanding int
+	getCount    float32
+	hitCount    float32
+}
+
+// raKey is the future key. Rather than simply use the hash, we combines it
+// with the local chunk offset. This increases the likelihood that repeat values
+// in the sequence will get unique entries in the map.
+type raKey struct {
+	idx int
+	hash hash.Hash
+}
+
+func newSequenceReadAhead(cursor *sequenceCursor, parallelism int) *sequenceReadAhead {
+	m := map[raKey]chan sequence{}
+	return &sequenceReadAhead{cursor.clone(), m, parallelism, 0, 0.0, 0.0}
+}
+
+func (ram *sequenceReadAhead) get(idx int, h hash.Hash) (sequence, bool) {
+	ram.readAhead()
+	key := raKey{idx,  h}
+	ram.getCount += 1
+	if future, ok := ram.cache[key]; ok {
+		ram.outstanding -= 1
+		result := <-future
+		ram.hitCount += 1
+		delete(ram.cache, key)
+		return result, true
+	}
+	return nil, false
+}
+
+// readAhead (called when read-ahead is enabled) primes the next entries in the
+// read-ahead cache. It ensures that go routines have been allocated for reading
+// the next n entries in the current sequence. N is either readAheadParallelism
+// or the number of entries left in the sequence if smaller.
+func (ram *sequenceReadAhead) readAhead() {
+	// the next position to be primed
+	count := ram.parallelism - ram.outstanding
+	for i := 0; i < count; i += 1 {
+		ram.cursor.advance()
+		if !ram.cursor.valid() {
+			break
+		}
+		future := make(chan sequence, 1)
+		key := raKey{
+			ram.cursor.idx,
+			ram.cursor.current().(metaTuple).ref.target,
+		}
+		ram.cache[key] = future
+		seq := ram.cursor.seq
+		idx := ram.cursor.idx
+		go func() {
+			defer close(future)
+			val := seq.getChildSequence(idx)
+			future <- val
+
+		}()
+		ram.outstanding += 1
+	}
+}
+
+func (rc *sequenceReadAhead) hitRate() float32 {
+	return rc.hitCount/rc.getCount
+}
+
+
+

--- a/go/util/math/minmax.go
+++ b/go/util/math/minmax.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package math
+
+// MaxInt returns the larger of x or y.
+func MaxInt(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}
+
+// MinInt returns the smaller of x or y.
+func MinInt(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}


### PR DESCRIPTION
This change implements read-ahead in the sequence_cursor to speed up sequence reads.

Some before and after numbers reading sf-registered-businesses/raw:

| Origin | Before | After |
| --- | --- | --- |
| ldb | 45 MB/s | 60 MB/s |
| localhost | 7.5 MB/s | 27 MB/s |
| demo.noms.io | 140 KB/s | 2.1 MB/s |

The approach:

For each meta-sequence that contains leaf sequences, start reading ahead in
parallel and deliver in order to a buffered channel. Each advance of the cursor gets
the next sequence in the read-ahead channel.

Since this is operating on the sequence_cursor, it benefits all sequence types.
## toward: #2079
