### PR TITLE
Address write timeout

### DIFF
--- a/go/datas/http_batch_store.go
+++ b/go/datas/http_batch_store.go
@@ -94,7 +94,7 @@ func makeHTTPClient(requestLimit int) *http.Client {
 	t := http.Transport(*http.DefaultTransport.(*http.Transport))
 	t.MaxIdleConnsPerHost = requestLimit
 	// This sets, essentially, an idle-timeout. The timer starts counting AFTER the client has finished sending the entire request to the server. As soon as the client receives the server's response headers, the timeout is canceled.
-	t.ResponseHeaderTimeout = time.Duration(2) * time.Minute
+	t.ResponseHeaderTimeout = time.Duration(4) * time.Minute
 
 	return &http.Client{Transport: &t}
 }

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/constants"
@@ -123,8 +124,15 @@ func handleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs
 		d.Panic("Expected post method.")
 	}
 
+	t1 := time.Now()
+	totalDataWritten := 0
+	chunkCount := 0
+
 	verbose.Log("Handling WriteValue from " + req.RemoteAddr)
-	defer verbose.Log("Finished handling WriteValue from " + req.RemoteAddr)
+	defer func() {
+		verbose.Log("Wrote %d Kb as %d chunks from %s in %s", totalDataWritten/1024, chunkCount, req.RemoteAddr, time.Since(t1))
+	}()
+
 	reader := bodyReader(req)
 	defer func() {
 		// Ensure all data on reader is consumed
@@ -151,16 +159,16 @@ func handleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs
 		},
 		writeValueConcurrency)
 
-	count := 0
 	var bpe chunks.BackpressureError
 	for dci := range decoded {
 		dc := dci.(types.DecodedChunk)
 		if dc.Chunk != nil && dc.Value != nil {
 			if bpe == nil {
+				totalDataWritten += len(dc.Chunk.Data())
 				bpe = vbs.Enqueue(*dc.Chunk, *dc.Value)
-				count++
-				if count%100 == 0 {
-					verbose.Log("Enqueued %d chunks", count)
+				chunkCount++
+				if chunkCount%100 == 0 {
+					verbose.Log("Enqueued %d chunks", chunkCount)
 				}
 			} else {
 				bpe = append(bpe, dc.Chunk.Hash())

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -8,9 +8,11 @@ import (
 	"bytes"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/util/sizecache"
+	"github.com/attic-labs/noms/go/util/verbose"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -38,6 +40,7 @@ func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 	name, data, chunkCount := mt.write(haver)
 
 	if chunkCount > 0 {
+		t1 := time.Now()
 		result, err := s3p.s3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 			Bucket: aws.String(s3p.bucket),
 			Key:    aws.String(name.String()),
@@ -65,6 +68,7 @@ func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 		d.Chk.NoError(err)
 		s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name}
 
+		verbose.Log("Compacted table of %d Kb in %s", len(data), time.Since(t1))
 		index := parseTableIndex(data)
 		if s3p.indexCache != nil {
 			s3p.indexCache.put(name, index)

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -68,7 +68,7 @@ func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 		d.Chk.NoError(err)
 		s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name}
 
-		verbose.Log("Compacted table of %d Kb in %s", len(data), time.Since(t1))
+		verbose.Log("Compacted table of %d Kb in %s", len(data)/1024, time.Since(t1))
 		index := parseTableIndex(data)
 		if s3p.indexCache != nil {
 			s3p.indexCache.put(name, index)


### PR DESCRIPTION
Relevant to: https://github.com/attic-labs/noms/issues/3006.

Ups the response-header timeout to 4m, and adds some additional log output which hopefully will shed some light on why some writes are taking so long.