### PR TITLE
Noms, demo-server, and photos UI changes to support auth

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "63.3.0",
+  "version": "64.0.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/http-batch-store.js
+++ b/js/noms/src/http-batch-store.js
@@ -19,6 +19,7 @@ import HTTPError from './http-error.js';
 import {notNull} from './assert.js';
 import nomsVersion from './version.js';
 
+export const DEFAULT_MAX_READS = 5;
 const HTTP_STATUS_CONFLICT = 409;
 const versionHeader = 'x-noms-vers';
 
@@ -52,7 +53,8 @@ const readBatchOptions = {
 export default class HttpBatchStore extends RemoteBatchStore {
   _rpc: RpcStrings;
 
-  constructor(urlparam: string, maxReads: number = 5, fetchOptions: FetchOptions = {}) {
+  constructor(
+      urlparam: string, maxReads: number = DEFAULT_MAX_READS, fetchOptions: FetchOptions = {}) {
     const [url, params] = separateParams(urlparam);
     const rpc = {
       getRefs: url + '/getRefs/' + params,

--- a/js/noms/src/noms.js
+++ b/js/noms/src/noms.js
@@ -59,6 +59,7 @@ export {
   getTypeOfValue,
 } from './type.js';
 export {equals, less} from './compare.js';
+export {default as Spec} from './spec.js';
 export {DatabaseSpec, DatasetSpec, PathSpec} from './specs.js';
 export {default as walk} from './walk.js';
 export {default as jsonToNoms} from './json-convert.js';

--- a/js/noms/src/spec-test.js
+++ b/js/noms/src/spec-test.js
@@ -1,0 +1,260 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// @flow
+
+import {assert} from 'chai';
+import {suite, test} from 'mocha';
+import {invariant} from './assert.js';
+import {getHash} from './get-hash.js';
+import List from './list.js';
+import Spec from './spec.js';
+import Struct, {StructMirror} from './struct.js';
+import type Value from './value.js';
+
+const assertThrowsSyntaxError = (parse, s) => {
+  let msg = '';
+  try {
+    parse(s);
+  } catch (e) {
+    assert.instanceOf(e, SyntaxError,
+                      `${s} did not produce a SyntaxError, instead ${e.constructor.name}`);
+    msg = e.message;
+  }
+  assert.notEqual('', msg, `${s} did not produce an error`);
+};
+
+suite('Spec', () => {
+  test('mem database', async () => {
+    const spec = Spec.forDatabase('mem');
+    assert.strictEqual('mem', spec.protocol());
+    assert.strictEqual('', spec.databaseName());
+
+    spec.database().writeValue(true);
+    assert.strictEqual(true, await spec.database().readValue(getHash(true)));
+  });
+
+  test('mem dataset', async () => {
+    const spec = Spec.forDataset('mem::test');
+    assert.strictEqual('test', spec.datasetName());
+    assert.strictEqual('', spec.databaseName());
+
+    let head = await spec.dataset().headValue();
+    assert.strictEqual(null, head);
+
+    await spec.database().commit(spec.dataset(), 'Commit Value');
+    head = await spec.dataset().headValue();
+    assert.strictEqual('Commit Value', head);
+  });
+
+  test('mem hash path', async () => {
+    const trueHash = getHash(true).toString();
+    const spec = Spec.forPath(`mem::#${trueHash}`);
+
+    assert.strictEqual(null, await spec.value());
+
+    spec.database().writeValue(true);
+    assert.strictEqual(true, await spec.value());
+  });
+
+  test('mem dataset path', async () => {
+    const spec = Spec.forPath('mem::test.value[0]');
+
+    assert.strictEqual(null, await spec.value());
+
+    const db = spec.database();
+    await db.commit(db.getDataset('test'), new List([42]));
+    assert.strictEqual(42, await spec.value());
+  });
+
+  test('database spec', async () => {
+    const invalid = [
+      'mem:stuff', 'mem::', 'mem:', 'http:', 'https:', 'random:', 'random:random',
+      'local', './local', 'ldb', 'ldb:', 'ldb:local',
+    ];
+    invalid.forEach(s => assertThrowsSyntaxError(Spec.forDatabase, s));
+
+    const valid = [
+      {spec: 'http://localhost:8000', protocol: 'http', databaseName: 'localhost:8000'},
+      {spec: 'http://localhost:8000/fff', protocol: 'http', databaseName: 'localhost:8000/fff'},
+      {spec: 'https://local.attic.io/john/doe', protocol: 'https',
+        databaseName: 'local.attic.io/john/doe'},
+      {spec: 'mem', protocol: 'mem', databaseName: ''},
+      {spec: 'http://server.com/john/doe?access_token=jane', protocol: 'http',
+        databaseName: 'server.com/john/doe?access_token=jane'},
+      {spec: 'https://server.com/john/doe/?arg=2&qp1=true&access_token=jane', protocol: 'https',
+        databaseName: 'server.com/john/doe/?arg=2&qp1=true&access_token=jane'},
+      // TODO: This isn't valid, see https://github.com/attic-labs/noms/issues/2351.
+      {spec: 'http://some/::/one', protocol: 'http', databaseName: 'some/::/one'},
+      {spec: 'http://::1', protocol: 'http', databaseName: '::1'},
+      {spec: 'http://192.30.252.154', protocol: 'http', databaseName: '192.30.252.154'},
+      {spec: 'http://::192.30.252.154', protocol: 'http', databaseName: '::192.30.252.154'},
+      {spec: 'http://0:0:0:0:0:ffff:c01e:fc9a', protocol: 'http',
+        databaseName: '0:0:0:0:0:ffff:c01e:fc9a'},
+      {spec: 'http://::ffff:c01e:fc9a', protocol: 'http', databaseName: '::ffff:c01e:fc9a'},
+      {spec: 'http://::ffff::1e::9a', protocol: 'http', databaseName: '::ffff::1e::9a'},
+    ];
+
+    for (const tc of valid) {
+      const spec = Spec.forDatabase(tc.spec);
+      assert.strictEqual(tc.protocol, spec.protocol());
+      assert.strictEqual(tc.databaseName, spec.databaseName());
+      assert.strictEqual(tc.spec, spec.spec());
+    }
+  });
+
+  test('dataset spec', async () => {
+    const assertInvalid = s => assertThrowsSyntaxError(Spec.forDataset, s);
+
+    const invalid = [
+      'mem', 'mem:', 'http', 'http:', 'http://foo', 'monkey', 'monkey:balls',
+      'http::dsname', 'http:::dsname', 'mem:/a/bogus/path::dsname',
+      'ldb:', 'ldb:hello',
+    ];
+    invalid.forEach(assertInvalid);
+
+    const invalidDatasetNames = [' ', '', '$', '#', ':', '\n', '💩'];
+    invalidDatasetNames.map(s => `mem::${s}`).forEach(assertInvalid);
+
+    const validDatasetNames = ['a', 'Z', '0','/', '-', '_'];
+    for (const s of validDatasetNames) {
+      Spec.forDataset(`mem::${s}`);
+    }
+
+    const valid = [
+      {spec: 'http://localhost:8000/foo::ds', protocol: 'http', databaseName: 'localhost:8000/foo',
+        datasetName: 'ds'},
+      {spec: 'http://localhost:8000::ds1', protocol: 'http', databaseName: 'localhost:8000',
+        datasetName: 'ds1'},
+      {spec: 'http://localhost:8000/john/doe/::ds2', protocol: 'http',
+        databaseName: 'localhost:8000/john/doe/', datasetName: 'ds2'},
+      {spec: 'https://local.attic.io/john/doe::ds3', protocol: 'https',
+        databaseName: 'local.attic.io/john/doe', datasetName: 'ds3'},
+      {spec: 'http://local.attic.io/john/doe::ds1', protocol: 'http',
+        databaseName: 'local.attic.io/john/doe', datasetName: 'ds1'},
+      {spec: 'http://localhost:8000/john/doe?access_token=abc::ds/one', protocol: 'http',
+        databaseName: 'localhost:8000/john/doe?access_token=abc', datasetName: 'ds/one'},
+      {spec: 'https://localhost:8000?qp1=x&access_token=abc&qp2=y::ds/one', protocol: 'https',
+        databaseName: 'localhost:8000?qp1=x&access_token=abc&qp2=y', datasetName: 'ds/one'},
+      {spec: 'http://localhost:8000/pa::th/foo::ds', protocol: 'http',
+        databaseName: 'localhost:8000/pa::th/foo', datasetName: 'ds'},
+      {spec: 'http://192.30.252.154::foo', protocol: 'http', databaseName: '192.30.252.154',
+        datasetName: 'foo'},
+      {spec: 'http://::1::foo', protocol: 'http', databaseName: '::1', datasetName: 'foo'},
+      {spec: 'http://::192.30.252.154::foo', protocol: 'http', databaseName: '::192.30.252.154',
+        datasetName: 'foo'},
+      {spec: 'http://0:0:0:0:0:ffff:c01e:fc9a::foo', protocol: 'http',
+        databaseName: '0:0:0:0:0:ffff:c01e:fc9a', datasetName: 'foo'},
+      {spec: 'http://::ffff:c01e:fc9a::foo', protocol: 'http', databaseName: '::ffff:c01e:fc9a',
+        datasetName: 'foo'},
+      {spec: 'http://::ffff::1e::9a::foo', protocol: 'http', databaseName: '::ffff::1e::9a',
+        datasetName: 'foo'},
+    ];
+
+    for (const tc of valid) {
+      const spec = Spec.forDataset(tc.spec);
+      assert.strictEqual(tc.protocol, spec.protocol());
+      assert.strictEqual(tc.databaseName, spec.databaseName());
+      assert.strictEqual(tc.datasetName, spec.datasetName());
+      assert.strictEqual(tc.spec, spec.spec());
+    }
+  });
+
+  test('path spec', async () => {
+    const badSpecs = ['mem::#', 'mem::#s', 'mem::#foobarbaz', 'mem::.hello', 'ldb:path::foo.bar'];
+    badSpecs.forEach(bs => assertThrowsSyntaxError(Spec.forPath, bs));
+
+    const valid = [
+      {spec: 'http://local.attic.io/john/doe::#0123456789abcdefghijklmnopqrstuv', protocol: 'http',
+        databaseName: 'local.attic.io/john/doe', path: '#0123456789abcdefghijklmnopqrstuv'},
+      {spec: 'mem::#0123456789abcdefghijklmnopqrstuv', protocol: 'mem', databaseName: '',
+        path: '#0123456789abcdefghijklmnopqrstuv'},
+      {spec: 'http://local.attic.io/john/doe::#0123456789abcdefghijklmnopqrstuv', protocol: 'http',
+        databaseName: 'local.attic.io/john/doe', path: '#0123456789abcdefghijklmnopqrstuv'},
+      {spec: 'http://localhost:8000/john/doe/::ds1', protocol: 'http',
+        databaseName: 'localhost:8000/john/doe/', path: 'ds1'},
+      {spec: 'http://192.30.252.154::foo.bar', protocol: 'http', databaseName: '192.30.252.154',
+        path: 'foo.bar'},
+      {spec: 'http://::1::foo.bar.baz', protocol: 'http', databaseName: '::1', path: 'foo.bar.baz'},
+      {spec: 'http://::192.30.252.154::baz[42]', protocol: 'http', databaseName: '::192.30.252.154',
+        path: 'baz[42]'},
+      {spec: 'http://0:0:0:0:0:ffff:c01e:fc9a::foo[42].bar', protocol: 'http',
+        databaseName: '0:0:0:0:0:ffff:c01e:fc9a', path: 'foo[42].bar'},
+      {spec: 'http://::ffff:c01e:fc9a::foo.foo', protocol: 'http', databaseName: '::ffff:c01e:fc9a',
+        path: 'foo.foo'},
+      {spec: 'http://::ffff::1e::9a::hello["world"]', protocol: 'http',
+        databaseName: '::ffff::1e::9a', path: 'hello["world"]'},
+    ];
+
+    for (const tc of valid) {
+      const spec = Spec.forPath(tc.spec);
+      assert.strictEqual(tc.protocol, spec.protocol());
+      assert.strictEqual(tc.databaseName, spec.databaseName());
+      assert.strictEqual(tc.path, spec.path().toString());
+      assert.strictEqual(tc.spec, spec.spec());
+    }
+  });
+
+  test('pin path spec', async () => {
+    const unpinned = Spec.forPath('mem::foo.value');
+
+    const db = unpinned.database();
+    await db.commit(db.getDataset('foo'), 42);
+
+    const pinned = await unpinned.pin();
+    invariant(pinned);
+    pinned._database = unpinned._database;
+
+    const pinnedHash = pinned.path().hash;
+    invariant(pinnedHash);
+
+    const h = await db.getDataset('foo').head();
+    invariant(h);
+
+    assert.strictEqual(h.hash.toString(), pinnedHash.toString());
+    assert.strictEqual(`mem::#${h.hash.toString()}.value`, pinned.spec());
+    assert.strictEqual(42, await pinned.value());
+    assert.strictEqual(42, await unpinned.value());
+
+    await db.commit(db.getDataset('foo'), 43);
+    assert.strictEqual(42, await pinned.value());
+    assert.strictEqual(43, await unpinned.value());
+  });
+
+  test('pin dataset spec', async () => {
+    const unpinned = Spec.forDataset('mem::foo');
+
+    const db = unpinned.database();
+    await db.commit(db.getDataset('foo'), 42);
+
+    const pinned = await unpinned.pin();
+    invariant(pinned);
+    pinned._database = unpinned._database;
+
+    const pinnedHash = pinned.path().hash;
+    invariant(pinnedHash);
+
+    const h = await db.getDataset('foo').head();
+    invariant(h);
+
+    const commitValue = (commit: ?Value) => {
+      invariant(commit instanceof Struct);
+      return new StructMirror(commit).get('value');
+    };
+
+    assert.strictEqual(h.hash.toString(), pinnedHash.toString());
+    assert.strictEqual(`mem::#${h.hash.toString()}`, pinned.spec());
+    assert.strictEqual(42, commitValue(await pinned.value()));
+    assert.strictEqual(42, await unpinned.dataset().headValue());
+
+    await db.commit(db.getDataset('foo'), 43);
+    assert.strictEqual(42, commitValue(await pinned.value()));
+    assert.strictEqual(43, await unpinned.dataset().headValue());
+  });
+
+  test('already pinned', async () => {
+    const spec = Spec.forPath('mem::#imgp9mp1h3b9nv0gna6mri53dlj9f4ql.value');
+    assert.strictEqual(spec, await spec.pin());
+  });
+});

--- a/js/noms/src/spec.js
+++ b/js/noms/src/spec.js
@@ -1,0 +1,315 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// @flow
+
+import AbsolutePath from './absolute-path.js';
+import {invariant} from './assert.js';
+import {BatchStoreAdaptor} from './batch-store.js';
+import Dataset, {datasetRe} from './dataset.js';
+import Database from './database.js';
+import HttpBatchStore, {DEFAULT_MAX_READS} from './http-batch-store.js';
+import MemoryStore from './memory-store.js';
+import type Value from './value.js';
+
+export type SpecOptions = {
+  /**
+   * Authorization token for requests. For example, if the Database is backed by
+   * HTTP this will used for an `Authorization: Bearer ${authorization}` header.
+   */
+  authorization?: string;
+
+  /**
+   * If this is specified and > 0, the Database instances returned by
+   * `database()` will be backed by a cache.
+   */
+  cacheSize?: number;
+};
+
+/**
+ * Spec is a parsed specification for the location of a Noms database, dataset,
+ * or value.
+ *
+ * Spec has the same `Database` instance for its construction, and the
+ * accessors have the same mutability semantics as the `Database` interface,
+ * which is mutable. For example, if the underlying `Database` commits a
+ * dataset, then calls to `Spec.dataset()` will return the new one.
+ *
+ * For example:
+ *  - a database spec might be `mem` or `https://demo.noms.io/cli-tour`.
+ *  - a dataset spec might be `mem::photos` or `https://demo.noms.io/cli-tour::sf-crime`.
+ *  - a path spec might be `http://demo.noms.io::foo.bar` or `http://demo.noms.io::#abcdef.bar`
+ *
+ * See https://github.com/attic-labs/noms/blob/master/doc/spelling.md.
+ */
+export default class Spec {
+  _spec: string;
+  _opts: ?SpecOptions;
+  _protocol: string;
+  _databaseName: string;
+
+  // Lazily created.
+  _database: ?Database;
+
+  // Exists if the spec was constructed through `forDataset()`.
+  _datasetName: ?string;
+
+  // Exists if the spec was constructed through `fromValue()` or `pin()`.
+  _path: ?AbsolutePath;
+
+  constructor(spec: string, databaseSpec: string, opts: ?SpecOptions) {
+    this._spec = spec;
+    this._opts = opts;
+    const [protocol, databaseName] = parseDatabaseSpec(databaseSpec);
+    this._protocol = protocol;
+    this._databaseName = databaseName;
+  }
+
+  /**
+   * Creates a `Spec` from a spec to a database.
+   */
+  static forDatabase(spec: string, opts: ?SpecOptions): Spec {
+    return new Spec(spec, spec, opts);
+  }
+
+  /**
+   * Creates a `Spec` from a spec to a dataset.
+   */
+  static forDataset(spec: string, opts: ?SpecOptions): Spec {
+    const [databaseSpec, datasetName] = splitDatabaseSpec(spec);
+    if (!datasetRe.test(datasetName)) {
+      throw new SyntaxError(`Invalid dataset ${datasetName}, must match ${datasetRe.source}`);
+    }
+
+    const specObj = new Spec(spec, databaseSpec, opts);
+    specObj._datasetName = datasetName;
+    return specObj;
+  }
+
+  /**
+   * Creates a `Spec` from a spec to a value path.
+   */
+  static forPath(spec: string, opts: ?SpecOptions): Spec {
+    const [databaseSpec, pathStr] = splitDatabaseSpec(spec);
+    const path = AbsolutePath.parse(pathStr);
+
+    const specObj = new Spec(spec, databaseSpec, opts);
+    specObj._path = path;
+    return specObj;
+  }
+
+  /**
+   * Returns the spec string.
+   */
+  spec(): string {
+    return this._spec;
+  }
+
+  /**
+   * Returns the database protocol, for example `"mem"` or `"http"`.
+   */
+  protocol(): string {
+    return this._protocol;
+  }
+
+  /**
+   * Returns the database name, e.g. `"demo.noms.io"` or `"localhost:8000"`.
+   */
+  databaseName(): string {
+    return this._databaseName;
+  }
+
+  /**
+   * Returns the `Database`.
+   */
+  database(): Database {
+    if (!this._database) {
+      this._database = this._createDatabase();
+    }
+    return this._database;
+  }
+
+  /**
+   * Returns the dataset name, for example `"sf-crime"`.
+   *
+   * Throws a `TypeError` if this spec does not have an associated value.
+   */
+  datasetName(): string {
+    const name = this._datasetName;
+    if (name === undefined || name === null) {
+      throw new TypeError(`${this._spec} is not a dataset spec`);
+    }
+    return name;
+  }
+
+  /**
+   * Returns the path with this spec's `Database`. Throws a `TypeError` if this
+   * spec does not have an associated path.
+   */
+  path(): AbsolutePath {
+    if (!this._path) {
+      throw new TypeError(`${this._spec} is not a path spec`);
+    }
+    return this._path;
+  }
+
+  /**
+   * Returns the `Dataset` from the spec.
+   *
+   * Throws a `TypeError` if this spec does not have a associated dataset.
+   *
+   * Make sure to call `close()`.
+   */
+  dataset(): Dataset {
+    return this.database().getDataset(this.datasetName());
+  }
+
+  /**
+   * Resolves this to a `Value`, or `null` if the value isn't found.
+   *
+   * Throws a `TypeError` if this spec does not have an associated value.
+   *
+   * Make sure to call `close()`.
+   */
+  value(): Promise<Value | null> {
+    return this.path().resolve(this.database());
+  }
+
+  /**
+   * Returns a `Spec` in which the dataset component, if any, has been replaced
+   * with the hash of the HEAD of that dataset. This "pins" the path to the
+   * state of the database at the current moment in time.
+   *
+   * Returns this if the PathSpec is already "pinned".
+   *
+   * Throws a `TypeError` if this spec does not have an associated dataset.
+   */
+  async pin(): Promise<?Spec> {
+    let dataset;
+
+    const path = this._path;
+    if (path) {
+      if (path.hash !== null) {
+        // PathSpec is already pinned.
+        invariant(this._datasetName === undefined || this._datasetName === null);
+        return this;
+      }
+
+      dataset = this.database().getDataset(path.dataset);
+    } else {
+      dataset = this.dataset();
+    }
+
+    const commit = await dataset.head();
+    if (!commit) {
+      return null;
+    }
+
+    let spec = `${this._protocol}`;
+    if (this._databaseName !== '') {
+      spec += `://${this._databaseName}`;
+    }
+
+    spec += `::#${commit.hash.toString()}`;
+    if (this._path && this._path.path !== null) {
+      spec += this._path.path.toString();
+    }
+
+    return Spec.forPath(spec, this._opts);
+  }
+
+  /**
+   * Closes the database backed by this spec, if any.
+   */
+  close(): Promise<void> {
+    if (!this._database) {
+      return Promise.resolve();
+    }
+    return this._database.close();
+  }
+
+  _createDatabase(): Database {
+    let batchStore;
+
+    switch (this._protocol) {
+      case 'mem':
+        batchStore = new BatchStoreAdaptor(new MemoryStore());
+        break;
+
+      case 'http':
+      case 'https': {
+        let fetchOptions;
+        if (this._opts && this._opts.authorization) {
+          fetchOptions = {
+            headers: {
+              'Authorization': `Bearer ${this._opts.authorization}`,
+            },
+          };
+        }
+        const url = `${this._protocol}://${this._databaseName}`;
+        batchStore = new HttpBatchStore(url, DEFAULT_MAX_READS, fetchOptions);
+        break;
+      }
+
+      default:
+        throw new Error('unreachable');
+    }
+
+    let cacheSize;
+    if (this._opts && this._opts.cacheSize) {
+      cacheSize = this._opts.cacheSize;
+    }
+
+    return new Database(batchStore, cacheSize);
+  }
+}
+
+function parseDatabaseSpec(spec: string): [string, string] {
+  // A common mistake is to accidentally use the "ldb" protocol thinking it works,
+  // because the Go SDK does.
+  const ldbNotSupported = 'The "ldb" protocol is not supported in the JS SDK. ' +
+    'Instead, use "noms serve" and point at "http://localhost:8000"';
+
+  const protoIdx = spec.indexOf(':');
+
+  if (protoIdx === -1) {
+    if (spec !== 'mem') {
+      // In the Go SDK this would be interpreted as "ldb", but JS doesn't support ldb.
+      throw new SyntaxError(ldbNotSupported);
+    }
+    return ['mem', ''];
+  }
+
+  const protocol = spec.slice(0, protoIdx);
+  const databaseName = spec.slice(protoIdx + 1);
+
+  switch (protocol) {
+    case 'ldb':
+      throw new SyntaxError(ldbNotSupported);
+
+    case 'mem':
+      throw new SyntaxError('In-memory database must be specified as "mem" not "mem:');
+
+    case 'http':
+    case 'https':
+      // TODO: better validation, see https://github.com/attic-labs/noms/issues/2351.
+      if (databaseName === '') {
+        throw new SyntaxError(`Invalid URL ${spec}`);
+      }
+      return [protocol, databaseName.slice('//'.length)];
+
+    default:
+      throw new SyntaxError(`Unsupported protocol ${protocol}`);
+  }
+}
+
+function splitDatabaseSpec(str: string): [string /* database */, string /* rest */] {
+  const sep = '::';
+  const sepIdx = str.lastIndexOf(sep);
+  if (sepIdx === -1) {
+    throw new SyntaxError(`Missing ${sep} separator between database and dataset: ${str}`);
+  }
+
+  return [str.slice(0, sepIdx), str.slice(sepIdx + sep.length)];
+}

--- a/samples/go/demo-server/web_server.go
+++ b/samples/go/demo-server/web_server.go
@@ -171,6 +171,7 @@ func corsHandle(f httprouter.Handle) httprouter.Handle {
 		// Can't use * when clients are using cookies.
 		w.Header().Add("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 		w.Header().Add("Access-Control-Allow-Methods", "GET, POST")
+		w.Header().Add("Access-Control-Allow-Headers", "Authorization")
 		w.Header().Add("Access-Control-Allow-Headers", datas.NomsVersionHeader)
 		w.Header().Add("Access-Control-Expose-Headers", datas.NomsVersionHeader)
 		w.Header().Add(datas.NomsVersionHeader, constants.NomsVersion)

--- a/samples/js/photos/src/main.js
+++ b/samples/js/photos/src/main.js
@@ -12,7 +12,7 @@ import PhotosPage from './photos-page.js';
 import Viewport from './viewport.js';
 import {createPhoto} from './photo.js';
 import type {PhotoIndex, NomsPhoto} from './types.js';
-import {Path, PathSpec, Struct} from '@attic/noms';
+import {Path, Spec, Struct} from '@attic/noms';
 
 // Cache of index paths to indices. Otherwise calls to render are pretty slow,
 // which is noticeable when resizing, toggling between full screen photos, etc.
@@ -42,14 +42,22 @@ async function getRenderElement(nav: Nav): Promise<React.Element<any>> {
 
   let index = indexMap.get(indexStr);
   if (!index) {
+    // TODO: Proper auth with localStorage.
+    let specOptions;
+    if (params.has('access_token')) {
+      specOptions = {
+        authorization: params.get('access_token'),
+      };
+    }
+
     let indexSpec;
     try {
-      indexSpec = PathSpec.parse(indexStr);
+      indexSpec = Spec.forPath(indexStr, specOptions);
     } catch (e) {
       return <div>{notice(indexStr)} is not a valid path: {notice(e.message)}.</div>;
     }
 
-    const [, indexValue] = await indexSpec.value();
+    const indexValue = await indexSpec.value();
     if (!(indexValue instanceof Struct)) {
       return <div>{notice(indexStr)} not found.</div>;
     }

--- a/samples/js/photos/src/params.js
+++ b/samples/js/photos/src/params.js
@@ -21,8 +21,8 @@ export function searchToParams(search: string): Map<string, string> {
   const paramsIdx = search.indexOf('?');
   if (paramsIdx > -1) {
     decodeURIComponent(search.slice(paramsIdx + 1)).split('&').forEach(pair => {
-      const [k, v] = pair.split('=');
-      params.set(k, v);
+      const idx = pair.indexOf('=');
+      params.set(pair.slice(0, idx), pair.slice(idx + 1));
     });
   }
   return params;


### PR DESCRIPTION
The big change here is adding a new Spec class in spec.js. This replaces
DatabaseSpec/DatasetSpec/PathSpec in specs.js, but I'm leaving those in
and moving code over in a later patch. For now, only photos UI.

The photos UI change is to plumb through the authorization token through
the Spec code. For now, it's reading it from a URL parameter, but soon
I'll make it session based (probably localStorage).

The demo-server change is to add the Authorization header into CORS.