### PR TITLE
Modify httpBatchStore so that writing values maintains some locality

### DIFF
--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -86,7 +86,7 @@ func runSync(args []string) int {
 	nonFF := false
 	err = d.Try(func() {
 		defer profile.MaybeStartProfile().Stop()
-		datas.Pull(sourceStore, sinkDB, sourceRef, sinkRef, p, progressCh)
+		datas.PullWithFlush(sourceStore, sinkDB, sourceRef, sinkRef, p, progressCh)
 
 		var err error
 		sinkDataset, err = sinkDB.FastForward(sinkDataset, sourceRef)

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -477,7 +477,10 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfRefs() {
 
 	r2 := suite.db.WriteValue(r1)
 	suite.Equal(uint64(2), r2.Height())
-	suite.Equal(uint64(3), suite.db.WriteValue(r2).Height())
+	r3 := suite.db.WriteValue(r2)
+	suite.Equal(uint64(3), r3.Height())
+	_, err := suite.db.CommitValue(suite.db.GetDataset("ds1"), r3)
+	suite.NoError(err)
 }
 
 func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
@@ -524,7 +527,8 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
 	}
 	andMore = append(andMore, setOfStringType, setOfRefOfStringType)
 
-	suite.db.WriteValue(types.NewList(andMore...))
+	_, err := suite.db.CommitValue(suite.db.GetDataset("ds1"), suite.db.WriteValue(types.NewList(andMore...)))
+	suite.NoError(err)
 }
 
 func (suite *DatabaseSuite) TestMetaOption() {

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -477,10 +477,7 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfRefs() {
 
 	r2 := suite.db.WriteValue(r1)
 	suite.Equal(uint64(2), r2.Height())
-	r3 := suite.db.WriteValue(r2)
-	suite.Equal(uint64(3), r3.Height())
-	_, err := suite.db.CommitValue(suite.db.GetDataset("ds1"), r3)
-	suite.NoError(err)
+	suite.Equal(uint64(3), suite.db.WriteValue(r2).Height())
 }
 
 func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
@@ -527,8 +524,7 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
 	}
 	andMore = append(andMore, setOfStringType, setOfRefOfStringType)
 
-	_, err := suite.db.CommitValue(suite.db.GetDataset("ds1"), suite.db.WriteValue(types.NewList(andMore...)))
-	suite.NoError(err)
+	suite.db.WriteValue(types.NewList(andMore...))
 }
 
 func (suite *DatabaseSuite) TestMetaOption() {

--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/hash"
-	"github.com/attic-labs/noms/go/nbs"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/testify/suite"
 	"github.com/julienschmidt/httprouter"
@@ -130,7 +129,7 @@ func (suite *HTTPBatchStoreSuite) TearDownTest() {
 func (suite *HTTPBatchStoreSuite) TestPutChunk() {
 	c := types.EncodeValue(types.String("abc"), nil)
 	suite.store.SchedulePut(c, 1, types.Hints{})
-	suite.store.flushInternal(nbs.InsertOrder)
+	suite.store.Flush()
 
 	suite.Equal(1, suite.cs.Writes)
 }
@@ -146,7 +145,7 @@ func (suite *HTTPBatchStoreSuite) TestPutChunksInOrder() {
 		l = l.Append(types.NewRef(val))
 	}
 	suite.store.SchedulePut(types.EncodeValue(l, nil), 2, types.Hints{})
-	suite.store.flushInternal(nbs.InsertOrder)
+	suite.store.Flush()
 
 	suite.Equal(3, suite.cs.Writes)
 }
@@ -157,6 +156,7 @@ func (suite *HTTPBatchStoreSuite) TestPutChunksReverseOrder() {
 
 	suite.store.SchedulePut(types.EncodeValue(l, nil), 2, types.Hints{})
 	suite.store.SchedulePut(types.EncodeValue(val, nil), 1, types.Hints{})
+	suite.store.SetReverseFlushOrder()
 	suite.store.Flush()
 
 	suite.Equal(2, suite.cs.Writes)
@@ -178,7 +178,7 @@ func (suite *HTTPBatchStoreSuite) TestPutChunkWithHints() {
 		chnx[0].Hash(): struct{}{},
 		chnx[1].Hash(): struct{}{},
 	})
-	suite.store.flushInternal(nbs.InsertOrder)
+	suite.store.Flush()
 
 	suite.Equal(3, suite.cs.Writes)
 }
@@ -224,7 +224,7 @@ func (suite *HTTPBatchStoreSuite) TestPutChunksBackpressure() {
 		l = l.Append(types.NewRef(v))
 	}
 	bs.SchedulePut(types.EncodeValue(l, nil), 2, types.Hints{})
-	bs.flushInternal(nbs.InsertOrder)
+	bs.Flush()
 
 	suite.Equal(6, suite.cs.Writes)
 }

--- a/go/datas/remote_database_client.go
+++ b/go/datas/remote_database_client.go
@@ -20,8 +20,7 @@ func NewRemoteDatabase(baseURL, auth string) *RemoteDatabaseClient {
 }
 
 func (rdb *RemoteDatabaseClient) validatingBatchStore() (bs types.BatchStore) {
-	bs = rdb.ValueStore.BatchStore()
-	return
+	return rdb.BatchStore()
 }
 
 func (rdb *RemoteDatabaseClient) GetDataset(datasetID string) Dataset {
@@ -43,11 +42,13 @@ func (rdb *RemoteDatabaseClient) Delete(ds Dataset) (Dataset, error) {
 }
 
 func (rdb *RemoteDatabaseClient) SetHead(ds Dataset, newHeadRef types.Ref) (Dataset, error) {
+	rdb.BatchStore().Flush()
 	err := rdb.doSetHead(ds, newHeadRef)
 	return rdb.GetDataset(ds.ID()), err
 }
 
 func (rdb *RemoteDatabaseClient) FastForward(ds Dataset, newHeadRef types.Ref) (Dataset, error) {
+	rdb.BatchStore().Flush()
 	err := rdb.doFastForward(ds, newHeadRef)
 	return rdb.GetDataset(ds.ID()), err
 }

--- a/go/nbs/cache.go
+++ b/go/nbs/cache.go
@@ -31,11 +31,9 @@ type NomsBlockCache struct {
 	dbDir  string
 }
 
-// Insert stores c in the cache. If c is successfully added to the cache,
-// Insert returns true. If c was already in the cache, Insert returns false.
-func (nbc *NomsBlockCache) Insert(c chunks.Chunk) bool {
-	a := addr(c.Hash())
-	return nbc.chunks.addChunk(a, c.Data())
+// Insert stores c in the cache.
+func (nbc *NomsBlockCache) Insert(c chunks.Chunk) {
+	d.PanicIfFalse(nbc.chunks.addChunk(addr(c.Hash()), c.Data()))
 }
 
 // Has checks if the chunk referenced by hash is in the cache.
@@ -51,11 +49,16 @@ func (nbc *NomsBlockCache) Get(hash hash.Hash) chunks.Chunk {
 
 // ExtractChunks writes the entire contents of the cache to chunkChan. The
 // chunks are extracted in insertion order.
-func (nbc *NomsBlockCache) ExtractChunks(order EnumerationOrder, chunkChan chan *chunks.Chunk) error {
+func (nbc *NomsBlockCache) ExtractChunks(order EnumerationOrder, chunkChan chan *chunks.Chunk) {
 	nbc.chunks.extractChunks(order, chunkChan)
-	return nil
 }
 
+// Count returns the number of items in the cache.
+func (nbc *NomsBlockCache) Count() uint32 {
+	return nbc.chunks.Count()
+}
+
+// Destroy drops the cache and deletes any backing storage.
 func (nbc *NomsBlockCache) Destroy() error {
 	d.Chk.NoError(nbc.chunks.Close())
 	return os.RemoveAll(nbc.dbDir)

--- a/go/nbs/cache.go
+++ b/go/nbs/cache.go
@@ -1,0 +1,62 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/hash"
+)
+
+const (
+	defaultCacheMemTableSize uint64 = 1 << 27 // 128MiB
+)
+
+func NewCache() *NomsBlockCache {
+	dir, err := ioutil.TempDir("", "")
+	d.PanicIfError(err)
+	store := NewLocalStore(dir, defaultCacheMemTableSize)
+	d.Chk.NoError(err, "opening put cache in %s", dir)
+	return &NomsBlockCache{store, dir}
+}
+
+// NomsBlockCache holds Chunks, allowing them to be retrieved by hash or enumerated in hash order.
+type NomsBlockCache struct {
+	chunks *NomsBlockStore
+	dbDir  string
+}
+
+// Insert stores c in the cache. If c is successfully added to the cache,
+// Insert returns true. If c was already in the cache, Insert returns false.
+func (nbc *NomsBlockCache) Insert(c chunks.Chunk) bool {
+	a := addr(c.Hash())
+	return nbc.chunks.addChunk(a, c.Data())
+}
+
+// Has checks if the chunk referenced by hash is in the cache.
+func (nbc *NomsBlockCache) Has(hash hash.Hash) bool {
+	return nbc.chunks.Has(hash)
+}
+
+// Get retrieves the chunk referenced by hash. If the chunk is not present,
+// Get returns the empty Chunk.
+func (nbc *NomsBlockCache) Get(hash hash.Hash) chunks.Chunk {
+	return nbc.chunks.Get(hash)
+}
+
+// ExtractChunks writes the entire contents of the cache to chunkChan. The
+// chunks are extracted in insertion order.
+func (nbc *NomsBlockCache) ExtractChunks(order EnumerationOrder, chunkChan chan *chunks.Chunk) error {
+	nbc.chunks.extractChunks(order, chunkChan)
+	return nil
+}
+
+func (nbc *NomsBlockCache) Destroy() error {
+	d.Chk.NoError(nbc.chunks.Close())
+	return os.RemoveAll(nbc.dbDir)
+}

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -92,6 +92,12 @@ func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize, maxRead
 	return ccs.cs.calcReads(reqs, blockSize, maxReadSize, ampThresh)
 }
 
+func (ccs *compactingChunkSource) extract(order EnumerationOrder, chunks chan<- extractRecord) {
+	cr := ccs.getReader()
+	d.Chk.True(cr != nil)
+	cr.extract(order, chunks)
+}
+
 type emptyChunkSource struct{}
 
 func (ecs emptyChunkSource) has(h addr) bool {
@@ -125,3 +131,5 @@ func (ecs emptyChunkSource) hash() addr {
 func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool) {
 	return 0, true
 }
+
+func (ecs emptyChunkSource) extract(order EnumerationOrder, chunks chan<- extractRecord) {}

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -93,9 +93,9 @@ func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize, maxRead
 }
 
 func (ccs *compactingChunkSource) extract(order EnumerationOrder, chunks chan<- extractRecord) {
-	cr := ccs.getReader()
-	d.Chk.True(cr != nil)
-	cr.extract(order, chunks)
+	ccs.wg.Wait()
+	d.Chk.True(ccs.cs != nil)
+	ccs.cs.extract(order, chunks)
 }
 
 type emptyChunkSource struct{}

--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -4,12 +4,14 @@
 
 package nbs
 
-import "sort"
-import "sync"
+import (
+	"sort"
+	"sync"
+)
 
 type memTable struct {
 	chunks             map[addr][]byte
-	order              []hasRecord
+	order              []hasRecord // Must maintain the invariant that these are sorted by rec.order
 	maxData, totalData uint64
 }
 
@@ -80,7 +82,6 @@ func (mt *memTable) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining boo
 }
 
 func (mt *memTable) extract(order EnumerationOrder, chunks chan<- extractRecord) {
-	sort.Sort(hasRecordByOrder(mt.order)) // ensure "insertion" order for extraction
 	if order == InsertOrder {
 		for _, hrec := range mt.order {
 			chunks <- extractRecord{*hrec.a, mt.chunks[*hrec.a]}

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -140,3 +140,15 @@ func (crg chunkReaderGroup) count() (count uint32) {
 	}
 	return
 }
+
+func (crg chunkReaderGroup) extract(order EnumerationOrder, chunks chan<- extractRecord) {
+	if order == InsertOrder {
+		for _, haver := range crg {
+			haver.extract(order, chunks)
+		}
+		return
+	}
+	for i := len(crg) - 1; i >= 0; i-- {
+		crg[i].extract(order, chunks)
+	}
+}

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -22,12 +22,17 @@ import (
 // names of the tables that hold all the chunks in the store. The number of
 // chunks in each table is also stored in the manifest.
 
+type EnumerationOrder uint8
+
 const (
 	// StorageVersion is the version of the on-disk Noms Chunks Store data format.
 	StorageVersion = "0"
 
 	defaultMemTableSize uint64 = 512 * 1 << 20 // 512MB
 	defaultAWSReadLimit        = 1024
+
+	InsertOrder EnumerationOrder = iota
+	ReverseOrder
 )
 
 type NomsBlockStore struct {
@@ -226,6 +231,31 @@ func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash, blockSize, maxReadSize,
 	reads, split, remaining := tables.calcReads(reqs, blockSize, maxReadSize, ampThresh)
 	d.Chk.False(remaining)
 	return
+}
+
+func (nbs *NomsBlockStore) extractChunks(order EnumerationOrder, chunkChan chan<- *chunks.Chunk) {
+	ch := make(chan extractRecord, 1)
+	go func() {
+		nbs.mu.RLock()
+		defer nbs.mu.RUnlock()
+		// Chunks in nbs.tables were inserted before those in nbs.mt, so extract chunks there _first_ if we're doing InsertOrder...
+		if order == InsertOrder {
+			nbs.tables.extract(order, ch)
+		}
+		if nbs.mt != nil {
+			nbs.mt.extract(order, ch)
+		}
+		// ...and do them _second_ if we're doing ReverseOrder
+		if order == ReverseOrder {
+			nbs.tables.extract(order, ch)
+		}
+
+		close(ch)
+	}()
+	for rec := range ch {
+		c := chunks.NewChunkWithHash(hash.Hash(rec.a), rec.data)
+		chunkChan <- &c
+	}
 }
 
 func (nbs *NomsBlockStore) Has(h hash.Hash) bool {

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -129,6 +129,7 @@ func (nbs *NomsBlockStore) PutMany(chunx []chunks.Chunk) (err chunks.Backpressur
 	return err
 }
 
+// TODO: figure out if there's a non-error reason for this to return false. If not, get rid of return value.
 func (nbs *NomsBlockStore) addChunk(h addr, data []byte) bool {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
@@ -256,6 +257,18 @@ func (nbs *NomsBlockStore) extractChunks(order EnumerationOrder, chunkChan chan<
 		c := chunks.NewChunkWithHash(hash.Hash(rec.a), rec.data)
 		chunkChan <- &c
 	}
+}
+
+func (nbs *NomsBlockStore) Count() uint32 {
+	count, tables := func() (count uint32, tables chunkReader) {
+		nbs.mu.RLock()
+		defer nbs.mu.RUnlock()
+		if nbs.mt != nil {
+			count = nbs.mt.count()
+		}
+		return count, nbs.tables
+	}()
+	return count + tables.count()
 }
 
 func (nbs *NomsBlockStore) Has(h hash.Hash) bool {

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -32,9 +32,9 @@ import (
       of CRC32) as a checksum and a filter against false positive reads costing more than one IOP.
 
    Index:
-   +------------+-------+----------+
-   | Prefix Map | Sizes | Suffixes |
-   +------------+-------+----------+
+   +------------+---------+----------+
+   | Prefix Map | Lengths | Suffixes |
+   +------------+---------+----------+
 
    Prefix Map:
    +--------------+--------------+-----+----------------+
@@ -200,12 +200,18 @@ func (hs getRecordByOrder) Len() int           { return len(hs) }
 func (hs getRecordByOrder) Less(i, j int) bool { return hs[i].order < hs[j].order }
 func (hs getRecordByOrder) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
 
+type extractRecord struct {
+	a    addr
+	data []byte
+}
+
 type chunkReader interface {
 	has(h addr) bool
 	hasMany(addrs []hasRecord) bool
 	get(h addr) []byte
 	getMany(reqs []getRecord, wg *sync.WaitGroup) bool
 	count() uint32
+	extract(order EnumerationOrder, chunks chan<- extractRecord)
 }
 
 type chunkSource interface {

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -96,6 +96,19 @@ func (ts tableSet) Prepend(mt *memTable) tableSet {
 	return tableSet{newTables, ts.p, ts.rl}
 }
 
+func (ts tableSet) extract(order EnumerationOrder, chunks chan<- extractRecord) {
+	// Since new tables are _prepended_ to a tableSet, extracting chunks in ReverseOrder requires iterating ts.chunkSources from front to back, while doing insertOrder requires iterating back to front.
+	if order == ReverseOrder {
+		for _, cs := range ts.chunkSources {
+			cs.extract(order, chunks)
+		}
+		return
+	}
+	for i := len(ts.chunkSources) - 1; i >= 0; i-- {
+		ts.chunkSources[i].extract(order, chunks)
+	}
+}
+
 // Union returns a new tableSet holding the union of the tables managed by
 // |ts| and those specified by |specs|.
 func (ts tableSet) Union(specs []tableSpec) tableSet {

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -88,8 +88,8 @@ func TestTableSetExtract(t *testing.T) {
 	for rec := range chunkChan {
 		a := computeAddr(testChunks[i])
 		assert.NotNil(rec.data, "Nothing for", a)
+		assert.Equal(testChunks[i], rec.data, "Item %d: %s != %s", i, string(testChunks[i]), string(rec.data))
 		assert.Equal(a, rec.a)
-		assert.Equal(testChunks[i], rec.data)
 		i++
 	}
 
@@ -99,8 +99,8 @@ func TestTableSetExtract(t *testing.T) {
 	for rec := range chunkChan {
 		a := computeAddr(testChunks[i])
 		assert.NotNil(rec.data, "Nothing for", a)
+		assert.Equal(testChunks[i], rec.data, "Item %d: %s != %s", i, string(testChunks[i]), string(rec.data))
 		assert.Equal(a, rec.a)
-		assert.Equal(testChunks[i], rec.data)
 		i--
 	}
 

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -66,6 +66,47 @@ func TestTableToSpecsExcludesEmptyTable(t *testing.T) {
 	ts.Close()
 }
 
+func TestTableSetExtract(t *testing.T) {
+	assert := assert.New(t)
+	ts := newFakeTableSet()
+	assert.Empty(ts.ToSpecs())
+
+	// Put in one table
+	mt := newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
+	ts = ts.Prepend(mt)
+
+	// Put in a second
+	mt = newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
+	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
+	ts = ts.Prepend(mt)
+
+	chunkChan := make(chan extractRecord)
+	go func() { ts.extract(InsertOrder, chunkChan); close(chunkChan) }()
+	i := 0
+	for rec := range chunkChan {
+		a := computeAddr(testChunks[i])
+		assert.NotNil(rec.data, "Nothing for", a)
+		assert.Equal(a, rec.a)
+		assert.Equal(testChunks[i], rec.data)
+		i++
+	}
+
+	chunkChan = make(chan extractRecord)
+	go func() { ts.extract(ReverseOrder, chunkChan); close(chunkChan) }()
+	i = len(testChunks) - 1
+	for rec := range chunkChan {
+		a := computeAddr(testChunks[i])
+		assert.NotNil(rec.data, "Nothing for", a)
+		assert.Equal(a, rec.a)
+		assert.Equal(testChunks[i], rec.data)
+		i--
+	}
+
+	ts.Close()
+}
+
 func makeTempDir(assert *assert.Assertions) string {
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(err)

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -211,6 +211,41 @@ func TestCalcReads(t *testing.T) {
 	assert.Equal(2, reads)
 }
 
+func TestExtract(t *testing.T) {
+	assert := assert.New(t)
+
+	chunks := [][]byte{
+		[]byte("hello2"),
+		[]byte("goodbye2"),
+		[]byte("badbye2"),
+	}
+
+	tableData, _ := buildTable(chunks)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+
+	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
+
+	chunkChan := make(chan extractRecord)
+	go func() { tr.extract(InsertOrder, chunkChan); close(chunkChan) }()
+	i := 0
+	for rec := range chunkChan {
+		assert.NotNil(rec.data, "Nothing for", addrs[i])
+		assert.Equal(addrs[i], rec.a)
+		assert.Equal(chunks[i], rec.data)
+		i++
+	}
+
+	chunkChan = make(chan extractRecord)
+	go func() { tr.extract(ReverseOrder, chunkChan); close(chunkChan) }()
+	i = len(chunks) - 1
+	for rec := range chunkChan {
+		assert.NotNil(rec.data, "Nothing for", addrs[i])
+		assert.Equal(addrs[i], rec.a)
+		assert.Equal(chunks[i], rec.data)
+		i--
+	}
+}
+
 func Test65k(t *testing.T) {
 	assert := assert.New(t)
 

--- a/go/types/batch_store.go
+++ b/go/types/batch_store.go
@@ -16,11 +16,22 @@ import (
 
 // BatchStore provides an interface similar to chunks.ChunkStore, but batch-oriented. Instead of Put(), it provides SchedulePut(), which enqueues a Chunk to be sent at a possibly later time.
 type BatchStore interface {
-	// Get returns from the store the Value Chunk by h. If h is absent from the store, chunks.EmptyChunk is returned.
+	// Get returns the Chunk with the hash h from the store. If h is absent
+	// from the store, chunks.EmptyChunk is returned.
 	Get(h hash.Hash) chunks.Chunk
 
-	// SchedulePut enqueues a write for the Chunk c with the given refHeight. Typically, the Value which was encoded to provide c can also be queried for its refHeight. The call may or may not block until c is persisted. The provided hints are used to assist in validation. Validation requires checking that all refs embedded in c are themselves valid, which could naively be done by resolving each one. Instead, hints provides a (smaller) set of refs that point to Chunks that themselves contain many of c's refs. Thus, by checking only the hinted Chunks, c can be validated with fewer read operations.
-	// c may or may not be persisted when Put() returns, but is guaranteed to be persistent after a call to Flush() or Close().
+	// SchedulePut enqueues a write for the Chunk c with the given refHeight.
+	// c must be visible to subsequent Get() calls upon return. Typically, the
+	// Value which was encoded to provide c can also be queried for its
+	// refHeight. The call may or may not block until c is persisted. The
+	// provided hints are used to assist in validation. Validation requires
+	// checking that all refs embedded in c are themselves valid, which could
+	// naively be done by resolving each one. Instead, hints provides a
+	// (smaller) set of refs that point to Chunks that themselves contain many
+	// of c's refs. Thus, by checking only the hinted Chunks, c can be
+	// validated with fewer read operations.
+	// c may or may not be persisted when SchedulePut() returns, but is
+	// guaranteed to be persistent after a call to Flush() or Close().
 	SchedulePut(c chunks.Chunk, refHeight uint64, hints Hints)
 
 	// AddHints allows additional hints, as used by SchedulePut, to be added for use in the current batch.

--- a/go/types/batch_store.go
+++ b/go/types/batch_store.go
@@ -31,7 +31,7 @@ type BatchStore interface {
 	// of c's refs. Thus, by checking only the hinted Chunks, c can be
 	// validated with fewer read operations.
 	// c may or may not be persisted when SchedulePut() returns, but is
-	// guaranteed to be persistent after a call to Flush() or Close().
+	// guaranteed to be persistent after a call to Flush() or UpdateRoot().
 	SchedulePut(c chunks.Chunk, refHeight uint64, hints Hints)
 
 	// AddHints allows additional hints, as used by SchedulePut, to be added for use in the current batch.


### PR DESCRIPTION
NBS benefits from related chunks being near one another. Initially,
let's use write-order as a proxy for "related".

This patch contains a pretty heinous hack to allow sync to continue
putting chunks into httpBatchStore top-down without breaking
server-side validation. Work to fix this is tracked in #2982

This patch fixes #2968, at least for now