### PR TITLE
Parallel s3 Slice reads

### DIFF
--- a/go/nbs/benchmarks/block_store_benchmarks.go
+++ b/go/nbs/benchmarks/block_store_benchmarks.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-
 	"sync"
 
 	"github.com/attic-labs/noms/go/chunks"

--- a/go/nbs/benchmarks/main.go
+++ b/go/nbs/benchmarks/main.go
@@ -137,11 +137,16 @@ func main() {
 		{"ReadSequential", writeDB, func() {
 			benchmarkRead(open, src.GetHashes(), src, pb)
 		}},
-		{"ReadManySequential", writeDB, func() { benchmarkReadMany(open, src.GetHashes(), src, 1<<8, 6, pb) }},
 		{"ReadHashOrder", writeDB, func() {
 			ordered := src.GetHashes()
 			sort.Sort(ordered)
 			benchmarkRead(open, ordered, src, pb)
+		}},
+		{"ReadManySequential", writeDB, func() { benchmarkReadMany(open, src.GetHashes(), src, 1<<8, 6, pb) }},
+		{"ReadManyHashOrder", writeDB, func() {
+			ordered := src.GetHashes()
+			sort.Sort(ordered)
+			benchmarkReadMany(open, ordered, src, 1<<8, 6, pb)
 		}},
 	}
 	w := 0

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -86,10 +86,10 @@ func (ccs *compactingChunkSource) hash() addr {
 	return ccs.cs.hash()
 }
 
-func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize, ampThresh uint64) (reads int, remaining bool) {
+func (ccs *compactingChunkSource) calcReads(reqs []getRecord) (reads int, remaining bool) {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.calcReads(reqs, blockSize, ampThresh)
+	return ccs.cs.calcReads(reqs)
 }
 
 type emptyChunkSource struct{}
@@ -122,6 +122,6 @@ func (ecs emptyChunkSource) hash() addr {
 	return addr{} // TODO: is this legal?
 }
 
-func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize, ampThresh uint64) (reads int, remaining bool) {
+func (ecs emptyChunkSource) calcReads(reqs []getRecord) (reads int, remaining bool) {
 	return 0, true
 }

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -86,10 +86,10 @@ func (ccs *compactingChunkSource) hash() addr {
 	return ccs.cs.hash()
 }
 
-func (ccs *compactingChunkSource) calcReads(reqs []getRecord) (reads int, remaining bool) {
+func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool) {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.calcReads(reqs)
+	return ccs.cs.calcReads(reqs, blockSize, maxReadSize, ampThresh)
 }
 
 type emptyChunkSource struct{}
@@ -122,6 +122,6 @@ func (ecs emptyChunkSource) hash() addr {
 	return addr{} // TODO: is this legal?
 }
 
-func (ecs emptyChunkSource) calcReads(reqs []getRecord) (reads int, remaining bool) {
+func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool) {
 	return 0, true
 }

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -62,10 +62,10 @@ func (ccs *compactingChunkSource) get(h addr) []byte {
 	return cr.get(h)
 }
 
-func (ccs *compactingChunkSource) getMany(reqs []getRecord) bool {
+func (ccs *compactingChunkSource) getMany(reqs []getRecord, wg *sync.WaitGroup) bool {
 	cr := ccs.getReader()
 	d.Chk.True(cr != nil)
-	return cr.getMany(reqs)
+	return cr.getMany(reqs, wg)
 }
 
 func (ccs *compactingChunkSource) close() error {
@@ -106,7 +106,7 @@ func (ecs emptyChunkSource) get(h addr) []byte {
 	return nil
 }
 
-func (ecs emptyChunkSource) getMany(reqs []getRecord) bool {
+func (ecs emptyChunkSource) getMany(reqs []getRecord, wg *sync.WaitGroup) bool {
 	return true
 }
 

--- a/go/nbs/frag/main.go
+++ b/go/nbs/frag/main.go
@@ -94,7 +94,7 @@ func main() {
 						}
 					})
 
-					reads, split := store.CalcReads(hashes)
+					reads, split := store.CalcReads(hashes, 0, 1<<63, 0)
 					numbers <- record{count: 1, calc: reads, split: split}
 
 					wg.Add(len(children))

--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -5,6 +5,7 @@
 package nbs
 
 import "sort"
+import "sync"
 
 type memTable struct {
 	chunks             map[addr][]byte
@@ -66,7 +67,7 @@ func (mt *memTable) get(h addr) []byte {
 	return mt.chunks[h]
 }
 
-func (mt *memTable) getMany(reqs []getRecord) (remaining bool) {
+func (mt *memTable) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining bool) {
 	for i, r := range reqs {
 		data := mt.chunks[*r.a]
 		if data != nil {

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -6,6 +6,7 @@ package nbs
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/attic-labs/testify/assert"
@@ -124,9 +125,9 @@ func (crg chunkReaderGroup) hasMany(addrs []hasRecord) (remaining bool) {
 	return true
 }
 
-func (crg chunkReaderGroup) getMany(reqs []getRecord) (remaining bool) {
+func (crg chunkReaderGroup) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining bool) {
 	for _, haver := range crg {
-		if !haver.getMany(reqs) {
+		if !haver.getMany(reqs, wg) {
 			return false
 		}
 	}

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -82,15 +82,15 @@ func TestMemTableWrite(t *testing.T) {
 
 	td1, _ := buildTable(chunks[1:2])
 	td2, _ := buildTable(chunks[2:])
-	tr1 := newTableReader(parseTableIndex(td1), bytes.NewReader(td1), fileBlockSize, fileReadAmpThresh)
-	tr2 := newTableReader(parseTableIndex(td2), bytes.NewReader(td2), fileBlockSize, fileReadAmpThresh)
+	tr1 := newTableReader(parseTableIndex(td1), bytes.NewReader(td1), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr2 := newTableReader(parseTableIndex(td2), bytes.NewReader(td2), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
 	assert.True(tr1.has(computeAddr(chunks[1])))
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
 	_, data, count := mt.write(chunkReaderGroup{tr1, tr2})
 	assert.Equal(uint32(1), count)
 
-	outReader := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize, fileReadAmpThresh)
+	outReader := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
 	assert.True(outReader.has(computeAddr(chunks[0])))
 	assert.False(outReader.has(computeAddr(chunks[1])))
 	assert.False(outReader.has(computeAddr(chunks[2])))

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -25,6 +25,7 @@ type mmapTableReader struct {
 const (
 	fileReadAmpThresh = uint64(2)
 	fileBlockSize     = 1 << 12
+	fileMaxReadSize   = 1 << 28 // 268MiB
 )
 
 var (
@@ -61,7 +62,7 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32) chunkSource {
 	success = true
 
 	index := parseTableIndex(buff[indexOffset-aligned:])
-	source := &mmapTableReader{newTableReader(index, f, fileBlockSize, fileReadAmpThresh), f, buff, h}
+	source := &mmapTableReader{newTableReader(index, f, fileBlockSize, fileMaxReadSize, fileReadAmpThresh), f, buff, h}
 
 	d.PanicIfFalse(chunkCount == source.count())
 	return source

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -199,7 +199,7 @@ func (ftp fakeTablePersister) Compact(mt *memTable, haver chunkReader) chunkSour
 	if mt.count() > 0 {
 		var data []byte
 		name, data, _ := mt.write(haver)
-		ftp.sources[name] = newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize, fileReadAmpThresh)
+		ftp.sources[name] = newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
 		return chunkSourceAdapter{ftp.sources[name], name}
 	}
 	return emptyChunkSource{}

--- a/go/nbs/s3_fake_test.go
+++ b/go/nbs/s3_fake_test.go
@@ -56,7 +56,7 @@ func (m *fakeS3) readerForTable(name addr) chunkReader {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if buff, present := m.data[name.String()]; present {
-		return newTableReader(parseTableIndex(buff), bytes.NewReader(buff), s3BlockSize, s3ReadAmpThresh)
+		return newTableReader(parseTableIndex(buff), bytes.NewReader(buff), s3BlockSize, s3MaxReadSize, s3ReadAmpThresh)
 	}
 	return nil
 }

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -17,7 +17,7 @@ const (
 	s3RangePrefix   = "bytes"
 	s3ReadAmpThresh = uint64(5)
 	s3BlockSize     = (1 << 20) * 5  // 8MiB
-	s3MaxReadSize   = (1 << 20) * 20 // 32MiB
+	s3MaxReadSize   = (1 << 20) * 20 // 20MiB
 )
 
 type s3TableReader struct {

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -16,7 +16,8 @@ import (
 const (
 	s3RangePrefix   = "bytes"
 	s3ReadAmpThresh = uint64(5)
-	s3BlockSize     = 0
+	s3BlockSize     = (1 << 20) * 5  // 8MiB
+	s3MaxReadSize   = (1 << 20) * 20 // 32MiB
 )
 
 type s3TableReader struct {
@@ -24,6 +25,7 @@ type s3TableReader struct {
 	s3     s3svc
 	bucket string
 	h      addr
+	readRl chan struct{}
 }
 
 type s3svc interface {
@@ -35,8 +37,8 @@ type s3svc interface {
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
-func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *s3IndexCache) chunkSource {
-	source := &s3TableReader{s3: s3, bucket: bucket, h: h}
+func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *s3IndexCache, readRl chan struct{}) chunkSource {
+	source := &s3TableReader{s3: s3, bucket: bucket, h: h, readRl: readRl}
 
 	var index tableIndex
 	found := false
@@ -58,7 +60,7 @@ func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexC
 		}
 	}
 
-	source.tableReader = newTableReader(index, source, s3BlockSize, s3ReadAmpThresh)
+	source.tableReader = newTableReader(index, source, s3BlockSize, s3MaxReadSize, s3ReadAmpThresh)
 	d.PanicIfFalse(chunkCount == source.count())
 	return source
 }
@@ -78,6 +80,13 @@ func (s3tr *s3TableReader) ReadAt(p []byte, off int64) (n int, err error) {
 }
 
 func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err error) {
+	if s3tr.readRl != nil {
+		s3tr.readRl <- struct{}{}
+		defer func() {
+			<-s3tr.readRl
+		}()
+	}
+
 	result, err := s3tr.s3.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s3tr.bucket),
 		Key:    aws.String(s3tr.hash().String()),

--- a/go/nbs/s3_table_reader_test.go
+++ b/go/nbs/s3_table_reader_test.go
@@ -23,7 +23,7 @@ func TestS3TableReader(t *testing.T) {
 	tableData, h := buildTable(chunks)
 	s3.data[h.String()] = tableData
 
-	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), nil)
+	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), nil, nil)
 	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }
@@ -46,7 +46,7 @@ func TestS3TableReaderIndexCache(t *testing.T) {
 	cache := newS3IndexCache(1024)
 	cache.put(h, index)
 
-	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), cache)
+	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), cache, nil)
 
 	assert.Equal(0, s3.getCount) // constructing the table shouldn't have resulted in any reads
 

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -163,7 +163,7 @@ func (nbs *NomsBlockStore) GetMany(hashes []hash.Hash) []chunks.Chunk {
 		tables = nbs.tables
 
 		if nbs.mt != nil {
-			remaining = nbs.mt.getMany(reqs)
+			remaining = nbs.mt.getMany(reqs, &sync.WaitGroup{})
 		} else {
 			remaining = true
 		}
@@ -174,7 +174,9 @@ func (nbs *NomsBlockStore) GetMany(hashes []hash.Hash) []chunks.Chunk {
 	sort.Sort(getRecordByPrefix(reqs))
 
 	if remaining {
-		tables.getMany(reqs)
+		wg := &sync.WaitGroup{}
+		tables.getMany(reqs, wg)
+		wg.Wait()
 	}
 
 	sort.Sort(getRecordByOrder(reqs))

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -27,6 +27,7 @@ const (
 	StorageVersion = "0"
 
 	defaultMemTableSize uint64 = 512 * 1 << 20 // 512MB
+	defaultAWSReadLimit        = 1024
 )
 
 type NomsBlockStore struct {
@@ -46,6 +47,7 @@ type AWSStoreFactory struct {
 	sess          *session.Session
 	table, bucket string
 	indexCache    *s3IndexCache
+	readRl        chan struct{}
 }
 
 func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheSize uint64) chunks.Factory {
@@ -53,23 +55,23 @@ func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheS
 	if indexCacheSize > 0 {
 		indexCache = newS3IndexCache(indexCacheSize)
 	}
-	return &AWSStoreFactory{sess, table, bucket, indexCache}
+	return &AWSStoreFactory{sess, table, bucket, indexCache, make(chan struct{}, defaultAWSReadLimit)}
 }
 
 func (asf *AWSStoreFactory) CreateStore(ns string) chunks.ChunkStore {
-	return newAWSStore(asf.table, ns, asf.bucket, asf.sess, 1<<26 /* 64MB */, asf.indexCache)
+	return newAWSStore(asf.table, ns, asf.bucket, asf.sess, defaultMemTableSize, asf.indexCache, asf.readRl)
 }
 
 func (asf *AWSStoreFactory) Shutter() {
 }
 
 func NewAWSStore(table, ns, bucket string, sess *session.Session, memTableSize uint64) *NomsBlockStore {
-	return newAWSStore(table, ns, bucket, sess, memTableSize, nil)
+	return newAWSStore(table, ns, bucket, sess, memTableSize, nil, nil)
 }
 
-func newAWSStore(table, ns, bucket string, sess *session.Session, memTableSize uint64, indexCache *s3IndexCache) *NomsBlockStore {
+func newAWSStore(table, ns, bucket string, sess *session.Session, memTableSize uint64, indexCache *s3IndexCache, readRl chan struct{}) *NomsBlockStore {
 	mm := newDynamoManifest(table, ns, dynamodb.New(sess))
-	ts := newS3TableSet(s3.New(sess), bucket, indexCache)
+	ts := newS3TableSet(s3.New(sess), bucket, indexCache, readRl)
 	return newNomsBlockStore(mm, ts, memTableSize)
 }
 
@@ -218,7 +220,7 @@ func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash) (reads int, split bool)
 
 	sort.Sort(getRecordByPrefix(reqs))
 
-	reads, split, remaining := tables.calcReads(reqs, 0, 0)
+	reads, split, remaining := tables.calcReads(reqs)
 	d.Chk.False(remaining)
 	return
 }

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -208,7 +208,7 @@ func toGetRecords(hashes []hash.Hash) []getRecord {
 	return reqs
 }
 
-func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash) (reads int, split bool) {
+func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash, blockSize, maxReadSize, ampThresh uint64) (reads int, split bool) {
 	reqs := toGetRecords(hashes)
 	tables := func() (tables tableSet) {
 		nbs.mu.RLock()
@@ -220,7 +220,7 @@ func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash) (reads int, split bool)
 
 	sort.Sort(getRecordByPrefix(reqs))
 
-	reads, split, remaining := tables.calcReads(reqs)
+	reads, split, remaining := tables.calcReads(reqs, blockSize, maxReadSize, ampThresh)
 	d.Chk.False(remaining)
 	return
 }

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -183,6 +183,7 @@ type getRecord struct {
 	a      *addr
 	prefix uint64
 	order  int
+	found  bool
 	data   []byte
 }
 

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base32"
 	"encoding/binary"
 	"hash/crc32"
+	"sync"
 )
 
 /*
@@ -203,7 +204,7 @@ type chunkReader interface {
 	has(h addr) bool
 	hasMany(addrs []hasRecord) bool
 	get(h addr) []byte
-	getMany(reqs []getRecord) bool
+	getMany(reqs []getRecord, wg *sync.WaitGroup) bool
 	count() uint32
 }
 

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -212,5 +212,5 @@ type chunkSource interface {
 	chunkReader
 	close() error
 	hash() addr
-	calcReads(reqs []getRecord) (reads int, remaining bool)
+	calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool)
 }

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -212,5 +212,5 @@ type chunkSource interface {
 	chunkReader
 	close() error
 	hash() addr
-	calcReads(reqs []getRecord, blockSize, ampThresh uint64) (reads int, remaining bool)
+	calcReads(reqs []getRecord) (reads int, remaining bool)
 }

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"io"
 	"sort"
+	"sync"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/golang/snappy"
@@ -203,7 +204,7 @@ func (tr tableReader) get(h addr) (data []byte) {
 	n, err := tr.r.ReadAt(buff, int64(offset))
 	d.Chk.NoError(err)
 	d.Chk.True(n == int(length))
-	data = tr.parseChunk(h, buff)
+	data = tr.parseChunk(buff)
 	d.Chk.True(data != nil)
 
 	return
@@ -220,9 +221,27 @@ func (hs offsetRecSlice) Len() int           { return len(hs) }
 func (hs offsetRecSlice) Less(i, j int) bool { return hs[i].offset < hs[j].offset }
 func (hs offsetRecSlice) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
 
+func (tr tableReader) readAtOffsets(readStart, readEnd uint64, reqs []getRecord, offsets offsetRecSlice, wg *sync.WaitGroup) {
+	readLength := readEnd - readStart
+	buff := make([]byte, readLength)
+	n, err := tr.r.ReadAt(buff, int64(readStart))
+	d.Chk.NoError(err)
+	d.Chk.True(uint64(n) == readLength)
+
+	for _, rec := range offsets {
+		d.Chk.True(rec.offset >= readStart)
+		localStart := rec.offset - readStart
+		localEnd := localStart + uint64(tr.lengths[rec.ordinal])
+		d.Chk.True(localEnd <= readLength)
+		reqs[rec.reqIdx].data = tr.parseChunk(buff[localStart:localEnd])
+	}
+
+	wg.Done()
+}
+
 // getMany retrieves multiple stored blocks and optimizes by attempting to read in larger physical
 // blocks which contain multiple stored blocks. |reqs| must be sorted by address prefix.
-func (tr tableReader) getMany(reqs []getRecord) (remaining bool) {
+func (tr tableReader) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining bool) {
 	// Pass #1: Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
 	// of table locations which must be read in order to satisfy the getMany operation.
 	var offsetRecords offsetRecSlice
@@ -233,69 +252,41 @@ func (tr tableReader) getMany(reqs []getRecord) (remaining bool) {
 	// grouping sequences of reads into large physical reads.
 	sort.Sort(offsetRecords)
 
-	scratch := []byte{} // raw byte area into which reads occur
-	// slice within |scratch| which contains a contiguous sequence of bytes read from the table
-	buff := scratch[:]
-	baseOffset := uint64(0) // the offset within the table which corresponds to byte 0 of |buff|
+	var batch offsetRecSlice
+	var readStart, readEnd, readAmp uint64
 
-	for i, rec := range offsetRecords {
-		if reqs[rec.reqIdx].data != nil {
-			continue // already satisfied
-		}
-
-		// offset within |buff| which corresponds to the logical location of the chunkRecord
-		localOffset := rec.offset - baseOffset
+	for i := 0; i < len(offsetRecords); {
+		rec := offsetRecords[i]
 		length := tr.lengths[rec.ordinal]
 
-		if uint64(len(buff)) < localOffset+uint64(length) {
-			// |buff| doesn't contain sufficient bytes to read the current chunk record. scan forward
-			// and read in a new sequence of bytes
-
-			readStart := rec.offset
-			readEnd := rec.offset + uint64(length) // implicitly include the first chunk
-
-			// As we scan forward, for each location/length, we'll include it in the current read if
-			// the total number of bytes we'll read contains fewer than X bytes we don't care about.
-			readAmp := uint64(0)
-
-			// scan ahead in offsets
-			for j := i + 1; j < len(offsetRecords); j++ {
-				fRec := offsetRecords[j]
-
-				if reqs[fRec.reqIdx].data != nil {
-					continue // already satisfied
-				}
-
-				newEnd, newAmp, canRead := canReadAhead(fRec, tr.lengths[fRec.ordinal], readStart, readEnd, readAmp, tr.blockSize, tr.readAmpThresh)
-				if !canRead {
-					break // including the next block will read too many unneeded bytes
-				}
-
-				readEnd = newEnd
-				readAmp = newAmp
-			}
-
-			// Ensure our memory buffer is large enough
-			if readEnd-readStart > uint64(len(scratch)) {
-				scratch = make([]byte, readEnd-readStart)
-			}
-
-			buff = scratch[:readEnd-readStart]
-			n, err := tr.r.ReadAt(buff, int64(readStart))
-			d.Chk.NoError(err)
-			d.Chk.True(uint64(n) == readEnd-readStart)
-
-			baseOffset = readStart
-			localOffset = 0
+		if batch == nil {
+			batch = make(offsetRecSlice, 1)
+			batch[0] = offsetRecords[i]
+			readStart = rec.offset
+			readEnd = readStart + uint64(length)
+			readAmp = 0
+			i++
+			continue
 		}
 
-		chunkRecord := buff[localOffset : localOffset+uint64(length)]
-		data := tr.parseChunk(*reqs[rec.reqIdx].a, chunkRecord)
-		if data != nil {
-			reqs[rec.reqIdx].data = data
-		} else {
-			remaining = true
+		newReadEnd, newReadAmp, canRead := canReadAhead(rec, tr.lengths[rec.ordinal], readStart, readEnd, readAmp, tr.blockSize, tr.readAmpThresh)
+		if canRead {
+			batch = append(batch, rec)
+			readEnd = newReadEnd
+			readAmp = newReadAmp
+			i++
+			continue
 		}
+
+		wg.Add(1)
+		go tr.readAtOffsets(readStart, readEnd, reqs, batch, wg)
+		batch = nil
+	}
+
+	if batch != nil {
+		wg.Add(1)
+		go tr.readAtOffsets(readStart, readEnd, reqs, batch, wg)
+		batch = nil
 	}
 
 	return
@@ -373,7 +364,7 @@ func canReadAhead(fRec offsetRec, fLength uint32, readStart, readEnd, readAmp, b
 }
 
 // Fetches the byte stream of data logically encoded within the table starting at |pos|.
-func (tr tableReader) parseChunk(h addr, buff []byte) []byte {
+func (tr tableReader) parseChunk(buff []byte) []byte {
 	dataLen := uint64(len(buff)) - checksumSize
 	data, err := snappy.Decode(nil, buff[:dataLen])
 	d.Chk.NoError(err)

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -314,6 +314,10 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 	// Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
 	// of table locations which must be read in order to satisfy |reqs|.
 	for i, req := range reqs {
+		if req.found {
+			continue
+		}
+
 		// advance within the prefixes until we reach one which is >= req.prefix
 		for filterIdx < filterLen && tr.prefixes[filterIdx] < req.prefix {
 			filterIdx++
@@ -332,6 +336,7 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 		// record all offsets within the table which contain the data required.
 		for j := filterIdx; j < filterLen && req.prefix == tr.prefixes[j]; j++ {
 			if tr.ordinalSuffixMatches(tr.prefixIdxToOrdinal(j), *req.a) {
+				reqs[i].found = true
 				ors = append(ors, offsetRec{uint32(i), tr.ordinals[j], tr.offsets[tr.ordinals[j]]})
 			}
 		}

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -58,9 +58,9 @@ func (css chunkSources) get(h addr) []byte {
 	return nil
 }
 
-func (css chunkSources) getMany(reqs []getRecord) (remaining bool) {
+func (css chunkSources) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining bool) {
 	for _, haver := range css {
-		if !haver.getMany(reqs) {
+		if !haver.getMany(reqs, wg) {
 			return false
 		}
 	}

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -68,9 +68,9 @@ func (css chunkSources) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining
 	return true
 }
 
-func (css chunkSources) calcReads(reqs []getRecord) (reads int, split, remaining bool) {
+func (css chunkSources) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, split, remaining bool) {
 	for _, haver := range css {
-		rds, remaining := haver.calcReads(reqs)
+		rds, remaining := haver.calcReads(reqs, blockSize, maxReadSize, ampThresh)
 		reads += rds
 		if !remaining {
 			return reads, split, remaining

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -211,7 +211,7 @@ func TestFSTablePersisterCompact(t *testing.T) {
 	if assert.True(src.count() > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
 		assert.NoError(err)
-		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize, fileReadAmpThresh)
+		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
 		for _, c := range testChunks {
 			assert.True(tr.has(computeAddr(c)))
 		}

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -163,9 +163,9 @@ func TestGetMany(t *testing.T) {
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, nil},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, nil},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, nil},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, false, nil},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, false, nil},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, false, nil},
 	}
 	sort.Sort(getRecordByPrefix(getBatch))
 
@@ -188,9 +188,9 @@ func TestCalcReads(t *testing.T) {
 	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), 0, 0)
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, nil},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, nil},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, nil},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, false, nil},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, false, nil},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, false, nil},
 	}
 
 	gb2 := []getRecord{getBatch[0], getBatch[2]}
@@ -271,7 +271,7 @@ func doTestNGetMany(t *testing.T, count int) {
 	getBatch := make([]getRecord, len(chunks))
 	for i := 0; i < count; i++ {
 		a := computeAddr(dataFn(i))
-		getBatch[i] = getRecord{&a, a.Prefix(), i, nil}
+		getBatch[i] = getRecord{&a, a.Prefix(), i, false, nil}
 	}
 
 	sort.Sort(getRecordByPrefix(getBatch))

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -201,12 +201,12 @@ func TestCalcReads(t *testing.T) {
 	gb2 := []getRecord{getBatch[0], getBatch[2]}
 	sort.Sort(getRecordByPrefix(getBatch))
 
-	reads, remaining := tr.calcReads(getBatch)
+	reads, remaining := tr.calcReads(getBatch, 0, fileMaxReadSize, 0)
 	assert.False(remaining)
 	assert.Equal(1, reads)
 
 	sort.Sort(getRecordByPrefix(gb2))
-	reads, remaining = tr.calcReads(gb2)
+	reads, remaining = tr.calcReads(gb2, 0, fileMaxReadSize, 0)
 	assert.False(remaining)
 	assert.Equal(2, reads)
 }

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -12,6 +12,8 @@ import (
 
 	"bytes"
 
+	"sync"
+
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/testify/assert"
@@ -169,7 +171,10 @@ func TestGetMany(t *testing.T) {
 	}
 	sort.Sort(getRecordByPrefix(getBatch))
 
-	tr.getMany(getBatch)
+	wg := &sync.WaitGroup{}
+	tr.getMany(getBatch, wg)
+	wg.Wait()
+
 	for _, rec := range getBatch {
 		assert.NotNil(rec.data, "Nothing for prefix %d", rec.prefix)
 	}
@@ -276,7 +281,9 @@ func doTestNGetMany(t *testing.T, count int) {
 
 	sort.Sort(getRecordByPrefix(getBatch))
 
-	tr.getMany(getBatch)
+	wg := &sync.WaitGroup{}
+	tr.getMany(getBatch, wg)
+	wg.Wait()
 
 	sort.Sort(getRecordByOrder(getBatch))
 


### PR DESCRIPTION
GetMany() calls can now be serviced by <= N goroutines, where N is the number of physical reads the request in broken down into.

This patch also adds a `maxReadSize` param to the code which decides how to break chunk reads into physical reads, and sets the s3 blockSize to 5MB, which experimentally resulted to lower total latency.

Lastly, some small refactors.