### PR TITLE
Implement private databases for the demo server

### DIFF
--- a/go/util/receipts/receipts.go
+++ b/go/util/receipts/receipts.go
@@ -1,0 +1,130 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package receipts
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/hash"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+// Data stores parsed receipt data.
+type Data struct {
+	Database string
+	Date     time.Time
+}
+
+// KeySize is the size in bytes of receipt keys.
+const KeySize = 32 // secretbox
+
+// Key is used to encrypt receipt data.
+type Key [KeySize]byte
+
+// Don't use a nonce when sealing/opening secretbox because these receipts need
+// to be used across sessions.
+var emptyNonce [24]byte
+
+// Force all receipts to have the same size, to avoid size attacks.
+const receiptSize = 256
+
+// DecodeKey converts a base64 encoded string to a receipt key.
+func DecodeKey(s string) (key Key, err error) {
+	keySlice, err2 := base64.URLEncoding.DecodeString(s)
+	if err2 != nil {
+		err = err2
+		return
+	}
+
+	if len(keySlice) != len(key) {
+		err = fmt.Errorf("--key must be %d bytes when decoded, not %d", len(key), len(keySlice))
+		return
+	}
+
+	copy(key[:], keySlice)
+	return
+}
+
+// Generate returns a receipt for Data, which is an encrypted query string
+// encoded as base64.
+func Generate(key Key, data Data) (string, error) {
+	d.PanicIfTrue(data.Database == "" || data.Date == (time.Time{}))
+
+	receiptPlainOrig := []byte(url.Values{
+		"Database": []string{nomsHash(data.Database)},
+		"Date":     []string{data.Date.Format(time.RFC3339Nano)},
+		"Salt":     []string{genSalt()},
+	}.Encode())
+	// This should be a constant size because the database name is hashed, the
+	// date format is standard, and the salt is 32 bytes. As of writing this is
+	// 140 bytes - you can even tweet them. 256 bytes is plenty of room.
+	d.PanicIfTrue(len(receiptPlainOrig) > receiptSize)
+
+	var receiptPlain [receiptSize]byte
+	copy(receiptPlain[:], receiptPlainOrig)
+
+	var keyBytes [KeySize]byte = key
+	receiptSealed := secretbox.Seal(nil, receiptPlain[:], &emptyNonce, &keyBytes)
+
+	return base64.URLEncoding.EncodeToString(receiptSealed), nil
+}
+
+// Verify verifies that a generated receipt grants access to a database.
+// The Date field will be populated with the date from the decrypted receipt.
+//
+// Returns a tuple (ok, error) where ok is true if verification succeeds and
+// false if not. Error is non-nil if the receipt itself is invalid.
+func Verify(key Key, receiptText string, data *Data) (bool, error) {
+	d.PanicIfTrue(data.Database == "")
+
+	receiptSealed, err := base64.URLEncoding.DecodeString(receiptText)
+	if err != nil {
+		return false, err
+	}
+
+	var keyBytes [KeySize]byte = key
+	receiptPlain, ok := secretbox.Open(nil, receiptSealed, &emptyNonce, &keyBytes)
+	if !ok {
+		return false, fmt.Errorf("Failed to decrypt receipt")
+	}
+
+	query, err := url.ParseQuery(string(receiptPlain))
+	if err != nil {
+		return false, fmt.Errorf("Receipt is not a valid query string")
+	}
+
+	database := query.Get("Database")
+	if database == "" {
+		return false, fmt.Errorf("Receipt is missing a Database field")
+	}
+
+	dateString := query.Get("Date")
+	if dateString == "" {
+		return false, fmt.Errorf("Receipt is missing a Date field")
+	}
+
+	date, err := time.Parse(time.RFC3339Nano, dateString)
+	if err != nil {
+		return false, err
+	}
+
+	data.Date = date
+	return nomsHash(data.Database) == database, nil
+}
+
+func nomsHash(s string) string {
+	return hash.FromData([]byte(s)).String()
+}
+
+func genSalt() string {
+	var salt [32]byte
+	rand.Read(salt[:])
+	return base64.URLEncoding.EncodeToString(salt[:])
+}

--- a/go/util/receipts/receipts.go
+++ b/go/util/receipts/receipts.go
@@ -33,9 +33,10 @@ const nonceSize = 24
 
 // DecodeKey converts a base64 encoded string to a receipt key.
 func DecodeKey(s string) (key Key, err error) {
-	keySlice, err2 := base64.URLEncoding.DecodeString(s)
-	if err2 != nil {
-		err = err2
+	var keySlice []byte
+	keySlice, err = base64.URLEncoding.DecodeString(s)
+
+	if err != nil {
 		return
 	}
 
@@ -125,6 +126,6 @@ func Verify(key Key, receiptText string, data *Data) (bool, error) {
 }
 
 func hash(s string) string {
-	h := sha512.Sum512([]byte(s))
+	h := sha512.Sum512_224([]byte(s))
 	return base64.URLEncoding.EncodeToString(h[:])
 }

--- a/go/util/receipts/receipts.go
+++ b/go/util/receipts/receipts.go
@@ -62,7 +62,7 @@ func Generate(key Key, data Data) (string, error) {
 	rand.Read(nonce[:])
 
 	var keyBytes [keySize]byte = key
-	receiptSealed := secretbox.Seal(nil, receiptPlain[:], &nonce, new([keySize]byte(key)))
+	receiptSealed := secretbox.Seal(nil, receiptPlain[:], &nonce, &keyBytes)
 
 	// Put the nonce before the main receipt data.
 	receiptFull := make([]byte, len(nonce)+len(receiptSealed))

--- a/go/util/receipts/receipts_test.go
+++ b/go/util/receipts/receipts_test.go
@@ -1,0 +1,125 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package receipts
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestDecodeKey(t *testing.T) {
+	assert := assert.New(t)
+
+	var emptyKey Key
+
+	key, err := DecodeKey("QN8bb2Sj9wp1U7YZ5_O1VYpEVD26YbIFe0b8tw4aW08=")
+	assert.NoError(err)
+	assert.Equal(Key{
+		0x40, 0xdf, 0x1b, 0x6f, 0x64, 0xa3, 0xf7, 0x0a,
+		0x75, 0x53, 0xb6, 0x19, 0xe7, 0xf3, 0xb5, 0x55,
+		0x8a, 0x44, 0x54, 0x3d, 0xba, 0x61, 0xb2, 0x05,
+		0x7b, 0x46, 0xfc, 0xb7, 0x0e, 0x1a, 0x5b, 0x4f,
+	}, key)
+
+	key, err = DecodeKey("")
+	assert.Error(err)
+	assert.Equal(emptyKey, key)
+
+	// Invalid base64.
+	key, err = DecodeKey("QN8bb2Sj9wp1U7YZ5_O1VYpEVD26YbIFe0b8tw4aW08")
+	assert.Error(err)
+	assert.Equal(emptyKey, key)
+
+	// Valid base64, short key.
+	key, err = DecodeKey("QN8bb2Sj9wp1U7YZ5_O1VYpEVD26YbIFe0b8tw4a")
+	assert.Error(err)
+	assert.Equal(emptyKey, key)
+
+	// Valid base64, long key.
+	key, err = DecodeKey("QN8bb2Sj9wp1U7YZ5_O1VYpEVD26YbIFe0b8tw4aW088")
+	assert.Error(err)
+	assert.Equal(emptyKey, key)
+}
+
+func TestGenerateValidReceipts(t *testing.T) {
+	assert := assert.New(t)
+
+	key := randomKey()
+	now := time.Now()
+
+	d := Data{
+		Database: "MyDB",
+		Date:     now,
+	}
+
+	receipt, err := Generate(key, d)
+	assert.NoError(err)
+	assert.True(receipt != "")
+
+	d2 := Data{
+		Database: "MyDB",
+	}
+
+	ok, err := Verify(key, receipt, &d2)
+	assert.NoError(err)
+	assert.True(ok)
+	assert.True(now.Equal(d2.Date), "Expected %s, got %s", now, d2.Date)
+
+	d3 := Data{
+		Database: "NotMyDB",
+	}
+
+	ok, err = Verify(key, receipt, &d3)
+	assert.NoError(err)
+	assert.False(ok)
+	assert.True(now.Equal(d3.Date), "Expected %s, got %s", now, d3.Date)
+}
+
+func TestVerifyInvalidReceipt(t *testing.T) {
+	assert := assert.New(t)
+
+	key := randomKey()
+	d := Data{
+		Database: "MyDB",
+	}
+
+	ok, err := Verify(key, "foobar", &d)
+	assert.Error(err)
+	assert.False(ok)
+	assert.True((time.Time{}).Equal(d.Date))
+}
+
+func TestReceiptsAreUnique(t *testing.T) {
+	assert := assert.New(t)
+
+	key := randomKey()
+	d := Data{
+		Database: "MyDB",
+		Date:     time.Now(),
+	}
+
+	r1, err := Generate(key, d)
+	assert.NoError(err)
+	r2, err := Generate(key, d)
+	assert.NoError(err)
+	r3, err := Generate(key, d)
+	assert.NoError(err)
+
+	assert.NotEqual(r1, r2)
+	assert.NotEqual(r1, r3)
+	assert.NotEqual(r2, r3)
+
+	assert.Equal(len(r1), len(r2))
+	assert.Equal(len(r1), len(r3))
+	assert.Equal(len(r2), len(r3))
+}
+
+func randomKey() (key Key) {
+	rand.Read(key[:])
+	return
+}

--- a/go/util/receipts/receipts_test.go
+++ b/go/util/receipts/receipts_test.go
@@ -53,8 +53,8 @@ func TestGenerateValidReceipts(t *testing.T) {
 	now := time.Now()
 
 	d := Data{
-		Database: "MyDB",
-		Date:     now,
+		Database:  "MyDB",
+		IssueDate: now,
 	}
 
 	receipt, err := Generate(key, d)
@@ -68,7 +68,7 @@ func TestGenerateValidReceipts(t *testing.T) {
 	ok, err := Verify(key, receipt, &d2)
 	assert.NoError(err)
 	assert.True(ok)
-	assert.True(now.Equal(d2.Date), "Expected %s, got %s", now, d2.Date)
+	assert.True(now.Equal(d2.IssueDate), "Expected %s, got %s", now, d2.IssueDate)
 
 	d3 := Data{
 		Database: "NotMyDB",
@@ -77,7 +77,7 @@ func TestGenerateValidReceipts(t *testing.T) {
 	ok, err = Verify(key, receipt, &d3)
 	assert.NoError(err)
 	assert.False(ok)
-	assert.True(now.Equal(d3.Date), "Expected %s, got %s", now, d3.Date)
+	assert.True(now.Equal(d3.IssueDate), "Expected %s, got %s", now, d3.IssueDate)
 }
 
 func TestVerifyInvalidReceipt(t *testing.T) {
@@ -91,7 +91,7 @@ func TestVerifyInvalidReceipt(t *testing.T) {
 	ok, err := Verify(key, "foobar", &d)
 	assert.Error(err)
 	assert.False(ok)
-	assert.True((time.Time{}).Equal(d.Date))
+	assert.True((time.Time{}).Equal(d.IssueDate))
 }
 
 func TestReceiptsAreUnique(t *testing.T) {
@@ -99,8 +99,8 @@ func TestReceiptsAreUnique(t *testing.T) {
 
 	key := randomKey()
 	d := Data{
-		Database: "MyDB",
-		Date:     time.Now(),
+		Database:  "MyDB",
+		IssueDate: time.Now(),
 	}
 
 	r1, err := Generate(key, d)

--- a/samples/go/demo-server/main.go
+++ b/samples/go/demo-server/main.go
@@ -6,32 +6,43 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/util/receipts"
 	flag "github.com/juju/gnuflag"
 )
 
 var (
-	portFlag    = flag.Int("port", 8000, "port to listen on")
-	ldbDir      = flag.String("ldb-dir", "", "directory for ldb database")
-	authKeyFlag = flag.String("authkey", "", "token to use for authenticating write operations")
+	portFlag       = flag.Int("port", 8000, "port to listen on")
+	ldbDir         = flag.String("ldb-dir", "", "directory for ldb database")
+	authKeyFlag    = flag.String("authkey", "", "token to use for authenticating write operations")
+	receiptKeyFlag = flag.String("receiptkey", "", "Receipt key to use for generating and verifying receipts (generate with tools/crypto/receiptkey)")
 )
-
-func usage() {
-	fmt.Println("Usage: demo-server -authkey <authkey> [options]")
-	flag.PrintDefaults()
-}
 
 func main() {
 	chunks.RegisterLevelDBFlags(flag.CommandLine)
 	dynFlags := chunks.DynamoFlags("")
 
-	flag.Usage = usage
+	flag.Usage = func() {
+		fmt.Println("Usage: demo-server --authkey <authkey> [options]")
+		flag.PrintDefaults()
+	}
 	flag.Parse(true)
 
-	if *portFlag == 0 || *authKeyFlag == "" {
-		usage()
-		return
+	if *authKeyFlag == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	var receiptKey receipts.Key
+	if *receiptKeyFlag != "" {
+		var err error
+		receiptKey, err = receipts.DecodeKey(*receiptKeyFlag)
+		if err != nil {
+			fmt.Printf("Invalid receipt key: %s\n", err.Error())
+			os.Exit(1)
+		}
 	}
 
 	var factory chunks.Factory
@@ -46,5 +57,5 @@ func main() {
 	}
 	defer factory.Shutter()
 
-	startWebServer(factory, *authKeyFlag)
+	startWebServer(factory, *authKeyFlag, receiptKey)
 }

--- a/samples/go/demo-server/web_server.go
+++ b/samples/go/demo-server/web_server.go
@@ -19,18 +19,21 @@ import (
 	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/util/receipts"
 	"github.com/julienschmidt/httprouter"
 )
 
 const (
-	dbParam      = "dbName"
-	nomsBaseHtml = "<html><head></head><body><p>Hi. This is a Noms HTTP server.</p><p>To learn more, visit <a href=\"https://github.com/attic-labs/noms\">our GitHub project</a>.</p></body></html>"
+	dbParam       = "dbName"
+	privatePrefix = "/p/"
+	nomsBaseHtml  = "<html><head></head><body><p>Hi. This is a Noms HTTP server.</p><p>To learn more, visit <a href=\"https://github.com/attic-labs/noms\">our GitHub project</a>.</p></body></html>"
 )
 
 var (
 	authRegexp = regexp.MustCompile("^Bearer\\s+(\\S*)$")
 	router     *httprouter.Router
 	authKey    = ""
+	receiptKey receipts.Key
 )
 
 func setupWebServer(factory chunks.Factory) *httprouter.Router {
@@ -65,9 +68,13 @@ func setupWebServer(factory chunks.Factory) *httprouter.Router {
 	return router
 }
 
-func startWebServer(factory chunks.Factory, key string) {
-	d.Chk.NotEmpty(key, "No auth key was provided to startWebServer")
-	authKey = key
+func startWebServer(factory chunks.Factory, authKeyParam string, receiptKeyParam receipts.Key) {
+	d.Chk.NotEmpty(authKeyParam, "No auth key was provided to startWebServer")
+	// Allow receiptKey to be empty, we'll just always fail verification if
+	// anybody tries to access a private database.
+
+	authKey = authKeyParam
+	receiptKey = receiptKeyParam
 	router = setupWebServer(factory)
 
 	fmt.Printf("Listening on http://localhost:%d/...\n", *portFlag)
@@ -85,36 +92,73 @@ func startWebServer(factory chunks.Factory, key string) {
 // Attach handlers that provide the Database API
 func storeHandle(factory chunks.Factory, hndlr datas.Handler) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
-		cs := factory.CreateStore(params.ByName(dbParam))
+		dbName := params.ByName(dbParam)
+
+		if isPrivate(dbName) {
+			// Private database access is granted with the master auth key, or a receipt.
+			token := getAuthToken(req)
+			if token != authKey && !checkReceipt(dbName, token) {
+				setUnauthorized(w)
+				return
+			}
+		}
+
+		cs := factory.CreateStore(dbName)
 		defer cs.Close()
 		hndlr(w, req, params, cs)
 	}
 }
 
 func authorizeHandle(f httprouter.Handle) httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		authHeader := r.Header.Get("Authorization")
-		token := ""
+	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+		// If it's a private database, delegate authentication to storeHandle.
+		isPriv := isPrivate(params.ByName(dbParam))
 
-		if authHeader != "" {
-			res := authRegexp.FindStringSubmatch(authHeader)
-			if res != nil {
-				token = res[1]
-			}
-		}
-
-		if token == "" {
-			token = r.URL.Query().Get("access_token")
-		}
-
-		authorized := token == authKey
-		if !authorized {
-			w.Header().Set("WWW-Authenticate", "Bearer realm=\"Restricted\", error=\"invalid token\"")
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		if !isPriv && getAuthToken(r) != authKey {
+			setUnauthorized(w)
 			return
 		}
-		f(w, r, ps)
+
+		f(w, r, params)
 	}
+}
+
+func getAuthToken(r *http.Request) (token string) {
+	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
+		if res := authRegexp.FindStringSubmatch(authHeader); res != nil {
+			token = res[1]
+		}
+	} else {
+		token = r.URL.Query().Get("access_token")
+	}
+	return
+}
+
+func isPrivate(dbName string) bool {
+	return strings.HasPrefix(dbName, privatePrefix)
+}
+
+func checkReceipt(dbName, token string) bool {
+	if receiptKey == (receipts.Key{}) {
+		return false
+	}
+
+	data := receipts.Data{
+		Database: dbName,
+	}
+	ok, err := receipts.Verify(receiptKey, token, &data)
+
+	if err != nil {
+		fmt.Printf("Error decoding receipt for %s: %s\n", dbName, err.Error())
+	} else if !ok {
+		fmt.Printf("Receipt verification failed for %s issued at %s\n", dbName, data.Date.String())
+	}
+	return ok
+}
+
+func setUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", "Bearer realm=\"Restricted\", error=\"invalid token\"")
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 }
 
 func noopHandle(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/samples/go/demo-server/web_server.go
+++ b/samples/go/demo-server/web_server.go
@@ -151,7 +151,7 @@ func checkReceipt(dbName, token string) bool {
 	if err != nil {
 		fmt.Printf("Error decoding receipt for %s: %s\n", dbName, err.Error())
 	} else if !ok {
-		fmt.Printf("Receipt verification failed for %s issued at %s\n", dbName, data.Date.String())
+		fmt.Printf("Receipt verification failed for %s issued at %s\n", dbName, data.IssueDate.String())
 	}
 	return ok
 }

--- a/samples/go/demo-server/web_server_test.go
+++ b/samples/go/demo-server/web_server_test.go
@@ -72,8 +72,8 @@ func TestWriteValue(t *testing.T) {
 
 	// Auth with receipt encrypted with empty (invalid) key:
 	receipt, err := receipts.Generate(receiptKey, receipts.Data{
-		Database: "/p/test/db",
-		Date:     time.Now(),
+		Database:  "/p/test/db",
+		IssueDate: time.Now(),
 	})
 	assert.NoError(err)
 
@@ -84,8 +84,8 @@ func TestWriteValue(t *testing.T) {
 	rand.Read(receiptKey[:])
 
 	receipt, err = receipts.Generate(receiptKey, receipts.Data{
-		Database: "/p/test/db",
-		Date:     time.Now(),
+		Database:  "/p/test/db",
+		IssueDate: time.Now(),
 	})
 	assert.NoError(err)
 
@@ -97,8 +97,8 @@ func TestWriteValue(t *testing.T) {
 	rand.Read(wrongReceiptKey[:])
 
 	receipt, err = receipts.Generate(wrongReceiptKey, receipts.Data{
-		Database: "/p/test/db",
-		Date:     time.Now(),
+		Database:  "/p/test/db",
+		IssueDate: time.Now(),
 	})
 	assert.NoError(err)
 
@@ -107,8 +107,8 @@ func TestWriteValue(t *testing.T) {
 
 	// Receipts cannot grant write access to non-private databases:
 	receipt, err = receipts.Generate(receiptKey, receipts.Data{
-		Database: "/test/db",
-		Date:     time.Now(),
+		Database:  "/test/db",
+		IssueDate: time.Now(),
 	})
 	assert.NoError(err)
 

--- a/samples/go/demo-server/web_server_test.go
+++ b/samples/go/demo-server/web_server_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -15,17 +16,15 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/receipts"
 	"github.com/attic-labs/testify/assert"
-)
-
-var (
-	dbName = "/test/db"
 )
 
 func TestRoot(t *testing.T) {
@@ -36,6 +35,8 @@ func TestRoot(t *testing.T) {
 
 	router = setupWebServer(factory)
 	defer func() { router = nil }()
+
+	dbName := "/test/db"
 
 	w := httptest.NewRecorder()
 	r, _ := newRequest("GET", dbName+constants.RootPath, nil)
@@ -59,6 +60,64 @@ func buildGetRefsRequestBody(hashes map[hash.Hash]struct{}) io.Reader {
 
 func TestWriteValue(t *testing.T) {
 	assert := assert.New(t)
+
+	// Auth with master key:
+	authKey = "goodAuthKey"
+	wrongKey := "wrongAuthKey"
+
+	testWriteValue(t, "/test/db", authKey, true, true)
+	testWriteValue(t, "/test/db", wrongKey, true, false)
+	testWriteValue(t, "/p/test/db", authKey, true, true)
+	testWriteValue(t, "/p/test/db", wrongKey, false, false)
+
+	// Auth with receipt encrypted with empty (invalid) key:
+	receipt, err := receipts.Generate(receiptKey, receipts.Data{
+		Database: "/p/test/db",
+		Date:     time.Now(),
+	})
+	assert.NoError(err)
+
+	testWriteValue(t, "/p/test/db", receipt, false, false)
+	testWriteValue(t, "/p/test/db2", receipt, false, false)
+
+	// Auth with good receipt:
+	rand.Read(receiptKey[:])
+
+	receipt, err = receipts.Generate(receiptKey, receipts.Data{
+		Database: "/p/test/db",
+		Date:     time.Now(),
+	})
+	assert.NoError(err)
+
+	testWriteValue(t, "/p/test/db", receipt, true, true)
+	testWriteValue(t, "/p/test/db2", receipt, false, false)
+
+	// Auth with wrong receipt (different receipt key):
+	var wrongReceiptKey receipts.Key
+	rand.Read(wrongReceiptKey[:])
+
+	receipt, err = receipts.Generate(wrongReceiptKey, receipts.Data{
+		Database: "/p/test/db",
+		Date:     time.Now(),
+	})
+	assert.NoError(err)
+
+	testWriteValue(t, "/p/test/db", receipt, false, false)
+	testWriteValue(t, "/p/test/db2", receipt, false, false)
+
+	// Receipts cannot grant write access to non-private databases:
+	receipt, err = receipts.Generate(receiptKey, receipts.Data{
+		Database: "/test/db",
+		Date:     time.Now(),
+	})
+	assert.NoError(err)
+
+	testWriteValue(t, "/test/db", receipt, true, false)
+	testWriteValue(t, "/test/db2", receipt, true, false)
+}
+
+func testWriteValue(t *testing.T, dbName, testAuthKey string, expectRead, expectWrite bool) {
+	assert := assert.New(t)
 	factory := chunks.NewMemoryStoreFactory()
 	defer factory.Shutter()
 
@@ -66,14 +125,35 @@ func TestWriteValue(t *testing.T) {
 	defer func() { router = nil }()
 
 	testString := "Now, what?"
-	authKey = "anauthkeyvalue"
 
-	w := httptest.NewRecorder()
-	r, err := newRequest("GET", dbName+constants.RootPath, nil)
-	assert.NoError(err)
-	router.ServeHTTP(w, r)
-	lastRoot := w.Body
-	assert.Equal(http.StatusOK, w.Code)
+	var (
+		w        *httptest.ResponseRecorder
+		r        *http.Request
+		err      error
+		lastRoot *bytes.Buffer
+	)
+
+	// GET /root/
+
+	runTestGetRoot := func(key string) {
+		path := dbName + constants.RootPath + prefixIfNotEmpty("?access_token=", key)
+		r, err = newRequest("GET", path, nil)
+		assert.NoError(err)
+		w = httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		lastRoot = w.Body
+	}
+
+	runTestGetRoot(testAuthKey)
+
+	if expectRead {
+		assert.Equal(http.StatusOK, w.Code)
+	} else {
+		assert.Equal(http.StatusUnauthorized, w.Code)
+		runTestGetRoot(authKey) // this should always succeed
+	}
+
+	// POST /writeValue/ preamble
 
 	craftCommit := func(v types.Value) types.Struct {
 		return datas.NewCommit(v, types.NewSet(), types.NewStruct("Meta", types.StructData{}))
@@ -97,25 +177,66 @@ func TestWriteValue(t *testing.T) {
 	chunks.Serialize(chunk2, body)
 	chunks.Serialize(chunk3, body)
 
-	w = httptest.NewRecorder()
-	r, err = newRequest("POST", dbName+constants.WriteValuePath+"?access_token="+authKey, ioutil.NopCloser(body))
-	assert.NoError(err)
-	router.ServeHTTP(w, r)
-	assert.Equal(http.StatusCreated, w.Code)
+	// POST /writeValue/
 
-	w = httptest.NewRecorder()
-	args := fmt.Sprintf("&last=%s&current=%s", lastRoot, types.NewRef(refMap).TargetHash())
-	r, _ = newRequest("POST", dbName+constants.RootPath+"?access_token="+authKey+args, ioutil.NopCloser(body))
-	router.ServeHTTP(w, r)
-	assert.Equal(http.StatusOK, w.Code, string(w.Body.Bytes()))
+	runTestPostWriteValue := func(key string) {
+		path := dbName + constants.WriteValuePath + prefixIfNotEmpty("?access_token=", key)
+		w = httptest.NewRecorder()
+		r, err = newRequest("POST", path, ioutil.NopCloser(body))
+		assert.NoError(err)
+		router.ServeHTTP(w, r)
+	}
+
+	runTestPostWriteValue(testAuthKey)
+
+	if expectWrite {
+		assert.Equal(http.StatusCreated, w.Code)
+	} else {
+		assert.Equal(http.StatusUnauthorized, w.Code)
+		runTestPostWriteValue(authKey) // this should always succeed
+	}
+
+	// POST /root/
+
+	runTestPostRoot := func(key string) {
+		args := fmt.Sprintf("?last=%s&current=%s", lastRoot, types.NewRef(refMap).TargetHash())
+		path := dbName + constants.RootPath + args + prefixIfNotEmpty("&access_token=", key)
+		w = httptest.NewRecorder()
+		r, _ = newRequest("POST", path, ioutil.NopCloser(body))
+		router.ServeHTTP(w, r)
+	}
+
+	runTestPostRoot(testAuthKey)
+
+	if expectWrite {
+		assert.Equal(http.StatusOK, w.Code, string(w.Body.Bytes()))
+	} else {
+		assert.Equal(http.StatusUnauthorized, w.Code)
+		runTestPostRoot(authKey) // this should always succeed
+	}
+
+	// POST /getRefs/
 
 	whash := wval.Hash()
 	hints := map[hash.Hash]struct{}{whash: {}}
 	rdr := buildGetRefsRequestBody(hints)
-	r, _ = newRequest("POST", dbName+constants.GetRefsPath, rdr)
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	router.ServeHTTP(w, r)
-	assert.Equal(http.StatusOK, w.Code, string(w.Body.Bytes()))
+
+	runTestPostGetRefs := func(key string) {
+		path := dbName + constants.GetRefsPath + prefixIfNotEmpty("?access_token=", key)
+		w = httptest.NewRecorder()
+		r, _ = newRequest("POST", path, rdr)
+		r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		router.ServeHTTP(w, r)
+	}
+
+	runTestPostGetRefs(testAuthKey)
+
+	if expectRead {
+		assert.Equal(http.StatusOK, w.Code, string(w.Body.Bytes()))
+	} else {
+		assert.Equal(http.StatusUnauthorized, w.Code)
+		runTestPostGetRefs(authKey) // this should always succeed
+	}
 
 	ms := chunks.NewMemoryStore()
 	chunks.Deserialize(w.Body, ms, nil)
@@ -130,4 +251,11 @@ func newRequest(method, url string, body io.Reader) (req *http.Request, err erro
 	}
 	req.Header.Set(datas.NomsVersionHeader, constants.NomsVersion)
 	return
+}
+
+func prefixIfNotEmpty(prefix, s string) string {
+	if s != "" {
+		return prefix + s
+	}
+	return ""
 }

--- a/tools/crypto/receiptkey/main.go
+++ b/tools/crypto/receiptkey/main.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/attic-labs/noms/go/util/receipts"
+)
+
+func main() {
+	var key receipts.Key
+	rand.Read(key[:])
+	fmt.Println(base64.URLEncoding.EncodeToString(key[:]))
+}

--- a/tools/crypto/receipttool/main.go
+++ b/tools/crypto/receipttool/main.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/attic-labs/noms/go/util/receipts"
+	flag "github.com/juju/gnuflag"
+)
+
+var (
+	databaseFlag = flag.String("database", "", "Name of the database this receipt is for")
+	keyFlag      = flag.String("key", "", "Receipt key to encrypt the receipt as base64, 32 bytes when decoded")
+	verifyFlag   = flag.String("verify", "", "Cipher text to verify (optional)")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, `receipttool generates or verifies database receipts.
+
+A --database name and receipt --key are required.
+
+By default, generates a receipt for --database, encrypted with --key.
+If --verify is given, receipttool will instead verify that the
+receipt matches --database and output "OK" on stdout if it does, or
+nothing on stdout and an error string on stderr if it doesn't.
+`)
+		flag.PrintDefaults()
+	}
+
+	flag.Parse(true)
+
+	if *databaseFlag == "" && *keyFlag == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *databaseFlag == "" {
+		exitIfError(fmt.Errorf("--database is required"))
+	}
+
+	if *keyFlag == "" {
+		exitIfError(fmt.Errorf("--key is required"))
+	}
+
+	key, err := receipts.DecodeKey(*keyFlag)
+	exitIfError(err)
+
+	if *verifyFlag == "" {
+		receipt, err := receipts.Generate(key, receipts.Data{
+			Database: *databaseFlag,
+			Date:     time.Now(),
+		})
+		exitIfError(err)
+		fmt.Println(receipt)
+	} else {
+		ok, err := receipts.Verify(key, *verifyFlag, &receipts.Data{
+			Database: *databaseFlag,
+		})
+		exitIfError(err)
+		if ok {
+			fmt.Println("OK")
+		} else {
+			fmt.Println("FAIL")
+		}
+	}
+}
+
+func exitIfError(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		os.Exit(1)
+	}
+}

--- a/tools/crypto/receipttool/main.go
+++ b/tools/crypto/receipttool/main.go
@@ -53,8 +53,8 @@ nothing on stdout and an error string on stderr if it doesn't.
 
 	if *verifyFlag == "" {
 		receipt, err := receipts.Generate(key, receipts.Data{
-			Database: *databaseFlag,
-			Date:     time.Now(),
+			Database:  *databaseFlag,
+			IssueDate: time.Now(),
 		})
 		exitIfError(err)
 		fmt.Println(receipt)


### PR DESCRIPTION
Private databases begin with "/p/" - for example, "/kalman" is not
private, but "/p/kalman" is private. They are not the same database.

The bulk of this work is the receipt infrastructure.

A receipt is form data that gives access to a database, encrypted using
secretbox. For example, "Database=/p/kalman&Date=12345678" might encrypt
to "SFH5bcIJ3_XgEbtmi_AdCKTItW20fl90czVl5_pF5PAXhNQ366U1yOpYGAjT".
- A new tool receiptkey generates random receipt (secretbox) keys.
- A new tool receipttool generates receipts for databases.
- demo-server has been updated to check for a receipt in the
  Authorization header to access private databases.

receipttool and demo-server must be given the same receipt key.
