### PR TITLE
tablePersister.Compact returns a chunkSource

### DIFF
--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -16,10 +16,8 @@ func newCompactingChunkSource(mt *memTable, haver chunkReader, p tablePersister,
 	rl <- struct{}{}
 	go func() {
 		defer ccs.wg.Done()
-		var cs chunkSource = emptyChunkSource{}
-		if tableHash, chunkCount := p.Compact(mt, haver); chunkCount > 0 {
-			cs = p.Open(tableHash, chunkCount)
-		}
+		cs := p.Compact(mt, haver)
+
 		ccs.mu.Lock()
 		defer ccs.mu.Unlock()
 		ccs.cs = cs

--- a/go/nbs/compacting_chunk_source_test.go
+++ b/go/nbs/compacting_chunk_source_test.go
@@ -22,7 +22,7 @@ type pausingFakeTablePersister struct {
 	trigger <-chan struct{}
 }
 
-func (ftp pausingFakeTablePersister) Compact(mt *memTable, haver chunkReader) (name addr, count uint32) {
+func (ftp pausingFakeTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
 	<-ftp.trigger
 	return ftp.tablePersister.Compact(mt, haver)
 }


### PR DESCRIPTION
It turns out the only caller of Compact() immediately
turns around and calls Open, so why don't I just do
that FOR you?

Fixes #2935