### PR TITLE
Marshal: Use nil for empty Go collections

### DIFF
--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -29,14 +29,14 @@ import (
 //
 // To unmarshal a Noms list or set into a slice, Unmarshal resets the slice
 // length to zero and then appends each element to the slice. If the Go slice
-// was nil a new slice is created.
+// was nil a new slice is created when an element is added.
 //
 // To unmarshal a Noms list into a Go array, Unmarshal decodes Noms list
 // elements into corresponding Go array elements.
 //
 // To unmarshal a Noms map into a Go map, Unmarshal decodes Noms key and values
 // into corresponding Go array elements. If the Go map was nil a new map is
-// created.
+// created if any value is set.
 //
 // To unmarshal Noms sets, it depends on the presence of a `noms:",set"` tag:
 //  - Without (default), Unmarshal decodes into corresponding Go list elements.

--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -331,7 +331,7 @@ func sliceDecoder(t reflect.Type) decoderFunc {
 	d = func(v types.Value, rv reflect.Value) {
 		var slice reflect.Value
 		if rv.IsNil() {
-			slice = reflect.MakeSlice(t, 0, int(v.(types.Collection).Len()))
+			slice = rv
 		} else {
 			slice = rv.Slice(0, 0)
 		}
@@ -387,9 +387,6 @@ func mapFromSetDecoder(t reflect.Type) decoderFunc {
 
 	d = func(v types.Value, rv reflect.Value) {
 		m := rv
-		if m.IsNil() {
-			m = reflect.MakeMap(t)
-		}
 
 		nomsSet, ok := v.(types.Set)
 		if !ok {
@@ -399,6 +396,9 @@ func mapFromSetDecoder(t reflect.Type) decoderFunc {
 		nomsSet.IterAll(func(v types.Value) {
 			keyRv := reflect.New(t.Key()).Elem()
 			decoder(v, keyRv)
+			if m.IsNil() {
+				m = reflect.MakeMap(t)
+			}
 			m.SetMapIndex(keyRv, reflect.New(t.Elem()).Elem())
 		})
 		rv.Set(m)
@@ -420,9 +420,6 @@ func mapDecoder(t reflect.Type, tags nomsTags) decoderFunc {
 
 	d = func(v types.Value, rv reflect.Value) {
 		m := rv
-		if m.IsNil() {
-			m = reflect.MakeMap(t)
-		}
 
 		// Special case decoding failure if it looks like the "set" tag is missing,
 		// because it's helpful.
@@ -440,6 +437,9 @@ func mapDecoder(t reflect.Type, tags nomsTags) decoderFunc {
 			keyDecoder(k, keyRv)
 			valueRv := reflect.New(t.Elem()).Elem()
 			valueDecoder(v, valueRv)
+			if m.IsNil() {
+				m = reflect.MakeMap(t)
+			}
 			m.SetMapIndex(keyRv, valueRv)
 		})
 		rv.Set(m)

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -456,6 +456,28 @@ func TestDecodeSlice(t *testing.T) {
 	assert.Equal([]string{"a", "b", "c"}, s)
 }
 
+func TestDecodeSliceEmpty(t *testing.T) {
+	assert := assert.New(t)
+	var s []string
+
+	err := Unmarshal(types.NewList(), &s)
+	assert.NoError(err)
+	assert.Equal([]string(nil), s)
+
+	err = Unmarshal(types.NewSet(), &s)
+	assert.NoError(err)
+	assert.Equal([]string(nil), s)
+
+	s2 := []string{}
+	err = Unmarshal(types.NewList(), &s2)
+	assert.NoError(err)
+	assert.Equal([]string{}, s2)
+
+	err = Unmarshal(types.NewSet(), &s2)
+	assert.NoError(err)
+	assert.Equal([]string{}, s2)
+}
+
 func TestDecodeSliceReuse(t *testing.T) {
 	assert := assert.New(t)
 	s := []string{"A", "B", "C", "D"}
@@ -482,6 +504,19 @@ func TestDecodeArray(t *testing.T) {
 	err = Unmarshal(types.NewSet(types.String("a"), types.String("b"), types.String("c")), &s)
 	assert.NoError(err)
 	assert.Equal([3]string{"a", "b", "c"}, s)
+}
+
+func TestDecodeArrayEmpty(t *testing.T) {
+	assert := assert.New(t)
+	var s [0]string
+
+	err := Unmarshal(types.NewList(), &s)
+	assert.NoError(err)
+	assert.Equal([0]string{}, s)
+
+	err = Unmarshal(types.NewSet(), &s)
+	assert.NoError(err)
+	assert.Equal([0]string{}, s)
 }
 
 func TestDecodeStructWithSlice(t *testing.T) {
@@ -575,8 +610,8 @@ func TestDecodeRecursive(t *testing.T) {
 
 	assert.Equal(Node{
 		1, []Node{
-			{2, []Node{}},
-			{3, []Node{}},
+			{2, nil},
+			{3, nil},
 		},
 	}, n)
 }
@@ -611,6 +646,20 @@ func TestDecodeMap(t *testing.T) {
 		types.NewStruct("S", types.StructData{"n": types.String("No")}), types.Bool(false)), &m2)
 	assert.NoError(err)
 	assert.Equal(map[S]bool{S{"Yes"}: true, S{"No"}: false}, m2)
+}
+
+func TestDecodeMapEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	var m map[string]int
+	err := Unmarshal(types.NewMap(), &m)
+	assert.NoError(err)
+	assert.Equal(map[string]int(nil), m)
+
+	m2 := map[string]int{}
+	err = Unmarshal(types.NewMap(), &m2)
+	assert.NoError(err)
+	assert.Equal(map[string]int{}, m2)
 }
 
 func TestDecodeMapWrongNomsType(t *testing.T) {
@@ -648,7 +697,7 @@ func TestDecodeOntoInterface(t *testing.T) {
 
 	err = Unmarshal(types.NewMap(types.String("a"), types.Bool(true), types.Number(42), types.NewList()), &i)
 	assert.NoError(err)
-	assert.Equal(map[interface{}]interface{}{"a": true, float64(42): []interface{}{}}, i)
+	assert.Equal(map[interface{}]interface{}{"a": true, float64(42): []interface{}(nil)}, i)
 }
 
 func TestDecodeOntoNonSupportedInterface(t *testing.T) {
@@ -696,6 +745,23 @@ func TestDecodeSet(t *testing.T) {
 		E: []int{6, 7, 8},
 		F: []int{9, 10, 11},
 	}, gs)
+
+	ns2 := types.NewStruct("T", types.StructData{
+		"a": types.NewSet(),
+		"b": types.NewMap(),
+		"c": types.NewSet(),
+		"d": types.NewMap(),
+		"e": types.NewSet(),
+		"f": types.NewList(),
+	})
+
+	gs2 := T{
+		A: map[int]struct{}{},
+	}
+	assert.NoError(Unmarshal(ns2, &gs2))
+	assert.Equal(T{
+		A: map[int]struct{}{},
+	}, gs2)
 }
 
 func TestDecodeNamedSet(t *testing.T) {


### PR DESCRIPTION
This is a breaking change!

We used to create empty Go collections `[]int{}` when unmarshalling an
empty Noms collection onto a Go collection that was `nil`. Now we keep
the Go collection as `nil` which means that you will get `[]int(nil)`
for an empty Noms List.

Fixes #2969