### PR TITLE
Port new Spec API to Go from JS

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/attic-labs/noms/go/spec"
@@ -95,18 +94,18 @@ func (c *Config) WriteTo(configHome string) (string, error) {
 // Replace relative directory in path part of spec with an absolute
 // directory. Assumes the path is relative to the location of the config file
 func absDbSpec(configHome string, url string) string {
-	dbSpec, err := spec.ParseDatabaseSpec(url)
+	dbSpec, err := spec.ForDatabase(url)
 	if err != nil {
 		return url
 	}
 	if dbSpec.Protocol != "ldb" {
 		return url
 	}
-	path := dbSpec.Path
-	if !strings.HasPrefix(path, "/") {
-		path = filepath.Join(configHome, path)
+	dbName := dbSpec.DatabaseName
+	if !filepath.IsAbs(dbName) {
+		dbName = filepath.Join(configHome, dbName)
 	}
-	return "ldb:" + path
+	return "ldb:" + dbName
 }
 
 func qualifyPaths(configPath string, c *Config) (*Config, error) {

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -81,22 +81,22 @@ func qualifyFilePath(assert *assert.Assertions, path string) string {
 }
 
 func assertDbSpecsEquiv(assert *assert.Assertions, expected string, actual string) {
-	e, err := spec.ParseDatabaseSpec(expected)
+	e, err := spec.ForDatabase(expected)
 	assert.NoError(err)
 	if e.Protocol != "ldb" {
 		assert.Equal(expected, actual)
 	} else {
-		a, err := spec.ParseDatabaseSpec(actual)
+		a, err := spec.ForDatabase(actual)
 		assert.NoError(err)
 		assert.Equal(e.Protocol, a.Protocol, actual)
-		if strings.HasPrefix(e.Path, "/") {
-			assert.Equal(e.Path, a.Path, actual)
+		if filepath.IsAbs(e.DatabaseName) {
+			assert.Equal(e.DatabaseName, a.DatabaseName, actual)
 		} else {
 			// If the original path is relative, it will return as absolute.
 			// All we do here is ensure that the path suffix is the same.
-			ePath := strings.TrimPrefix(strings.TrimPrefix(e.Path, "."), ".")
-			assert.True(strings.HasSuffix(a.Path, ePath),
-				"expected: %s; actual: %s", ePath, actual)
+			eName := strings.TrimPrefix(e.DatabaseName, ".")
+			assert.True(strings.HasSuffix(a.DatabaseName, eName),
+				"expected: %s; actual: %s", eName, actual)
 		}
 	}
 }

--- a/go/config/resolver.go
+++ b/go/config/resolver.go
@@ -88,24 +88,40 @@ func (r *Resolver) ResolvePathSpec(str string) string {
 //   - resolve a db alias to its db spec
 //   - resolve "" to the default db spec
 func (r *Resolver) GetDatabase(str string) (datas.Database, error) {
-	return spec.GetDatabase(r.verbose(str, r.ResolveDbSpec(str)))
+	sp, err := spec.ForDatabase(r.verbose(str, r.ResolveDbSpec(str)))
+	if err != nil {
+		return nil, err
+	}
+	return sp.GetDatabase(), nil
 }
 
 // Resolve string to a chunkstore. Like ResolveDatabase, but returns the underlying ChunkStore
 func (r *Resolver) GetChunkStore(str string) (chunks.ChunkStore, error) {
-	return spec.GetChunkStore(r.verbose(str, r.ResolveDbSpec(str)))
+	sp, err := spec.ForDatabase(r.verbose(str, r.ResolveDbSpec(str)))
+	if err != nil {
+		return nil, err
+	}
+	return sp.NewChunkStore(), nil
 }
 
 // Resolve string to a dataset. If a config is present,
 //  - if no db prefix is present, assume the default db
 //  - if the db prefix is an alias, replace it
 func (r *Resolver) GetDataset(str string) (datas.Database, datas.Dataset, error) {
-	return spec.GetDataset(r.verbose(str, r.ResolvePathSpec(str)))
+	sp, err := spec.ForDataset(r.verbose(str, r.ResolvePathSpec(str)))
+	if err != nil {
+		return nil, datas.Dataset{}, err
+	}
+	return sp.GetDatabase(), sp.GetDataset(), nil
 }
 
 // Resolve string to a value path. If a config is present,
 //  - if no db spec is present, assume the default db
 //  - if the db spec is an alias, replace it
 func (r *Resolver) GetPath(str string) (datas.Database, types.Value, error) {
-	return spec.GetPath(r.verbose(str, r.ResolvePathSpec(str)))
+	sp, err := spec.ForPath(r.verbose(str, r.ResolvePathSpec(str)))
+	if err != nil {
+		return nil, nil, err
+	}
+	return sp.GetDatabase(), sp.GetValue(), nil
 }

--- a/go/spec/absolute_path.go
+++ b/go/spec/absolute_path.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
@@ -85,7 +84,7 @@ func (p AbsolutePath) Resolve(db datas.Database) (val types.Value) {
 	} else if !p.Hash.IsEmpty() {
 		val = db.ReadValue(p.Hash)
 	} else {
-		d.Chk.Fail("Unreachable")
+		panic("Unreachable")
 	}
 
 	if val != nil && p.Path != nil {
@@ -94,13 +93,17 @@ func (p AbsolutePath) Resolve(db datas.Database) (val types.Value) {
 	return
 }
 
+func (p AbsolutePath) IsEmpty() bool {
+	return p.Dataset == "" && p.Hash.IsEmpty()
+}
+
 func (p AbsolutePath) String() (str string) {
 	if len(p.Dataset) > 0 {
 		str = p.Dataset
 	} else if !p.Hash.IsEmpty() {
 		str = "#" + p.Hash.String()
 	} else {
-		d.Chk.Fail("Unreachable")
+		panic("Unreachable")
 	}
 
 	return str + p.Path.String()

--- a/go/spec/spec.go
+++ b/go/spec/spec.go
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// TODO: Make sure that removing access_token still works.
-
 // Package spec provides builders and parsers for spelling Noms databases,
 // datasets and values.
 package spec

--- a/go/spec/spec.go
+++ b/go/spec/spec.go
@@ -1,0 +1,297 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// TODO: Make sure that removing access_token still works.
+
+// Package spec provides builders and parsers for spelling Noms databases,
+// datasets and values.
+package spec
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/types"
+)
+
+// SpecOptions customize Spec behavior.
+type SpecOptions struct {
+	// Authorization token for requests. For example, if the database is HTTP
+	// this will used for an `Authorization: Bearer ${authorization}` header.
+	Authorization string
+}
+
+// Spec describes a Database, Dataset, or a path to a Value. They should be
+// constructed by parsing strings, either through ForDatabase, ForDataset, or
+// ForPath (or their Opts variations).
+type Spec struct {
+	// Spec is the spec string this was parsed into.
+	Spec string
+
+	// Protocol is one of "mem", "ldb", "http", or "https".
+	Protocol string
+
+	// DatabaseName is the name of the Spec's database, which is the string after
+	// "protocol:". http/https specs include their leading "//" characters.
+	DatabaseName string
+
+	// Options are the SpecOptions that the Spec was constructed with.
+	Options SpecOptions
+
+	// DatasetName is empty unless the spec was created with ForDataset.
+	DatasetName string
+
+	// Path is nil unless the spec was created with ForPath.
+	Path AbsolutePath
+
+	// db is lazily created, so it needs to be a pointer to a Database.
+	db *datas.Database
+}
+
+func newSpec(spec string, dbSpec string, opts SpecOptions) (Spec, error) {
+	protocol, dbName, err := parseDatabaseSpec(dbSpec)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	return Spec{
+		Spec:         spec,
+		Protocol:     protocol,
+		DatabaseName: dbName,
+		Options:      opts,
+		db:           new(datas.Database),
+	}, nil
+}
+
+// ForDatabase parses a spec for a Database.
+func ForDatabase(spec string) (Spec, error) {
+	return ForDatabaseOpts(spec, SpecOptions{})
+}
+
+// ForDatabaseOpts parses a spec for a Database.
+func ForDatabaseOpts(spec string, opts SpecOptions) (Spec, error) {
+	return newSpec(spec, spec, opts)
+}
+
+// ForDataset parses a spec for a Dataset.
+func ForDataset(spec string) (Spec, error) {
+	return ForDatasetOpts(spec, SpecOptions{})
+}
+
+// ForDatasetOpts parses a spec for a Dataset.
+func ForDatasetOpts(spec string, opts SpecOptions) (Spec, error) {
+	dbSpec, dsName, err := splitDatabaseSpec(spec)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	if !datasetRe.MatchString(dsName) {
+		return Spec{}, fmt.Errorf("Dataset %s must match %s", dsName, datasetRe.String())
+	}
+
+	sp, err := newSpec(spec, dbSpec, opts)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	sp.DatasetName = dsName
+	return sp, nil
+}
+
+// ForPath parses a spec for a path to a Value.
+func ForPath(spec string) (Spec, error) {
+	return ForPathOpts(spec, SpecOptions{})
+}
+
+// ForPathOpts parses a spec for a path to a Value.
+func ForPathOpts(spec string, opts SpecOptions) (Spec, error) {
+	dbSpec, pathStr, err := splitDatabaseSpec(spec)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	path, err := NewAbsolutePath(pathStr)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	sp, err := newSpec(spec, dbSpec, opts)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	sp.Path = path
+	return sp, nil
+}
+
+// GetDatabase returns the Database instance that this Spec's DatabaseName
+// describes. The same Database instance is returned every time, unless Close
+// is called. If the Spec is closed, it is re-opened with a new Database.
+func (sp Spec) GetDatabase() datas.Database {
+	if *sp.db == nil {
+		*sp.db = sp.createDatabase()
+	}
+	return *sp.db
+}
+
+// NewChunkStore returns a new ChunkStore instance that this Spec's
+// DatabaseName describes. It's unusual to call this method, GetDatabase is
+// more useful. Unlike GetDatabase, a new ChunkStore instance is returned every
+// time. If there is no ChunkStore, for example remote databases, returns nil.
+func (sp Spec) NewChunkStore() chunks.ChunkStore {
+	switch sp.Protocol {
+	case "http", "https":
+		return nil
+	case "ldb":
+		return getLDBStore(sp.DatabaseName)
+	case "mem":
+		return chunks.NewMemoryStore()
+	}
+	panic("unreachable")
+}
+
+// GetDataset returns the current Dataset instance for this Spec's Database.
+// GetDataset is live, so if Commit is called on this Spec's Database later, a
+// new up-to-date Dataset will returned on the next call to GetDataset.  If
+// this is not a Dataset spec, returns nil.
+func (sp Spec) GetDataset() (ds datas.Dataset) {
+	if sp.DatasetName != "" {
+		ds = sp.GetDatabase().GetDataset(sp.DatasetName)
+	}
+	return
+}
+
+// GetValue returns the Value at this Spec's Path within its Database, or nil
+// if this isn't a Path Spec or if that path isn't found.
+func (sp Spec) GetValue() (val types.Value) {
+	if !sp.Path.IsEmpty() {
+		val = sp.Path.Resolve(sp.GetDatabase())
+	}
+	return
+}
+
+// Href treats the Protocol and DatabaseName as a URL, and returns its href.
+// For example, the spec http://example.com/path::ds returns
+// "http://example.com/path". If the Protocol is not "http" or "http", returns
+// an empty string.
+func (sp Spec) Href() string {
+	proto := sp.Protocol
+	if proto == "http" || proto == "https" {
+		return proto + ":" + sp.DatabaseName
+	}
+	return ""
+}
+
+// Pin returns a Spec in which the dataset component, if any, has been replaced
+// with the hash of the HEAD of that dataset. This "pins" the path to the state
+// of the database at the current moment in time.  Returns itself if the
+// PathSpec is already "pinned".
+func (sp Spec) Pin() (Spec, bool) {
+	var ds datas.Dataset
+
+	if !sp.Path.IsEmpty() {
+		if !sp.Path.Hash.IsEmpty() {
+			// Spec is already pinned.
+			return sp, true
+		}
+
+		ds = sp.GetDatabase().GetDataset(sp.Path.Dataset)
+	} else {
+		ds = sp.GetDataset()
+	}
+
+	commit, ok := ds.MaybeHead()
+	if !ok {
+		return Spec{}, false
+	}
+
+	spec := sp.Protocol + sp.DatabaseName + Separator + "#" + commit.Hash().String()
+	if sp.Path.Path != nil {
+		spec += sp.Path.Path.String()
+	}
+
+	pinned, err := ForPathOpts(spec, sp.Options)
+	d.PanicIfError(err)
+	*pinned.db = *sp.db
+
+	return pinned, true
+}
+
+func (sp Spec) Close() error {
+	db := *sp.db
+	if db == nil {
+		return nil
+	}
+
+	*sp.db = nil
+	return db.Close()
+}
+
+func (sp Spec) createDatabase() datas.Database {
+	switch sp.Protocol {
+	case "http", "https":
+		return datas.NewRemoteDatabase(sp.Href(), sp.Options.Authorization)
+	case "ldb":
+		return datas.NewDatabase(getLDBStore(sp.DatabaseName))
+	case "mem":
+		return datas.NewDatabase(chunks.NewMemoryStore())
+	}
+	panic("unreachable")
+}
+
+func parseDatabaseSpec(spec string) (protocol, name string, err error) {
+	if len(spec) == 0 {
+		err = fmt.Errorf("Empty spec")
+		return
+	}
+
+	parts := strings.SplitN(spec, ":", 2) // [protocol] [, path]?
+
+	// If there was no ":" then this is either a mem spec, or a filesystem path.
+	// This is ambiguous if the file system path is "mem" but that just means the
+	// path needs to be explicitly "ldb:mem".
+	if len(parts) == 1 {
+		if spec == "mem" {
+			protocol = "mem"
+		} else {
+			protocol, name = "ldb", spec
+		}
+		return
+	}
+
+	switch parts[0] {
+	case "ldb":
+		protocol, name = parts[0], parts[1]
+
+	case "http", "https":
+		var u *url.URL
+		u, err = url.Parse(spec)
+		if err == nil && u.Host == "" {
+			err = fmt.Errorf("%s has empty host", spec)
+		}
+		if err == nil {
+			protocol, name = parts[0], parts[1]
+		}
+
+	case "mem":
+		err = fmt.Errorf(`In-memory database must be specified as "mem", not "mem:"`)
+
+	default:
+		err = fmt.Errorf("Invalid database protocol %s in %s", protocol, spec)
+	}
+	return
+}
+
+func splitDatabaseSpec(spec string) (string, string, error) {
+	lastIdx := strings.LastIndex(spec, Separator)
+	if lastIdx == -1 {
+		return "", "", fmt.Errorf("Missing %s after database in %s", Separator, spec)
+	}
+
+	return spec[:lastIdx], spec[lastIdx+len(Separator):], nil
+}

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -439,3 +439,31 @@ func TestMultipleSpecsSameLeveldb(t *testing.T) {
 	spec1.GetDatabase().WriteValue(s)
 	assert.Equal(s, spec2.GetDatabase().ReadValue(s.Hash()))
 }
+
+func TestAcccessingInvalidSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	test := func(spec string) {
+		sp, err := ForDatabase(spec)
+		assert.Error(err)
+		assert.Equal("", sp.Href())
+		assert.Panics(func() { sp.GetDatabase() })
+		assert.Panics(func() { sp.GetDatabase() })
+		assert.Panics(func() { sp.NewChunkStore() })
+		assert.Panics(func() { sp.NewChunkStore() })
+		assert.Panics(func() { sp.Close() })
+		assert.Panics(func() { sp.Close() })
+		// Spec was created with ForDatabase, so dataset/path related functions
+		// should just fail not panic.
+		_, ok := sp.Pin()
+		assert.False(ok)
+		assert.Equal(datas.Dataset{}, sp.GetDataset())
+		assert.Nil(sp.GetValue())
+	}
+
+	test("")
+	test("invalid:spec")
+	test("💩:spec")
+	test("http:")
+	test("http:💩:")
+}

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -421,3 +421,21 @@ func TestAlreadyPinnedPathSpec(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(unpinned, pinned)
 }
+
+func TestMultipleSpecsSameLeveldb(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir, err := ioutil.TempDir("", "spec_test")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	spec1, err1 := ForDatabase(tmpDir)
+	spec2, err2 := ForDatabase(tmpDir)
+
+	assert.NoError(err1)
+	assert.NoError(err2)
+
+	s := types.String("hello")
+	spec1.GetDatabase().WriteValue(s)
+	assert.Equal(s, spec2.GetDatabase().ReadValue(s.Hash()))
+}

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -1,0 +1,423 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestMemDatabaseSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	spec, err := ForDatabase("mem")
+	assert.NoError(err)
+	defer spec.Close()
+
+	assert.Equal("mem", spec.Protocol)
+	assert.Equal("", spec.DatabaseName)
+	assert.Equal("", spec.DatasetName)
+	assert.True(spec.Path.IsEmpty())
+
+	s := types.String("hello")
+	db := spec.GetDatabase()
+	db.WriteValue(s)
+	assert.Equal(s, db.ReadValue(s.Hash()))
+}
+
+func TestMemDatasetSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	spec, err := ForDataset("mem::test")
+	assert.NoError(err)
+	defer spec.Close()
+
+	assert.Equal("mem", spec.Protocol)
+	assert.Equal("", spec.DatabaseName)
+	assert.Equal("test", spec.DatasetName)
+	assert.True(spec.Path.IsEmpty())
+
+	ds := spec.GetDataset()
+	_, ok := spec.GetDataset().MaybeHeadValue()
+	assert.False(ok)
+
+	s := types.String("hello")
+	ds, err = spec.GetDatabase().CommitValue(ds, s)
+	assert.NoError(err)
+	assert.Equal(s, ds.HeadValue())
+}
+
+func TestMemHashPathSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	s := types.String("hello")
+
+	spec, err := ForPath("mem::#" + s.Hash().String())
+	assert.NoError(err)
+	defer spec.Close()
+
+	assert.Equal("mem", spec.Protocol)
+	assert.Equal("", spec.DatabaseName)
+	assert.Equal("", spec.DatasetName)
+	assert.False(spec.Path.IsEmpty())
+
+	// This would be a reasonable check, and the equivalent JS test does it, but
+	// it causes the next GetValue to return nil. This is inconsistent with JS.
+	// See https://github.com/attic-labs/noms/issues/2802:
+	// assert.Nil(spec.GetValue())
+
+	spec.GetDatabase().WriteValue(s)
+	assert.Equal(s, spec.GetValue())
+}
+
+func TestMemDatasetPathSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	spec, err := ForPath("mem::test.value[0]")
+	assert.NoError(err)
+	defer spec.Close()
+
+	assert.Equal("mem", spec.Protocol)
+	assert.Equal("", spec.DatabaseName)
+	assert.Equal("", spec.DatasetName)
+	assert.False(spec.Path.IsEmpty())
+
+	assert.Nil(spec.GetValue())
+
+	db := spec.GetDatabase()
+	ds := db.GetDataset("test")
+	ds, err = db.CommitValue(ds, types.NewList(types.Number(42)))
+	assert.NoError(err)
+
+	assert.Equal(types.Number(42), spec.GetValue())
+}
+
+func TestLDBDatabaseSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	run := func(prefix string) {
+		tmpDir, err := ioutil.TempDir("", "spec_test")
+		assert.NoError(err)
+		defer os.RemoveAll(tmpDir)
+
+		s := types.String("string")
+
+		// Existing database in the database are read from the spec.
+		store1 := path.Join(tmpDir, "store1")
+		cs := chunks.NewLevelDBStoreUseFlags(store1, "")
+		db := datas.NewDatabase(cs)
+		db.WriteValue(s)
+		db.Close() // must close immediately to free ldb
+
+		spec1, err := ForDatabase(prefix + store1)
+		assert.NoError(err)
+		defer spec1.Close()
+
+		assert.Equal("ldb", spec1.Protocol)
+		assert.Equal(store1, spec1.DatabaseName)
+
+		assert.Equal(s, spec1.GetDatabase().ReadValue(s.Hash()))
+
+		// New databases can be created and read/written from.
+		store2 := path.Join(tmpDir, "store2")
+		spec2, err := ForDatabase(prefix + store2)
+		assert.NoError(err)
+		defer spec2.Close()
+
+		assert.Equal("ldb", spec2.Protocol)
+		assert.Equal(store2, spec2.DatabaseName)
+
+		db = spec2.GetDatabase()
+		db.WriteValue(s)
+		assert.Equal(s, db.ReadValue(s.Hash()))
+	}
+
+	run("")
+	run("ldb:")
+}
+
+// Skip LDB dataset and path tests: the database behaviour is tested in
+// TestLDBDatabaseSpec, TestMemDatasetSpec/TestMem*PathSpec cover general
+// dataset/path behaviour, and ForDataset/ForPath test LDB parsing.
+
+func TestCloseSpecWithoutOpen(t *testing.T) {
+	s, err := ForDatabase("mem")
+	assert.NoError(t, err)
+	s.Close()
+}
+
+func TestHref(t *testing.T) {
+	assert := assert.New(t)
+
+	sp, _ := ForDatabase("http://localhost")
+	assert.Equal("http://localhost", sp.Href())
+	sp, _ = ForDatabase("http://localhost/foo/bar/baz")
+	assert.Equal("http://localhost/foo/bar/baz", sp.Href())
+	sp, _ = ForDatabase("https://my.example.com/foo/bar/baz")
+	assert.Equal("https://my.example.com/foo/bar/baz", sp.Href())
+	sp, _ = ForDataset("https://my.example.com/foo/bar/baz::myds")
+	assert.Equal("https://my.example.com/foo/bar/baz", sp.Href())
+	sp, _ = ForPath("https://my.example.com/foo/bar/baz::myds.my.path")
+	assert.Equal("https://my.example.com/foo/bar/baz", sp.Href())
+
+	sp, err := ForPath("mem::myds.my.path")
+	assert.NoError(err)
+	assert.Equal("", sp.Href())
+}
+
+func TestForDatabase(t *testing.T) {
+	assert := assert.New(t)
+
+	badSpecs := []string{
+		"mem:stuff",
+		"mem::",
+		"mem:",
+		"http:",
+		"http://",
+		"http://%",
+		"https:",
+		"https://",
+		"https://%",
+		"random:",
+		"random:random",
+		"/file/ba:d",
+	}
+
+	for _, spec := range badSpecs {
+		_, err := ForDatabase(spec)
+		assert.Error(err, spec)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "spec_test")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	testCases := []struct {
+		spec, protocol, databaseName string
+	}{
+		{"http://localhost:8000", "http", "//localhost:8000"},
+		{"http://localhost:8000/fff", "http", "//localhost:8000/fff"},
+		{"https://local.attic.io/john/doe", "https", "//local.attic.io/john/doe"},
+		{"mem", "mem", ""},
+		{tmpDir, "ldb", tmpDir},
+		{"ldb:" + tmpDir, "ldb", tmpDir},
+		{"http://server.com/john/doe?access_token=jane", "http", "//server.com/john/doe?access_token=jane"},
+		{"https://server.com/john/doe/?arg=2&qp1=true&access_token=jane", "https", "//server.com/john/doe/?arg=2&qp1=true&access_token=jane"},
+		{"http://some/::/one", "http", "//some/::/one"},
+		{"http://::1", "http", "//::1"},
+		{"http://192.30.252.154", "http", "//192.30.252.154"},
+		{"http://::192.30.252.154", "http", "//::192.30.252.154"},
+		{"http://0:0:0:0:0:ffff:c01e:fc9a", "http", "//0:0:0:0:0:ffff:c01e:fc9a"},
+		{"http://::ffff:c01e:fc9a", "http", "//::ffff:c01e:fc9a"},
+		{"http://::ffff::1e::9a", "http", "//::ffff::1e::9a"},
+	}
+
+	for _, tc := range testCases {
+		spec, err := ForDatabase(tc.spec)
+		assert.NoError(err, tc.spec)
+		defer spec.Close()
+
+		assert.Equal(tc.spec, spec.Spec)
+		assert.Equal(tc.protocol, spec.Protocol)
+		assert.Equal(tc.databaseName, spec.DatabaseName)
+		assert.Equal("", spec.DatasetName)
+		assert.True(spec.Path.IsEmpty())
+	}
+}
+
+func TestForDataset(t *testing.T) {
+	assert := assert.New(t)
+
+	badSpecs := []string{
+		"mem",
+		"mem:",
+		"mem:::ds",
+		"http",
+		"http:",
+		"http://foo",
+		"monkey",
+		"monkey:balls",
+		"http:::dsname",
+		"mem:/a/bogus/path:dsname",
+		"http://localhost:8000/one",
+		"ldb:",
+		"ldb:hello",
+	}
+
+	for _, spec := range badSpecs {
+		_, err := ForDataset(spec)
+		assert.Error(err, spec)
+	}
+
+	invalidDatasetNames := []string{" ", "", "$", "#", ":", "\n", "💩"}
+	for _, s := range invalidDatasetNames {
+		_, err := ForDataset("mem::" + s)
+		assert.Error(err)
+	}
+
+	validDatasetNames := []string{"a", "Z", "0", "/", "-", "_"}
+	for _, s := range validDatasetNames {
+		_, err := ForDataset("mem::" + s)
+		assert.NoError(err)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "spec_test")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	testCases := []struct {
+		spec, protocol, databaseName, datasetName string
+	}{
+		{"http://localhost:8000::ds1", "http", "//localhost:8000", "ds1"},
+		{"http://localhost:8000/john/doe/::ds2", "http", "//localhost:8000/john/doe/", "ds2"},
+		{"https://local.attic.io/john/doe::ds3", "https", "//local.attic.io/john/doe", "ds3"},
+		{"http://local.attic.io/john/doe::ds1", "http", "//local.attic.io/john/doe", "ds1"},
+		{tmpDir + "::ds/one", "ldb", tmpDir, "ds/one"},
+		{"ldb:" + tmpDir + "::ds/one", "ldb", tmpDir, "ds/one"},
+		{"http://localhost:8000/john/doe?access_token=abc::ds/one", "http", "//localhost:8000/john/doe?access_token=abc", "ds/one"},
+		{"https://localhost:8000?qp1=x&access_token=abc&qp2=y::ds/one", "https", "//localhost:8000?qp1=x&access_token=abc&qp2=y", "ds/one"},
+		{"http://192.30.252.154::foo", "http", "//192.30.252.154", "foo"},
+		{"http://::1::foo", "http", "//::1", "foo"},
+		{"http://::192.30.252.154::foo", "http", "//::192.30.252.154", "foo"},
+		{"http://0:0:0:0:0:ffff:c01e:fc9a::foo", "http", "//0:0:0:0:0:ffff:c01e:fc9a", "foo"},
+		{"http://::ffff:c01e:fc9a::foo", "http", "//::ffff:c01e:fc9a", "foo"},
+		{"http://::ffff::1e::9a::foo", "http", "//::ffff::1e::9a", "foo"},
+	}
+
+	for _, tc := range testCases {
+		spec, err := ForDataset(tc.spec)
+		assert.NoError(err, tc.spec)
+		defer spec.Close()
+
+		assert.Equal(tc.spec, spec.Spec)
+		assert.Equal(tc.protocol, spec.Protocol)
+		assert.Equal(tc.databaseName, spec.DatabaseName)
+		assert.Equal(tc.datasetName, spec.DatasetName)
+		assert.True(spec.Path.IsEmpty())
+	}
+}
+
+func TestForPath(t *testing.T) {
+	assert := assert.New(t)
+
+	badSpecs := []string{
+		"mem::#",
+		"mem::#s",
+		"mem::#foobarbaz",
+		"mem::#wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww",
+	}
+
+	for _, bs := range badSpecs {
+		_, err := ForPath(bs)
+		assert.Error(err)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "spec_test")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	testCases := []struct {
+		spec, protocol, databaseName, pathString string
+	}{
+		{"http://local.attic.io/john/doe::#0123456789abcdefghijklmnopqrstuv", "http", "//local.attic.io/john/doe", "#0123456789abcdefghijklmnopqrstuv"},
+		{tmpDir + "::#0123456789abcdefghijklmnopqrstuv", "ldb", tmpDir, "#0123456789abcdefghijklmnopqrstuv"},
+		{"ldb:" + tmpDir + "::#0123456789abcdefghijklmnopqrstuv", "ldb", tmpDir, "#0123456789abcdefghijklmnopqrstuv"},
+		{"mem::#0123456789abcdefghijklmnopqrstuv", "mem", "", "#0123456789abcdefghijklmnopqrstuv"},
+		{"http://local.attic.io/john/doe::#0123456789abcdefghijklmnopqrstuv", "http", "//local.attic.io/john/doe", "#0123456789abcdefghijklmnopqrstuv"},
+		{"http://localhost:8000/john/doe/::ds1", "http", "//localhost:8000/john/doe/", "ds1"},
+		{"http://192.30.252.154::foo.bar", "http", "//192.30.252.154", "foo.bar"},
+		{"http://::1::foo.bar.baz", "http", "//::1", "foo.bar.baz"},
+		{"http://::192.30.252.154::baz[42]", "http", "//::192.30.252.154", "baz[42]"},
+		{"http://0:0:0:0:0:ffff:c01e:fc9a::foo[42].bar", "http", "//0:0:0:0:0:ffff:c01e:fc9a", "foo[42].bar"},
+		{"http://::ffff:c01e:fc9a::foo.foo", "http", "//::ffff:c01e:fc9a", "foo.foo"},
+		{"http://::ffff::1e::9a::hello[\"world\"]", "http", "//::ffff::1e::9a", "hello[\"world\"]"},
+	}
+
+	for _, tc := range testCases {
+		spec, err := ForPath(tc.spec)
+		assert.NoError(err)
+		defer spec.Close()
+
+		assert.Equal(tc.spec, spec.Spec)
+		assert.Equal(tc.protocol, spec.Protocol)
+		assert.Equal(tc.databaseName, spec.DatabaseName)
+		assert.Equal("", spec.DatasetName)
+		assert.Equal(tc.pathString, spec.Path.String())
+	}
+}
+
+func TestPinPathSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	unpinned, err := ForPath("mem::foo.value")
+	assert.NoError(err)
+	defer unpinned.Close()
+
+	db := unpinned.GetDatabase()
+	db.CommitValue(db.GetDataset("foo"), types.Number(42))
+
+	pinned, ok := unpinned.Pin()
+	assert.True(ok)
+	defer pinned.Close()
+
+	head := db.GetDataset("foo").Head()
+
+	assert.Equal(head.Hash(), pinned.Path.Hash)
+	assert.Equal(fmt.Sprintf("mem::#%s.value", head.Hash().String()), pinned.Spec)
+	assert.Equal(types.Number(42), pinned.GetValue())
+	assert.Equal(types.Number(42), unpinned.GetValue())
+
+	db.CommitValue(db.GetDataset("foo"), types.Number(43))
+	assert.Equal(types.Number(42), pinned.GetValue())
+	assert.Equal(types.Number(43), unpinned.GetValue())
+}
+
+func TestPinDatasetSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	unpinned, err := ForDataset("mem::foo")
+	assert.NoError(err)
+	defer unpinned.Close()
+
+	db := unpinned.GetDatabase()
+	db.CommitValue(db.GetDataset("foo"), types.Number(42))
+
+	pinned, ok := unpinned.Pin()
+	assert.True(ok)
+	defer pinned.Close()
+
+	head := db.GetDataset("foo").Head()
+
+	commitValue := func(val types.Value) types.Value {
+		return val.(types.Struct).Get(datas.ValueField)
+	}
+
+	assert.Equal(head.Hash(), pinned.Path.Hash)
+	assert.Equal(fmt.Sprintf("mem::#%s", head.Hash().String()), pinned.Spec)
+	assert.Equal(types.Number(42), commitValue(pinned.GetValue()))
+	assert.Equal(types.Number(42), unpinned.GetDataset().HeadValue())
+
+	db.CommitValue(db.GetDataset("foo"), types.Number(43))
+	assert.Equal(types.Number(42), commitValue(pinned.GetValue()))
+	assert.Equal(types.Number(43), unpinned.GetDataset().HeadValue())
+}
+
+func TestAlreadyPinnedPathSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	unpinned, err := ForPath("mem::#imgp9mp1h3b9nv0gna6mri53dlj9f4ql.value")
+	assert.NoError(err)
+	pinned, ok := unpinned.Pin()
+	assert.True(ok)
+	assert.Equal(unpinned, pinned)
+}

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -86,7 +86,6 @@ func (s Struct) WalkRefs(cb RefCallback) {
 	for _, v := range s.values {
 		v.WalkRefs(cb)
 	}
-
 }
 
 func (s Struct) Type() *Type {

--- a/samples/go/poke/main_test.go
+++ b/samples/go/poke/main_test.go
@@ -70,7 +70,7 @@ func (s *testSuite) TestLose() {
 		{[]string{"foo"}, "Incorrect number of arguments\n"},
 		{[]string{"foo", "bar"}, "Incorrect number of arguments\n"},
 		{[]string{"foo", "bar", "baz", "quux"}, "Incorrect number of arguments\n"},
-		{[]string{sp + "!!", ".foo", `"bar"`}, "Invalid input dataset '" + sp + "!!': Invalid dataset, must match [a-zA-Z0-9\\-_/]+: test!!\n"},
+		{[]string{sp + "!!", ".foo", `"bar"`}, "Invalid input dataset '" + sp + "!!': Dataset test!! must match ^[a-zA-Z0-9\\-_/]+$\n"},
 		{[]string{sp + "2", ".foo", `"bar"`}, "Input dataset '" + sp + "2' does not exist\n"},
 		{[]string{sp, "[invalid", `"bar"`}, "Invalid path '[invalid': Invalid index: invalid\n"},
 		{[]string{sp, ".nothinghere", `"bar"`}, "No value at path '.nothinghere' - cannot update\n"},


### PR DESCRIPTION
This is a side-by-side port, taking inspiration from the old dataspec.go
code. Notably:

- LDB support has been added in Go. It wasn't needed in JS.
- There is an Href() method on Spec now.
- Go now handles IPV6.
- Go no longer treats access_token specially.
- Go now has Pin.
- I found some issues in the JS while doing this, I'll fix later.

I've also updated the config code to use the new API so that basically
all the Go samples use the code, even if they don't really change.