### PR TITLE
[NBS] Implement Streaming GetMany

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -11,14 +11,16 @@ import (
 	"github.com/attic-labs/noms/go/hash"
 )
 
-// ChunkStore is the core storage abstraction in noms. We can put data anyplace we have a ChunkStore implementation for.
+// ChunkStore is the core storage abstraction in noms. We can put data anyplace we have a
+// ChunkStore implementation for.
 type ChunkStore interface {
 	ChunkSource
 	ChunkSink
 	RootTracker
 }
 
-// Factory allows the creation of namespaced ChunkStore instances. The details of how namespaces are separated is left up to the particular implementation of Factory and ChunkStore.
+// Factory allows the creation of namespaced ChunkStore instances. The details of how namespaces
+// are separated is left up to the particular implementation of Factory and ChunkStore.
 type Factory interface {
 	CreateStore(ns string) ChunkStore
 
@@ -26,7 +28,10 @@ type Factory interface {
 	Shutter()
 }
 
-// RootTracker allows querying and management of the root of an entire tree of references. The "root" is the single mutable variable in a ChunkStore. It can store any hash, but it is typically used by higher layers (such as Database) to store a hash to a value that represents the current state and entire history of a database.
+// RootTracker allows querying and management of the root of an entire tree of references. The
+// "root" is the single mutable variable in a ChunkStore. It can store any hash, but it is
+// typically used by higher layers (such as Database) to store a hash to a value that represents
+// the current state and entire history of a database.
 type RootTracker interface {
 	Root() hash.Hash
 	UpdateRoot(current, last hash.Hash) bool
@@ -34,11 +39,12 @@ type RootTracker interface {
 
 // ChunkSource is a place to get chunks from.
 type ChunkSource interface {
-	// Get the Chunk for the value of the hash in the store. If the hash is absent from the store nil is returned.
+	// Get the Chunk for the value of the hash in the store. If the hash is absent from the store nil
+	// is returned.
 	Get(h hash.Hash) Chunk
 
-	// On return, |foundChunks| will have been fully sent all chunks which have been found and the
-	// channel will be closed.
+	// On return, |foundChunks| will have been fully sent all chunks which have been found. Any
+	// non-present chunks will silently be ignored.
 	GetMany(hashes hash.HashSet, foundChunks chan *Chunk)
 
 	// Returns true iff the value at the address |h| is contained in the source
@@ -53,7 +59,8 @@ type ChunkSink interface {
 	// Put writes c into the ChunkSink, blocking until the operation is complete.
 	Put(c Chunk)
 
-	// PutMany tries to write chunks into the sink. It will block as it handles as many as possible, then return a BackpressureError containing the rest (if any).
+	// PutMany tries to write chunks into the sink. It will block as it handles as many as possible,
+	// then return a BackpressureError containing the rest (if any).
 	PutMany(chunks []Chunk) BackpressureError
 
 	// On return, any previously Put chunks should be durable
@@ -62,7 +69,8 @@ type ChunkSink interface {
 	io.Closer
 }
 
-// BackpressureError is a slice of hash.Hash that indicates some chunks could not be Put(). Caller is free to try to Put them again later.
+// BackpressureError is a slice of hash.Hash that indicates some chunks could not be Put(). Caller
+// is free to try to Put them again later.
 type BackpressureError hash.HashSlice
 
 func (b BackpressureError) Error() string {

--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -36,7 +36,10 @@ type RootTracker interface {
 type ChunkSource interface {
 	// Get the Chunk for the value of the hash in the store. If the hash is absent from the store nil is returned.
 	Get(h hash.Hash) Chunk
-	GetMany(hashes []hash.Hash) []Chunk
+
+	// On return, |foundChunks| will have been fully sent all chunks which have been found and the
+	// channel will be closed.
+	GetMany(hashes hash.HashSet, foundChunks chan *Chunk)
 
 	// Returns true iff the value at the address |h| is contained in the source
 	Has(h hash.Hash) bool

--- a/go/chunks/dynamo_store.go
+++ b/go/chunks/dynamo_store.go
@@ -119,10 +119,10 @@ func (s *DynamoStore) Get(h hash.Hash) Chunk {
 	return <-ch
 }
 
-func (s *DynamoStore) GetMany(hashes []hash.Hash) (batch []Chunk) {
-	batch = make([]Chunk, len(hashes))
-	for i, h := range hashes {
-		batch[i] = s.Get(h)
+func (s *DynamoStore) GetMany(hashes hash.HashSet, foundChunks chan *Chunk) {
+	for h, _ := range hashes {
+		c := s.Get(h)
+		foundChunks <- &c
 	}
 	return
 }

--- a/go/chunks/leveldb_store.go
+++ b/go/chunks/leveldb_store.go
@@ -100,10 +100,10 @@ func (l *LevelDBStore) Get(ref hash.Hash) Chunk {
 	return l.getByKey(l.toChunkKey(ref), ref)
 }
 
-func (l *LevelDBStore) GetMany(hashes []hash.Hash) (batch []Chunk) {
-	batch = make([]Chunk, len(hashes))
-	for i, h := range hashes {
-		batch[i] = l.Get(h)
+func (l *LevelDBStore) GetMany(hashes hash.HashSet, foundChunks chan *Chunk) {
+	for h, _ := range hashes {
+		c := l.Get(h)
+		foundChunks <- &c
 	}
 	return
 }

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -32,10 +32,10 @@ func (ms *MemoryStore) Get(h hash.Hash) Chunk {
 	return EmptyChunk
 }
 
-func (ms *MemoryStore) GetMany(hashes []hash.Hash) (batch []Chunk) {
-	batch = make([]Chunk, len(hashes))
-	for i, h := range hashes {
-		batch[i] = ms.Get(h)
+func (ms *MemoryStore) GetMany(hashes hash.HashSet, foundChunks chan *Chunk) {
+	for h, _ := range hashes {
+		c := ms.Get(h)
+		foundChunks <- &c
 	}
 	return
 }

--- a/go/datas/local_batch_store.go
+++ b/go/datas/local_batch_store.go
@@ -44,8 +44,8 @@ func (lbs *localBatchStore) Get(h hash.Hash) chunks.Chunk {
 	return lbs.cs.Get(h)
 }
 
-func (lbs *localBatchStore) GetMany(hashes []hash.Hash) (batch []chunks.Chunk) {
-	return lbs.cs.GetMany(hashes)
+func (lbs *localBatchStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk) {
+	lbs.cs.GetMany(hashes, foundChunks)
 }
 
 // Has checks the internal Chunk cache, proxying to the backing ChunkStore if not present.

--- a/go/hash/hash_slice.go
+++ b/go/hash/hash_slice.go
@@ -29,3 +29,12 @@ func (rs HashSlice) Equals(other HashSlice) bool {
 	}
 	return true
 }
+
+func (rs HashSlice) HashSet() HashSet {
+	hs := make(HashSet, len(rs))
+	for _, h := range rs {
+		hs[h] = struct{}{}
+	}
+
+	return hs
+}

--- a/go/nbs/benchmarks/file_block_store.go
+++ b/go/nbs/benchmarks/file_block_store.go
@@ -28,7 +28,7 @@ func (fb fileBlockStore) Get(h hash.Hash) chunks.Chunk {
 	panic("not impl")
 }
 
-func (fb fileBlockStore) GetMany(batch []hash.Hash) (result []chunks.Chunk) {
+func (fb fileBlockStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk) {
 	panic("not impl")
 }
 

--- a/go/nbs/benchmarks/null_block_store.go
+++ b/go/nbs/benchmarks/null_block_store.go
@@ -22,7 +22,7 @@ func (nb nullBlockStore) Get(h hash.Hash) chunks.Chunk {
 	panic("not impl")
 }
 
-func (nb nullBlockStore) GetMany(batch []hash.Hash) (result []chunks.Chunk) {
+func (nb nullBlockStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk) {
 	panic("not impl")
 }
 

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -113,7 +113,7 @@ func (ecs emptyChunkSource) get(h addr) []byte {
 	return nil
 }
 
-func (ecs emptyChunkSource) getMany(reqs []getRecord, foundChuns chan *chunks.Chunk, wg *sync.WaitGroup) bool {
+func (ecs emptyChunkSource) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool {
 	return true
 }
 

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -7,6 +7,7 @@ package nbs
 import (
 	"sync"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/d"
 )
 
@@ -62,10 +63,10 @@ func (ccs *compactingChunkSource) get(h addr) []byte {
 	return cr.get(h)
 }
 
-func (ccs *compactingChunkSource) getMany(reqs []getRecord, wg *sync.WaitGroup) bool {
+func (ccs *compactingChunkSource) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool {
 	cr := ccs.getReader()
 	d.Chk.True(cr != nil)
-	return cr.getMany(reqs, wg)
+	return cr.getMany(reqs, foundChunks, wg)
 }
 
 func (ccs *compactingChunkSource) close() error {
@@ -112,7 +113,7 @@ func (ecs emptyChunkSource) get(h addr) []byte {
 	return nil
 }
 
-func (ecs emptyChunkSource) getMany(reqs []getRecord, wg *sync.WaitGroup) bool {
+func (ecs emptyChunkSource) getMany(reqs []getRecord, foundChuns chan *chunks.Chunk, wg *sync.WaitGroup) bool {
 	return true
 }
 

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -87,10 +87,10 @@ func (ccs *compactingChunkSource) hash() addr {
 	return ccs.cs.hash()
 }
 
-func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool) {
+func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool) {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.calcReads(reqs, blockSize, maxReadSize, ampThresh)
+	return ccs.cs.calcReads(reqs, blockSize)
 }
 
 func (ccs *compactingChunkSource) extract(order EnumerationOrder, chunks chan<- extractRecord) {
@@ -129,7 +129,7 @@ func (ecs emptyChunkSource) hash() addr {
 	return addr{} // TODO: is this legal?
 }
 
-func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool) {
+func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool) {
 	return 0, true
 }
 

--- a/go/nbs/frag/main.go
+++ b/go/nbs/frag/main.go
@@ -94,7 +94,7 @@ func main() {
 						}
 					})
 
-					reads, split := store.CalcReads(hashes, 0, 1<<63, 0)
+					reads, split := store.CalcReads(hashes.HashSet(), 0, 1<<63, 0)
 					numbers <- record{count: 1, calc: reads, split: split}
 
 					wg.Add(len(children))

--- a/go/nbs/frag/main.go
+++ b/go/nbs/frag/main.go
@@ -94,7 +94,7 @@ func main() {
 						}
 					})
 
-					reads, split := store.CalcReads(hashes.HashSet(), 0, 1<<63, 0)
+					reads, split := store.CalcReads(hashes.HashSet(), 0)
 					numbers <- record{count: 1, calc: reads, split: split}
 
 					wg.Add(len(children))

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/testify/assert"
 )
 
@@ -125,9 +126,9 @@ func (crg chunkReaderGroup) hasMany(addrs []hasRecord) (remaining bool) {
 	return true
 }
 
-func (crg chunkReaderGroup) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining bool) {
+func (crg chunkReaderGroup) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) (remaining bool) {
 	for _, haver := range crg {
-		if !haver.getMany(reqs, wg) {
+		if !haver.getMany(reqs, foundChunks, wg) {
 			return false
 		}
 	}

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -83,15 +83,15 @@ func TestMemTableWrite(t *testing.T) {
 
 	td1, _ := buildTable(chunks[1:2])
 	td2, _ := buildTable(chunks[2:])
-	tr1 := newTableReader(parseTableIndex(td1), bytes.NewReader(td1), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
-	tr2 := newTableReader(parseTableIndex(td2), bytes.NewReader(td2), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr1 := newTableReader(parseTableIndex(td1), bytes.NewReader(td1), fileBlockSize)
+	tr2 := newTableReader(parseTableIndex(td2), bytes.NewReader(td2), fileBlockSize)
 	assert.True(tr1.has(computeAddr(chunks[1])))
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
 	_, data, count := mt.write(chunkReaderGroup{tr1, tr2})
 	assert.Equal(uint32(1), count)
 
-	outReader := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	outReader := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
 	assert.True(outReader.has(computeAddr(chunks[0])))
 	assert.False(outReader.has(computeAddr(chunks[1])))
 	assert.False(outReader.has(computeAddr(chunks[2])))

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -23,9 +23,7 @@ type mmapTableReader struct {
 }
 
 const (
-	fileReadAmpThresh = uint64(2)
-	fileBlockSize     = 1 << 12
-	fileMaxReadSize   = 1 << 28 // 268MiB
+	fileBlockSize = 1 << 12
 )
 
 var (
@@ -62,7 +60,7 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32) chunkSource {
 	success = true
 
 	index := parseTableIndex(buff[indexOffset-aligned:])
-	source := &mmapTableReader{newTableReader(index, f, fileBlockSize, fileMaxReadSize, fileReadAmpThresh), f, buff, h}
+	source := &mmapTableReader{newTableReader(index, f, fileBlockSize), f, buff, h}
 
 	d.PanicIfFalse(chunkCount == source.count())
 	return source

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -199,7 +199,7 @@ func (ftp fakeTablePersister) Compact(mt *memTable, haver chunkReader) chunkSour
 	if mt.count() > 0 {
 		var data []byte
 		name, data, _ := mt.write(haver)
-		ftp.sources[name] = newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+		ftp.sources[name] = newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
 		return chunkSourceAdapter{ftp.sources[name], name}
 	}
 	return emptyChunkSource{}

--- a/go/nbs/s3_fake_test.go
+++ b/go/nbs/s3_fake_test.go
@@ -56,7 +56,7 @@ func (m *fakeS3) readerForTable(name addr) chunkReader {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if buff, present := m.data[name.String()]; present {
-		return newTableReader(parseTableIndex(buff), bytes.NewReader(buff), s3BlockSize, s3MaxReadSize, s3ReadAmpThresh)
+		return newTableReader(parseTableIndex(buff), bytes.NewReader(buff), s3BlockSize)
 	}
 	return nil
 }

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -69,7 +69,7 @@ func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 		if s3p.indexCache != nil {
 			s3p.indexCache.put(name, index)
 		}
-		s3tr.tableReader = newTableReader(index, s3tr, s3BlockSize, s3MaxReadSize, s3ReadAmpThresh)
+		s3tr.tableReader = newTableReader(index, s3tr, s3BlockSize)
 		return s3tr
 	}
 	return emptyChunkSource{}

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -16,8 +16,8 @@ import (
 const (
 	s3RangePrefix   = "bytes"
 	s3ReadAmpThresh = uint64(5)
-	s3BlockSize     = (1 << 20) * 5  // 8MiB
-	s3MaxReadSize   = (1 << 20) * 20 // 20MiB
+	s3BlockSize     = (1 << 10) * 512 // 512K
+	s3MaxReadSize   = (1 << 20) * 20  // 20MiB
 )
 
 type s3TableReader struct {

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -14,10 +14,8 @@ import (
 )
 
 const (
-	s3RangePrefix   = "bytes"
-	s3ReadAmpThresh = uint64(5)
-	s3BlockSize     = (1 << 10) * 512 // 512K
-	s3MaxReadSize   = (1 << 20) * 20  // 20MiB
+	s3RangePrefix = "bytes"
+	s3BlockSize   = (1 << 10) * 512 // 512K
 )
 
 type s3TableReader struct {
@@ -60,7 +58,7 @@ func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexC
 		}
 	}
 
-	source.tableReader = newTableReader(index, source, s3BlockSize, s3MaxReadSize, s3ReadAmpThresh)
+	source.tableReader = newTableReader(index, source, s3BlockSize)
 	d.PanicIfFalse(chunkCount == source.count())
 	return source
 }

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -28,7 +28,7 @@ const (
 	// StorageVersion is the version of the on-disk Noms Chunks Store data format.
 	StorageVersion = "0"
 
-	defaultMemTableSize uint64 = 512 * 1 << 20 // 512MB
+	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
 	defaultAWSReadLimit        = 1024
 
 	InsertOrder EnumerationOrder = iota

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -203,7 +203,7 @@ func toGetRecords(hashes hash.HashSet) []getRecord {
 	return reqs
 }
 
-func (nbs *NomsBlockStore) CalcReads(hashes hash.HashSet, blockSize, maxReadSize, ampThresh uint64) (reads int, split bool) {
+func (nbs *NomsBlockStore) CalcReads(hashes hash.HashSet, blockSize uint64) (reads int, split bool) {
 	reqs := toGetRecords(hashes)
 	tables := func() (tables tableSet) {
 		nbs.mu.RLock()
@@ -213,7 +213,7 @@ func (nbs *NomsBlockStore) CalcReads(hashes hash.HashSet, blockSize, maxReadSize
 		return
 	}()
 
-	reads, split, remaining := tables.calcReads(reqs, blockSize, maxReadSize, ampThresh)
+	reads, split, remaining := tables.calcReads(reqs, blockSize)
 	d.Chk.False(remaining)
 	return
 }

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -191,12 +191,14 @@ func (nbs *NomsBlockStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks
 
 func toGetRecords(hashes hash.HashSet) []getRecord {
 	reqs := make([]getRecord, len(hashes))
+	idx := 0
 	for h, _ := range hashes {
 		a := addr(h)
-		reqs = append(reqs, getRecord{
+		reqs[idx] = getRecord{
 			a:      &a,
 			prefix: a.Prefix(),
-		})
+		}
+		idx++
 	}
 
 	sort.Sort(getRecordByPrefix(reqs))

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -163,7 +163,7 @@ func (nbs *NomsBlockStore) Get(h hash.Hash) chunks.Chunk {
 	return chunks.EmptyChunk
 }
 
-func (nbs *NomsBlockStore) GetMany(hashes []hash.Hash) []chunks.Chunk {
+func (nbs *NomsBlockStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk) {
 	reqs := toGetRecords(hashes)
 
 	wg := &sync.WaitGroup{}
@@ -174,7 +174,7 @@ func (nbs *NomsBlockStore) GetMany(hashes []hash.Hash) []chunks.Chunk {
 		tables = nbs.tables
 
 		if nbs.mt != nil {
-			remaining = nbs.mt.getMany(reqs, &sync.WaitGroup{})
+			remaining = nbs.mt.getMany(reqs, foundChunks, &sync.WaitGroup{})
 			wg.Wait()
 		} else {
 			remaining = true
@@ -183,41 +183,27 @@ func (nbs *NomsBlockStore) GetMany(hashes []hash.Hash) []chunks.Chunk {
 		return
 	}()
 
-	sort.Sort(getRecordByPrefix(reqs))
-
 	if remaining {
-		tables.getMany(reqs, wg)
+		tables.getMany(reqs, foundChunks, wg)
 		wg.Wait()
 	}
-
-	sort.Sort(getRecordByOrder(reqs))
-
-	resp := make([]chunks.Chunk, len(hashes))
-	for i, req := range reqs {
-		if req.data == nil {
-			resp[i] = chunks.EmptyChunk
-		} else {
-			resp[i] = chunks.NewChunkWithHash(hashes[i], req.data)
-		}
-	}
-
-	return resp
 }
 
-func toGetRecords(hashes []hash.Hash) []getRecord {
+func toGetRecords(hashes hash.HashSet) []getRecord {
 	reqs := make([]getRecord, len(hashes))
-	for i, h := range hashes {
+	for h, _ := range hashes {
 		a := addr(h)
-		reqs[i] = getRecord{
+		reqs = append(reqs, getRecord{
 			a:      &a,
 			prefix: a.Prefix(),
-			order:  i,
-		}
+		})
 	}
+
+	sort.Sort(getRecordByPrefix(reqs))
 	return reqs
 }
 
-func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash, blockSize, maxReadSize, ampThresh uint64) (reads int, split bool) {
+func (nbs *NomsBlockStore) CalcReads(hashes hash.HashSet, blockSize, maxReadSize, ampThresh uint64) (reads int, split bool) {
 	reqs := toGetRecords(hashes)
 	tables := func() (tables tableSet) {
 		nbs.mu.RLock()
@@ -226,8 +212,6 @@ func (nbs *NomsBlockStore) CalcReads(hashes []hash.Hash, blockSize, maxReadSize,
 
 		return
 	}()
-
-	sort.Sort(getRecordByPrefix(reqs))
 
 	reads, split, remaining := tables.calcReads(reqs, blockSize, maxReadSize, ampThresh)
 	d.Chk.False(remaining)

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -11,6 +11,8 @@ import (
 	"encoding/binary"
 	"hash/crc32"
 	"sync"
+
+	"github.com/attic-labs/noms/go/chunks"
 )
 
 /*
@@ -183,9 +185,7 @@ func (hs hasRecordByOrder) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
 type getRecord struct {
 	a      *addr
 	prefix uint64
-	order  int
 	found  bool
-	data   []byte
 }
 
 type getRecordByPrefix []getRecord
@@ -193,12 +193,6 @@ type getRecordByPrefix []getRecord
 func (hs getRecordByPrefix) Len() int           { return len(hs) }
 func (hs getRecordByPrefix) Less(i, j int) bool { return hs[i].prefix < hs[j].prefix }
 func (hs getRecordByPrefix) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
-
-type getRecordByOrder []getRecord
-
-func (hs getRecordByOrder) Len() int           { return len(hs) }
-func (hs getRecordByOrder) Less(i, j int) bool { return hs[i].order < hs[j].order }
-func (hs getRecordByOrder) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
 
 type extractRecord struct {
 	a    addr
@@ -209,7 +203,7 @@ type chunkReader interface {
 	has(h addr) bool
 	hasMany(addrs []hasRecord) bool
 	get(h addr) []byte
-	getMany(reqs []getRecord, wg *sync.WaitGroup) bool
+	getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool
 	count() uint32
 	extract(order EnumerationOrder, chunks chan<- extractRecord)
 }

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -212,5 +212,5 @@ type chunkSource interface {
 	chunkReader
 	close() error
 	hash() addr
-	calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, remaining bool)
+	calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool)
 }

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -387,6 +387,7 @@ func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64) (reads int, 
 
 		if !readStarted {
 			readStarted = true
+			reads++
 			readStart = rec.offset
 			readEnd = readStart + uint64(length)
 			i++
@@ -399,12 +400,7 @@ func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64) (reads int, 
 			continue
 		}
 
-		reads++
 		readStarted = false
-	}
-
-	if readStarted {
-		reads++
 	}
 
 	return

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -236,7 +236,8 @@ func (tr tableReader) readAtOffsets(readStart, readEnd uint64, reqs []getRecord,
 		localStart := rec.offset - readStart
 		localEnd := localStart + uint64(tr.lengths[rec.ordinal])
 		d.Chk.True(localEnd <= readLength)
-		c := chunks.NewChunkWithHash(hash.Hash(*rec.a), tr.parseChunk(buff[localStart:localEnd]))
+		data := tr.parseChunk(buff[localStart:localEnd])
+		c := chunks.NewChunkWithHash(hash.Hash(*rec.a), data)
 		foundChunks <- &c
 	}
 

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -72,9 +72,9 @@ func (css chunkSources) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk
 	return true
 }
 
-func (css chunkSources) calcReads(reqs []getRecord, blockSize, maxReadSize, ampThresh uint64) (reads int, split, remaining bool) {
+func (css chunkSources) calcReads(reqs []getRecord, blockSize uint64) (reads int, split, remaining bool) {
 	for _, haver := range css {
-		rds, remaining := haver.calcReads(reqs, blockSize, maxReadSize, ampThresh)
+		rds, remaining := haver.calcReads(reqs, blockSize)
 		reads += rds
 		if !remaining {
 			return reads, split, remaining

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -4,7 +4,11 @@
 
 package nbs
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/go/chunks"
+)
 
 const concurrentCompactions = 5
 
@@ -58,9 +62,9 @@ func (css chunkSources) get(h addr) []byte {
 	return nil
 }
 
-func (css chunkSources) getMany(reqs []getRecord, wg *sync.WaitGroup) (remaining bool) {
+func (css chunkSources) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) (remaining bool) {
 	for _, haver := range css {
-		if !haver.getMany(reqs, wg) {
+		if !haver.getMany(reqs, foundChunks, wg) {
 			return false
 		}
 	}

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -252,7 +252,7 @@ func TestFSTablePersisterCompact(t *testing.T) {
 	if assert.True(src.count() > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
 		assert.NoError(err)
-		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
 		for _, c := range testChunks {
 			assert.True(tr.has(computeAddr(c)))
 		}

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -49,7 +49,7 @@ func TestSimple(t *testing.T) {
 	}
 
 	tableData, _ := buildTable(chunks)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize)
 
 	assertChunksInReader(chunks, tr, assert)
 
@@ -92,7 +92,7 @@ func TestHasMany(t *testing.T) {
 	}
 
 	tableData, _ := buildTable(chunks)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize)
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	hasAddrs := []hasRecord{
@@ -138,7 +138,7 @@ func TestHasManySequentialPrefix(t *testing.T) {
 	length, _ := tw.finish()
 	buff = buff[:length]
 
-	tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
 
 	hasAddrs := make([]hasRecord, 2)
 	// Leave out the first address
@@ -162,7 +162,7 @@ func TestGetMany(t *testing.T) {
 	}
 
 	tableData, _ := buildTable(data)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize)
 
 	addrs := addrSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
 	getBatch := []getRecord{
@@ -197,7 +197,7 @@ func TestCalcReads(t *testing.T) {
 	}
 
 	tableData, _ := buildTable(chunks)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), 0, fileMaxReadSize, 0)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), 0)
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
 		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
@@ -208,12 +208,12 @@ func TestCalcReads(t *testing.T) {
 	gb2 := []getRecord{getBatch[0], getBatch[2]}
 	sort.Sort(getRecordByPrefix(getBatch))
 
-	reads, remaining := tr.calcReads(getBatch, 0, fileMaxReadSize, 0)
+	reads, remaining := tr.calcReads(getBatch, 0)
 	assert.False(remaining)
 	assert.Equal(1, reads)
 
 	sort.Sort(getRecordByPrefix(gb2))
-	reads, remaining = tr.calcReads(gb2, 0, fileMaxReadSize, 0)
+	reads, remaining = tr.calcReads(gb2, 0)
 	assert.False(remaining)
 	assert.Equal(2, reads)
 }
@@ -228,7 +228,7 @@ func TestExtract(t *testing.T) {
 	}
 
 	tableData, _ := buildTable(chunks)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize)
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 
@@ -268,7 +268,7 @@ func Test65k(t *testing.T) {
 	}
 
 	tableData, _ := buildTable(chunks)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize)
 
 	for i := 0; i < count; i++ {
 		data := dataFn(i)
@@ -313,7 +313,7 @@ func doTestNGetMany(t *testing.T, count int) {
 	}
 
 	tableData, _ := buildTable(data)
-	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
+	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize)
 
 	getBatch := make([]getRecord, len(data))
 	for i := 0; i < count; i++ {

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -14,6 +14,7 @@ import (
 
 	"sync"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/testify/assert"
@@ -154,30 +155,36 @@ func TestHasManySequentialPrefix(t *testing.T) {
 func TestGetMany(t *testing.T) {
 	assert := assert.New(t)
 
-	chunks := [][]byte{
+	data := [][]byte{
 		[]byte("hello2"),
 		[]byte("goodbye2"),
 		[]byte("badbye2"),
 	}
 
-	tableData, _ := buildTable(chunks)
+	tableData, _ := buildTable(data)
 	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
 
-	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
+	addrs := addrSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
 	getBatch := []getRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, false, nil},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, false, nil},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, false, nil},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), false},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), false},
 	}
 	sort.Sort(getRecordByPrefix(getBatch))
 
 	wg := &sync.WaitGroup{}
-	tr.getMany(getBatch, wg)
-	wg.Wait()
 
-	for _, rec := range getBatch {
-		assert.NotNil(rec.data, "Nothing for prefix %d", rec.prefix)
+	chunkChan := make(chan *chunks.Chunk, len(getBatch))
+	tr.getMany(getBatch, chunkChan, wg)
+	wg.Wait()
+	close(chunkChan)
+
+	gotCount := 0
+	for _ = range chunkChan {
+		gotCount++
 	}
+
+	assert.True(gotCount == len(getBatch))
 }
 
 func TestCalcReads(t *testing.T) {
@@ -193,9 +200,9 @@ func TestCalcReads(t *testing.T) {
 	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), 0, fileMaxReadSize, 0)
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, false, nil},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, false, nil},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, false, nil},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), false},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), false},
 	}
 
 	gb2 := []getRecord{getBatch[0], getBatch[2]}
@@ -295,36 +302,39 @@ func computeAddrCommonPrefix(data []byte) addr {
 func doTestNGetMany(t *testing.T, count int) {
 	assert := assert.New(t)
 
-	chunks := make([][]byte, count)
+	data := make([][]byte, count)
 
 	dataFn := func(i int) []byte {
 		return []byte(fmt.Sprintf("data%d", i*2))
 	}
 
 	for i := 0; i < count; i++ {
-		chunks[i] = dataFn(i)
+		data[i] = dataFn(i)
 	}
 
-	tableData, _ := buildTable(chunks)
+	tableData, _ := buildTable(data)
 	tr := newTableReader(parseTableIndex(tableData), bytes.NewReader(tableData), fileBlockSize, fileMaxReadSize, fileReadAmpThresh)
 
-	getBatch := make([]getRecord, len(chunks))
+	getBatch := make([]getRecord, len(data))
 	for i := 0; i < count; i++ {
 		a := computeAddr(dataFn(i))
-		getBatch[i] = getRecord{&a, a.Prefix(), i, false, nil}
+		getBatch[i] = getRecord{&a, a.Prefix(), false}
 	}
 
 	sort.Sort(getRecordByPrefix(getBatch))
 
 	wg := &sync.WaitGroup{}
-	tr.getMany(getBatch, wg)
+	chunkChan := make(chan *chunks.Chunk, len(getBatch))
+	tr.getMany(getBatch, chunkChan, wg)
 	wg.Wait()
+	close(chunkChan)
 
-	sort.Sort(getRecordByOrder(getBatch))
-
-	for i := 0; i < count; i++ {
-		assert.True(bytes.Compare(getBatch[i].data, dataFn(i)) == 0)
+	gotCount := 0
+	for _ = range chunkChan {
+		gotCount++
 	}
+
+	assert.True(gotCount == len(getBatch))
 }
 
 func Test65kGetMany(t *testing.T) {


### PR DESCRIPTION
Adds the ability to stream individual chunks requested via GetMany() back to caller.

Removes readAmpThresh and maxReadSize. Lowers the S3ReadBlockSize to 512k.

Fixes #2981
Fixes #2980 