### PR TITLE
Make pin return unchanged spec if it's already pinned

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "63.2.0",
+  "version": "63.2.1",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/specs-test.js
+++ b/js/noms/src/specs-test.js
@@ -221,5 +221,8 @@ suite('Specs', () => {
     ds = await db.commit(ds, 43);
     assert.strictEqual(42, (await pinned.value())[1]);
     assert.strictEqual(43, (await unpinned.value())[1]);
+
+    const pinned1 = PathSpec.parse('mem::#imgp9mp1h3b9nv0gna6mri53dlj9f4ql.value');
+    assert.strictEqual(pinned1, await pinned1.pin());
   });
 });

--- a/js/noms/src/specs.js
+++ b/js/noms/src/specs.js
@@ -176,7 +176,8 @@ export class PathSpec {
   /**
    * Returns a new PathSpec in which the dataset component, if any, has been
    * replaced with the hash of the HEAD of that dataset. This "pins" the path
-   * to the state of the database at the current moment in time.
+   * to the state of the database at the current moment in time. Returns this
+   * if the PathSpec is already "pinned".
    */
   async pin(): Promise<?PathSpec> {
     if (this.path.dataset !== '') {
@@ -188,6 +189,7 @@ export class PathSpec {
       return new PathSpec(this.database,
         new AbsolutePath('', commit.hash, this.path.path));
     }
+    return this;
   }
 
   /**


### PR DESCRIPTION
The current implementation of pin means that programs like find-photos can't take a pinned path as it's <in-path> argument. This should re-enable that functionality.

Do I need to bump up the noms version for this change?