### PR TITLE
Remove commit de-duping

### DIFF
--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -114,12 +114,8 @@ func (dbc *databaseCommon) doCommit(datasetID string, commit types.Struct) error
 
 			// First commit in dataset is always fast-forward, so go through all this iff there's already a Head for datasetID.
 			if hasHead {
-				currentHeadRef := r.(types.Ref)
-				if commitRef.Equals(currentHeadRef) {
-					return nil
-				}
 				// This covers all cases where commit doesn't descend from the Head of datasetID, including the case where we hit an ErrOptimisticLockFailed and looped back around because some other process changed the Head out from under us.
-				if !CommitDescendsFrom(commit, currentHeadRef, dbc) {
+				if !CommitDescendsFrom(commit, r.(types.Ref), dbc) {
 					return ErrMergeNeeded
 				}
 			}

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -191,6 +191,20 @@ func (suite *DatabaseSuite) TestDatabaseCommit() {
 	newDB.Close()
 }
 
+func (suite *DatabaseSuite) TestDatabaseDuplicateCommit() {
+	datasetID := "ds1"
+	ds := suite.db.GetDataset(datasetID)
+	datasets := suite.db.Datasets()
+	suite.Zero(datasets.Len())
+
+	v := types.String("Hello")
+	_, err := suite.db.CommitValue(ds, v)
+	suite.NoError(err)
+
+	_, err = suite.db.CommitValue(ds, v)
+	suite.Error(err)
+}
+
 func (suite *DatabaseSuite) TestDatabaseDelete() {
 	datasetID1, datasetID2 := "ds1", "ds2"
 	ds1, ds2 := suite.db.GetDataset(datasetID1), suite.db.GetDataset(datasetID2)

--- a/js/noms/src/database-test.js
+++ b/js/noms/src/database-test.js
@@ -109,6 +109,28 @@ suite('Database', () => {
     await db.close();
   });
 
+  test('duplicate commit', async () => {
+    const bs = makeRemoteBatchStoreFake();
+    const db = new Database(bs);
+    const ds = await db.getDataset('ds1');
+
+    const datasets = await db.datasets();
+    assert.isTrue(datasets.isEmpty());
+
+    await db.commit(ds, 'a');
+    // Should be disallowed, Dataset returned by Commit() should have |c| as Head.
+    let message = '';
+    try {
+      await db.commit(ds, 'a');
+      throw new Error('not reached');
+    } catch (ex) {
+      message = ex.message;
+    }
+    assert.strictEqual('Merge needed', message);
+
+    await db.close();
+  });
+
   test('concurrency', async () => {
     const bs = makeRemoteBatchStoreFake();
     const db = new Database(bs);

--- a/js/noms/src/database.js
+++ b/js/noms/src/database.js
@@ -14,7 +14,6 @@ import ValueStore from './value-store.js';
 import type {BatchStore} from './batch-store.js';
 import Dataset from './dataset.js';
 import Commit from './commit.js';
-import {equals} from './compare.js';
 import type Struct from './struct.js';
 
 type CommitOptions = {
@@ -133,9 +132,6 @@ export default class Database {
       if (!currentRootRef.isEmpty()) {
         const currentHeadRef = await currentDatasets.get(datasetId);
         if (currentHeadRef) {
-          if (equals(commitRef, currentHeadRef)) {
-            break;
-          }
           if (!await this._descendsFrom(commit, currentHeadRef)) {
             throw new Error('Merge needed');
           }


### PR DESCRIPTION
Now that we're going to put in real commit-merge logic, we
can take out the very-old hack that deduplicated identical
commits.

Fixes #2720