### PR TITLE
Add new spec for nbs-aws

### DIFF
--- a/doc/spelling.md
+++ b/doc/spelling.md
@@ -16,6 +16,8 @@ The `path` part of the name is interpreted differently depending on the protocol
 - **ldb** specs describe a local [LevelDB](https://github.com/google/leveldb)-backed database. In this case, the path component should be a relative or absolute path on disk to a directory in which to store the LevelDB data. For example: `ldb:/tmp/noms-data`.
   - In Go, `ldb:` can be ommitted (just `/tmp/noms-data` will work).
 - **mem** specs describe an ephemeral memory-backed database. In this case, the path component is not used and must be empty.
+- **nbs** specs describe a local [Noms Block Store (NBS)](https://github.com/attic-labs/noms/tree/master/go/nbs)-backed database. In this case, the path component should be a relative or absolute path on disk to a directory in which to store the data, e.g. `nbs:/tmp/noms-data`.
+- **aws** specs describe a remote Noms Block Store backed directly by Amazon Web Services, specifically DynamoDB and S3. The format is a URI containing the names of the DynamoDB table to use, the S3 bucket to use, and the database to serve. For example: `aws://dynamo-table:s3-bucket/database`.
 
 ## Spelling Datasets
 
@@ -58,7 +60,7 @@ For example, if the `root` is a dataset, then one can use `.value` to get the ro
 ### Specifying Collection Values
 Elements of a Noms list, map, or set can be retrieved using brackets `[...]`.
 
-For example, if the dataset is a Noms map of number to struct then one could use `.value[42]` to get the Noms struct associated with the key 42. Similarly selecting the first element from a Noms list would be `.value[0]`. If the Noms map was keyed by string, then using `.value["0000024-02-999"]` would reference the Noms struct associated with key "0000024-02-999".  
+For example, if the dataset is a Noms map of number to struct then one could use `.value[42]` to get the Noms struct associated with the key 42. Similarly selecting the first element from a Noms list would be `.value[0]`. If the Noms map was keyed by string, then using `.value["0000024-02-999"]` would reference the Noms struct associated with key "0000024-02-999".
 
 Noms lists also support indexing from the back, using `.value[-1]` to mean the last element of a last, `.value[-2]` for the 2nd last, and so on.
 
@@ -83,7 +85,7 @@ https://localhost:8000/monkey::#o38hugtf3l1e8rqtj89mijj1dq57eh4m
 # “bonk” dataset at /foo/bar
 /foo/bar::bonk
 
-# from https://demo.noms.io/cli-tour, select the "sf-registered-business" dataset, 
+# from https://demo.noms.io/cli-tour, select the "sf-registered-business" dataset,
 # the root value is a Noms map, select the value of the Noms map identified by string
 # key "0000024-02-999", then from that resulting struct select the Ownership_Name field
 https://demo.noms.io/cli-tour::sf-registered-business.value["0000024-02-999"].Ownership_Name

--- a/go/chunks/dynamo_store.go
+++ b/go/chunks/dynamo_store.go
@@ -81,10 +81,8 @@ type DynamoStore struct {
 }
 
 // NewDynamoStore returns a new DynamoStore instance pointed at a DynamoDB table in the given region. All keys used to access items are prefixed with the given namespace.
-// Uses credential from the AWS config parameter.
-func NewDynamoStore(table, namespace string, config *aws.Config, showStats bool) *DynamoStore {
-	sess := session.New(config)
-
+// Uses credentials from the AWS session parameter.
+func NewDynamoStore(table, namespace string, sess *session.Session, showStats bool) *DynamoStore {
 	return newDynamoStoreFromDDBsvc(table, namespace, dynamodb.New(sess), showStats)
 }
 
@@ -537,7 +535,7 @@ func (f DynamoStoreFlags) CreateStore(ns string) ChunkStore {
 		if *f.awsKey != "" {
 			config = config.WithCredentials(credentials.NewStaticCredentials(*f.awsKey, *f.awsSecret, ""))
 		}
-		return NewDynamoStore(*f.dynamoTable, ns, config, *f.dynamoStats)
+		return NewDynamoStore(*f.dynamoTable, ns, session.Must(session.NewSession(config)), *f.dynamoStats)
 	}
 	return nil
 }

--- a/go/nbs/benchmarks/main.go
+++ b/go/nbs/benchmarks/main.go
@@ -93,7 +93,7 @@ func main() {
 			reset = func() { os.RemoveAll(dir); os.MkdirAll(dir, 0777) }
 
 		} else if *toAWS != "" {
-			sess := session.New(aws.NewConfig().WithRegion("us-west-2"))
+			sess := session.Must(session.NewSession(aws.NewConfig().WithRegion("us-west-2")))
 			open = func() blockStore {
 				return nbs.NewAWSStore(dynamoTable, *toAWS, s3Bucket, sess, bufSize)
 			}
@@ -118,7 +118,7 @@ func main() {
 		if *useNBS != "" {
 			open = func() blockStore { return nbs.NewLocalStore(*useNBS, bufSize) }
 		} else if *useAWS != "" {
-			sess := session.New(aws.NewConfig().WithRegion("us-west-2"))
+			sess := session.Must(session.NewSession(aws.NewConfig().WithRegion("us-west-2")))
 			open = func() blockStore {
 				return nbs.NewAWSStore(dynamoTable, *useAWS, s3Bucket, sess, bufSize)
 			}

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -167,8 +167,17 @@ func TestHref(t *testing.T) {
 	assert.Equal("https://my.example.com/foo/bar/baz", sp.Href())
 	sp, _ = ForDataset("https://my.example.com/foo/bar/baz::myds")
 	assert.Equal("https://my.example.com/foo/bar/baz", sp.Href())
+	sp, _ = ForDataset("https://my.example.com:8080/foo/bar/baz::myds")
+	assert.Equal("https://my.example.com:8080/foo/bar/baz", sp.Href())
 	sp, _ = ForPath("https://my.example.com/foo/bar/baz::myds.my.path")
 	assert.Equal("https://my.example.com/foo/bar/baz", sp.Href())
+
+	sp, _ = ForDatabase("aws://table/foo/bar/baz")
+	assert.Equal("aws://table/foo/bar/baz", sp.Href())
+	sp, _ = ForDataset("aws://table:bucket/foo/bar/baz::myds")
+	assert.Equal("aws://table:bucket/foo/bar/baz", sp.Href())
+	sp, _ = ForPath("aws://table:bucket/foo/bar/baz::myds.my.path")
+	assert.Equal("aws://table:bucket/foo/bar/baz", sp.Href())
 
 	sp, err := ForPath("mem::myds.my.path")
 	assert.NoError(err)
@@ -191,6 +200,9 @@ func TestForDatabase(t *testing.T) {
 		"random:",
 		"random:random",
 		"/file/ba:d",
+		"aws://t:b",
+		"aws://t",
+		"aws://t:",
 	}
 
 	for _, spec := range badSpecs {
@@ -220,6 +232,8 @@ func TestForDatabase(t *testing.T) {
 		{"http://0:0:0:0:0:ffff:c01e:fc9a", "http", "//0:0:0:0:0:ffff:c01e:fc9a"},
 		{"http://::ffff:c01e:fc9a", "http", "//::ffff:c01e:fc9a"},
 		{"http://::ffff::1e::9a", "http", "//::ffff::1e::9a"},
+		{"aws://table:bucket/db", "aws", "//table:bucket/db"},
+		{"aws://table/db", "aws", "//table/db"},
 	}
 
 	for _, tc := range testCases {
@@ -252,6 +266,7 @@ func TestForDataset(t *testing.T) {
 		"http://localhost:8000/one",
 		"ldb:",
 		"ldb:hello",
+		"aws://t:b/db",
 	}
 
 	for _, spec := range badSpecs {
@@ -292,6 +307,8 @@ func TestForDataset(t *testing.T) {
 		{"http://0:0:0:0:0:ffff:c01e:fc9a::foo", "http", "//0:0:0:0:0:ffff:c01e:fc9a", "foo"},
 		{"http://::ffff:c01e:fc9a::foo", "http", "//::ffff:c01e:fc9a", "foo"},
 		{"http://::ffff::1e::9a::foo", "http", "//::ffff::1e::9a", "foo"},
+		{"aws://table:bucket/db::ds", "aws", "//table:bucket/db", "ds"},
+		{"aws://table/db::ds", "aws", "//table/db", "ds"},
 	}
 
 	for _, tc := range testCases {
@@ -341,6 +358,8 @@ func TestForPath(t *testing.T) {
 		{"http://0:0:0:0:0:ffff:c01e:fc9a::foo[42].bar", "http", "//0:0:0:0:0:ffff:c01e:fc9a", "foo[42].bar"},
 		{"http://::ffff:c01e:fc9a::foo.foo", "http", "//::ffff:c01e:fc9a", "foo.foo"},
 		{"http://::ffff::1e::9a::hello[\"world\"]", "http", "//::ffff::1e::9a", "hello[\"world\"]"},
+		{"aws://table:bucket/db::foo.foo", "aws", "//table:bucket/db", "foo.foo"},
+		{"aws://table/db::foo.foo", "aws", "//table/db", "foo.foo"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The new spec is a URI, akin to what we use for HTTP It allows the
specification of a DynamoDB table, an S3 bucket, a database ID, and a
dataset ID: aws://table-name:bucket-name/database::dataset

The bucket name is optional and, if not provided, Noms will use a
ChunkStore implementation backed only by DynamoDB.