### PR TITLE
Export HttpError and SpecOptions to Noms JS API

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "64.1.0",
+  "version": "64.2.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/browser/fetch.js
+++ b/js/noms/src/browser/fetch.js
@@ -5,7 +5,7 @@
 // @flow
 
 import {notNull} from '../assert.js';
-import HTTPError from '../http-error.js';
+import HttpError from '../http-error.js';
 
 export type FetchOptions = {
   method?: ?MethodType, // from flowlib bom.js
@@ -39,7 +39,7 @@ function internalFetch<T>(url: string, responseType: string, options: FetchOptio
         }
         resolve({headers: makeHeaders(xhr), buf});
       } else {
-        reject(new HTTPError(xhr.status));
+        reject(new HttpError(xhr.status));
       }
     };
   });

--- a/js/noms/src/fetch.js
+++ b/js/noms/src/fetch.js
@@ -8,7 +8,7 @@ import * as http from 'http';
 import * as https from 'https';
 import {parse} from 'url';
 import * as Bytes from './bytes.js';
-import HTTPError from './http-error.js';
+import HttpError from './http-error.js';
 
 export type FetchOptions = {
   method?: ?MethodType, // from flowlib bom.js
@@ -43,7 +43,7 @@ function fetch(url: string, options: FetchOptions = {}): Promise<BufResponse> {
   return new Promise((resolve, reject) => {
     const req = requestModules[opts.protocol].request(opts, res => {
       if (res.statusCode < 200 || res.statusCode >= 300) {
-        reject(new HTTPError(res.statusCode));
+        reject(new HttpError(res.statusCode));
         return;
       }
 

--- a/js/noms/src/http-batch-store.js
+++ b/js/noms/src/http-batch-store.js
@@ -15,7 +15,7 @@ import {
   fetchUint8Array as fetchUint8ArrayWithoutVersion,
   fetchText as fetchTextWithoutVersion,
 } from './fetch.js';
-import HTTPError from './http-error.js';
+import HttpError from './http-error.js';
 import {notNull} from './assert.js';
 import nomsVersion from './version.js';
 
@@ -154,7 +154,7 @@ export class Delegate {
       }
       return true;
     } catch (ex) {
-      if (ex instanceof HTTPError && ex.status === HTTP_STATUS_CONFLICT) {
+      if (ex instanceof HttpError && ex.status === HTTP_STATUS_CONFLICT) {
         return false;
       }
       throw ex;

--- a/js/noms/src/http-error-test.js
+++ b/js/noms/src/http-error-test.js
@@ -4,36 +4,36 @@
 
 // @flow
 
-import HTTPError from './http-error.js';
+import HttpError from './http-error.js';
 import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
 suite('http-error', () => {
   test('prototype', () => {
-    assert.equal(HTTPError.prototype.__proto__, Error.prototype);
+    assert.equal(HttpError.prototype.__proto__, Error.prototype);
 
-    const e = new HTTPError(42);
-    assert.equal(e.__proto__, HTTPError.prototype);
+    const e = new HttpError(42);
+    assert.equal(e.__proto__, HttpError.prototype);
   });
 
   test('instanceof', () => {
-    const e = new HTTPError(42);
-    assert.isTrue(e instanceof HTTPError);
+    const e = new HttpError(42);
+    assert.isTrue(e instanceof HttpError);
     assert.isTrue(e instanceof Error);
   });
 
   test('message', () => {
-    const e = new HTTPError(42);
+    const e = new HttpError(42);
     assert.strictEqual(e.message, '42');
   });
 
   test('name', () => {
-    const e = new HTTPError(42);
-    assert.strictEqual(e.name, 'HTTPError');
+    const e = new HttpError(42);
+    assert.strictEqual(e.name, 'HttpError');
   });
 
   test('toString', () => {
-    const e = new HTTPError(42);
-    assert.strictEqual(e.toString(), 'HTTPError: 42');
+    const e = new HttpError(42);
+    assert.strictEqual(e.toString(), 'HttpError: 42');
   });
 });

--- a/js/noms/src/http-error.js
+++ b/js/noms/src/http-error.js
@@ -7,7 +7,7 @@
 /**
  * This `Error` class is used to signal an non 2xx response fromg `fetchText` and `fetchUint8Array`.
  */
-export default class HTTPError extends Error {
+export default class HttpError extends Error {
 
   /**
    * The HTTP error code for this error.
@@ -18,9 +18,9 @@ export default class HTTPError extends Error {
     super();  // Make Babel happy!
 
     // Babel does not support extending native classes.
-    const e = Object.create(HTTPError.prototype);
+    const e = Object.create(HttpError.prototype);
     e.status = status;
-    e.name = 'HTTPError';
+    e.name = 'HttpError';
     e.message = String(status);
     return e;
   }

--- a/js/noms/src/noms.js
+++ b/js/noms/src/noms.js
@@ -16,6 +16,7 @@ export {default as Chunk} from './chunk.js';
 export {getHashOfValue} from './get-hash.js';
 export {BatchStoreAdaptor} from './batch-store.js';
 export {default as HttpBatchStore} from './http-batch-store.js';
+export {default as HttpError} from './http-error.js';
 export {default as MemoryStore} from './memory-store.js';
 export {default as Hash, emptyHash} from './hash.js';
 export {default as Path} from './path.js';
@@ -59,7 +60,7 @@ export {
   getTypeOfValue,
 } from './type.js';
 export {equals, less} from './compare.js';
-export {default as Spec} from './spec.js';
+export {default as Spec, SpecOptions} from './spec.js';
 export {DatabaseSpec, DatasetSpec, PathSpec} from './specs.js';
 export {default as walk} from './walk.js';
 export {default as jsonToNoms} from './json-convert.js';


### PR DESCRIPTION
I renamed HTTPError to HttpError for consistency with HttpBatchStore
(and XMLHttpRequest).