### PR TITLE
fix .nomsconfig error: Near line 11

### DIFF
--- a/samples/cli/nomsconfig/.nomsconfig
+++ b/samples/cli/nomsconfig/.nomsconfig
@@ -8,9 +8,8 @@ url = "http://demo.noms.io/cli-tour"
 
 # DB alias named `temp` that refers to a noms db stored under /tmp
 [db.temp]
-url = "ldb:/tmp/noms/shared
+url = "ldb:/tmp/noms/shared"
 
 # DB alias named `http` that refers to the local http db
 [db.http]
-url = "http://localhost:8000
-
+url = "http://localhost:8000"


### PR DESCRIPTION

when you run 

noms config

in the directory samples/cli/nomsconfig 

you get the following error message.

error: Near line 11 (last key parsed 'db.temp.url'): Strings can not contain new lines...

line 11 and line 15 need quotes at the end of the line...

