### PR TITLE
Marshal: Be more lenient when unmarshal a struct

### DIFF
--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -20,10 +20,7 @@ import (
 //
 // To unmarshal a Noms struct into a Go struct, Unmarshal matches incoming
 // object fields to the fields used by Marshal (either the struct field name or
-// its tag).  Unmarshal will only set exported fields of the struct.  The name
-// of the Go struct must match (ignoring case) the name of the Noms struct. All
-// exported fields on the Go struct must be present in the Noms struct, unless
-// the field on the Go struct is marked with the "omitempty" tag. Go struct
+// its tag). Unmarshal will only set exported fields of the struct. Go struct
 // fields also support the "original" tag which causes the Go field to receive
 // the entire original unmarshaled Noms struct.
 //
@@ -234,11 +231,10 @@ func (c *decoderCacheT) set(t reflect.Type, d decoderFunc) {
 }
 
 type decField struct {
-	name      string
-	decoder   decoderFunc
-	index     int
-	omitEmpty bool
-	original  bool
+	name     string
+	decoder  decoderFunc
+	index    int
+	original bool
 }
 
 func structDecoder(t reflect.Type) decoderFunc {
@@ -262,11 +258,10 @@ func structDecoder(t reflect.Type) decoderFunc {
 		validateField(f, t)
 
 		fields = append(fields, decField{
-			name:      tags.name,
-			decoder:   typeDecoder(f.Type, tags),
-			index:     i,
-			omitEmpty: tags.omitEmpty,
-			original:  tags.original,
+			name:     tags.name,
+			decoder:  typeDecoder(f.Type, tags),
+			index:    i,
+			original: tags.original,
 		})
 	}
 
@@ -288,8 +283,6 @@ func structDecoder(t reflect.Type) decoderFunc {
 			fv, ok := s.MaybeGet(f.name)
 			if ok {
 				f.decoder(fv, sf)
-			} else if !f.omitEmpty {
-				panic(&UnmarshalTypeMismatchError{v, rv.Type(), ", missing field \"" + f.name + "\""})
 			}
 		}
 	}

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -309,9 +309,11 @@ func TestDecodeMissingField(t *testing.T) {
 		B bool
 	}
 	var s S
-	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
+	Unmarshal(types.NewStruct("S", types.StructData{
 		"a": types.Number(42),
-	}), &s, "Cannot unmarshal struct S {\n  a: Number,\n} into Go value of type marshal.S, missing field \"b\"")
+	}), &s)
+	assert.Equal(t, int32(42), s.A)
+	assert.False(t, s.B)
 }
 
 func TestDecodeEmbeddedStruct(tt *testing.T) {


### PR DESCRIPTION
This is a potentially breaking change!

Before this change we required all the fields in a Go struct to be
present in the Noms struct when we unmarshal the Noms struct onto the
Go struct. This is no longer the case, which means that all fields in
the Go struct that are present in the Noms struct will be copied over.

This also means that `omitempty` is useless in Unmarshal and it has been
removed.

This might break your code if expected to get errors when the field
names did not match!

Fixes #2971