### PR TITLE
ValueStore writes chunks only when referenced

### DIFF
--- a/cmd/noms/noms_show_test.go
+++ b/cmd/noms/noms_show_test.go
@@ -93,6 +93,7 @@ func (s *nomsShowTestSuite) TestNomsShowRaw() {
 	// out to same thing.
 	test := func(in types.Value) {
 		r1 := db.WriteValue(in)
+		db.CommitValue(sp.GetDataset(), r1)
 		res, _ := s.MustRun(main, []string{"show", "--raw",
 			spec.CreateValueSpecString("ldb", s.LdbDir, "#"+r1.TargetHash().String())})
 		ch := chunks.NewChunk([]byte(res))

--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -191,6 +191,7 @@ func (dbc *databaseCommon) getRootAndDatasets() (currentRootHash hash.Hash, curr
 func (dbc *databaseCommon) tryUpdateRoot(currentDatasets types.Map, currentRootHash hash.Hash) (err error) {
 	// TODO: This Map will be orphaned if the UpdateRoot below fails
 	newRootRef := dbc.WriteValue(currentDatasets).TargetHash()
+	dbc.Flush()
 	// If the root has been updated by another process in the short window since we read it, this call will fail. See issue #404
 	if !dbc.rt.UpdateRoot(newRootRef, currentRootHash) {
 		err = ErrOptimisticLockFailed

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -116,7 +116,9 @@ func TestLDBDatabaseSpec(t *testing.T) {
 		store1 := path.Join(tmpDir, "store1")
 		cs := chunks.NewLevelDBStoreUseFlags(store1, "")
 		db := datas.NewDatabase(cs)
-		db.WriteValue(s)
+		r := db.WriteValue(s)
+		_, err = db.CommitValue(db.GetDataset("datasetID"), r)
+		assert.NoError(err)
 		db.Close() // must close immediately to free ldb
 
 		spec1, err := ForDatabase(prefix + store1)
@@ -139,6 +141,9 @@ func TestLDBDatabaseSpec(t *testing.T) {
 
 		db = spec2.GetDatabase()
 		db.WriteValue(s)
+		r = db.WriteValue(s)
+		_, err = db.CommitValue(db.GetDataset("datasetID"), r)
+		assert.NoError(err)
 		assert.Equal(s, db.ReadValue(s.Hash()))
 	}
 
@@ -455,7 +460,10 @@ func TestMultipleSpecsSameLeveldb(t *testing.T) {
 	assert.NoError(err2)
 
 	s := types.String("hello")
-	spec1.GetDatabase().WriteValue(s)
+	db := spec1.GetDatabase()
+	r := db.WriteValue(s)
+	_, err = db.CommitValue(db.GetDataset("datasetID"), r)
+	assert.NoError(err)
 	assert.Equal(s, spec2.GetDatabase().ReadValue(s.Hash()))
 }
 

--- a/go/types/incremental_test.go
+++ b/go/types/incremental_test.go
@@ -40,6 +40,7 @@ func TestIncrementalLoadList(t *testing.T) {
 
 	expected := NewList(testVals...)
 	ref := vs.WriteValue(expected).TargetHash()
+	vs.Flush()
 
 	actualVar := vs.ReadValue(ref)
 	actual := actualVar.(List)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -959,6 +959,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	nums1 := generateNumbersAsValues(4000)
 	l1 := NewList(nums1...)
 	ref1 := vs1.WriteValue(l1).TargetHash()
+	vs1.Flush()
 	refList1 := vs1.ReadValue(ref1).(List)
 
 	cs2 := chunks.NewTestStore()
@@ -966,6 +967,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	nums2 := generateNumbersAsValuesFromToBy(5, 3550, 1)
 	l2 := NewList(nums2...)
 	ref2 := vs2.WriteValue(l2).TargetHash()
+	vs2.Flush()
 	refList2 := vs2.ReadValue(ref2).(List)
 
 	// diff lists without value store

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -97,7 +97,9 @@ func (suite *diffTestSuite) TestDiff() {
 
 	rw := func(col Collection) Collection {
 		vs := NewTestValueStore()
-		return vs.ReadValue(vs.WriteValue(col).target).(Collection)
+		r := vs.WriteValue(col)
+		vs.Flush()
+		return vs.ReadValue(r.TargetHash()).(Collection)
 	}
 	newSetAsColRw := func(vs []Value) Collection { return rw(newSetAsCol(vs)) }
 	newMapAsColRw := func(vs []Value) Collection { return rw(newMapAsCol(vs)) }

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -13,35 +13,45 @@ import (
 	"github.com/attic-labs/noms/go/util/sizecache"
 )
 
-// ValueReader is an interface that knows how to read Noms Values, e.g. datas/Database. Required to avoid import cycle between this package and the package that implements Value reading.
+// ValueReader is an interface that knows how to read Noms Values, e.g.
+// datas/Database. Required to avoid import cycle between this package and the
+// package that implements Value reading.
 type ValueReader interface {
 	ReadValue(h hash.Hash) Value
 }
 
-// ValueWriter is an interface that knows how to write Noms Values, e.g. datas/Database. Required to avoid import cycle between this package and the package that implements Value writing.
+// ValueWriter is an interface that knows how to write Noms Values, e.g.
+// datas/Database. Required to avoid import cycle between this package and the
+// package that implements Value writing.
 type ValueWriter interface {
 	WriteValue(v Value) Ref
 }
 
-// ValueReadWriter is an interface that knows how to read and write Noms Values, e.g. datas/Database. Required to avoid import cycle between this package and the package that implements Value read/writing.
+// ValueReadWriter is an interface that knows how to read and write Noms
+// Values, e.g. datas/Database. Required to avoid import cycle between this
+// package and the package that implements Value read/writing.
 type ValueReadWriter interface {
 	ValueReader
 	ValueWriter
 	opCache() opCache
 }
 
-// ValueStore provides methods to read and write Noms Values to a BatchStore. It validates Values as they are written, but does not guarantee that these Values are persisted to the BatchStore until a subsequent Flush. or Close.
+// ValueStore provides methods to read and write Noms Values to a BatchStore.
+// It validates Values as they are written, but does not guarantee that these
+// Values are persisted through the BatchStore until a subsequent Flush.
 // Currently, WriteValue validates the following properties of a Value v:
 // - v can be correctly serialized and its Ref taken
 // - all Refs in v point to a Value that can be read from this ValueStore
 // - all Refs in v point to a Value of the correct Type
 type ValueStore struct {
-	bs         BatchStore
-	cache      map[hash.Hash]chunkCacheEntry
-	mu         sync.RWMutex
-	valueCache *sizecache.SizeCache
-	opcStore   opCacheStore
-	once       sync.Once
+	bs          BatchStore
+	cacheMu     sync.RWMutex
+	cache       map[hash.Hash]chunkCacheEntry
+	pendingMu   sync.RWMutex
+	pendingPuts map[hash.Hash]pendingChunk
+	valueCache  *sizecache.SizeCache
+	opcStore    opCacheStore
+	once        sync.Once
 }
 
 const defaultValueCacheSize = 1 << 25 // 32MB
@@ -52,7 +62,14 @@ type chunkCacheEntry interface {
 	Type() *Type
 }
 
-// NewTestValueStore creates a simple struct that satisfies ValueReadWriter and is backed by a chunks.TestStore.
+type pendingChunk struct {
+	c      chunks.Chunk
+	height uint64
+	hints  Hints
+}
+
+// NewTestValueStore creates a simple struct that satisfies ValueReadWriter
+// and is backed by a chunks.TestStore.
 func NewTestValueStore() *ValueStore {
 	return newLocalValueStore(chunks.NewTestStore())
 }
@@ -61,20 +78,32 @@ func newLocalValueStore(cs chunks.ChunkStore) *ValueStore {
 	return NewValueStore(NewBatchStoreAdaptor(cs))
 }
 
-// NewValueStore returns a ValueStore instance that owns the provided BatchStore and manages its lifetime. Calling Close on the returned ValueStore will Close bs.
+// NewValueStore returns a ValueStore instance that owns the provided
+// BatchStore and manages its lifetime. Calling Close on the returned
+// ValueStore will Close bs.
 func NewValueStore(bs BatchStore) *ValueStore {
 	return NewValueStoreWithCache(bs, defaultValueCacheSize)
 }
 
 func NewValueStoreWithCache(bs BatchStore, cacheSize uint64) *ValueStore {
-	return &ValueStore{bs, map[hash.Hash]chunkCacheEntry{}, sync.RWMutex{}, sizecache.New(cacheSize), nil, sync.Once{}}
+	return &ValueStore{
+		bs:          bs,
+		cacheMu:     sync.RWMutex{},
+		cache:       map[hash.Hash]chunkCacheEntry{},
+		pendingMu:   sync.RWMutex{},
+		pendingPuts: map[hash.Hash]pendingChunk{},
+		valueCache:  sizecache.New(cacheSize),
+		once:        sync.Once{},
+	}
 }
 
 func (lvs *ValueStore) BatchStore() BatchStore {
 	return lvs.bs
 }
 
-// ReadValue reads and decodes a value from lvs. It is not considered an error for the requested chunk to be empty; in this case, the function simply returns nil.
+// ReadValue reads and decodes a value from lvs. It is not considered an error
+// for the requested chunk to be empty; in this case, the function simply
+// returns nil.
 func (lvs *ValueStore) ReadValue(h hash.Hash) Value {
 	if v, ok := lvs.valueCache.Get(h); ok {
 		if v == nil {
@@ -82,11 +111,23 @@ func (lvs *ValueStore) ReadValue(h hash.Hash) Value {
 		}
 		return v.(Value)
 	}
-	chunk := lvs.bs.Get(h)
+
+	chunk := func() chunks.Chunk {
+		lvs.pendingMu.RLock()
+		defer lvs.pendingMu.RUnlock()
+		if pc, ok := lvs.pendingPuts[h]; ok {
+			return pc.c
+		}
+		return chunks.EmptyChunk
+	}()
+	if chunk.IsEmpty() {
+		chunk = lvs.bs.Get(h)
+	}
 	if chunk.IsEmpty() {
 		lvs.valueCache.Add(h, 0, nil)
 		return nil
 	}
+
 	v := DecodeValue(chunk, lvs)
 	lvs.valueCache.Add(h, uint64(len(chunk.Data())), v)
 
@@ -103,32 +144,53 @@ func (lvs *ValueStore) ReadValue(h hash.Hash) Value {
 	return v
 }
 
-// WriteValue takes a Value, schedules it to be written it to lvs, and returns an appropriately-typed types.Ref. v is not guaranteed to be actually written until after Flush().
+// WriteValue takes a Value, schedules it to be written it to lvs, and returns
+// an appropriately-typed types.Ref. v is not guaranteed to be actually
+// written until after Flush().
 func (lvs *ValueStore) WriteValue(v Value) Ref {
 	d.PanicIfFalse(v != nil)
 	// Encoding v causes any child chunks, e.g. internal nodes if v is a meta sequence, to get written. That needs to happen before we try to validate v.
 	c := EncodeValue(v, lvs)
 	d.PanicIfTrue(c.IsEmpty())
-	hash := c.Hash()
+	h := c.Hash()
 	height := maxChunkHeight(v) + 1
-	r := constructRef(MakeRefType(v.Type()), hash, height)
-	if lvs.isPresent(hash) {
+	r := constructRef(MakeRefType(v.Type()), h, height)
+	if lvs.isPresent(h) {
 		return r
 	}
+
+	// TODO: It _really_ feels like there should be some refactoring that allows us to only have to walk the refs of |v| once, but I'm hesitant to undertake that refactor right now.
 	hints := lvs.chunkHintsFromCache(v)
-	lvs.bs.SchedulePut(c, height, hints)
-	lvs.set(hash, (*presentChunk)(v.Type()))
-	lvs.valueCache.Drop(hash)
+
+	lvs.pendingMu.Lock()
+	lvs.pendingPuts[h] = pendingChunk{c, height, hints}
+	v.WalkRefs(func(reachable Ref) {
+		if pc, present := lvs.pendingPuts[reachable.TargetHash()]; present {
+			lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
+			delete(lvs.pendingPuts, reachable.TargetHash())
+		}
+	})
+	lvs.pendingMu.Unlock()
+
+	lvs.set(h, (*presentChunk)(v.Type()))
+	lvs.valueCache.Drop(h)
 	return r
 }
 
 func (lvs *ValueStore) Flush() {
+	func() {
+		lvs.pendingMu.Lock()
+		defer lvs.pendingMu.Unlock()
+		for _, pc := range lvs.pendingPuts {
+			lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
+		}
+		lvs.pendingPuts = map[hash.Hash]pendingChunk{}
+	}()
 	lvs.bs.Flush()
 }
 
 // Close closes the underlying BatchStore
 func (lvs *ValueStore) Close() error {
-	lvs.Flush()
 	if lvs.opcStore != nil {
 		err := lvs.opcStore.destroy()
 		d.Chk.NoError(err, "Attempt to clean up opCacheStore failed, error: %s\n", err)
@@ -155,14 +217,14 @@ func (lvs *ValueStore) isPresent(r hash.Hash) (present bool) {
 }
 
 func (lvs *ValueStore) check(r hash.Hash) chunkCacheEntry {
-	lvs.mu.RLock()
-	defer lvs.mu.RUnlock()
+	lvs.cacheMu.RLock()
+	defer lvs.cacheMu.RUnlock()
 	return lvs.cache[r]
 }
 
 func (lvs *ValueStore) set(r hash.Hash, entry chunkCacheEntry) {
-	lvs.mu.Lock()
-	defer lvs.mu.Unlock()
+	lvs.cacheMu.Lock()
+	defer lvs.cacheMu.Unlock()
 	lvs.cache[r] = entry
 }
 

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -95,6 +95,7 @@ func TestCacheOnReadValue(t *testing.T) {
 	b := NewEmptyBlob()
 	bref := cvs.WriteValue(b)
 	r := cvs.WriteValue(bref)
+	cvs.Flush()
 
 	cvs2 := newLocalValueStore(cs)
 	v := cvs2.ReadValue(r.TargetHash())
@@ -141,7 +142,7 @@ func TestPanicOnReadBadVersion(t *testing.T) {
 
 func TestPanicOnWriteBadVersion(t *testing.T) {
 	cvs := newLocalValueStore(&badVersionStore{chunks.NewTestStore()})
-	assert.Panics(t, func() { cvs.WriteValue(NewEmptyBlob()) })
+	assert.Panics(t, func() { cvs.WriteValue(NewEmptyBlob()); cvs.Flush() })
 }
 
 type badVersionStore struct {

--- a/samples/go/blob-get/blob_get_test.go
+++ b/samples/go/blob-get/blob_get_test.go
@@ -32,9 +32,12 @@ func (s *bgSuite) TestBlobGet() {
 	sp, err := spec.ForDatabase(s.TempDir)
 	s.NoError(err)
 	defer sp.Close()
-	hash := sp.GetDatabase().WriteValue(blob)
+	db := sp.GetDatabase()
+	ref := db.WriteValue(blob)
+	_, err = db.CommitValue(db.GetDataset("datasetID"), ref)
+	s.NoError(err)
 
-	hashSpec := fmt.Sprintf("%s::#%s", s.TempDir, hash.TargetHash().String())
+	hashSpec := fmt.Sprintf("%s::#%s", s.TempDir, ref.TargetHash().String())
 	filePath := filepath.Join(s.TempDir, "out")
 	s.MustRun(main, []string{hashSpec, filePath})
 


### PR DESCRIPTION
The old strategy for writing values was to recursively encode them,
putting the resulting chunks into a BatchStore from the bottom up as
they were generated. The BatchStore implementation was responsible for
handling concurrency, so chunks from different Values would be
interleaved if the there were multiple calls to WriteValue happening
at the same time.

The new strategy tries to keep chunks from the same 'level' of a
graph together by caching chunks as they're encoded and only writing
them once they're referenced by some other value. When a collection
is written, the graph representing it is encoded recursively, and
chunks are generated bottom-up. The new strategy should, in practice,
mean that the children of a given parent node in this graph will be
cached until that parent gets written, and then they'll get written
all at once.