### PR TITLE
Js sequence refactor

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "65.4.1",
+  "version": "65.4.2",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/blob.js
+++ b/js/noms/src/blob.js
@@ -8,19 +8,18 @@ import * as Bytes from './bytes.js';
 import Collection from './collection.js';
 import RollingValueHasher from './rolling-value-hasher.js';
 import {default as SequenceChunker, chunkSequence} from './sequence-chunker.js';
-import type {EqualsFn} from './edit-distance.js';
 import type {ValueReader, ValueReadWriter} from './value-store.js';
 import type {makeChunkFn} from './sequence-chunker.js';
-import {IndexedSequence, newCursorAtIndex} from './indexed-sequence.js';
+import {newCursorAtIndex} from './indexed-sequence.js';
 import {Kind} from './noms-kind.js';
-import {OrderedKey, newIndexedMetaSequenceChunkFn} from './meta-sequence.js';
-import {SequenceCursor} from './sequence.js';
+import {newIndexedMetaSequenceChunkFn} from './meta-sequence.js';
+import Sequence, {OrderedKey, SequenceCursor} from './sequence.js';
 import {blobType} from './type.js';
 import {invariant} from './assert.js';
 import {hashValueByte} from './rolling-value-hasher.js';
 import type {WalkCallback} from './walk.js';
 
-export default class Blob extends Collection<IndexedSequence<any>> {
+export default class Blob extends Collection<Sequence<any>> {
   constructor(bytes: Uint8Array) {
     const chunker = new SequenceChunker(null, null, null, newBlobLeafChunkFn(null),
         newIndexedMetaSequenceChunkFn(Kind.Blob, null), blobHashValueBytes);
@@ -30,7 +29,6 @@ export default class Blob extends Collection<IndexedSequence<any>> {
     }
 
     const seq = chunker.doneSync();
-    invariant(seq instanceof IndexedSequence);
     super(seq);
   }
 
@@ -57,12 +55,12 @@ export default class Blob extends Collection<IndexedSequence<any>> {
 }
 
 export class BlobReader {
-  _sequence: IndexedSequence<any>;
-  _cursor: Promise<SequenceCursor<number, IndexedSequence<number>>>;
+  _sequence: Sequence<any>;
+  _cursor: Promise<SequenceCursor<number, Sequence<number>>>;
   _pos: number;
   _lock: string;
 
-  constructor(sequence: IndexedSequence<any>) {
+  constructor(sequence: Sequence<any>) {
     this._sequence = sequence;
     this._cursor = newCursorAtIndex(sequence, 0, true);
     this._pos = 0;
@@ -146,19 +144,10 @@ export class BlobReader {
   }
 }
 
-export class BlobLeafSequence extends IndexedSequence<number> {
+export class BlobLeafSequence extends Sequence<number> {
   constructor(vr: ?ValueReader, items: Uint8Array) {
     // $FlowIssue: The super class expects Array<T> but we sidestep that.
     super(vr, blobType, items);
-  }
-
-  cumulativeNumberOfLeaves(idx: number): number {
-    return idx + 1;
-  }
-
-  getCompareFn(other: IndexedSequence<any>): EqualsFn {
-    return (idx: number, otherIdx: number) =>
-      this.items[idx] === other.items[otherIdx];
   }
 }
 

--- a/js/noms/src/encoding-test.js
+++ b/js/noms/src/encoding-test.js
@@ -26,8 +26,8 @@ import {encodeValue, decodeValue} from './codec.js';
 import {equals} from './compare.js';
 import {invariant, notNull} from './assert.js';
 import {newStruct, newStructWithType} from './struct.js';
+import {OrderedKey} from './sequence.js';
 import {
-  OrderedKey,
   MetaTuple,
   newBlobMetaSequence,
   newListMetaSequence,

--- a/js/noms/src/indexed-sequence-diff.js
+++ b/js/noms/src/indexed-sequence-diff.js
@@ -7,17 +7,17 @@
 import type {Splice} from './edit-distance.js';
 import {calcSplices, SPLICE_ADDED, SPLICE_AT, SPLICE_FROM,
   SPLICE_REMOVED} from './edit-distance.js';
-import {getCompositeChildSequence, IndexedMetaSequence} from './meta-sequence.js';
+import {getCompositeChildSequence, MetaSequence} from './meta-sequence.js';
 import {invariant} from './assert.js';
-import type {IndexedSequence} from './indexed-sequence.js';
+import Sequence from './sequence.js';
 
-export function diff(last: IndexedSequence<any>, lastHeight: number, lastOffset: number,
-                     current: IndexedSequence<any>, currentHeight: number, currentOffset: number,
+export function diff(last: Sequence<any>, lastHeight: number, lastOffset: number,
+                     current: Sequence<any>, currentHeight: number, currentOffset: number,
                      maxSpliceMatrixSize: number): Promise<Array<Splice>> {
 
   if (lastHeight > currentHeight) {
     invariant(lastOffset === 0 && currentOffset === 0);
-    invariant(last instanceof IndexedMetaSequence);
+    invariant(last instanceof MetaSequence);
     return getCompositeChildSequence(last, 0, last.length).then(lastChild =>
         diff(lastChild, lastHeight - 1, lastOffset, current, currentHeight, currentOffset,
              maxSpliceMatrixSize));
@@ -25,7 +25,7 @@ export function diff(last: IndexedSequence<any>, lastHeight: number, lastOffset:
 
   if (currentHeight > lastHeight) {
     invariant(lastOffset === 0 && currentOffset === 0);
-    invariant(current instanceof IndexedMetaSequence);
+    invariant(current instanceof MetaSequence);
     return getCompositeChildSequence(current, 0, current.length).then(currentChild =>
         diff(last, lastHeight, lastOffset, currentChild, currentHeight - 1, currentOffset,
              maxSpliceMatrixSize));
@@ -82,7 +82,7 @@ export function diff(last: IndexedSequence<any>, lastHeight: number, lastOffset:
     }
 
     // Meta sequence splice which includes removed & added sub-sequences. Must recurse down.
-    invariant(last instanceof IndexedMetaSequence && current instanceof IndexedMetaSequence);
+    invariant(last instanceof MetaSequence && current instanceof MetaSequence);
     const lastChildP = getCompositeChildSequence(last, splice[SPLICE_AT], splice[SPLICE_REMOVED]);
     const currentChildP = getCompositeChildSequence(current, splice[SPLICE_FROM],
       splice[SPLICE_ADDED]);

--- a/js/noms/src/indexed-sequence-diff.js
+++ b/js/noms/src/indexed-sequence-diff.js
@@ -7,7 +7,7 @@
 import type {Splice} from './edit-distance.js';
 import {calcSplices, SPLICE_ADDED, SPLICE_AT, SPLICE_FROM,
   SPLICE_REMOVED} from './edit-distance.js';
-import {IndexedMetaSequence} from './meta-sequence.js';
+import {getCompositeChildSequence, IndexedMetaSequence} from './meta-sequence.js';
 import {invariant} from './assert.js';
 import type {IndexedSequence} from './indexed-sequence.js';
 
@@ -18,7 +18,7 @@ export function diff(last: IndexedSequence<any>, lastHeight: number, lastOffset:
   if (lastHeight > currentHeight) {
     invariant(lastOffset === 0 && currentOffset === 0);
     invariant(last instanceof IndexedMetaSequence);
-    return last.getCompositeChildSequence(0, last.length).then(lastChild =>
+    return getCompositeChildSequence(last, 0, last.length).then(lastChild =>
         diff(lastChild, lastHeight - 1, lastOffset, current, currentHeight, currentOffset,
              maxSpliceMatrixSize));
   }
@@ -26,7 +26,7 @@ export function diff(last: IndexedSequence<any>, lastHeight: number, lastOffset:
   if (currentHeight > lastHeight) {
     invariant(lastOffset === 0 && currentOffset === 0);
     invariant(current instanceof IndexedMetaSequence);
-    return current.getCompositeChildSequence(0, current.length).then(currentChild =>
+    return getCompositeChildSequence(current, 0, current.length).then(currentChild =>
         diff(last, lastHeight, lastOffset, currentChild, currentHeight - 1, currentOffset,
              maxSpliceMatrixSize));
   }
@@ -83,8 +83,8 @@ export function diff(last: IndexedSequence<any>, lastHeight: number, lastOffset:
 
     // Meta sequence splice which includes removed & added sub-sequences. Must recurse down.
     invariant(last instanceof IndexedMetaSequence && current instanceof IndexedMetaSequence);
-    const lastChildP = last.getCompositeChildSequence(splice[SPLICE_AT], splice[SPLICE_REMOVED]);
-    const currentChildP = current.getCompositeChildSequence(splice[SPLICE_FROM],
+    const lastChildP = getCompositeChildSequence(last, splice[SPLICE_AT], splice[SPLICE_REMOVED]);
+    const currentChildP = getCompositeChildSequence(current, splice[SPLICE_FROM],
       splice[SPLICE_ADDED]);
 
     let lastChildOffset = lastOffset;

--- a/js/noms/src/indexed-sequence.js
+++ b/js/noms/src/indexed-sequence.js
@@ -7,12 +7,10 @@
 import Sequence, {SequenceCursor} from './sequence.js';
 import search from './binary-search.js';
 import type {AsyncIteratorResult} from './async-iterator.js';
-import type {EqualsFn} from './edit-distance.js';
 import {AsyncIterator} from './async-iterator.js';
-import {equals} from './compare.js';
 import {notNull} from './assert.js';
 
-export async function newCursorAtIndex(sequence: IndexedSequence<any>, idx: number,
+export async function newCursorAtIndex(sequence: Sequence<any>, idx: number,
     readAhead: boolean = false): Promise<IndexedSequenceCursor<any>> {
   let cursor: ?IndexedSequenceCursor<any> = null;
 
@@ -25,19 +23,7 @@ export async function newCursorAtIndex(sequence: IndexedSequence<any>, idx: numb
   return notNull(cursor);
 }
 
-export class IndexedSequence<T> extends Sequence<T> {
-  cumulativeNumberOfLeaves(idx: number): number { // eslint-disable-line no-unused-vars
-    throw new Error('override');
-  }
-
-  getCompareFn(other: IndexedSequence<any>): EqualsFn {
-    return (idx: number, otherIdx: number) =>
-      // $FlowIssue: Does not realize that these are Values.
-      equals(this.items[idx], other.items[otherIdx]);
-  }
-}
-
-export class IndexedSequenceCursor<T> extends SequenceCursor<T, IndexedSequence<any>> {
+export class IndexedSequenceCursor<T> extends SequenceCursor<T, Sequence<any>> {
   advanceToOffset(idx: number): number {
     this.idx = search(this.length, (i: number) => idx < this.sequence.cumulativeNumberOfLeaves(i));
 

--- a/js/noms/src/indexed-sequence.js
+++ b/js/noms/src/indexed-sequence.js
@@ -35,11 +35,6 @@ export class IndexedSequence<T> extends Sequence<T> {
       // $FlowIssue: Does not realize that these are Values.
       equals(this.items[idx], other.items[otherIdx]);
   }
-
-
-  range(start: number, end: number): Promise<Array<T>> { // eslint-disable-line no-unused-vars
-    throw new Error('override');
-  }
 }
 
 export class IndexedSequenceCursor<T> extends SequenceCursor<T, IndexedSequence<any>> {

--- a/js/noms/src/list-test.js
+++ b/js/noms/src/list-test.js
@@ -40,13 +40,6 @@ import {IndexedMetaSequence} from './meta-sequence.js';
 const testListSize = 5000;
 const listOfNRef = 'tqpbqlu036sosdq9kg3lka7sjaklgslg';
 
-async function assertToJS(list: List<any>, nums: Array<any>, start: number = 0,
-    end: number = nums.length): Promise<void> {
-  const jsArray = await list.toJS(start, end);
-  const expect = nums.slice(start, end);
-  assert.deepEqual(expect, jsArray);
-}
-
 async function validateList(l: List<any>, values: number[]): Promise<void> {
   assert.isTrue(equals(new List(values), l));
   const out = [];
@@ -80,17 +73,6 @@ suite('List', () => {
 
     const v2 = new List(nn);
     assert.strictEqual(expectCount, chunkDiffCount(list, v2));
-  }
-
-  async function testToJS(expect: Array<any>, list: List<any>): Promise<void> {
-    const length = expect.length;
-    let start = 0;
-
-    for (let count = Math.round(length / 2); count > 2;) {
-      assert.deepEqual(expect.slice(start, start + count), await list.toJS(start, start + count));
-      start = start + count;
-      count = (length - start) / 2;
-    }
   }
 
   async function testGet(nums: Array<any>, list: List<any>): Promise<void> {
@@ -138,12 +120,11 @@ suite('List', () => {
     assertChunkCountAndType(expectChunkCount, makeRefType(tr), list);
 
     await testRoundTripAndValidate(list, async(v2) => {
-      await assertToJS(v2, nums);
+      await validateList(v2, nums);
     });
 
     await testForEach(nums, list);
     await testForEachAsyncCB(nums, list);
-    await testToJS(nums, list);
     await testGet(nums, list);
     await testPrependChunkDiff(nums, list, expectPrependChunkDiff);
     await testAppendChunkDiff(nums, list, expectAppendChunkDiff);
@@ -237,17 +218,15 @@ suite('List', () => {
     const db = new TestDatabase();
 
     const nums = intSequence(testListSize);
-    const s = new List(nums);
-    const r = db.writeValue(s).targetHash;
-    const s2 = await db.readValue(r);
-    const outNums = await s2.toJS();
-    assert.deepEqual(nums, outNums);
+    const l = new List(nums);
+    const r = db.writeValue(l).targetHash;
+    const l2 = await db.readValue(r);
+    validateList(l2, nums);
 
-    invariant(s2 instanceof List);
-    const s3 = await s2.splice(testListSize - 1, 1);
-    const outNums2 = await s3.toJS();
+    invariant(l2 instanceof List);
+    const l3 = await l2.splice(testListSize - 1, 1);
     nums.splice(testListSize - 1, 1);
-    assert.deepEqual(nums, outNums2);
+    validateList(l3, nums);
     await db.close();
   });
 });

--- a/js/noms/src/list-test.js
+++ b/js/noms/src/list-test.js
@@ -9,7 +9,7 @@ import {suite, setup, teardown, test} from 'mocha';
 
 import List, {ListWriter, ListLeafSequence, newListLeafSequence} from './list.js';
 import Ref from './ref.js';
-import {OrderedKey, MetaTuple, newListMetaSequence} from './meta-sequence.js';
+import {MetaSequence, MetaTuple, newListMetaSequence} from './meta-sequence.js';
 import {DEFAULT_MAX_SPLICE_MATRIX_SIZE, calcSplices} from './edit-distance.js';
 import {equals} from './compare.js';
 import {invariant, notNull} from './assert.js';
@@ -35,7 +35,7 @@ import {
   testRoundTripAndValidate,
 } from './test-util.js';
 import {TestDatabase} from './test-util.js';
-import {IndexedMetaSequence} from './meta-sequence.js';
+import {OrderedKey} from './sequence.js';
 
 const testListSize = 5000;
 const listOfNRef = 'tqpbqlu036sosdq9kg3lka7sjaklgslg';
@@ -696,6 +696,6 @@ suite('ListWriter', () => {
     }
 
     await t(15, ListLeafSequence);
-    await t(1500, IndexedMetaSequence);
+    await t(1500, MetaSequence);
   });
 });

--- a/js/noms/src/list.js
+++ b/js/noms/src/list.js
@@ -161,20 +161,6 @@ export default class List<T: Value> extends Collection<IndexedSequence<any>> {
   }
 
   /**
-   * Returns a new JS array with the same values as list.
-   */
-  // $FlowIssue: Flow doesn't understand this in default param expressions.
-  toJS(start: number = 0, end: number = this.length): Promise<Array<T>> {
-    const l = this.length;
-    start = clampIndex(start, l);
-    end = clampIndex(end, l);
-    if (start >= end) {
-      return Promise.resolve([]);
-    }
-    return this.sequence.range(start, end);
-  }
-
-  /**
    * The number of elements in the list.
    */
   get length(): number {
@@ -197,27 +183,11 @@ export class ListLeafSequence<T: Value> extends IndexedSequence<T> {
   cumulativeNumberOfLeaves(idx: number): number {
     return idx + 1;
   }
-
-  /**
-   * Returns an array of the values in the list.
-   */
-  range(start: number, end: number): Promise<Array<T>> {
-    invariant(start >= 0 && end >= 0 && end <= this.items.length);
-    return Promise.resolve(this.items.slice(start, end));
-  }
 }
 
 export function newListLeafSequence<T: Value>(vr: ?ValueReader, items: T[]): ListLeafSequence<T> {
   const t = makeListType(makeUnionType(items.map(getTypeOfValue)));
   return new ListLeafSequence(vr, t, items);
-}
-
-function clampIndex(idx: number, length: number): number {
-  if (idx > length) {
-    return length;
-  }
-
-  return idx < 0 ? Math.max(0, length + idx) : idx;
 }
 
 type ListWriterState = 'writable' | 'closed';

--- a/js/noms/src/map-test.js
+++ b/js/noms/src/map-test.js
@@ -27,10 +27,10 @@ import type Value from './value.js';
 import {invariant, notNull} from './assert.js';
 import List from './list.js';
 import Map, {MapLeafSequence} from './map.js';
-import {OrderedKey, MetaTuple, newMapMetaSequence} from './meta-sequence.js';
+import {MetaSequence, MetaTuple, newMapMetaSequence} from './meta-sequence.js';
 import type {ValueReadWriter} from './value-store.js';
 import {compare, equals} from './compare.js';
-import {OrderedMetaSequence} from './meta-sequence.js';
+import {OrderedKey} from './sequence.js';
 import {smallTestChunks, normalProductionChunks} from './rolling-value-hasher.js';
 import {
   makeMapType,
@@ -738,7 +738,7 @@ suite('CompoundMap', () => {
       smallTestChunks();
     }
 
-    await t(1000, OrderedMetaSequence);
+    await t(1000, MetaSequence);
   });
 
   test('compound map with values of every type', async () => {

--- a/js/noms/src/map.js
+++ b/js/noms/src/map.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import {invariant} from './assert.js';
 import Ref from './ref.js';
 import type {ValueReader} from './value-store.js';
 import type {makeChunkFn} from './sequence-chunker.js';
@@ -14,12 +13,9 @@ import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import Collection from './collection.js';
 import {compare, equals} from './compare.js';
 import {getTypeOfValue, makeMapType, makeUnionType} from './type.js';
+import Sequence, {OrderedKey} from './sequence.js';
+import {newOrderedMetaSequenceChunkFn} from './meta-sequence.js';
 import {
-  OrderedKey,
-  newOrderedMetaSequenceChunkFn,
-} from './meta-sequence.js';
-import {
-  OrderedSequence,
   OrderedSequenceCursor,
   OrderedSequenceIterator,
   newCursorAt,
@@ -82,14 +78,13 @@ function buildMapData<K: Value, V: Value>(
 }
 
 export default class Map<K: Value, V: Value> extends
-    Collection<OrderedSequence<any>> {
+    Collection<Sequence<any>> {
   constructor(kvs: Array<MapEntry<K, V>> = []) {
     const seq = chunkSequenceSync(
         buildMapData(kvs),
         newMapLeafChunkFn(null),
         newOrderedMetaSequenceChunkFn(Kind.Map, null),
         mapHashValueBytes);
-    invariant(seq instanceof OrderedSequence);
     super(seq);
   }
 
@@ -191,13 +186,12 @@ export default class Map<K: Value, V: Value> extends
   }
 }
 
-export class MapLeafSequence<K: Value, V: Value> extends
-    OrderedSequence<MapEntry<K, V>> {
+export class MapLeafSequence<K: Value, V: Value> extends Sequence<MapEntry<K, V>> {
   getKey(idx: number): OrderedKey<any> {
     return new OrderedKey(this.items[idx][KEY]);
   }
 
-  getCompareFn(other: OrderedSequence<any>): EqualsFn {
+  getCompareFn(other: Sequence<any>): EqualsFn {
     return (idx: number, otherIdx: number) =>
       equals(this.items[idx][KEY], other.items[otherIdx][KEY]) &&
       equals(this.items[idx][VALUE], other.items[otherIdx][VALUE]);

--- a/js/noms/src/map.js
+++ b/js/noms/src/map.js
@@ -22,6 +22,7 @@ import {
   OrderedSequence,
   OrderedSequenceCursor,
   OrderedSequenceIterator,
+  newCursorAt,
 } from './ordered-sequence.js';
 import diff from './ordered-sequence-diff.js';
 import {ValueBase} from './value.js';
@@ -101,7 +102,7 @@ export default class Map<K: Value, V: Value> extends
   }
 
   async _firstOrLast(last: boolean): Promise<?MapEntry<K, V>> {
-    const cursor = await this.sequence.newCursorAt(null, false, last, true);
+    const cursor = await newCursorAt(this.sequence, null, false, last, true);
     if (!cursor.valid) {
       return undefined;
     }
@@ -128,7 +129,7 @@ export default class Map<K: Value, V: Value> extends
   }
 
   async forEach(cb: (v: V, k: K) => ?Promise<any>): Promise<void> {
-    const cursor = await this.sequence.newCursorAt(null, false, false, true);
+    const cursor = await newCursorAt(this.sequence, null, false, false, true);
     const promises = [];
     await cursor.iter(entry => {
       promises.push(cb(entry[VALUE], entry[KEY]));
@@ -138,7 +139,7 @@ export default class Map<K: Value, V: Value> extends
   }
 
   iterator(): AsyncIterator<MapEntry<K, V>> {
-    return new OrderedSequenceIterator(this.sequence.newCursorAt(null, false, false, true));
+    return new OrderedSequenceIterator(newCursorAt(this.sequence, null, false, false, true));
   }
 
   iteratorAt(k: K): AsyncIterator<MapEntry<K, V>> {

--- a/js/noms/src/meta-sequence-test.js
+++ b/js/noms/src/meta-sequence-test.js
@@ -8,8 +8,8 @@ import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
 import List from './list.js';
+import {OrderedKey} from './sequence.js';
 import {
-  OrderedKey,
   MetaTuple,
   newOrderedMetaSequenceChunkFn,
   newIndexedMetaSequenceChunkFn,

--- a/js/noms/src/meta-sequence.js
+++ b/js/noms/src/meta-sequence.js
@@ -244,21 +244,21 @@ export class IndexedMetaSequence extends IndexedSequence<MetaTuple<any>> {
   }
 }
 
-export function newMapMetaSequence<K: Value>(vr: ?ValueReader,
-    tuples: Array<MetaTuple<any>>): OrderedMetaSequence<K> {
+export function newMapMetaSequence(vr: ?ValueReader,
+    tuples: Array<MetaTuple<any>>): OrderedMetaSequence {
   const kt = makeUnionType(tuples.map(mt => getCollectionTypes(mt)[0]));
   const vt = makeUnionType(tuples.map(mt => getCollectionTypes(mt)[1]));
   const t = makeMapType(kt, vt);
   return new OrderedMetaSequence(vr, t, tuples);
 }
 
-export function newSetMetaSequence<K: Value>(vr: ?ValueReader,
-    tuples: Array<MetaTuple<any>>): OrderedMetaSequence<K> {
+export function newSetMetaSequence(vr: ?ValueReader,
+    tuples: Array<MetaTuple<any>>): OrderedMetaSequence {
   const t = makeSetType(makeUnionType(tuples.map(mt => getCollectionTypes(mt)[0])));
   return new OrderedMetaSequence(vr, t, tuples);
 }
 
-export class OrderedMetaSequence<K: Value> extends OrderedSequence<K, MetaTuple<any>> {
+export class OrderedMetaSequence extends OrderedSequence<MetaTuple<any>> {
   _numLeaves: number;
 
   constructor(vr: ?ValueReader, t: Type<any>, items: Array<MetaTuple<any>>) {
@@ -300,7 +300,7 @@ export class OrderedMetaSequence<K: Value> extends OrderedSequence<K, MetaTuple<
     return this.items[idx].key;
   }
 
-  getCompareFn(other: OrderedSequence<any, any>): EqualsFn {
+  getCompareFn(other: OrderedSequence<any>): EqualsFn {
     return (idx: number, otherIdx: number) =>
       this.items[idx].ref.targetHash.equals(other.items[otherIdx].ref.targetHash);
   }
@@ -311,7 +311,7 @@ export function newOrderedMetaSequenceChunkFn(kind: NomsKind, vr: ?ValueReader)
   return (tuples: Array<MetaTuple<any>>) => {
     const numLeaves = tuples.reduce((l, mt) => l + mt.numLeaves, 0);
     const last = tuples[tuples.length - 1];
-    let seq: OrderedMetaSequence<any>;
+    let seq: OrderedMetaSequence;
     let col: Collection<any>;
     if (kind === Kind.Map) {
       seq = newMapMetaSequence(vr, tuples);

--- a/js/noms/src/noms.js
+++ b/js/noms/src/noms.js
@@ -36,8 +36,7 @@ export {isPrimitiveKind, Kind, kindToString} from './noms-kind.js';
 export {default as List, ListWriter, ListLeafSequence} from './list.js';
 export {default as Map, MapLeafSequence} from './map.js';
 export {default as Set, SetLeafSequence} from './set.js';
-export {IndexedSequence} from './indexed-sequence.js';
-export {OrderedMetaSequence, IndexedMetaSequence} from './meta-sequence.js';
+export {MetaSequence} from './meta-sequence.js';
 export {SPLICE_AT, SPLICE_REMOVED, SPLICE_ADDED, SPLICE_FROM} from './edit-distance.js';
 export {
   blobType,

--- a/js/noms/src/ordered-sequence-diff-test.js
+++ b/js/noms/src/ordered-sequence-diff-test.js
@@ -6,7 +6,8 @@
 
 import {suite, suiteSetup, suiteTeardown, test} from 'mocha';
 import {assert} from 'chai';
-import {MetaTuple, newSetMetaSequence, OrderedKey} from './meta-sequence.js';
+import {OrderedKey} from './sequence.js';
+import {MetaTuple, newSetMetaSequence} from './meta-sequence.js';
 import {default as diff, fastForward} from './ordered-sequence-diff.js';
 import {default as Set, newSetLeafSequence} from './set.js';
 import Ref from './ref.js';

--- a/js/noms/src/ordered-sequence-diff-test.js
+++ b/js/noms/src/ordered-sequence-diff-test.js
@@ -11,6 +11,7 @@ import {default as diff, fastForward} from './ordered-sequence-diff.js';
 import {default as Set, newSetLeafSequence} from './set.js';
 import Ref from './ref.js';
 import {smallTestChunks, normalProductionChunks} from './rolling-value-hasher.js';
+import {newCursorAt} from './ordered-sequence.js';
 
 suite('OrderedSequence', () => {
   suiteSetup(() => {
@@ -33,7 +34,7 @@ suite('OrderedSequence', () => {
     const newMetaSequenceCursor = nums => {
       const lst = new Set(nums);
       assert.isTrue(lst.sequence.isMeta);
-      return lst.sequence.newCursorAt();
+      return newCursorAt(lst.sequence);
     };
 
     {

--- a/js/noms/src/ordered-sequence-diff.js
+++ b/js/noms/src/ordered-sequence-diff.js
@@ -15,7 +15,7 @@ import type Value from './value.js'; // eslint-disable-line no-unused-vars
  * Returns a 3-tuple [added, removed, modified] sorted keys.
  */
 export default async function diff<K: Value, T>(
-    last: OrderedSequence<K, T>, current: OrderedSequence<K, T>): Promise<[K[], K[], K[]]> {
+    last: OrderedSequence<T>, current: OrderedSequence<T>): Promise<[K[], K[], K[]]> {
   // TODO: Construct the cursor at exactly the right position. There is no point reading in the
   // first chunk of each sequence if we're not going to use them. This needs for chunks (or at
   // least meta chunks) to encode their height.

--- a/js/noms/src/ordered-sequence-diff.js
+++ b/js/noms/src/ordered-sequence-diff.js
@@ -5,8 +5,8 @@
 // @flow
 
 import {invariant} from './assert.js';
-import {OrderedSequence, OrderedSequenceCursor, newCursorAt} from './ordered-sequence.js';
-import {SequenceCursor} from './sequence.js';
+import {OrderedSequenceCursor, newCursorAt} from './ordered-sequence.js';
+import Sequence, {SequenceCursor} from './sequence.js';
 import type Value from './value.js'; // eslint-disable-line no-unused-vars
 
 // TODO: Expose an iteration API.
@@ -15,7 +15,7 @@ import type Value from './value.js'; // eslint-disable-line no-unused-vars
  * Returns a 3-tuple [added, removed, modified] sorted keys.
  */
 export default async function diff<K: Value, T>(
-    last: OrderedSequence<T>, current: OrderedSequence<T>): Promise<[K[], K[], K[]]> {
+    last: Sequence<T>, current: Sequence<T>): Promise<[K[], K[], K[]]> {
   // TODO: Construct the cursor at exactly the right position. There is no point reading in the
   // first chunk of each sequence if we're not going to use them. This needs for chunks (or at
   // least meta chunks) to encode their height.

--- a/js/noms/src/ordered-sequence-diff.js
+++ b/js/noms/src/ordered-sequence-diff.js
@@ -5,7 +5,7 @@
 // @flow
 
 import {invariant} from './assert.js';
-import {OrderedSequence, OrderedSequenceCursor} from './ordered-sequence.js';
+import {OrderedSequence, OrderedSequenceCursor, newCursorAt} from './ordered-sequence.js';
 import {SequenceCursor} from './sequence.js';
 import type Value from './value.js'; // eslint-disable-line no-unused-vars
 
@@ -20,7 +20,7 @@ export default async function diff<K: Value, T>(
   // first chunk of each sequence if we're not going to use them. This needs for chunks (or at
   // least meta chunks) to encode their height.
   // See https://github.com/attic-labs/noms/issues/1219.
-  const [lastCur, currentCur] = await Promise.all([last.newCursorAt(), current.newCursorAt()]);
+  const [lastCur, currentCur] = await Promise.all([newCursorAt(last), newCursorAt(current)]);
   const [added, removed, modified] = [[], [], []];
 
   while (lastCur.valid && currentCur.valid) {

--- a/js/noms/src/ordered-sequence.js
+++ b/js/noms/src/ordered-sequence.js
@@ -13,13 +13,25 @@ import search from './binary-search.js';
 import type {EqualsFn} from './edit-distance.js';
 import Sequence, {SequenceCursor} from './sequence.js';
 
+// See newCursorAt().
+export function newCursorAtValue<T>(sequence: OrderedSequence<T>, val: ?Value,
+    forInsertion: boolean = false, last: boolean = false, readAhead: boolean = false)
+    : Promise<OrderedSequenceCursor<any, any>> {
+  let key;
+  if (val !== null && val !== undefined) {
+    key = new OrderedKey(val);
+  }
+  return newCursorAt(sequence, key, forInsertion, last, readAhead);
+}
+
+
 // Returns:
 //   -null, if sequence is empty.
 //   -null, if all values in sequence are < key.
 //   -cursor positioned at
 //      -first value, if |key| is null
 //      -first value >= |key|
-export async function newCursorAt<K: Value, T>(sequence: ?OrderedSequence<K, T>,
+export async function newCursorAt<T>(sequence: ?OrderedSequence<T>,
     key: ?OrderedKey<any>, forInsertion: boolean = false, last: boolean = false,
     readAhead: boolean = false): Promise<OrderedSequenceCursor<any, any>> {
   let cursor: ?OrderedSequenceCursor<any, any> = null;
@@ -39,20 +51,7 @@ export async function newCursorAt<K: Value, T>(sequence: ?OrderedSequence<K, T>,
   return notNull(cursor);
 }
 
-
-
-export class OrderedSequence<K: Value, T> extends Sequence<T> {
-  // See newCursorAt().
-  newCursorAtValue(val: ?K, forInsertion: boolean = false, last: boolean = false,
-                   readAhead: boolean = false)
-      : Promise<OrderedSequenceCursor<any, any>> {
-    let key;
-    if (val !== null && val !== undefined) {
-      key = new OrderedKey(val);
-    }
-    return newCursorAt(this, key, forInsertion, last, readAhead);
-  }
-
+export class OrderedSequence<T> extends Sequence<T> {
   /**
    * Gets the key used for ordering the sequence at index |idx|.
    */
@@ -60,13 +59,13 @@ export class OrderedSequence<K: Value, T> extends Sequence<T> {
     throw new Error('override');
   }
 
-  getCompareFn(other: OrderedSequence<any, any>): EqualsFn { // eslint-disable-line no-unused-vars
+  getCompareFn(other: OrderedSequence<any>): EqualsFn { // eslint-disable-line no-unused-vars
     throw new Error('override');
   }
 }
 
 export class OrderedSequenceCursor<T, K: Value> extends
-    SequenceCursor<T, OrderedSequence<any, any>> {
+    SequenceCursor<T, OrderedSequence<any>> {
   getCurrentKey(): OrderedKey<any> {
     invariant(this.idx >= 0 && this.idx < this.length);
     return this.sequence.getKey(this.idx);

--- a/js/noms/src/ordered-sequence.js
+++ b/js/noms/src/ordered-sequence.js
@@ -6,15 +6,14 @@
 
 import {AsyncIterator} from './async-iterator.js';
 import type {AsyncIteratorResult} from './async-iterator.js';
-import {OrderedKey} from './meta-sequence.js';
+import {OrderedKey} from './sequence.js';
 import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import {invariant, notNull} from './assert.js';
 import search from './binary-search.js';
-import type {EqualsFn} from './edit-distance.js';
 import Sequence, {SequenceCursor} from './sequence.js';
 
 // See newCursorAt().
-export function newCursorAtValue<T>(sequence: OrderedSequence<T>, val: ?Value,
+export function newCursorAtValue<T>(sequence: Sequence<T>, val: ?Value,
     forInsertion: boolean = false, last: boolean = false, readAhead: boolean = false)
     : Promise<OrderedSequenceCursor<any, any>> {
   let key;
@@ -31,7 +30,7 @@ export function newCursorAtValue<T>(sequence: OrderedSequence<T>, val: ?Value,
 //   -cursor positioned at
 //      -first value, if |key| is null
 //      -first value >= |key|
-export async function newCursorAt<T>(sequence: ?OrderedSequence<T>,
+export async function newCursorAt<T>(sequence: ?Sequence<T>,
     key: ?OrderedKey<any>, forInsertion: boolean = false, last: boolean = false,
     readAhead: boolean = false): Promise<OrderedSequenceCursor<any, any>> {
   let cursor: ?OrderedSequenceCursor<any, any> = null;
@@ -51,21 +50,8 @@ export async function newCursorAt<T>(sequence: ?OrderedSequence<T>,
   return notNull(cursor);
 }
 
-export class OrderedSequence<T> extends Sequence<T> {
-  /**
-   * Gets the key used for ordering the sequence at index |idx|.
-   */
-  getKey(idx: number): OrderedKey<any> { // eslint-disable-line no-unused-vars
-    throw new Error('override');
-  }
-
-  getCompareFn(other: OrderedSequence<any>): EqualsFn { // eslint-disable-line no-unused-vars
-    throw new Error('override');
-  }
-}
-
 export class OrderedSequenceCursor<T, K: Value> extends
-    SequenceCursor<T, OrderedSequence<any>> {
+    SequenceCursor<T, Sequence<any>> {
   getCurrentKey(): OrderedKey<any> {
     invariant(this.idx >= 0 && this.idx < this.length);
     return this.sequence.getKey(this.idx);

--- a/js/noms/src/path.js
+++ b/js/noms/src/path.js
@@ -11,8 +11,8 @@ import {Kind} from './noms-kind.js';
 import List from './list.js';
 import Map from './map.js';
 import Set from './set.js';
-import {OrderedKey} from './meta-sequence.js';
-import {OrderedSequence, newCursorAt} from './ordered-sequence.js';
+import Sequence, {OrderedKey} from './sequence.js';
+import {newCursorAt} from './ordered-sequence.js';
 import {fieldNameComponentRe} from './struct.js';
 import {getTypeOfValue, StructDesc} from './type.js';
 
@@ -344,7 +344,7 @@ export class HashIndexPath {
   }
 
   async resolve(value: Value): Promise<Value | null> {
-    let seq: OrderedSequence<any>;
+    let seq: Sequence<any>;
     let getCurrentValue; // (cur: sequenceCursor): Value
 
     if (value instanceof Set) {

--- a/js/noms/src/path.js
+++ b/js/noms/src/path.js
@@ -12,7 +12,7 @@ import List from './list.js';
 import Map from './map.js';
 import Set from './set.js';
 import {OrderedKey} from './meta-sequence.js';
-import {OrderedSequence} from './ordered-sequence.js';
+import {OrderedSequence, newCursorAt} from './ordered-sequence.js';
 import {fieldNameComponentRe} from './struct.js';
 import {getTypeOfValue, StructDesc} from './type.js';
 
@@ -363,7 +363,7 @@ export class HashIndexPath {
       return null;
     }
 
-    const cur = await seq.newCursorAt(OrderedKey.fromHash(this.hash));
+    const cur = await newCursorAt(seq, OrderedKey.fromHash(this.hash));
     if (!cur.valid) {
       return null;
     }

--- a/js/noms/src/path.js
+++ b/js/noms/src/path.js
@@ -344,7 +344,7 @@ export class HashIndexPath {
   }
 
   async resolve(value: Value): Promise<Value | null> {
-    let seq: OrderedSequence<any, any>;
+    let seq: OrderedSequence<any>;
     let getCurrentValue; // (cur: sequenceCursor): Value
 
     if (value instanceof Set) {

--- a/js/noms/src/sequence-chunker.js
+++ b/js/noms/src/sequence-chunker.js
@@ -4,8 +4,8 @@
 
 // @flow
 
-import type Sequence from './sequence.js'; // eslint-disable-line no-unused-vars
-import type {MetaSequence, OrderedKey} from './meta-sequence.js';
+import type Sequence, {OrderedKey} from './sequence.js'; // eslint-disable-line no-unused-vars
+import type {MetaSequence} from './meta-sequence.js';
 import {metaHashValueBytes, MetaTuple} from './meta-sequence.js';
 import type {SequenceCursor} from './sequence.js';
 import type {ValueReader, ValueWriter} from './value-store.js';
@@ -25,7 +25,7 @@ export async function chunkSequence<T, S: Sequence<T>>(
     insert: Array<T>,
     remove: number,
     makeChunk: makeChunkFn<T, S>,
-    parentMakeChunk: makeChunkFn<MetaTuple<any>, MetaSequence<any>>,
+    parentMakeChunk: makeChunkFn<MetaTuple<any>, MetaSequence>,
     hashValueBytes: hashValueBytesFn<any>): Promise<Sequence<any>> {
 
   const chunker = new SequenceChunker(cursor, vr, null, makeChunk, parentMakeChunk, hashValueBytes);
@@ -51,7 +51,7 @@ export async function chunkSequence<T, S: Sequence<T>>(
 export function chunkSequenceSync<T, S: Sequence<T>>(
     insert: Array<T>,
     makeChunk: makeChunkFn<T, S>,
-    parentMakeChunk: makeChunkFn<MetaTuple<any>, MetaSequence<any>>,
+    parentMakeChunk: makeChunkFn<MetaTuple<any>, MetaSequence>,
     hashValueBytes: hashValueBytesFn<any>): Sequence<any> {
 
   const chunker = new SequenceChunker(null, null, null, makeChunk, parentMakeChunk, hashValueBytes);
@@ -65,10 +65,10 @@ export default class SequenceChunker<T, S: Sequence<T>> {
   _cursor: ?SequenceCursor<T, S>;
   _vr: ?ValueReader;
   _vw: ?ValueWriter;
-  _parent: ?SequenceChunker<MetaTuple<any>, MetaSequence<any>>;
+  _parent: ?SequenceChunker<MetaTuple<any>, MetaSequence>;
   _current: Array<T>;
   _makeChunk: makeChunkFn<T, S>;
-  _parentMakeChunk: makeChunkFn<MetaTuple<any>, MetaSequence<any>>;
+  _parentMakeChunk: makeChunkFn<MetaTuple<any>, MetaSequence>;
   _isLeaf: boolean;
   _hashValueBytes: hashValueBytesFn<any>;
   _rv: RollingValueHasher;

--- a/js/noms/src/sequence.js
+++ b/js/noms/src/sequence.js
@@ -16,6 +16,11 @@ import type Value from './value.js'; // eslint-disable-line no-unused-vars
 import Hash from './hash.js';
 import {compare, equals} from './compare.js';
 
+// Sequence<T> is the base class of all prolly-tree nodes. It represents a sequence of "values"
+// which are grouped together and defined by the output of a rolling hash value as a result of
+// chunking. In this context, |T| need not be a `Value` type. In the case of non-leaf prolly-tree
+// levels, it will be a |MetaTuple|, and in the case of a Map leaf sequence, it will be a
+// |MapEntry|.
 export default class Sequence<T> {
   vr: ?ValueReader;
   _type: Type<any>;

--- a/js/noms/src/sequence.js
+++ b/js/noms/src/sequence.js
@@ -11,6 +11,10 @@ import type {AsyncIteratorResult} from './async-iterator.js';
 import Ref from './ref.js';
 import type {Type} from './type.js';
 import {ValueBase} from './value.js';
+import type {EqualsFn} from './edit-distance.js';
+import type Value from './value.js'; // eslint-disable-line no-unused-vars
+import Hash from './hash.js';
+import {compare, equals} from './compare.js';
 
 export default class Sequence<T> {
   vr: ?ValueReader;
@@ -47,8 +51,28 @@ export default class Sequence<T> {
     return null;
   }
 
+  getKey(idx: number): OrderedKey<any> {
+    // $FlowIssue: getKey will be overridden if items isn't a value.
+    return new OrderedKey(this.items[idx]);
+  }
+
+  getCompareFn(other: Sequence<T>): EqualsFn {
+    // $FlowIssue: getKey will be overridden if items isn't a value.
+    return (idx: number, otherIdx: number) => equals(this.items[idx], other.items[otherIdx]);
+  }
+
+  cumulativeNumberOfLeaves(idx: number): number {
+    return idx + 1;
+  }
+
   get chunks(): Array<Ref<any>> {
-    return [];
+    const chunks = [];
+    for (const item of this.items) {
+      if (item instanceof ValueBase) {
+        chunks.push(...item.chunks);
+      }
+    }
+    return chunks;
   }
 
   get length(): number {
@@ -281,12 +305,49 @@ export class SequenceIterator<T, S: Sequence<any>> extends AsyncIterator<T> {
   }
 }
 
-export function getValueChunks<T>(items: Array<T>): Array<Ref<any>> {
-  const chunks = [];
-  for (const item of items) {
-    if (item instanceof ValueBase) {
-      chunks.push(...item.chunks);
+export class OrderedKey<T: Value> {
+  isOrderedByValue: boolean;
+  v: ?T;
+  h: ?Hash;
+
+  constructor(v: T) {
+    this.v = v;
+    if (v instanceof ValueBase) {
+      this.isOrderedByValue = false;
+      this.h = v.hash;
+    } else {
+      this.isOrderedByValue = true;
+      this.h = null;
     }
   }
-  return chunks;
+
+  static fromHash(h: Hash): OrderedKey<any> {
+    const k = Object.create(this.prototype);
+    k.isOrderedByValue = false;
+    k.v = null;
+    k.h = h;
+    return k;
+  }
+
+  value(): T {
+    return notNull(this.v);
+  }
+
+  numberValue(): number {
+    invariant(typeof this.v === 'number');
+    return this.v;
+  }
+
+  compare(other: OrderedKey<any>): number {
+    if (this.isOrderedByValue && other.isOrderedByValue) {
+      return compare(notNull(this.v), notNull(other.v));
+    }
+    if (this.isOrderedByValue) {
+      return -1;
+    }
+    if (other.isOrderedByValue) {
+      return 1;
+    }
+    return notNull(this.h).compare(notNull(other.h));
+  }
 }

--- a/js/noms/src/set-test.js
+++ b/js/noms/src/set-test.js
@@ -10,7 +10,7 @@ import {suite, setup, teardown, test} from 'mocha';
 import Ref from './ref.js';
 import Set, {SetLeafSequence} from './set.js';
 import type {ValueReadWriter} from './value-store.js';
-import {OrderedKey, MetaTuple, newSetMetaSequence} from './meta-sequence.js';
+import {MetaSequence, MetaTuple, newSetMetaSequence} from './meta-sequence.js';
 import {compare, equals} from './compare.js';
 import {
   assertChunkCountAndType,
@@ -27,7 +27,7 @@ import {getTypeOfValue} from './type.js';
 import type Value from './value.js';
 import {invariant, notNull} from './assert.js';
 import {newStruct} from './struct.js';
-import {OrderedMetaSequence} from './meta-sequence.js';
+import {OrderedKey} from './sequence.js';
 import {smallTestChunks, normalProductionChunks} from './rolling-value-hasher.js';
 import {
   makeRefType,
@@ -650,7 +650,7 @@ suite('CompoundSet', () => {
     }
 
     await t(10, SetLeafSequence);
-    await t(2000, OrderedMetaSequence);
+    await t(2000, MetaSequence);
   });
 
   test('Remove last when not loaded', async () => {

--- a/js/noms/src/set.js
+++ b/js/noms/src/set.js
@@ -17,7 +17,7 @@ import {
   OrderedKey,
   newOrderedMetaSequenceChunkFn,
 } from './meta-sequence.js';
-import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator} from
+import {OrderedSequence, OrderedSequenceCursor, OrderedSequenceIterator, newCursorAt} from
   './ordered-sequence.js';
 import diff from './ordered-sequence-diff.js';
 import {makeSetType, makeUnionType, getTypeOfValue} from './type.js';
@@ -71,7 +71,7 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any, any>>
   }
 
   async _firstOrLast(last: boolean): Promise<?T> {
-    const cursor = await this.sequence.newCursorAt(null, false, last);
+    const cursor = await newCursorAt(this.sequence, null, false, last);
     return cursor.valid ? cursor.getCurrent() : null;
   }
 
@@ -84,7 +84,7 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any, any>>
   }
 
   async forEach(cb: (v: T) => ?Promise<any>): Promise<void> {
-    const cursor = await this.sequence.newCursorAt(null, false, false, true);
+    const cursor = await newCursorAt(this.sequence, null, false, false, true);
     const promises = [];
     await cursor.iter(v => {
       promises.push(cb(v));
@@ -94,7 +94,7 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any, any>>
   }
 
   iterator(): AsyncIterator<T> {
-    return new OrderedSequenceIterator(this.sequence.newCursorAt(null, false, false, true));
+    return new OrderedSequenceIterator(newCursorAt(this.sequence, null, false, false, true));
   }
 
   iteratorAt(v: T): AsyncIterator<T> {
@@ -129,7 +129,7 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any, any>>
 
   // TODO: Find some way to return a Set.
   async map<S>(cb: (v: T) => (Promise<S> | S)): Promise<Array<S>> {
-    const cursor = await this.sequence.newCursorAt(null);
+    const cursor = await newCursorAt(this.sequence, null);
     const values = [];
     await cursor.iter(v => {
       values.push(cb(v));

--- a/js/noms/src/set.js
+++ b/js/noms/src/set.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import Ref from './ref.js';
 import type {ValueReader} from './value-store.js';
 import type {makeChunkFn} from './sequence-chunker.js';
 import type Value from './value.js'; // eslint-disable-line no-unused-vars
@@ -13,12 +12,11 @@ import {chunkSequence, chunkSequenceSync} from './sequence-chunker.js';
 import Collection from './collection.js';
 import {compare, equals} from './compare.js';
 import {invariant} from './assert.js';
+import Sequence, {OrderedKey} from './sequence.js';
 import {
-  OrderedKey,
   newOrderedMetaSequenceChunkFn,
 } from './meta-sequence.js';
 import {
-  OrderedSequence,
   OrderedSequenceCursor,
   OrderedSequenceIterator,
   newCursorAt,
@@ -27,9 +25,7 @@ import {
 import diff from './ordered-sequence-diff.js';
 import {makeSetType, makeUnionType, getTypeOfValue} from './type.js';
 import {removeDuplicateFromOrdered} from './map.js';
-import {getValueChunks} from './sequence.js';
 import {Kind} from './noms-kind.js';
-import type {EqualsFn} from './edit-distance.js';
 import {hashValueBytes} from './rolling-value-hasher.js';
 import walk from './walk.js';
 import type {WalkCallback} from './walk.js';
@@ -55,14 +51,13 @@ export function newSetLeafSequence<K: Value>(
   return new SetLeafSequence(vr, t, items);
 }
 
-export default class Set<T: Value> extends Collection<OrderedSequence<any>> {
+export default class Set<T: Value> extends Collection<Sequence<any>> {
   constructor(values: Array<T> = []) {
     const seq = chunkSequenceSync(
         buildSetData(values),
         newSetLeafChunkFn(null),
         newOrderedMetaSequenceChunkFn(Kind.Set, null),
         hashValueBytes);
-    invariant(seq instanceof OrderedSequence);
     super(seq);
   }
 
@@ -159,17 +154,4 @@ export default class Set<T: Value> extends Collection<OrderedSequence<any>> {
   }
 }
 
-export class SetLeafSequence<K: Value> extends OrderedSequence<K> {
-  getKey(idx: number): OrderedKey<any> {
-    return new OrderedKey(this.items[idx]);
-  }
-
-  getCompareFn(other: OrderedSequence<any>): EqualsFn {
-    return (idx: number, otherIdx: number) =>
-      equals(this.items[idx], other.items[otherIdx]);
-  }
-
-  get chunks(): Array<Ref<any>> {
-    return getValueChunks(this.items);
-  }
-}
+export class SetLeafSequence<K: Value> extends Sequence<K> {}

--- a/js/noms/src/value-decoder.js
+++ b/js/noms/src/value-decoder.js
@@ -14,13 +14,14 @@ import {
   StructDesc,
   Type,
 } from './type.js';
-import {OrderedKey, MetaTuple} from './meta-sequence.js';
+import {OrderedKey} from './sequence.js';
+import {MetaTuple} from './meta-sequence.js';
 import {invariant, notNull} from './assert.js';
 import {kindToString, Kind} from './noms-kind.js';
 import List, {ListLeafSequence} from './list.js';
 import Map, {MapLeafSequence} from './map.js';
 import Set, {SetLeafSequence} from './set.js';
-import {IndexedMetaSequence, OrderedMetaSequence} from './meta-sequence.js';
+import {MetaSequence} from './meta-sequence.js';
 import type Value from './value.js';
 import type {ValueReader} from './value-store.js';
 import type {NomsReader} from './codec.js';
@@ -114,7 +115,7 @@ export default class ValueDecoder {
     return new MapLeafSequence(this._ds, t, data);
   }
 
-  readMetaSequence(): Array<MetaTuple<any>> {
+  readMetaSequence(t: Type<any>): MetaSequence {
     const count = this._r.readUint32();
 
     const data: Array<MetaTuple<any>> = [];
@@ -126,15 +127,7 @@ export default class ValueDecoder {
       data.push(new MetaTuple(ref, key, numLeaves, null));
     }
 
-    return data;
-  }
-
-  readIndexedMetaSequence(t: Type<any>): IndexedMetaSequence {
-    return new IndexedMetaSequence(this._ds, t, this.readMetaSequence());
-  }
-
-  readOrderedMetaSequence(t: Type<any>): OrderedMetaSequence {
-    return new OrderedMetaSequence(this._ds, t, this.readMetaSequence());
+    return new MetaSequence(this._ds, t, data);
   }
 
   readValue(): any {
@@ -143,7 +136,7 @@ export default class ValueDecoder {
       case Kind.Blob: {
         const isMeta = this._r.readBool();
         if (isMeta) {
-          return Blob.fromSequence(this.readIndexedMetaSequence(t));
+          return Blob.fromSequence(this.readMetaSequence(t));
         }
 
         return Blob.fromSequence(this.readBlobLeafSequence());
@@ -157,14 +150,14 @@ export default class ValueDecoder {
       case Kind.List: {
         const isMeta = this._r.readBool();
         if (isMeta) {
-          return List.fromSequence(this.readIndexedMetaSequence(t));
+          return List.fromSequence(this.readMetaSequence(t));
         }
         return List.fromSequence(this.readListLeafSequence(t));
       }
       case Kind.Map: {
         const isMeta = this._r.readBool();
         if (isMeta) {
-          return Map.fromSequence(this.readOrderedMetaSequence(t));
+          return Map.fromSequence(this.readMetaSequence(t));
         }
         return Map.fromSequence(this.readMapLeafSequence(t));
       }
@@ -173,7 +166,7 @@ export default class ValueDecoder {
       case Kind.Set: {
         const isMeta = this._r.readBool();
         if (isMeta) {
-          return Set.fromSequence(this.readOrderedMetaSequence(t));
+          return Set.fromSequence(this.readMetaSequence(t));
         }
         return Set.fromSequence(this.readSetLeafSequence(t));
       }

--- a/js/noms/src/value-decoder.js
+++ b/js/noms/src/value-decoder.js
@@ -133,7 +133,7 @@ export default class ValueDecoder {
     return new IndexedMetaSequence(this._ds, t, this.readMetaSequence());
   }
 
-  readOrderedMetaSequence(t: Type<any>): OrderedMetaSequence<any> {
+  readOrderedMetaSequence(t: Type<any>): OrderedMetaSequence {
     return new OrderedMetaSequence(this._ds, t, this.readMetaSequence());
   }
 

--- a/samples/js/splore/src/main.js
+++ b/samples/js/splore/src/main.js
@@ -103,7 +103,7 @@ function formatKeyString(v: any): string {
 function handleChunkLoad(hash: Hash, val: any, fromHash: ?string) {
   let counter = 0;
 
-  function processMetaSequence(id, sequence: IndexedMetaSequence | OrderedMetaSequence<any>,
+  function processMetaSequence(id, sequence: IndexedMetaSequence | OrderedMetaSequence,
                                name: string) {
     data.nodes[id] = {name: name};
     sequence.items.forEach(tuple => {

--- a/samples/js/splore/src/main.js
+++ b/samples/js/splore/src/main.js
@@ -15,12 +15,11 @@ import {
   emptyHash,
   getHashOfValue,
   Hash,
-  IndexedMetaSequence,
   invariant,
   kindToString,
   List,
   Map,
-  OrderedMetaSequence,
+  MetaSequence,
   Ref,
   Set,
   Spec,
@@ -103,7 +102,7 @@ function formatKeyString(v: any): string {
 function handleChunkLoad(hash: Hash, val: any, fromHash: ?string) {
   let counter = 0;
 
-  function processMetaSequence(id, sequence: IndexedMetaSequence | OrderedMetaSequence,
+  function processMetaSequence(id, sequence: MetaSequence,
                                name: string) {
     data.nodes[id] = {name: name};
     sequence.items.forEach(tuple => {
@@ -148,7 +147,7 @@ function handleChunkLoad(hash: Hash, val: any, fromHash: ?string) {
       const {sequence} = val;
       const ks = kindToString(val.type.kind);
       const size = getSize(val);
-      if (sequence instanceof IndexedMetaSequence || sequence instanceof OrderedMetaSequence) {
+      if (sequence instanceof MetaSequence) {
         const name = `${ks}Node (${size})`;
         processMetaSequence(id, sequence, name);
       } else {


### PR DESCRIPTION
Fixes #2904 and lays some ground work for lazy sequence decoding.

In particular, removes `IndexedSequence` and `OrderedSequence`. What remain are `MetaSequence` and each of the leaf sequences which directly inherit from `Sequence`.

