### PR TITLE
Add simple read ahead for JS Collections

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "65.0.0",
+  "version": "65.1.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/blob.js
+++ b/js/noms/src/blob.js
@@ -58,7 +58,7 @@ export class BlobReader {
 
   constructor(sequence: IndexedSequence<any>) {
     this._sequence = sequence;
-    this._cursor = sequence.newCursorAt(0);
+    this._cursor = sequence.newCursorAt(0, true);
     this._pos = 0;
     this._lock = '';
   }
@@ -129,7 +129,7 @@ export class BlobReader {
 
     invariant(abs >= 0, `cannot seek to negative position ${abs}`);
 
-    this._cursor = this._sequence.newCursorAt(abs);
+    this._cursor = this._sequence.newCursorAt(abs, true);
 
     // Wait for the seek to complete so that reads will be relative to the new position.
     return this._cursor.then(() => {

--- a/js/noms/src/indexed-sequence.js
+++ b/js/noms/src/indexed-sequence.js
@@ -23,12 +23,12 @@ export class IndexedSequence<T> extends Sequence<T> {
       equals(this.items[idx], other.items[otherIdx]);
   }
 
-  async newCursorAt(idx: number): Promise<IndexedSequenceCursor<any>> {
+  async newCursorAt(idx: number, readAhead: boolean = false): Promise<IndexedSequenceCursor<any>> {
     let cursor: ?IndexedSequenceCursor<any> = null;
     let sequence: ?IndexedSequence<any> = this;
 
     while (sequence) {
-      cursor = new IndexedSequenceCursor(cursor, sequence, 0);
+      cursor = new IndexedSequenceCursor(cursor, sequence, 0, readAhead);
       idx -= cursor.advanceToOffset(idx);
       sequence = await cursor.getChildSequence();
     }
@@ -53,7 +53,8 @@ export class IndexedSequenceCursor<T> extends SequenceCursor<T, IndexedSequence<
   }
 
   clone(): IndexedSequenceCursor<T> {
-    return new IndexedSequenceCursor(this.parent && this.parent.clone(), this.sequence, this.idx);
+    return new IndexedSequenceCursor(this.parent && this.parent.clone(), this.sequence, this.idx,
+        this.readAhead);
   }
 }
 

--- a/js/noms/src/list.js
+++ b/js/noms/src/list.js
@@ -106,7 +106,7 @@ export default class List<T: Value> extends Collection<IndexedSequence<any>> {
    * promises have been fulfilled.
    */
   async forEach(cb: (v: T, i: number) => ?Promise<any>): Promise<void> {
-    const cursor = await this.sequence.newCursorAt(0);
+    const cursor = await this.sequence.newCursorAt(0, true);
     const promises = [];
     return cursor.iter((v, i) => {
       promises.push(cb(v, i));
@@ -118,14 +118,14 @@ export default class List<T: Value> extends Collection<IndexedSequence<any>> {
    * Returns a new `AsyncIterator` which can be used to iterate over the list.
    */
   iterator(): AsyncIterator<T> {
-    return new IndexedSequenceIterator(this.sequence.newCursorAt(0));
+    return new IndexedSequenceIterator(this.sequence.newCursorAt(0, true));
   }
 
   /**
    * Returns a new `AsyncIterator` starting at `i` which can be used to iterate over the list.
    */
   iteratorAt(i: number): AsyncIterator<T> {
-    return new IndexedSequenceIterator(this.sequence.newCursorAt(i));
+    return new IndexedSequenceIterator(this.sequence.newCursorAt(i, true));
   }
 
   /**

--- a/js/noms/src/map.js
+++ b/js/noms/src/map.js
@@ -95,7 +95,7 @@ export default class Map<K: Value, V: Value> extends
   }
 
   async _firstOrLast(last: boolean): Promise<?MapEntry<K, V>> {
-    const cursor = await this.sequence.newCursorAt(null, false, last);
+    const cursor = await this.sequence.newCursorAt(null, false, last, true);
     if (!cursor.valid) {
       return undefined;
     }
@@ -122,7 +122,7 @@ export default class Map<K: Value, V: Value> extends
   }
 
   async forEach(cb: (v: V, k: K) => ?Promise<any>): Promise<void> {
-    const cursor = await this.sequence.newCursorAt(null);
+    const cursor = await this.sequence.newCursorAt(null, false, false, true);
     const promises = [];
     return cursor.iter(entry => {
       promises.push(cb(entry[VALUE], entry[KEY]));
@@ -131,11 +131,11 @@ export default class Map<K: Value, V: Value> extends
   }
 
   iterator(): AsyncIterator<MapEntry<K, V>> {
-    return new OrderedSequenceIterator(this.sequence.newCursorAt(null));
+    return new OrderedSequenceIterator(this.sequence.newCursorAt(null, false, false, true));
   }
 
   iteratorAt(k: K): AsyncIterator<MapEntry<K, V>> {
-    return new OrderedSequenceIterator(this.sequence.newCursorAtValue(k));
+    return new OrderedSequenceIterator(this.sequence.newCursorAtValue(k, false, false, true));
   }
 
   _splice(cursor: OrderedSequenceCursor<any, any>, insert: Array<MapEntry<K, V>>, remove: number)

--- a/js/noms/src/ordered-sequence.js
+++ b/js/noms/src/ordered-sequence.js
@@ -15,13 +15,14 @@ import Sequence, {SequenceCursor} from './sequence.js';
 
 export class OrderedSequence<K: Value, T> extends Sequence<T> {
   // See newCursorAt().
-  newCursorAtValue(val: ?K, forInsertion: boolean = false, last: boolean = false)
+  newCursorAtValue(val: ?K, forInsertion: boolean = false, last: boolean = false,
+                   readAhead: boolean = false)
       : Promise<OrderedSequenceCursor<any, any>> {
     let key;
     if (val !== null && val !== undefined) {
       key = new OrderedKey(val);
     }
-    return this.newCursorAt(key, forInsertion, last);
+    return this.newCursorAt(key, forInsertion, last, readAhead);
   }
 
   // Returns:
@@ -30,13 +31,13 @@ export class OrderedSequence<K: Value, T> extends Sequence<T> {
   //   -cursor positioned at
   //      -first value, if |key| is null
   //      -first value >= |key|
-  async newCursorAt(key: ?OrderedKey<any>, forInsertion: boolean = false, last: boolean = false)
-      : Promise<OrderedSequenceCursor<any, any>> {
+  async newCursorAt(key: ?OrderedKey<any>, forInsertion: boolean = false, last: boolean = false,
+      readAhead: boolean = false): Promise<OrderedSequenceCursor<any, any>> {
     let cursor: ?OrderedSequenceCursor<any, any> = null;
     let sequence: ?OrderedSequence<any, any> = this;
 
     while (sequence) {
-      cursor = new OrderedSequenceCursor(cursor, sequence, last ? -1 : 0);
+      cursor = new OrderedSequenceCursor(cursor, sequence, last ? -1 : 0, readAhead);
       if (key !== null && key !== undefined) {
         const lastPositionIfNotfound = forInsertion && sequence.isMeta;
         if (!cursor._seekTo(key, lastPositionIfNotfound)) {
@@ -70,7 +71,8 @@ export class OrderedSequenceCursor<T, K: Value> extends
   }
 
   clone(): OrderedSequenceCursor<T, K> {
-    return new OrderedSequenceCursor(this.parent && this.parent.clone(), this.sequence, this.idx);
+    return new OrderedSequenceCursor(this.parent && this.parent.clone(), this.sequence, this.idx,
+                                     this.readAhead);
   }
 
   // Moves the cursor to the first value in sequence >= key and returns true.

--- a/js/noms/src/sequence-test.js
+++ b/js/noms/src/sequence-test.js
@@ -23,16 +23,16 @@ class TestSequence extends Sequence<any> {
 class TestSequenceCursor extends SequenceCursor<any, TestSequence> {
   clone(): TestSequenceCursor {
     return new TestSequenceCursor(this.parent ? this.parent.clone() : null, this.sequence,
-                                  this.idx);
+                                  this.idx, this.readAhead);
   }
 }
 
 suite('SequenceCursor', () => {
   function testCursor(data: Array<any>): TestSequenceCursor {
     const s1 = new TestSequence(data);
-    const c1 = new TestSequenceCursor(null, s1, 0);
+    const c1 = new TestSequenceCursor(null, s1, 0, false);
     const s2 = new TestSequence(data[0]);
-    return new TestSequenceCursor(c1, s2, 0);
+    return new TestSequenceCursor(c1, s2, 0, false);
   }
 
   function expect(c: TestSequenceCursor, expectIdx: number,

--- a/js/noms/src/set.js
+++ b/js/noms/src/set.js
@@ -78,7 +78,7 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any, any>>
   }
 
   async forEach(cb: (v: T) => ?Promise<any>): Promise<void> {
-    const cursor = await this.sequence.newCursorAt(null);
+    const cursor = await this.sequence.newCursorAt(null, false, false, true);
     const promises = [];
     return cursor.iter(v => {
       promises.push(cb(v));
@@ -87,11 +87,11 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any, any>>
   }
 
   iterator(): AsyncIterator<T> {
-    return new OrderedSequenceIterator(this.sequence.newCursorAt(null));
+    return new OrderedSequenceIterator(this.sequence.newCursorAt(null, false, false, true));
   }
 
   iteratorAt(v: T): AsyncIterator<T> {
-    return new OrderedSequenceIterator(this.sequence.newCursorAtValue(v));
+    return new OrderedSequenceIterator(this.sequence.newCursorAtValue(v, false, false, true));
   }
 
   _splice(cursor: OrderedSequenceCursor<any, any>, insert: Array<T>, remove: number)


### PR DESCRIPTION
Adds the ability for `SequenceCursor`s to eagerly load all child sequences when the first child is requested.

The effect is for uses where noms tends to forward scan, it will read in batches of ~150 chunks (e.g. ~512k) rather than one chunk at a time.

On my MBP, this improves the raw blob read perf over http from ~60K/s to ~5MB/s.

Fixes #2853 