### PR TITLE
Try to make path spec that references bare dataset default to .value

### DIFF
--- a/go/spec/absolute_path_test.go
+++ b/go/spec/absolute_path_test.go
@@ -124,7 +124,7 @@ func TestAbsolutePathParseErrors(t *testing.T) {
 	test(".foo.bar.baz", "Invalid dataset name: .foo.bar.baz")
 	test("#", "Invalid hash: ")
 	test("#abc", "Invalid hash: abc")
-	test("#abc@commit", "monkey")
+	test("#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@commit", "Unsupported annotation: @commit")
 	invHash := strings.Repeat("z", hash.StringLen)
 	test("#"+invHash, "Invalid hash: "+invHash)
 }

--- a/go/spec/absolute_path_test.go
+++ b/go/spec/absolute_path_test.go
@@ -60,11 +60,12 @@ func TestAbsolutePaths(t *testing.T) {
 		}
 	}
 
-	resolvesTo(head, "ds")
-	resolvesTo(emptySet, "ds.parents")
-	resolvesTo(list, "ds.value")
-	resolvesTo(s0, "ds.value[0]")
-	resolvesTo(s1, "ds.value[1]")
+	resolvesTo(list, "ds")
+	resolvesTo(head, "ds@commit")
+	resolvesTo(emptySet, "ds@commit.parents")
+	resolvesTo(list, "ds@commit.value")
+	resolvesTo(s0, "ds[0]")
+	resolvesTo(s1, "ds[1]")
 	resolvesTo(head, "#"+head.Hash().String())
 	resolvesTo(list, "#"+list.Hash().String())
 	resolvesTo(s0, "#"+s0.Hash().String())
@@ -73,9 +74,10 @@ func TestAbsolutePaths(t *testing.T) {
 	resolvesTo(s1, "#"+list.Hash().String()+"[1]")
 
 	resolvesTo(nil, "foo")
-	resolvesTo(nil, "foo.parents")
-	resolvesTo(nil, "foo.value")
-	resolvesTo(nil, "foo.value[0]")
+	resolvesTo(nil, "foo@commit")
+	resolvesTo(nil, "foo@commit.parents")
+	resolvesTo(nil, "foo@commit.value")
+	resolvesTo(nil, "foo[0]")
 	resolvesTo(nil, "#"+types.String("baz").Hash().String())
 	resolvesTo(nil, "#"+types.String("baz").Hash().String()+"[0]")
 }
@@ -91,7 +93,7 @@ func TestReadAbsolutePaths(t *testing.T) {
 	ds, err := db.CommitValue(ds, list)
 	assert.NoError(err)
 
-	vals, err := ReadAbsolutePaths(db, "ds.value[0]", "ds.value[1]")
+	vals, err := ReadAbsolutePaths(db, "ds[0]", "ds[1]")
 	assert.NoError(err)
 
 	assert.Equal(2, len(vals))
@@ -122,6 +124,7 @@ func TestAbsolutePathParseErrors(t *testing.T) {
 	test(".foo.bar.baz", "Invalid dataset name: .foo.bar.baz")
 	test("#", "Invalid hash: ")
 	test("#abc", "Invalid hash: abc")
+	test("#abc@commit", "monkey")
 	invHash := strings.Repeat("z", hash.StringLen)
 	test("#"+invHash, "Invalid hash: "+invHash)
 }

--- a/go/spec/spec.go
+++ b/go/spec/spec.go
@@ -222,6 +222,9 @@ func (sp Spec) Pin() (Spec, bool) {
 	}
 
 	spec := sp.Protocol + sp.DatabaseName + Separator + "#" + commit.Hash().String()
+	if !sp.Path.IsEmpty() && sp.Path.PathFromCommit {
+		spec += ".value"
+	}
 	if sp.Path.Path != nil {
 		spec += sp.Path.Path.String()
 	}

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -359,7 +359,7 @@ func TestForPath(t *testing.T) {
 func TestPinPathSpec(t *testing.T) {
 	assert := assert.New(t)
 
-	unpinned, err := ForPath("mem::foo.value")
+	unpinned, err := ForPath("mem::foo")
 	assert.NoError(err)
 	defer unpinned.Close()
 

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -83,7 +83,7 @@ func TestMemHashPathSpec(t *testing.T) {
 func TestMemDatasetPathSpec(t *testing.T) {
 	assert := assert.New(t)
 
-	spec, err := ForPath("mem::test.value[0]")
+	spec, err := ForPath("mem::test[0]")
 	assert.NoError(err)
 	defer spec.Close()
 


### PR DESCRIPTION
This got super gnarly because there are so many different variants of specs and paths.

After hacking at this, I think to be precise the behavior we want is:

absolute paths (as opposed to specs, and relative paths) that point to a bare dataset should default to `.value`.

specs would then inherit the behavior (because they use AbsolutePath)

and _dataset specs_ would be unaffected.