### PR TITLE
Support marshaling from and unmarshaling to *types.Type

### DIFF
--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -48,6 +48,7 @@ import (
 //    same rules.
 //  - types.Number -> float64
 //  - types.String -> string
+//  - *types.Type -> *types.Type
 //  - types.Union -> interface
 //  - Everything else an error
 //
@@ -149,7 +150,7 @@ func typeDecoder(t reflect.Type, tags nomsTags) decoderFunc {
 		if t.Implements(nomsValueInterface) {
 			return nomsValueDecoder
 		}
-		panic(&UnsupportedTypeError{Type: t})
+		fallthrough
 	default:
 		panic(&UnsupportedTypeError{Type: t})
 	}

--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -144,6 +144,12 @@ func typeDecoder(t reflect.Type, tags nomsTags) decoderFunc {
 			return mapFromSetDecoder(t)
 		}
 		return mapDecoder(t, tags)
+	case reflect.Ptr:
+		// Allow implementations of types.Value (like *types.Type)
+		if t.Implements(nomsValueInterface) {
+			return nomsValueDecoder
+		}
+		panic(&UnsupportedTypeError{Type: t})
 	default:
 		panic(&UnsupportedTypeError{Type: t})
 	}

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -399,6 +399,31 @@ func TestDecodeInvalidNomsType(t *testing.T) {
 	}), &s, "Cannot unmarshal Map<String, Number> into Go value of type types.List")
 }
 
+func TestDecodeNomsTypePtr(t *testing.T) {
+	assert := assert.New(t)
+
+	testUnmarshal := func(v types.Value, dest interface{}, expected interface{}) {
+		err := Unmarshal(v, dest)
+		assert.NoError(err)
+		assert.Equal(expected, dest)
+	}
+
+	type S struct{ Type *types.Type }
+	var s S
+
+	primitive := types.StringType
+	testUnmarshal(types.NewStruct("S", types.StructData{"type": primitive}), &s, &S{primitive})
+
+	complex := types.MakeStructType("Complex",
+		[]string{"stuff"},
+		[]*types.Type{types.StringType},
+	)
+	testUnmarshal(types.NewStruct("S", types.StructData{"type": complex}), &s, &S{complex})
+
+	var empty *types.Type
+	testUnmarshal(types.NewStruct("S", types.StructData{"type": empty}), &s, &S{empty})
+}
+
 func ExampleUnmarshal() {
 	type Person struct {
 		Given string

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -200,7 +200,7 @@ func typeEncoder(t reflect.Type, parentStructTypes []reflect.Type, tags nomsTags
 		if t.Implements(nomsValueInterface) {
 			return nomsValueEncoder
 		}
-		panic(&UnsupportedTypeError{Type: t})
+		fallthrough
 	default:
 		panic(&UnsupportedTypeError{Type: t})
 	}

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -195,6 +195,12 @@ func typeEncoder(t reflect.Type, parentStructTypes []reflect.Type, tags nomsTags
 			v2 := reflect.ValueOf(v.Interface())
 			return typeEncoder(v2.Type(), parentStructTypes, tags)(v2)
 		}
+	case reflect.Ptr:
+		// Allow implementations of types.Value (like *types.Type)
+		if t.Implements(nomsValueInterface) {
+			return nomsValueEncoder
+		}
+		panic(&UnsupportedTypeError{Type: t})
 	default:
 		panic(&UnsupportedTypeError{Type: t})
 	}

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -421,6 +421,32 @@ func TestEncodeStructWithArrayOfNomsValue(t *testing.T) {
 	}).Equals(v))
 }
 
+func TestEncodeNomsTypePtr(t *testing.T) {
+	assert := assert.New(t)
+
+	testMarshal := func(g interface{}, expected types.Value) {
+		v, err := Marshal(g)
+		assert.NoError(err)
+		assert.Equal(expected, v)
+	}
+
+	type S struct {
+		Type *types.Type
+	}
+
+	primitive := types.StringType
+	testMarshal(S{primitive}, types.NewStruct("S", types.StructData{"type": primitive}))
+
+	complex := types.MakeStructType("Complex",
+		[]string{"stuff"},
+		[]*types.Type{types.StringType},
+	)
+	testMarshal(S{complex}, types.NewStruct("S", types.StructData{"type": complex}))
+
+	var empty *types.Type
+	testMarshal(S{empty}, types.NewStruct("S", types.StructData{"type": empty}))
+}
+
 func TestEncodeRecursive(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Marshaling from `*types.Type` produces a noms type:
```
type S struct { Type *types.Type }
go := S{ types.String }
noms := types.NewStruct("S", types.StructData{"type": types.String})
v, err := marshal.Marshal(go) 
assert.Equals(t, noms, v)
```

Unmarshaling to `*types.Type` produces a pointer to an instance of the value:
```
type S struct { Type *types.Type }
noms := types.NewStruct("S", types.StructData{"type": types.String})
go :=  S{ types.String }

var s S
err := marshal.Unmarshal(v, &s) 
assert.Equals(t, go, s)
```

fixes: #2889