### PR TITLE
uint32ChunkCount

### DIFF
--- a/go/nbs/compact_test.go
+++ b/go/nbs/compact_test.go
@@ -31,8 +31,8 @@ func TestCompactMemTable(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
-	tableAddr, wrote := compact(dir, mt, nil)
-	if assert.True(wrote) {
+	tableAddr, chunkCount := compact(dir, mt, nil)
+	if assert.True(chunkCount > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, tableAddr.String()))
 		assert.NoError(err)
 		tr := newTableReader(buff, memReaderAt(buff))
@@ -62,8 +62,8 @@ func TestCompactMemTableNoData(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
-	tableAddr, wrote := compact(dir, mt, existingTable)
-	assert.False(wrote)
+	tableAddr, chunkCount := compact(dir, mt, existingTable)
+	assert.True(chunkCount == 0)
 
 	_, err = os.Stat(filepath.Join(dir, tableAddr.String()))
 	assert.True(os.IsNotExist(err), "%v", err)

--- a/go/nbs/file_manifest.go
+++ b/go/nbs/file_manifest.go
@@ -36,7 +36,7 @@ type fileManifest struct {
 
 type tableSpec struct {
 	name       addr
-	chunkCount uint64
+	chunkCount uint32
 }
 
 // ParseIfExists looks for a LOCK and manifest file in fm.dir. If it finds
@@ -92,8 +92,9 @@ func parseManifest(r io.Reader) (string, hash.Hash, []tableSpec) {
 	specs := make([]tableSpec, len(tableInfo)/2)
 	for i := range specs {
 		specs[i].name = ParseAddr(tableInfo[2*i])
-		specs[i].chunkCount, err = strconv.ParseUint(string(tableInfo[2*i+1]), 10, 64)
+		c, err := strconv.ParseUint(string(tableInfo[2*i+1]), 10, 32)
 		d.PanicIfError(err)
+		specs[i].chunkCount = uint32(c)
 	}
 
 	return string(slices[1]), hash.Parse(string(slices[2])), specs
@@ -105,7 +106,7 @@ func writeManifest(temp io.Writer, root hash.Hash, tables chunkSources) {
 	tableInfo := strs[3:]
 	for i, t := range tables {
 		tableInfo[2*i] = t.hash().String()
-		tableInfo[2*i+1] = strconv.FormatUint(t.count(), 10)
+		tableInfo[2*i+1] = strconv.FormatUint(uint64(t.count()), 10)
 	}
 	_, err := io.WriteString(temp, strings.Join(strs, ":"))
 	d.PanicIfError(err)

--- a/go/nbs/file_manifest_test.go
+++ b/go/nbs/file_manifest_test.go
@@ -45,7 +45,7 @@ func TestFileManifestParseIfExists(t *testing.T) {
 	assert.Equal(newRoot, root)
 	if assert.Len(tableSpecs, 1) {
 		assert.Equal(tableName.String(), tableSpecs[0].name.String())
-		assert.Equal(uint64(0), tableSpecs[0].chunkCount)
+		assert.Equal(uint32(0), tableSpecs[0].chunkCount)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestFileManifestParseIfExistsHoldsLock(t *testing.T) {
 	assert.Equal(newRoot, root)
 	if assert.Len(tableSpecs, 1) {
 		assert.Equal(tableName.String(), tableSpecs[0].name.String())
-		assert.Equal(uint64(0), tableSpecs[0].chunkCount)
+		assert.Equal(uint32(0), tableSpecs[0].chunkCount)
 	}
 }
 
@@ -120,7 +120,7 @@ func TestFileManifestUpdateRootOptimisticLockFail(t *testing.T) {
 	assert.Equal(newRoot, actual)
 	if assert.Len(tableSpecs, 1) {
 		assert.Equal(tableName.String(), tableSpecs[0].name.String())
-		assert.Equal(uint64(3), tableSpecs[0].chunkCount)
+		assert.Equal(uint32(3), tableSpecs[0].chunkCount)
 	}
 	actual, tableSpecs = fm.Update(nil, actual, newRoot2, nil)
 }

--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -38,8 +38,8 @@ func (mt *memTable) addChunk(h addr, data []byte) bool {
 	return true
 }
 
-func (mt *memTable) count() uint64 {
-	return uint64(len(mt.order))
+func (mt *memTable) count() uint32 {
+	return uint32(len(mt.order))
 }
 
 func (mt *memTable) has(h addr) (has bool) {
@@ -78,7 +78,7 @@ func (mt *memTable) getMany(reqs []getRecord) (remaining bool) {
 	return
 }
 
-func (mt *memTable) write(tw chunkWriter, haver chunkReader) {
+func (mt *memTable) write(tw chunkWriter, haver chunkReader) (count uint32) {
 	if haver != nil {
 		sort.Sort(hasRecordByPrefix(mt.order)) // hasMany() requires addresses to be sorted.
 		haver.hasMany(mt.order)
@@ -89,6 +89,8 @@ func (mt *memTable) write(tw chunkWriter, haver chunkReader) {
 		if !addr.has {
 			h := addr.a
 			tw.addChunk(*h, mt.chunks[*h])
+			count++
 		}
 	}
+	return
 }

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -22,7 +22,7 @@ type mmapTableReader struct {
 
 var pageSize = int64(os.Getpagesize())
 
-func newMmapTableReader(dir string, h addr, chunkCount uint64) chunkSource {
+func newMmapTableReader(dir string, h addr, chunkCount uint32) chunkSource {
 	success := false
 	f, err := os.Open(filepath.Join(dir, h.String()))
 	d.PanicIfError(err)
@@ -45,6 +45,7 @@ func newMmapTableReader(dir string, h addr, chunkCount uint64) chunkSource {
 	success = true
 
 	source := &mmapTableReader{newTableReader(buff[indexOffset-aligned:], f), f, buff, h}
+
 	d.PanicIfFalse(chunkCount == source.count())
 	return source
 }

--- a/go/nbs/mmap_table_reader_test.go
+++ b/go/nbs/mmap_table_reader_test.go
@@ -29,7 +29,7 @@ func TestMmapTableReader(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(dir, h.String()), tableData, 0666)
 	assert.NoError(err)
 
-	trc := newMmapTableReader(dir, h, uint64(len(chunks)))
+	trc := newMmapTableReader(dir, h, uint32(len(chunks)))
 	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -151,8 +151,8 @@ func (nbs *NomsBlockStore) addChunk(h addr, data []byte) bool {
 		nbs.mt = newMemTable(nbs.mtSize)
 	}
 	if !nbs.mt.addChunk(h, data) {
-		if tableHash, wrote := nbs.tm.compact(nbs.mt, nbs.immTables); wrote {
-			nbs.immTables = prependTable(nbs.immTables, nbs.tm.open(tableHash, nbs.mt.count()))
+		if tableHash, chunkCount := nbs.tm.compact(nbs.mt, nbs.immTables); chunkCount > 0 {
+			nbs.immTables = prependTable(nbs.immTables, nbs.tm.open(tableHash, chunkCount))
 		}
 		nbs.mt = newMemTable(nbs.mtSize)
 		return nbs.mt.addChunk(h, data)
@@ -253,8 +253,8 @@ func (nbs *NomsBlockStore) UpdateRoot(current, last hash.Hash) bool {
 	d.Chk.True(nbs.root == last, "UpdateRoot: last != nbs.Root(); %s != %s", last, nbs.root)
 
 	if nbs.mt != nil && nbs.mt.count() > 0 {
-		if tableHash, wrote := nbs.tm.compact(nbs.mt, nbs.immTables); wrote {
-			nbs.immTables = prependTable(nbs.immTables, nbs.tm.open(tableHash, nbs.mt.count()))
+		if tableHash, chunkCount := nbs.tm.compact(nbs.mt, nbs.immTables); chunkCount > 0 {
+			nbs.immTables = prependTable(nbs.immTables, nbs.tm.open(tableHash, chunkCount))
 		}
 		nbs.mt = nil
 	}

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -70,7 +70,7 @@ import (
 
    Footer:
    +----------------------+---------------------------+------------------+
-   | (Uint64) Chunk Count | (Uint64) Total Chunk Data | (8) Magic Number |
+   | (Uint32) Chunk Count | (Uint64) Total Chunk Data | (8) Magic Number |
    +----------------------+---------------------------+------------------+
 
      -Total Chunk Data is the sum of the logical byte lengths of all contained chunk byte slices.
@@ -107,9 +107,10 @@ const (
 	ordinalSize        = uint64(4)
 	lengthSize         = uint64(4)
 	uint64Size         = uint64(8)
+	uint32Size         = uint64(4)
 	magicNumber        = "\xff\xb5\xd8\xc2\x24\x63\xee\x50"
 	magicNumberSize    = uint64(len(magicNumber))
-	footerSize         = uint64Size + uint64Size + magicNumberSize
+	footerSize         = uint32Size + uint64Size + magicNumberSize
 	prefixTupleSize    = addrPrefixSize + ordinalSize
 	checksumSize       = uint64(4)
 	maxChunkLengthSize = uint64(binary.MaxVarintLen64)
@@ -200,7 +201,7 @@ type chunkReader interface {
 type chunkSource interface {
 	chunkReader
 	close() error
-	count() uint64
+	count() uint32
 	hash() addr
 }
 

--- a/go/nbs/table_manager.go
+++ b/go/nbs/table_manager.go
@@ -5,18 +5,18 @@
 package nbs
 
 type tableManager interface {
-	compact(mt *memTable, haver chunkReader) (name addr, wrote bool)
-	open(name addr, chunkCount uint64) chunkSource
+	compact(mt *memTable, haver chunkReader) (name addr, chunkCount uint32)
+	open(name addr, chunkCount uint32) chunkSource
 }
 
 type fileTableManager struct {
 	dir string
 }
 
-func (ftm *fileTableManager) compact(mt *memTable, haver chunkReader) (name addr, wrote bool) {
+func (ftm *fileTableManager) compact(mt *memTable, haver chunkReader) (name addr, chunkCount uint32) {
 	return compact(ftm.dir, mt, haver)
 }
 
-func (ftm *fileTableManager) open(name addr, chunkCount uint64) chunkSource {
+func (ftm *fileTableManager) open(name addr, chunkCount uint32) chunkSource {
 	return newMmapTableReader(ftm.dir, name, chunkCount)
 }

--- a/go/nbs/table_writer.go
+++ b/go/nbs/table_writer.go
@@ -31,8 +31,8 @@ func maxTableSize(numChunks, totalData uint64) uint64 {
 	return numChunks*(prefixTupleSize+lengthSize+addrSuffixSize+checksumSize+uint64(maxSnappySize)) + footerSize
 }
 
-func indexSize(numChunks uint64) uint64 {
-	return numChunks * (addrSuffixSize + lengthSize + prefixTupleSize)
+func indexSize(numChunks uint32) uint64 {
+	return uint64(numChunks) * (addrSuffixSize + lengthSize + prefixTupleSize)
 }
 
 // len(buff) must be >= maxTableSize(numChunks, totalData)
@@ -128,8 +128,9 @@ func (tw *tableWriter) writeIndex() {
 
 func (tw *tableWriter) writeFooter() {
 	// chunk count
-	binary.BigEndian.PutUint64(tw.buff[tw.pos:], uint64(len(tw.prefixes)))
-	tw.pos += uint64Size
+	chunkCount := uint32(len(tw.prefixes))
+	binary.BigEndian.PutUint32(tw.buff[tw.pos:], chunkCount)
+	tw.pos += uint32Size
 
 	// total chunk data
 	binary.BigEndian.PutUint64(tw.buff[tw.pos:], tw.totalPhysicalData)


### PR DESCRIPTION
Encode chunk counts consistently as uint32 until #2873 is addressed. This also fixes an error in passing chunkCounts resulting from compaction that don't account for dropped (duplicate) chunks.