### PR TITLE
Fix race conditions in encoder to address photo-dedup segfault

### DIFF
--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -153,9 +153,9 @@ func float64Encoder(v reflect.Value) types.Value {
 }
 
 func intEncoder(v reflect.Value) types.Value {
-
 	return types.Number(float64(v.Int()))
 }
+
 func uintEncoder(v reflect.Value) types.Value {
 	return types.Number(float64(v.Uint()))
 }
@@ -443,7 +443,13 @@ func listEncoder(t reflect.Type, parentStructTypes []reflect.Type) encoderFunc {
 	}
 
 	var elemEncoder encoderFunc
+	// lock e until encoder(s) are initialized
+	var init sync.RWMutex
+	init.Lock()
+	defer init.Unlock()
 	e = func(v reflect.Value) types.Value {
+		init.RLock()
+		defer init.RUnlock()
 		values := make([]types.Value, v.Len(), v.Len())
 		for i := 0; i < v.Len(); i++ {
 			values[i] = elemEncoder(v.Index(i))
@@ -463,7 +469,13 @@ func setEncoder(t reflect.Type, parentStructTypes []reflect.Type) encoderFunc {
 	}
 
 	var encoder encoderFunc
+	// lock e until encoder(s) are initialized
+	var init sync.RWMutex
+	init.Lock()
+	defer init.Unlock()
 	e = func(v reflect.Value) types.Value {
+		init.RLock()
+		defer init.RUnlock()
 		values := make([]types.Value, v.Len(), v.Len())
 		for i, k := range v.MapKeys() {
 			values[i] = encoder(k)
@@ -484,7 +496,13 @@ func mapEncoder(t reflect.Type, parentStructTypes []reflect.Type) encoderFunc {
 
 	var keyEncoder encoderFunc
 	var valueEncoder encoderFunc
+	// lock e until encoder(s) are initialized
+	var init sync.RWMutex
+	init.Lock()
+	defer init.Unlock()
 	e = func(v reflect.Value) types.Value {
+		init.RLock()
+		defer init.RUnlock()
 		keys := v.MapKeys()
 		kvs := make([]types.Value, 2*len(keys))
 		for i, k := range keys {


### PR DESCRIPTION
This change addresses race conditions revealed by a segfault while running photo-dedup in production. 

The root of the problem is described in #2849. The fix is to add use a RWMutex to block encoder function calls until the function is fully initialized. 

I've verified the fix by running photo-dedup under the race detector before and after. The race is detected in the before run and is gone in the after run.

An improvement over this fix would be to implement a fast path using an atomic int (see the sync.Once.Do() implementation for an example). 

-
toward: #2849