### PR TITLE
Add debug logging to HandleWriteValue

### DIFF
--- a/go/chunks/chunk_serializer.go
+++ b/go/chunks/chunk_serializer.go
@@ -87,7 +87,6 @@ func DeserializeToChan(reader io.Reader, chunkChan chan<- interface{}) {
 		}
 		chunkChan <- &c
 	}
-	close(chunkChan)
 }
 
 func deserializeChunk(reader io.Reader) (Chunk, bool) {

--- a/go/util/verbose/verbose.go
+++ b/go/util/verbose/verbose.go
@@ -5,6 +5,8 @@
 package verbose
 
 import (
+	"fmt"
+
 	flag "github.com/juju/gnuflag"
 )
 
@@ -29,4 +31,11 @@ func Verbose() bool {
 // Quiet returns True if the verbose flag was set
 func Quiet() bool {
 	return quiet
+}
+
+// Log calls Printf(format, args...) iff Verbose() returns true.
+func Log(format string, args ...interface{}) {
+	if Verbose() {
+		fmt.Printf(format+"\n", args...)
+	}
 }


### PR DESCRIPTION
This patch introduces optional debug logging in util/verbose, and adds
some usage of it to HandleWriteValue and the httpBatchStore
SchedulePut code path. It also modifies chunks.DeserializeToChan() so
that callers can better recover from panics in there.

https://github.com/attic-labs/attic/issues/103