### PR TITLE
Lock down Flow version

### DIFF
--- a/js/noms/.flowconfig
+++ b/js/noms/.flowconfig
@@ -15,3 +15,6 @@
 unsafe.enable_getters_and_setters=true
 munge_underscores=true
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue: .+
+
+[version]
+0.34.0

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -22,7 +22,7 @@
     "commander": "^2.9.0",
     "documentation": "4.0.0-beta12",
     "eslint-config-noms": "1.0.0",
-    "flow-bin": "^0.34.0",
+    "flow-bin": "0.34.0",
     "fs-extra": "^0.30.0",
     "mocha": "^2.5.3",
     "mock-require": "^1.3.0",

--- a/js/perf/package.json
+++ b/js/perf/package.json
@@ -16,7 +16,7 @@
     "csv": "^1.1.0",
     "eslint-config-noms": "1.0.0",
     "flickr-oauth-and-upload": "^0.8.0",
-    "flow-bin": "^0.34.0",
+    "flow-bin": "0.34.0",
     "http-server": "^0.9.0",
     "humanize": "^0.0.9",
     "mocha": "^2.5.3",

--- a/samples/js/package.json
+++ b/samples/js/package.json
@@ -18,7 +18,7 @@
     "csv": "^1.1.0",
     "eslint-config-noms": "1.0.0",
     "flickr-oauth-and-upload": "^0.8.0",
-    "flow-bin": "^0.34.0",
+    "flow-bin": "0.34.0",
     "http-server": "^0.9.0",
     "humanize": "^0.0.9",
     "mocha": "^2.5.3",


### PR DESCRIPTION
This is to prevent errors in the future when the code and flow version
do not match.