### PR TITLE
Make blob-get print to stdout if there is no file arg

### DIFF
--- a/samples/go/blob-get/blob_get_test.go
+++ b/samples/go/blob-get/blob_get_test.go
@@ -41,4 +41,8 @@ func (s *bgSuite) TestBlobGet() {
 	fileBytes, err := ioutil.ReadFile(filePath)
 	s.NoError(err)
 	s.Equal(blobBytes, fileBytes)
+
+	stdout, _ := s.MustRun(main, []string{hashSpec})
+	fmt.Println("stdout:", stdout)
+	s.Equal(blobBytes, []byte(stdout))
 }


### PR DESCRIPTION
I'd like to use blob-get to print string blobs directly to stdout. Here's a proposed change to make that happen.