### PR TITLE
Add s3 tableIndex cache

### DIFF
--- a/go/nbs/s3_fake_test.go
+++ b/go/nbs/s3_fake_test.go
@@ -44,6 +44,7 @@ type fakeS3 struct {
 	inProgressCounter int
 	inProgress        map[string]fakeS3Multipart // Key -> {UploadId, Etags...}
 	parts             map[string][]byte          // ETag -> data
+	getCount          int
 }
 
 type fakeS3Multipart struct {
@@ -137,6 +138,7 @@ func (m *fakeS3) CompleteMultipartUpload(input *s3.CompleteMultipartUploadInput)
 }
 
 func (m *fakeS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	m.getCount++
 	m.assert.NotNil(input.Bucket, "Bucket is a required field")
 	m.assert.NotNil(input.Key, "Key is a required field")
 

--- a/go/nbs/s3_table_reader_test.go
+++ b/go/nbs/s3_table_reader_test.go
@@ -23,7 +23,33 @@ func TestS3TableReader(t *testing.T) {
 	tableData, h := buildTable(chunks)
 	s3.data[h.String()] = tableData
 
-	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)))
+	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), nil)
+	defer trc.close()
+	assertChunksInReader(chunks, trc, assert)
+}
+
+func TestS3TableReaderIndexCache(t *testing.T) {
+	assert := assert.New(t)
+	s3 := makeFakeS3(assert)
+
+	chunks := [][]byte{
+		[]byte("hello2"),
+		[]byte("goodbye2"),
+		[]byte("badbye2"),
+	}
+
+	tableData, h := buildTable(chunks)
+
+	s3.data[h.String()] = tableData
+
+	index := parseTableIndex(tableData)
+	cache := newS3IndexCache(1024)
+	cache.put(h, index)
+
+	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), cache)
+
+	assert.Equal(0, s3.getCount) // constructing the table shouldn't have resulted in any reads
+
 	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -10,9 +10,9 @@ import (
 
 const concurrentCompactions = 5
 
-func newS3TableSet(s3 s3svc, bucket string) tableSet {
+func newS3TableSet(s3 s3svc, bucket string, indexCache *s3IndexCache) tableSet {
 	return tableSet{
-		p:  s3TablePersister{s3, bucket, defaultS3PartSize},
+		p:  s3TablePersister{s3, bucket, defaultS3PartSize, indexCache},
 		rl: make(chan struct{}, concurrentCompactions),
 	}
 }

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -85,9 +85,12 @@ func TestS3TablePersisterCompact(t *testing.T) {
 	}
 
 	s3svc := makeFakeS3(assert)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 3)}
+	cache := newS3IndexCache(1024)
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 3), indexCache: cache}
 
 	src := s3p.Compact(mt, nil)
+	assert.NotNil(cache.get(src.hash()))
+
 	if assert.True(src.count() > 0) {
 		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
 			assertChunksInReader(testChunks, r, assert)


### PR DESCRIPTION
Add an S3 tableIndex cache and allow AWSStoreFactory to create a cache which is sharable across stores.

fixes #2948