### PR TITLE
NBS: tableSet must exclude empty tables during ToSpecs()

### DIFF
--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -124,9 +124,11 @@ func (ts tableSet) Union(specs []tableSpec) tableSet {
 }
 
 func (ts tableSet) ToSpecs() []tableSpec {
-	tableSpecs := make([]tableSpec, len(ts.chunkSources))
-	for i, src := range ts.chunkSources {
-		tableSpecs[i] = tableSpec{src.hash(), src.count()}
+	tableSpecs := make([]tableSpec, 0, len(ts.chunkSources))
+	for _, src := range ts.chunkSources {
+		if src.count() > 0 {
+			tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
+		}
 	}
 	return tableSpecs
 }

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -20,9 +20,7 @@ var testChunks = [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2"
 
 func TestTableSetPrependEmpty(t *testing.T) {
 	ts := newFakeTableSet().Prepend(newMemTable(testMemTableSize))
-	// assert.Empty(t, ts.ToSpecs())
-	assert.Len(t, ts.ToSpecs(), 1)
-	assert.EqualValues(t, 0, ts.chunkSources[0].count())
+	assert.Empty(t, ts.ToSpecs())
 }
 
 func TestTableSetPrepend(t *testing.T) {
@@ -31,8 +29,8 @@ func TestTableSetPrepend(t *testing.T) {
 	assert.Empty(ts.ToSpecs())
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
-
 	ts = ts.Prepend(mt)
+
 	firstSpecs := ts.ToSpecs()
 	assert.Len(firstSpecs, 1)
 
@@ -40,9 +38,31 @@ func TestTableSetPrepend(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
 	ts = ts.Prepend(mt)
+
 	secondSpecs := ts.ToSpecs()
 	assert.Len(secondSpecs, 2)
 	assert.Equal(firstSpecs, secondSpecs[1:])
+	ts.Close()
+}
+
+func TestTableToSpecsExcludesEmptyTable(t *testing.T) {
+	assert := assert.New(t)
+	ts := newFakeTableSet()
+	assert.Empty(ts.ToSpecs())
+	mt := newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
+	ts = ts.Prepend(mt)
+
+	mt = newMemTable(testMemTableSize)
+	ts = ts.Prepend(mt)
+
+	mt = newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
+	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
+	ts = ts.Prepend(mt)
+
+	specs := ts.ToSpecs()
+	assert.Len(specs, 2)
 	ts.Close()
 }
 


### PR DESCRIPTION
Fixes #2957