### PR TITLE
Remove dependency on bash shell from package

### DIFF
--- a/samples/js/counter/package.json
+++ b/samples/js/counter/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main.js",
   "version": "1.0.1",
   "scripts": {
-    "preinstall": "pushd .. && npm install && popd && rm -rf node_modules && ln -sf ../node_modules/",
+    "preinstall": "cd .. && npm install && cd - && rm -rf node_modules && ln -sf ../node_modules/",
     "prepublish": "npm run build",
     "start": "babel -d dist -w src",
     "build": "BABEL_ENV=production babel -d dist src",


### PR DESCRIPTION
Change removes dependency on bash, pushd/popd breaks installation when installing in a non bash env