### PR TITLE
Introduce more fakes for testing NomsBlockStore

### DIFF
--- a/go/nbs/benchmarks/main.go
+++ b/go/nbs/benchmarks/main.go
@@ -71,7 +71,7 @@ func main() {
 		if *toNBS != "" {
 			dir = makeTempDir(*toNBS, pb)
 			open = func() blockStore {
-				return nbs.NewBlockStore(dir, bufSize)
+				return nbs.NewLocalStore(dir, bufSize)
 			}
 		} else if *toFile != "" {
 			dir = makeTempDir(*toFile, pb)
@@ -91,7 +91,7 @@ func main() {
 	} else {
 		if *useNBS != "" {
 			open = func() blockStore {
-				return nbs.NewBlockStore(*useNBS, bufSize)
+				return nbs.NewLocalStore(*useNBS, bufSize)
 			}
 		}
 		writeDB = func() {}

--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -5,6 +5,8 @@
 package nbs
 
 import (
+	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -14,6 +16,8 @@ import (
 	"github.com/attic-labs/testify/assert"
 	"github.com/attic-labs/testify/suite"
 )
+
+const testMemTableSize = 1 << 8
 
 func TestBlockStoreSuite(t *testing.T) {
 	suite.Run(t, &BlockStoreSuite{})
@@ -30,7 +34,7 @@ func (suite *BlockStoreSuite) SetupTest() {
 	var err error
 	suite.dir, err = ioutil.TempDir("", "")
 	suite.NoError(err)
-	suite.store = NewBlockStore(suite.dir, defaultMemTableSize)
+	suite.store = NewLocalStore(suite.dir, 1<<8)
 	suite.putCountFn = func() int {
 		return int(suite.store.putCount)
 	}
@@ -42,7 +46,7 @@ func (suite *BlockStoreSuite) TearDownTest() {
 }
 
 func (suite *BlockStoreSuite) TestChunkStorePut() {
-	input := "abc"
+	input := []byte("abc")
 	c := chunks.NewChunk([]byte(input))
 	suite.store.Put(c)
 	h := c.Hash()
@@ -59,7 +63,7 @@ func (suite *BlockStoreSuite) TestChunkStorePut() {
 	}
 
 	// Re-writing the same data should cause a second put
-	c = chunks.NewChunk([]byte(input))
+	c = chunks.NewChunk(input)
 	suite.store.Put(c)
 	suite.Equal(h, c.Hash())
 	assertInputInStore(input, h, suite.store, suite.Assert())
@@ -71,8 +75,8 @@ func (suite *BlockStoreSuite) TestChunkStorePut() {
 }
 
 func (suite *BlockStoreSuite) TestChunkStorePutMany() {
-	input1, input2 := "abc", "def"
-	c1, c2 := chunks.NewChunk([]byte(input1)), chunks.NewChunk([]byte(input2))
+	input1, input2 := []byte("abc"), []byte("def")
+	c1, c2 := chunks.NewChunk(input1), chunks.NewChunk(input2)
 	suite.store.PutMany([]chunks.Chunk{c1, c2})
 
 	suite.store.UpdateRoot(c1.Hash(), suite.store.Root()) // Commit writes
@@ -85,10 +89,27 @@ func (suite *BlockStoreSuite) TestChunkStorePutMany() {
 	}
 }
 
-func assertInputInStore(input string, h hash.Hash, s chunks.ChunkStore, assert *assert.Assertions) {
-	chunk := s.Get(h)
-	assert.False(chunk.IsEmpty(), "Shouldn't get empty chunk for %s", h.String())
-	assert.Equal(input, string(chunk.Data()))
+func (suite *BlockStoreSuite) TestChunkStorePutMoreThanMemTable() {
+	input1, input2 := make([]byte, testMemTableSize/2+1), make([]byte, testMemTableSize/2+1)
+	rand.Read(input1)
+	rand.Read(input2)
+	c1, c2 := chunks.NewChunk(input1), chunks.NewChunk(input2)
+	suite.store.PutMany([]chunks.Chunk{c1, c2})
+
+	suite.store.UpdateRoot(c1.Hash(), suite.store.Root()) // Commit writes
+
+	// And reading it via the API should work...
+	assertInputInStore(input1, c1.Hash(), suite.store, suite.Assert())
+	assertInputInStore(input2, c2.Hash(), suite.store, suite.Assert())
+	if suite.putCountFn != nil {
+		suite.Equal(2, suite.putCountFn())
+	}
+}
+
+func assertInputInStore(input []byte, h hash.Hash, s chunks.ChunkStore, assert *assert.Assertions) {
+	c := s.Get(h)
+	assert.False(c.IsEmpty(), "Shouldn't get empty chunk for %s", h.String())
+	assert.Zero(bytes.Compare(input, c.Data()), "%s != %s", string(input), string(c.Data()))
 }
 
 func (suite *BlockStoreSuite) TestChunkStoreGetNonExisting() {

--- a/go/nbs/file_manifest.go
+++ b/go/nbs/file_manifest.go
@@ -25,6 +25,11 @@ const (
 	lockFileName     = "LOCK"
 )
 
+type manifest interface {
+	ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec)
+	Update(tables chunkSources, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec)
+}
+
 // fileManifest provides access to a NomsBlockStore manifest stored on disk in |dir|. The format
 // is currently human readable:
 //

--- a/go/nbs/file_manifest.go
+++ b/go/nbs/file_manifest.go
@@ -26,7 +26,37 @@ const (
 )
 
 type manifest interface {
+	// ParseIfExists extracts and returns values from a NomsBlockStore
+	// manifest, if one exists. Concrete implementations are responsible for
+	// defining how to find and parse the desired manifest, e.g. a
+	// particularly-named file in a given directory. Implementations are also
+	// responsible for managing whatever concurrency guarantees they require
+	// for correctness.
+	// If the manifest exists, |exists| is set to true and manifest data is
+	// returned, including the version of the Noms data in the store, the root
+	// hash.Hash of the store, and a tableSpec describing every table that
+	// comprises the store.
+	// If the manifest doesn't exist, |exists| is set to false and the other
+	// return values are undefined. The |readHook| parameter allows race
+	// condition testing. If it is non-nil, it will be invoked while the
+	// implementation is guaranteeing exclusive access to the manifest.
 	ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec)
+
+	// Update optimistically tries to write a new manifest containing
+	// |newRoot| and the elements of |tables|. If |root| matches the root hash
+	// in the currently persisted manifest (logically, the root that would be
+	// returned by ParseIfExists), then Update succeeds and subsequent calls
+	// to both Update and ParseIfExists will reflect a manifest containing
+	// |newRoot| and |tables|. If not, Update fails. Regardless, |actual| and
+	// |tableSpecs| will reflect the current state of the world upon return.
+	// Callers should check that |actual| == |newRoot| and, if not, merge any
+	// desired new table information with the contents of |tableSpecs| before
+	// trying again.
+	// Concrete implementations are responsible for ensuring that concurrent
+	// Update calls (and ParseIfExists calls) are correct.
+	// If writeHook is non-nil, it will be invoked while the implementation is
+	// guaranteeing exclusive access to the manifest. This allows for testing
+	// of race conditions.
 	Update(tables chunkSources, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec)
 }
 
@@ -105,13 +135,13 @@ func parseManifest(r io.Reader) (string, hash.Hash, []tableSpec) {
 	return string(slices[1]), hash.Parse(string(slices[2])), specs
 }
 
-func writeManifest(temp io.Writer, root hash.Hash, tables chunkSources) {
-	strs := make([]string, 2*len(tables)+3)
+func writeManifest(temp io.Writer, root hash.Hash, specs []tableSpec) {
+	strs := make([]string, 2*len(specs)+3)
 	strs[0], strs[1], strs[2] = StorageVersion, constants.NomsVersion, root.String()
 	tableInfo := strs[3:]
-	for i, t := range tables {
-		tableInfo[2*i] = t.hash().String()
-		tableInfo[2*i+1] = strconv.FormatUint(uint64(t.count()), 10)
+	for i, t := range specs {
+		tableInfo[2*i] = t.name.String()
+		tableInfo[2*i+1] = strconv.FormatUint(uint64(t.chunkCount), 10)
 	}
 	_, err := io.WriteString(temp, strings.Join(strs, ":"))
 	d.PanicIfError(err)
@@ -126,6 +156,10 @@ func writeManifest(temp io.Writer, root hash.Hash, tables chunkSources) {
 // If writeHook is non-nil, it will be invoked wile the manifest file lock is
 // held. This is to allow for testing of race conditions.
 func (fm fileManifest) Update(tables chunkSources, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec) {
+	tableSpecs = make([]tableSpec, len(tables))
+	for i, src := range tables {
+		tableSpecs[i] = tableSpec{src.hash(), src.count()}
+	}
 
 	// Write a temporary manifest file, to be renamed over manifestFileName upon success.
 	// The closure here ensures this file is closed before moving on.
@@ -133,7 +167,7 @@ func (fm fileManifest) Update(tables chunkSources, root, newRoot hash.Hash, writ
 		temp, err := ioutil.TempFile(fm.dir, "nbs_manifest_")
 		d.PanicIfError(err)
 		defer checkClose(temp)
-		writeManifest(temp, newRoot, tables)
+		writeManifest(temp, newRoot, tableSpecs)
 		return temp.Name()
 	}()
 	defer os.Remove(tempManifestPath) // If we rename below, this will be a no-op
@@ -165,7 +199,7 @@ func (fm fileManifest) Update(tables chunkSources, root, newRoot hash.Hash, writ
 	}
 	err := os.Rename(tempManifestPath, manifestPath)
 	d.PanicIfError(err)
-	return newRoot, nil
+	return newRoot, tableSpecs
 }
 
 func checkClose(c io.Closer) {

--- a/go/nbs/file_manifest_test.go
+++ b/go/nbs/file_manifest_test.go
@@ -35,8 +35,8 @@ func TestFileManifestParseIfExists(t *testing.T) {
 	// Simulate another process writing a manifest (with an old Noms version).
 	newRoot := hash.Of([]byte("new root"))
 	tableName := hash.Of([]byte("table1"))
-	b, err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", newRoot.String(), tableName.String(), "0"}, ":"))
-	assert.NoError(err, string(b))
+	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", newRoot.String(), tableName.String(), "0"}, ":"))
+	assert.NoError(err)
 
 	// ParseIfExists should now reflect the manifest written above.
 	exists, vers, root, tableSpecs = fm.ParseIfExists(nil)
@@ -57,8 +57,8 @@ func TestFileManifestParseIfExistsHoldsLock(t *testing.T) {
 	// Simulate another process writing a manifest.
 	newRoot := hash.Of([]byte("new root"))
 	tableName := hash.Of([]byte("table1"))
-	b, err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot.String(), tableName.String(), "0"}, ":"))
-	assert.NoError(err, string(b))
+	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot.String(), tableName.String(), "0"}, ":"))
+	assert.NoError(err)
 
 	// ParseIfExists should now reflect the manifest written above.
 	exists, vers, root, tableSpecs := fm.ParseIfExists(func() {
@@ -77,76 +77,91 @@ func TestFileManifestParseIfExistsHoldsLock(t *testing.T) {
 	}
 }
 
-func TestFileManifestUpdate(t *testing.T) {
+func TestFileManifestUpdateWontClobberOldVersion(t *testing.T) {
 	assert := assert.New(t)
 	fm := makeFileManifestTempDir(t)
 	defer os.RemoveAll(fm.dir)
 
 	// Simulate another process having already put old Noms data in dir/.
-	b, err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", hash.Hash{}.String()}, ":"))
-	assert.NoError(err, string(b))
+	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", hash.Hash{}.String()}, ":"))
+	assert.NoError(err)
 
 	assert.Panics(func() { fm.Update(nil, hash.Hash{}, hash.Hash{}, nil) })
 }
 
-func TestFileManifestUpdateWinRace(t *testing.T) {
+func TestFileManifestUpdate(t *testing.T) {
 	assert := assert.New(t)
 	fm := makeFileManifestTempDir(t)
 	defer os.RemoveAll(fm.dir)
 
-	newRoot2 := hash.Of([]byte("new root 2"))
-	actual, tableSpecs := fm.Update(nil, hash.Hash{}, newRoot2, func() {
+	// First, test winning the race against another process.
+	newRoot := hash.Of([]byte("new root"))
+	source := fakeChunkSource{computeAddr([]byte("a")), 3}
+	actual, tableSpecs := fm.Update(chunkSources{source}, hash.Hash{}, newRoot, func() {
 		// This should fail to get the lock, and therefore _not_ clobber the manifest. So the Update should succeed.
-		newRoot := hash.Of([]byte("new root"))
-		b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot.String()}, ":"))
+		newRoot2 := hash.Of([]byte("new root 2"))
+		b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot2.String()}, ":"))
 		assert.NoError(err, string(b))
 	})
-	assert.Equal(newRoot2, actual)
+	assert.Equal(newRoot, actual)
 	assert.Nil(tableSpecs)
-}
 
-func TestFileManifestUpdateRootOptimisticLockFail(t *testing.T) {
-	assert := assert.New(t)
-	fm := makeFileManifestTempDir(t)
-	defer os.RemoveAll(fm.dir)
-
-	tableName := hash.Of([]byte("table1"))
-	newRoot := hash.Of([]byte("new root"))
-	b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot.String(), tableName.String(), "3"}, ":"))
-	assert.NoError(err, string(b))
-
+	// Now, test the case where the optimistic lock fails, and someone else updated the root since last we checked.
 	newRoot2 := hash.Of([]byte("new root 2"))
-	actual, tableSpecs := fm.Update(nil, hash.Hash{}, newRoot2, nil)
+	actual, tableSpecs = fm.Update(nil, hash.Hash{}, newRoot2, nil)
 	assert.Equal(newRoot, actual)
 	if assert.Len(tableSpecs, 1) {
-		assert.Equal(tableName.String(), tableSpecs[0].name.String())
+		assert.Equal(source.hash().String(), tableSpecs[0].name.String())
 		assert.Equal(uint32(3), tableSpecs[0].chunkCount)
 	}
 	actual, tableSpecs = fm.Update(nil, actual, newRoot2, nil)
 }
 
+type fakeChunkSource struct {
+	name       addr
+	chunkCount uint32
+}
+
+func (f fakeChunkSource) close() error {
+	return nil
+}
+
+func (f fakeChunkSource) count() uint32 {
+	return f.chunkCount
+}
+
+func (f fakeChunkSource) hash() addr {
+	return f.name
+}
+
+func (f fakeChunkSource) has(h addr) bool { panic("not implemented") }
+
+func (f fakeChunkSource) hasMany(addrs []hasRecord) bool { panic("not implemented") }
+
+func (f fakeChunkSource) get(h addr) []byte { panic("not implemented") }
+
+func (f fakeChunkSource) getMany(reqs []getRecord) bool { panic("not implemented") }
+
 // tryClobberManifest simulates another process trying to access dir/manifestFileName concurrently. To avoid deadlock, it does a non-blocking lock of dir/lockFileName. If it can get the lock, it clobbers the manifest.
 func tryClobberManifest(dir, contents string) ([]byte, error) {
-	return runClobber(dir, contents, false)
+	return runClobber(dir, contents)
 }
 
-// clobberManifest simulates another process writing dir/manifestFileName concurrently. It takes the lock, so it's up to the caller to avoid deadlock.
-func clobberManifest(dir, contents string) ([]byte, error) {
-	return runClobber(dir, contents, true)
+// clobberManifest simulates another process writing dir/manifestFileName concurrently. It ignores the lock file, so it's up to the caller to ensure correctness.
+func clobberManifest(dir, contents string) error {
+	if err := ioutil.WriteFile(filepath.Join(dir, lockFileName), nil, 0666); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(dir, manifestFileName), []byte(contents), 0666)
 }
 
-func runClobber(dir, contents string, takeLock bool) ([]byte, error) {
+func runClobber(dir, contents string) ([]byte, error) {
 	_, filename, _, _ := runtime.Caller(1)
 	clobber := filepath.Join(filepath.Dir(filename), "test/manifest_clobber.go")
 	mkPath := func(f string) string {
 		return filepath.Join(dir, f)
 	}
-	args := []string{"run", clobber}
-	if takeLock {
-		args = append(args, "--take-lock")
-	}
-	args = append(args, mkPath(lockFileName), mkPath(manifestFileName), contents)
 
-	c := exec.Command("go", args...)
+	c := exec.Command("go", "run", clobber, mkPath(lockFileName), mkPath(manifestFileName), contents)
 	return c.CombinedOutput()
 }

--- a/go/nbs/file_manifest_test.go
+++ b/go/nbs/file_manifest_test.go
@@ -104,7 +104,7 @@ func TestFileManifestUpdate(t *testing.T) {
 		assert.NoError(err, string(b))
 	})
 	assert.Equal(newRoot, actual)
-	assert.Nil(tableSpecs)
+	assert.Equal([]tableSpec{{source.hash(), source.count()}}, tableSpecs)
 
 	// Now, test the case where the optimistic lock fails, and someone else updated the root since last we checked.
 	newRoot2 := hash.Of([]byte("new root 2"))

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -5,30 +5,18 @@
 package nbs
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
+	"encoding/binary"
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/constants"
-	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/testify/assert"
 )
 
-func makeStoreInTempDir(t *testing.T) (dir string, store *NomsBlockStore) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	store = NewBlockStore(dir, defaultMemTableSize)
-	return
-}
-
 func TestChunkStoreZeroValue(t *testing.T) {
 	assert := assert.New(t)
-	dir, store := makeStoreInTempDir(t)
-	defer os.RemoveAll(dir)
+	_, _, store := makeStoreWithFakes(t)
 	defer store.Close()
 
 	// No manifest file gets written until the first call to UpdateRoot(). Prior to that, Root() will simply return hash.Hash{}.
@@ -38,8 +26,7 @@ func TestChunkStoreZeroValue(t *testing.T) {
 
 func TestChunkStoreVersion(t *testing.T) {
 	assert := assert.New(t)
-	dir, store := makeStoreInTempDir(t)
-	defer os.RemoveAll(dir)
+	_, _, store := makeStoreWithFakes(t)
 	defer store.Close()
 
 	assert.Equal(constants.NomsVersion, store.Version())
@@ -51,8 +38,7 @@ func TestChunkStoreVersion(t *testing.T) {
 
 func TestChunkStoreUpdateRoot(t *testing.T) {
 	assert := assert.New(t)
-	dir, store := makeStoreInTempDir(t)
-	defer os.RemoveAll(dir)
+	_, _, store := makeStoreWithFakes(t)
 	defer store.Close()
 
 	assert.Equal(hash.Hash{}, store.Root())
@@ -77,33 +63,72 @@ func TestChunkStoreUpdateRoot(t *testing.T) {
 
 func TestChunkStoreManifestAppearsAfterConstruction(t *testing.T) {
 	assert := assert.New(t)
-	dir, store := makeStoreInTempDir(t)
-	defer os.RemoveAll(dir)
+	fm, tm, store := makeStoreWithFakes(t)
 	defer store.Close()
 
 	assert.Equal(hash.Hash{}, store.Root())
 	assert.Equal(constants.NomsVersion, store.Version())
 
-	// Simulate another process writing a manifest (with an old Noms version) after construction.
+	// Simulate another process writing a manifest after construction.
 	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
 	newRoot := hash.Of([]byte("new root"))
-	h := createOnDiskTable(dir, chunks)
-	b, err := clobberManifest(dir, strings.Join([]string{StorageVersion, "0", newRoot.String(), h.String(), "3"}, ":"))
-	assert.NoError(err, string(b))
+	h, _ := tm.Compact(createMemTable(chunks), nil)
+	fm.Set(constants.NomsVersion, newRoot, []tableSpec{{h, uint32(len(chunks))}})
 
-	// Creating another store should reflect the manifest written above.
-	store2 := NewBlockStore(dir, defaultMemTableSize)
-	defer store2.Close()
-
-	assert.Equal(newRoot, store2.Root())
-	assert.Equal("0", store2.Version())
-	assertDataInStore(chunks, store2, assert)
+	// state in store shouldn't change
+	assert.Equal(hash.Hash{}, store.Root())
+	assert.Equal(constants.NomsVersion, store.Version())
 }
 
-func createOnDiskTable(dir string, chunks [][]byte) addr {
-	tableData, h := buildTable(chunks)
-	d.PanicIfError(ioutil.WriteFile(filepath.Join(dir, h.String()), tableData, 0666))
-	return h
+func TestChunkStoreManifestFirstWriteByOtherProcess(t *testing.T) {
+	assert := assert.New(t)
+	fm := &fakeManifest{}
+	tm := newFakeTableManager()
+
+	// Simulate another process having already written a manifest.
+	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
+	newRoot := hash.Of([]byte("new root"))
+	h, _ := tm.Compact(createMemTable(chunks), nil)
+	fm.Set(constants.NomsVersion, newRoot, []tableSpec{{h, uint32(len(chunks))}})
+
+	store := newNomsBlockStore(fm, tm, defaultMemTableSize)
+	defer store.Close()
+
+	assert.Equal(newRoot, store.Root())
+	assert.Equal(constants.NomsVersion, store.Version())
+	assertDataInStore(chunks, store, assert)
+}
+
+func TestChunkStoreUpdateRootOptimisticLockFail(t *testing.T) {
+	assert := assert.New(t)
+	fm, tm, store := makeStoreWithFakes(t)
+	defer store.Close()
+
+	// Simulate another process writing a manifest behind store's back.
+	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
+	newRoot := hash.Of([]byte("new root"))
+	h, _ := tm.Compact(createMemTable(chunks), nil)
+	fm.Set(constants.NomsVersion, newRoot, []tableSpec{{h, uint32(len(chunks))}})
+
+	newRoot2 := hash.Of([]byte("new root 2"))
+	assert.False(store.UpdateRoot(newRoot2, hash.Hash{}))
+	assertDataInStore(chunks, store, assert)
+	assert.True(store.UpdateRoot(newRoot2, newRoot))
+}
+
+func makeStoreWithFakes(t *testing.T) (fm *fakeManifest, tm tableManager, store *NomsBlockStore) {
+	fm = &fakeManifest{}
+	tm = newFakeTableManager()
+	store = newNomsBlockStore(fm, tm, 0)
+	return
+}
+
+func createMemTable(chunks [][]byte) *memTable {
+	mt := newMemTable(1 << 10)
+	for _, c := range chunks {
+		mt.addChunk(computeAddr(c), c)
+	}
+	return mt
 }
 
 func assertDataInStore(slices [][]byte, store chunks.ChunkSource, assert *assert.Assertions) {
@@ -112,28 +137,75 @@ func assertDataInStore(slices [][]byte, store chunks.ChunkSource, assert *assert
 	}
 }
 
-func TestChunkStoreManifestFirstWriteByOtherProcess(t *testing.T) {
-	assert := assert.New(t)
-	dir, err := ioutil.TempDir(os.TempDir(), "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
+type fakeManifest struct {
+	version    string
+	root       hash.Hash
+	tableSpecs []tableSpec
+}
 
-	// Simulate another process having already written a manifest (with an old Noms version).
-	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
-	h := createOnDiskTable(dir, chunks)
-	newRoot := hash.Of([]byte("new root"))
-	b, err := tryClobberManifest(dir, strings.Join([]string{StorageVersion, "0", newRoot.String(), h.String(), "3"}, ":"))
-	assert.NoError(err, string(b))
+func (fm *fakeManifest) ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
+	if fm.root != (hash.Hash{}) {
+		return true, fm.version, fm.root, fm.tableSpecs
+	}
+	return false, constants.NomsVersion, hash.Hash{}, nil
+}
 
-	store := hookedNewNomsBlockStore(dir, defaultMemTableSize, func() {
-		// This should fail to get the lock, and therefore _not_ clobber the manifest.
-		badRoot := hash.Of([]byte("bad root"))
-		b, err := tryClobberManifest(dir, strings.Join([]string{StorageVersion, "0", badRoot.String(), h.String(), "3"}, ":"))
-		assert.NoError(err, string(b))
-	})
-	defer store.Close()
+func (fm *fakeManifest) Update(tables chunkSources, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec) {
+	if fm.root != root {
+		return fm.root, fm.tableSpecs
+	}
+	fm.version = constants.NomsVersion
+	fm.root = newRoot
 
-	assert.Equal(newRoot, store.Root())
-	assert.Equal("0", store.Version())
-	assertDataInStore(chunks, store, assert)
+	newTables := make([]tableSpec, len(fm.tableSpecs))
+	known := map[addr]struct{}{}
+	for i, t := range fm.tableSpecs {
+		known[t.name] = struct{}{}
+		newTables[i] = t
+	}
+
+	for _, t := range tables {
+		if _, present := known[t.hash()]; !present {
+			newTables = append(newTables, tableSpec{t.hash(), t.count()})
+		}
+	}
+	fm.tableSpecs = newTables
+	return fm.root, fm.tableSpecs
+}
+
+func (fm *fakeManifest) Set(version string, root hash.Hash, specs []tableSpec) {
+	fm.version, fm.root, fm.tableSpecs = version, root, specs
+}
+
+func newFakeTableManager() fakeTableManager {
+	return fakeTableManager{map[addr]*memTable{}}
+}
+
+type fakeTableManager struct {
+	sources map[addr]*memTable
+}
+
+func (ftm fakeTableManager) Compact(mt *memTable, haver chunkReader) (name addr, count uint32) {
+	scratch := [binary.MaxVarintLen64]byte{}
+	binary.PutUvarint(scratch[:], uint64(len(ftm.sources)))
+	name = computeAddr(scratch[:])
+	ftm.sources[name] = mt
+	return name, uint32(len(ftm.sources))
+}
+
+func (ftm fakeTableManager) Open(name addr, chunkCount uint32) chunkSource {
+	return chunkSourceAdapter{ftm.sources[name], name}
+}
+
+type chunkSourceAdapter struct {
+	*memTable
+	h addr
+}
+
+func (csa chunkSourceAdapter) close() error {
+	return nil
+}
+
+func (csa chunkSourceAdapter) hash() addr {
+	return csa.h
 }

--- a/go/nbs/table_manager.go
+++ b/go/nbs/table_manager.go
@@ -5,18 +5,18 @@
 package nbs
 
 type tableManager interface {
-	compact(mt *memTable, haver chunkReader) (name addr, chunkCount uint32)
-	open(name addr, chunkCount uint32) chunkSource
+	Compact(mt *memTable, haver chunkReader) (name addr, chunkCount uint32)
+	Open(name addr, chunkCount uint32) chunkSource
 }
 
 type fileTableManager struct {
 	dir string
 }
 
-func (ftm *fileTableManager) compact(mt *memTable, haver chunkReader) (name addr, chunkCount uint32) {
+func (ftm *fileTableManager) Compact(mt *memTable, haver chunkReader) (name addr, chunkCount uint32) {
 	return compact(ftm.dir, mt, haver)
 }
 
-func (ftm *fileTableManager) open(name addr, chunkCount uint32) chunkSource {
+func (ftm *fileTableManager) Open(name addr, chunkCount uint32) chunkSource {
 	return newMmapTableReader(ftm.dir, name, chunkCount)
 }

--- a/go/nbs/test/manifest_clobber.go
+++ b/go/nbs/test/manifest_clobber.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var takeLock = flag.Bool("take-lock", false, "Expect to be able to lock the lock file.")
-
 func main() {
 	flag.Parse()
 
@@ -29,7 +27,7 @@ func main() {
 	// lock released by closing l.
 	err = unix.Flock(int(l.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 	if err != nil {
-		if !*takeLock && err == unix.EWOULDBLOCK {
+		if err == unix.EWOULDBLOCK {
 			return
 		}
 		log.Fatalln(err)

--- a/go/nbs/test/manifest_clobber.go
+++ b/go/nbs/test/manifest_clobber.go
@@ -26,10 +26,10 @@ func main() {
 	defer l.Close()
 	// lock released by closing l.
 	err = unix.Flock(int(l.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == unix.EWOULDBLOCK {
+		return
+	}
 	if err != nil {
-		if err == unix.EWOULDBLOCK {
-			return
-		}
 		log.Fatalln(err)
 	}
 

--- a/go/spec/spec.go
+++ b/go/spec/spec.go
@@ -157,7 +157,7 @@ func (sp Spec) NewChunkStore() chunks.ChunkStore {
 	case "http", "https":
 		return nil
 	case "nbs":
-		return nbs.NewBlockStore(sp.DatabaseName, 1<<28)
+		return nbs.NewLocalStore(sp.DatabaseName, 1<<28)
 	case "ldb":
 		return getLdbStore(sp.DatabaseName)
 	case "mem":
@@ -250,7 +250,7 @@ func (sp Spec) createDatabase() datas.Database {
 	case "ldb":
 		return datas.NewDatabase(getLdbStore(sp.DatabaseName))
 	case "nbs":
-		return datas.NewDatabase(nbs.NewBlockStore(sp.DatabaseName, 1<<28))
+		return datas.NewDatabase(nbs.NewLocalStore(sp.DatabaseName, 1<<28))
 	case "mem":
 		return datas.NewDatabase(chunks.NewMemoryStore())
 	}


### PR DESCRIPTION
Added a "constructor" for NomsBlockStore that takes a tableManager
and a manifest instance, so that fakes can be injected for testing.
This also allows me to break the dependency on on-disk manifests in
root_tracker_test.go

Towards issue #2877