### PR TITLE
Fix babel-preset-noms

### DIFF
--- a/js/babel-preset-noms/index.js
+++ b/js/babel-preset-noms/index.js
@@ -12,6 +12,18 @@ function plugin(n) {
   return require('babel-plugin-' + n);
 }
 
+const commonPlugins = [
+  plugin('syntax-async-functions'),
+  plugin('syntax-flow'),
+  plugin('transform-class-properties'),
+  [
+    plugin('transform-runtime'), {
+      polyfill: false,
+      regenerator: true,
+    },
+  ],
+];
+
 const production = {
   presets: [
     preset('es2015'),
@@ -19,16 +31,8 @@ const production = {
     preset('react'),
   ],
   plugins: [
-    plugin('syntax-async-functions'),
-    plugin('syntax-flow'),
-    plugin('transform-class-properties'),
+    ...commonPlugins,
     plugin('transform-regenerator'),
-    [
-      plugin('transform-runtime'), {
-        polyfill: false,
-        regenerator: true,
-      },
-    ],
   ],
 };
 
@@ -38,17 +42,9 @@ const development = {
     preset('react'),
   ],
   plugins: [
-    plugin('syntax-async-functions'),
-    plugin('syntax-flow'),
-    plugin('transform-async-to-generator'),
-    plugin('transform-class-properties'),
+    ...commonPlugins,
     plugin('transform-es2015-modules-commonjs'),
-    [
-      plugin('transform-runtime'), {
-        'polyfill': false,
-        'regenerator': true
-      }
-    ],
+    plugin('transform-async-to-generator'),
   ],
 };
 

--- a/js/babel-preset-noms/index.js
+++ b/js/babel-preset-noms/index.js
@@ -12,25 +12,24 @@ function plugin(n) {
   return require('babel-plugin-' + n);
 }
 
-const plugins = [
-  plugin('syntax-async-functions'),
-  plugin('transform-class-properties'),
-  plugin('transform-regenerator'),
-  [
-    plugin('transform-runtime'), {
-      polyfill: false,
-      regenerator: true,
-    },
-  ],
-];
-
 const production = {
   presets: [
     preset('es2015'),
     preset('es2016'),
     preset('react'),
   ],
-  plugins
+  plugins: [
+    plugin('syntax-async-functions'),
+    plugin('syntax-flow'),
+    plugin('transform-class-properties'),
+    plugin('transform-regenerator'),
+    [
+      plugin('transform-runtime'), {
+        polyfill: false,
+        regenerator: true,
+      },
+    ],
+  ],
 };
 
 const development = {
@@ -39,8 +38,17 @@ const development = {
     preset('react'),
   ],
   plugins: [
+    plugin('syntax-async-functions'),
+    plugin('syntax-flow'),
+    plugin('transform-async-to-generator'),
+    plugin('transform-class-properties'),
     plugin('transform-es2015-modules-commonjs'),
-    ...plugins,
+    [
+      plugin('transform-runtime'), {
+        'polyfill': false,
+        'regenerator': true
+      }
+    ],
   ],
 };
 

--- a/js/babel-preset-noms/package.json
+++ b/js/babel-preset-noms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-noms",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Babel preset for all Noms code.",
   "homepage": "https://babeljs.io/",
   "license": "Apache-2.0",
@@ -15,9 +15,7 @@
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-class-properties": "^6.11.5",
-    "babel-plugin-transform-es2015-destructuring": "^6.9.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
-    "babel-plugin-transform-es2015-parameters": "^6.11.4",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-es2016": "^6.16.0",


### PR DESCRIPTION
It wasn't working on the code coverage tests. Now I restored this
to what it was before these changes (minus removing some features
that chrome and node now supports out of the box)