### PR TITLE
Close and destroy databases being left open during tests

### DIFF
--- a/go/datas/local_batch_store.go
+++ b/go/datas/local_batch_store.go
@@ -127,6 +127,11 @@ func (lbs *localBatchStore) FlushAndDestroyWithoutClose() {
 	lbs.unwrittenPuts.Destroy()
 }
 
+// Destroy blows away lbs' cache of unwritten chunks without flushing. Used when the owning Database is closing and it isn't semantically correct to flush.
+func (lbs *localBatchStore) Destroy() {
+	lbs.unwrittenPuts.Destroy()
+}
+
 // Close is supposed to close the underlying ChunkStore, but the only place localBatchStore is currently used wants to keep the underlying ChunkStore open after it's done with lbs. Hence, the above method and the panic() here.
 func (lbs *localBatchStore) Close() error {
 	panic("Unreached")

--- a/go/datas/local_database.go
+++ b/go/datas/local_database.go
@@ -67,3 +67,11 @@ func (ldb *LocalDatabase) validatingBatchStore() types.BatchStore {
 	}
 	return ldb.vbs
 }
+
+func (ldb *LocalDatabase) Close() error {
+	if ldb.vbs != nil {
+		ldb.vbs.Destroy()
+		ldb.vbs = nil
+	}
+	return ldb.databaseCommon.Close()
+}


### PR DESCRIPTION
There were several tests in the Database suites that were failing to
close test Databases that had orderedChunkCaches in them (backed by
levelDBs). Close them.

I was ALSO failing to destroy the cache used in LocalDatabase
instances only while testing Pull(). That's cleared up now as well.