### PR TITLE
Correctly handle HTTP conflict status on updateRoot

### DIFF
--- a/js/noms/src/fetch.js
+++ b/js/noms/src/fetch.js
@@ -33,6 +33,15 @@ const requestModules = {
   'https:': https,
 };
 
+export class HTTPError extends Error {
+  constructor(status: number) {
+    super(`HTTP Error: ${status}`);
+    this.status = status;
+  }
+
+  status = 0;
+}
+
 function fetch(url: string, options: FetchOptions = {}): Promise<BufResponse> {
   const opts: any = parse(url);
   opts.method = options.method || 'GET';
@@ -42,7 +51,7 @@ function fetch(url: string, options: FetchOptions = {}): Promise<BufResponse> {
   return new Promise((resolve, reject) => {
     const req = requestModules[opts.protocol].request(opts, res => {
       if (res.statusCode < 200 || res.statusCode >= 300) {
-        reject(new Error(`HTTP Error: ${res.statusCode}`));
+        reject(new HTTPError(res.statusCode));
         return;
       }
 

--- a/js/noms/src/http-batch-store.js
+++ b/js/noms/src/http-batch-store.js
@@ -14,6 +14,7 @@ import {emptyChunk} from './chunk.js';
 import {
   fetchUint8Array as fetchUint8ArrayWithoutVersion,
   fetchText as fetchTextWithoutVersion,
+  HTTPError,
 } from './fetch.js';
 import {notNull} from './assert.js';
 import nomsVersion from './version.js';
@@ -151,7 +152,7 @@ export class Delegate {
       }
       return true;
     } catch (ex) {
-      if (ex === HTTP_STATUS_CONFLICT) {
+      if (ex instanceof HTTPError && ex.status === HTTP_STATUS_CONFLICT) {
         return false;
       }
       throw ex;


### PR DESCRIPTION
The code in fetch.js and http_batch_store.js weren't really
agreeing on how HTTP failures were reported up the stack. Now,
they agree, and this allows HttpBatchStore.updateRoot() to
correctly detect a conflict response and return false.

This means that the merge logic in Database.commit() works right,
now.

Fixes #2699