### PR TITLE
Add --subdir argument to roll.py

### DIFF
--- a/tools/roll.py
+++ b/tools/roll.py
@@ -10,10 +10,16 @@ import argparse, os, os.path, subprocess, sys, shutil, urlparse
 def main():
   parser = argparse.ArgumentParser(description='Dependency snapshotter')
   parser.add_argument('url')
-  parser.add_argument('--path', help='path to store the dependency at, defaults to vendor/[url without protocol]')
-  parser.add_argument('--incl', help='subdirectory of the dependency to check out, defaults to root. Evaluated before --excl.')
-  parser.add_argument('--excl', help='subdirectory of the dependency to delete after checking out, defaults to nothing. Evaluated after --incl.')
-  parser.add_argument('--version', default='HEAD', help='version of the dependency to snapshot, defaults to HEAD')
+  parser.add_argument('--path', help=(
+      'path to store the dependency at, defaults to vendor/[url without protocol]'))
+  parser.add_argument('--incl', help=(
+      'subdirectory of the dependency to check out, relative to the path. '
+      'Defaults to root. Evaluated before --excl.'))
+  parser.add_argument('--excl', help=(
+      'subdirectory of the dependency to delete after checking out, relative to the path. '
+      'Defaults to nothing. Evaluated after --incl.'))
+  parser.add_argument('--version', default='HEAD', help=(
+      'version of the dependency to snapshot, defaults to HEAD'))
 
   args = parser.parse_args()
 

--- a/tools/roll.py
+++ b/tools/roll.py
@@ -88,7 +88,7 @@ def main():
 
   if excl is not None:
     if not os.path.isdir(excl):
-      print 'Warning: --incl directory %s does not exist, skipping.' % incl
+      print 'Warning: --excl directory %s does not exist, skipping.' % incl
     else:
       exclPath = os.path.abspath(excl)
       print 'rm subdirectory: %s' % exclPath

--- a/tools/roll.py
+++ b/tools/roll.py
@@ -11,6 +11,8 @@ def main():
   parser = argparse.ArgumentParser(description='Dependency snapshotter')
   parser.add_argument('url')
   parser.add_argument('--path', help='path to store the dependency at, defaults to vendor/[url without protocol]')
+  parser.add_argument('--incl', help='subdirectory of the dependency to check out, defaults to root. Evaluated before --excl.')
+  parser.add_argument('--excl', help='subdirectory of the dependency to delete after checking out, defaults to nothing. Evaluated after --incl.')
   parser.add_argument('--version', default='HEAD', help='version of the dependency to snapshot, defaults to HEAD')
 
   args = parser.parse_args()
@@ -19,6 +21,14 @@ def main():
   if url.scheme == '':
     print 'Invalid url: no scheme'
     sys.exit(1)
+
+  def rel(subdir):
+    if subdir is not None and os.path.isabs(subdir):
+      print 'subdirectory %s must be a relative path' % subdir
+      sys.exit(1)
+    return subdir
+  incl = rel(args.incl)
+  excl = rel(args.excl)
 
   if not os.path.isdir('.git'):
     print '%s must be run from the root of a repository' % sys.argv[0]
@@ -29,7 +39,7 @@ def main():
     path = path[1:]
 
   depdir = args.path
-  if depdir == None:
+  if depdir is None:
     depdir = os.path.join('vendor', url.netloc, path)
 
   shutil.rmtree(depdir, True)
@@ -52,7 +62,6 @@ def main():
 
   shutil.rmtree('.git')
 
-  # TODO: Should we also do Godeps?
   if os.path.isdir('vendor'):
     deps = [dirName for dirName, _, files in os.walk('vendor') if files]
     if deps:
@@ -60,6 +69,30 @@ def main():
       print ' %s contains one or more dependencies which will need to be vendored as well:' % args.url
       print ' -', '\n - '.join(deps)
     shutil.rmtree('vendor')
+
+  if incl is not None:
+    if not os.path.isdir(incl):
+      print 'Warning: --incl directory %s does not exist, skipping.' % incl
+    else:
+      inclPath = os.path.abspath(incl)
+      inclParent, inclName = os.path.split(inclPath)
+
+      for (dirpath, dirnames, _) in os.walk(os.getcwd()):
+        if dirpath == inclParent:
+          # Don't descend into the included subdirectory.
+          dirnames.remove(inclName)
+        elif not inclPath.startswith(dirpath):
+          # Remove directories that aren't an ancestor of the included.
+          print 'rm subdirectory: %s' % dirpath
+          shutil.rmtree(dirpath)
+
+  if excl is not None:
+    if not os.path.isdir(excl):
+      print 'Warning: --incl directory %s does not exist, skipping.' % incl
+    else:
+      exclPath = os.path.abspath(excl)
+      print 'rm subdirectory: %s' % exclPath
+      shutil.rmtree(exclPath)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If you want to roll just the go/ directory of noms, you can do:

$ roll.py https://github.com/attic-labs/noms --subdir go

Or, the nacl/secretbox/ directory of https://go.googlesource.com/crypto:

$ roll.py https://go.googlesource.com/crypto --subdir nacl/secretbox
