### PR TITLE
Add CopyAppend() method to types.Path

### DIFF
--- a/go/diff/diff.go
+++ b/go/diff/diff.go
@@ -115,7 +115,7 @@ func (d differ) diffLists(p types.Path, v1, v2 types.List) (stop bool) {
 					idx := types.Number(splice.SpAt + i)
 					stop = d.diff(append(p, types.NewIndexPath(idx)), lastEl, newEl)
 				} else {
-					p1 := copyAppend(p, types.NewIndexPath(types.Number(splice.SpAt+i)))
+					p1 := p.Append(types.NewIndexPath(types.Number(splice.SpAt + i)))
 					dif := Difference{p1, types.DiffChangeModified, v1.Get(splice.SpAt + i), v2.Get(splice.SpFrom + i)}
 					stop = !d.sendDiff(dif)
 				}
@@ -125,12 +125,12 @@ func (d differ) diffLists(p types.Path, v1, v2 types.List) (stop bool) {
 
 		// Heuristic: list only has additions/removals.
 		for i := uint64(0); i < splice.SpRemoved && !stop; i++ {
-			p1 := copyAppend(p, types.NewIndexPath(types.Number(splice.SpAt+i)))
+			p1 := p.Append(types.NewIndexPath(types.Number(splice.SpAt + i)))
 			dif := Difference{Path: p1, ChangeType: types.DiffChangeRemoved, OldValue: v1.Get(splice.SpAt + i), NewValue: nil}
 			stop = !d.sendDiff(dif)
 		}
 		for i := uint64(0); i < splice.SpAdded && !stop; i++ {
-			p1 := copyAppend(p, types.NewIndexPath(types.Number(splice.SpFrom+i)))
+			p1 := p.Append(types.NewIndexPath(types.Number(splice.SpFrom + i)))
 			dif := Difference{Path: p1, ChangeType: types.DiffChangeAdded, OldValue: nil, NewValue: v2.Get(splice.SpFrom + i)}
 			stop = !d.sendDiff(dif)
 		}
@@ -212,7 +212,7 @@ func (d differ) diffOrdered(p types.Path, ppf pathPartFunc, df diffFunc, kf, v1,
 		}
 
 		k := kf(change.V)
-		p1 := copyAppend(p, ppf(k))
+		p1 := p.Append(ppf(k))
 
 		switch change.ChangeType {
 		case types.DiffChangeAdded:
@@ -241,12 +241,6 @@ func (d differ) diffOrdered(p types.Path, ppf pathPartFunc, df diffFunc, kf, v1,
 	}
 
 	return
-}
-
-func copyAppend(p types.Path, pp types.PathPart) types.Path {
-	p1 := make(types.Path, len(p), len(p)+1)
-	copy(p1, p)
-	return append(p1, pp)
 }
 
 // shouldDescend returns true, if Value is not primitive or is a Ref.

--- a/go/diff/diff_test.go
+++ b/go/diff/diff_test.go
@@ -453,24 +453,3 @@ func TestNomsDiffPrintRef(t *testing.T) {
 	tf(true)
 	tf(false)
 }
-
-func TestCopyPath(t *testing.T) {
-	assert := assert.New(t)
-
-	testCases := []string{
-		``,
-		`["key"]`,
-		`["key"].field1`,
-		`["key"]@key.field1`,
-	}
-
-	for _, s1 := range testCases {
-		expected := mustParsePath(assert, s1+`["anIndex"]`)
-		p := mustParsePath(assert, s1)
-		p1 := copyAppend(p, types.NewIndexPath(types.String("anIndex")))
-		if len(p) > 0 {
-			p[0] = expected[1] // if p1 really is a copy, this shouldn't be noticed
-		}
-		assert.Equal(expected, p1)
-	}
-}

--- a/go/types/path.go
+++ b/go/types/path.go
@@ -19,7 +19,8 @@ import (
 
 var annotationRe = regexp.MustCompile("^@([a-z]+)")
 
-// A Path is an address to a Noms value - and unlike hashes (i.e. #abcd...) they can address inlined values.
+// A Path is an address to a Noms value - and unlike hashes (i.e. #abcd...) they
+// can address inlined values.
 // See https://github.com/attic-labs/noms/blob/master/doc/spelling.md.
 type Path []PathPart
 
@@ -122,6 +123,13 @@ func (p Path) Equals(o Path) bool {
 	return true
 }
 
+// Append makes a copy of a p and appends the PathPart 'pp' to it.
+func (p Path) Append(pp PathPart) Path {
+	p1 := make(Path, len(p), len(p)+1)
+	copy(p1, p)
+	return append(p1, pp)
+}
+
 func (p Path) String() string {
 	strs := make([]string, 0, len(p))
 	for _, part := range p {
@@ -158,9 +166,12 @@ func (fp FieldPath) String() string {
 type IndexPath struct {
 	// The value of the index, e.g. `[42]` or `["value"]`.
 	Index Value
-	// Whether this index should resolve to the key of a map, given by a `@key` annotation.
-	// Typically IntoKey is false, and indices would resolve to the values. E.g. given `{a: 42}` then `["a"]` resolves to `42`.
-	// If IntoKey is true, then it resolves to `"a"`. For IndexPath this isn't particularly useful - it's mostly provided for consistency with HashIndexPath - but note that given `{a: 42}` then `["b"]` resolves to nil, not `"b"`.
+	// Whether this index should resolve to the key of a map, given by a `@key`
+	// annotation. Typically IntoKey is false, and indices would resolve to the
+	// values. E.g. given `{a: 42}` then `["a"]` resolves to `42`. If IntoKey is
+	// true, then it resolves to `"a"`. For IndexPath this isn't particularly
+	// useful - it's mostly provided for consistency with HashIndexPath - but
+	// note that given `{a: 42}` then `["b"]` resolves to nil, not `"b"`.
 	IntoKey bool
 }
 
@@ -220,11 +231,15 @@ func (ip IndexPath) String() (str string) {
 
 // Indexes into Maps by the hash of a key, or a Set by the hash of a value.
 type HashIndexPath struct {
-	// The hash of the key or value to search for. Maps and Set are ordered, so this in O(log(size)).
+	// The hash of the key or value to search for. Maps and Set are ordered, so
+	// this in O(log(size)).
 	Hash hash.Hash
-	// Whether this index should resolve to the key of a map, given by a `@key` annotation.
-	// Typically IntoKey is false, and indices would resolve to the values. E.g. given `{a: 42}` and if the hash of `"a"` is `#abcd`, then `[#abcd]` resolves to `42`.
-	// If IntoKey is true, then it resolves to `"a"`. This is useful for when Map keys aren't primitive values, e.g. a struct, since struct literals can't be spelled using a Path.
+	// Whether this index should resolve to the key of a map, given by a `@key`
+	// annotation. Typically IntoKey is false, and indices would resolve to the
+	// values. E.g. given `{a: 42}` and if the hash of `"a"` is `#abcd`, then
+	// `[#abcd]` resolves to `42`. If IntoKey is true, then it resolves to `"a"`.
+	// This is useful for when Map keys aren't primitive values, e.g. a struct,
+	// since struct literals can't be spelled using a Path.
 	IntoKey bool
 }
 

--- a/go/types/path_test.go
+++ b/go/types/path_test.go
@@ -339,3 +339,29 @@ func TestPathCanBePathIndex(t *testing.T) {
 	assert.False(ValueCanBePathIndex(NewRef(String("yes"))))
 	assert.False(ValueCanBePathIndex(NewBlob(bytes.NewReader([]byte("yes")))))
 }
+
+func TestCopyPath(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []string{
+		``,
+		`["key"]`,
+		`["key"].field1`,
+		`["key"]@key.field1`,
+	}
+
+	for _, s1 := range testCases {
+		expected, err := ParsePath(s1 + `["anIndex"]`)
+		assert.NoError(err)
+		var p Path
+		if s1 != "" {
+			p, err = ParsePath(s1)
+		}
+		assert.NoError(err)
+		p1 := p.Append(NewIndexPath(String("anIndex")))
+		if len(p) > 0 {
+			p[0] = expected[1] // if p1 really is a copy, this shouldn't be noticed
+		}
+		assert.Equal(expected, p1)
+	}
+}


### PR DESCRIPTION
I need this method in a couple of new places. It seems like it belongs in path.go.