### PR TITLE
Revert "Marshal: Be more lenient when unmarshal a struct (#2975)"

### DIFF
--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -309,11 +309,9 @@ func TestDecodeMissingField(t *testing.T) {
 		B bool
 	}
 	var s S
-	Unmarshal(types.NewStruct("S", types.StructData{
+	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
 		"a": types.Number(42),
-	}), &s)
-	assert.Equal(t, int32(42), s.A)
-	assert.False(t, s.B)
+	}), &s, "Cannot unmarshal struct S {\n  a: Number,\n} into Go value of type marshal.S, missing field \"b\"")
 }
 
 func TestDecodeEmbeddedStruct(tt *testing.T) {


### PR DESCRIPTION
This reverts commit b64f1d5dc936935f79718fe6a1b75b9a6b1af89b.

Reason: It is breaking samples/go/photo-index

Reopens: #2971