### PR TITLE
JS: Do not validate struct type when reading a chunk

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "65.2.0",
+  "version": "65.3.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/value-decoder.js
+++ b/js/noms/src/value-decoder.js
@@ -6,7 +6,7 @@
 
 import Blob, {BlobLeafSequence} from './blob.js';
 import Ref, {constructRef} from './ref.js';
-import {newStructWithType} from './struct.js';
+import {newStructWithValues} from './struct.js';
 import type Struct from './struct.js';
 import type {NomsKind} from './noms-kind.js';
 import {
@@ -201,7 +201,7 @@ export default class ValueDecoder {
       values[i] = this.readValue();
     }
 
-    return newStructWithType(type, values);
+    return newStructWithValues(type, values);
   }
 
   readCachedStructType(): ?Type<StructDesc> {


### PR DESCRIPTION
When we read a chunk and create structs we were validating that the
struct was of the type it claimed to be.

This now, no longer does that validation, which matches Go.