### PR TITLE
Remember hints for written chunks

### DIFF
--- a/go/types/validating_batching_sink.go
+++ b/go/types/validating_batching_sink.go
@@ -81,7 +81,7 @@ func (vbs *ValidatingBatchingSink) DecodeUnqueued(c *chunks.Chunk) DecodedChunk 
 func (vbs *ValidatingBatchingSink) Enqueue(c chunks.Chunk, v Value) (err chunks.BackpressureError) {
 	h := c.Hash()
 	vbs.vs.ensureChunksInCache(v)
-	vbs.vs.set(h, hintedChunk{v.Type(), h})
+	vbs.vs.set(h, hintedChunk{v.Type(), h}, false)
 
 	vbs.batch[vbs.count] = c
 	vbs.count++

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -30,7 +30,7 @@ func TestCheckChunksInCache(t *testing.T) {
 
 	b := NewEmptyBlob()
 	cs.Put(EncodeValue(b, nil))
-	cvs.set(b.Hash(), hintedChunk{b.Type(), b.Hash()})
+	cvs.set(b.Hash(), hintedChunk{b.Type(), b.Hash()}, false)
 
 	bref := NewRef(b)
 	assert.NotPanics(func() { cvs.chunkHintsFromCache(bref) })

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -36,6 +36,32 @@ func TestCheckChunksInCache(t *testing.T) {
 	assert.NotPanics(func() { cvs.chunkHintsFromCache(bref) })
 }
 
+func TestCheckChunksInCachePostCommit(t *testing.T) {
+	assert := assert.New(t)
+	cs := chunks.NewTestStore()
+	cvs := newLocalValueStore(cs)
+
+	l := NewList()
+	r := NewRef(l)
+	i := 0
+	for r.Height() == 1 {
+		l = l.Append(Number(i))
+		r = NewRef(l)
+		i++
+	}
+
+	cvs.WriteValue(l)
+	// Hints for leaf sequences should be absent prior to Flush...
+	l.WalkRefs(func(ref Ref) {
+		assert.True(cvs.check(ref.TargetHash()).Hint().IsEmpty())
+	})
+	cvs.Flush()
+	// ...And present afterwards
+	l.WalkRefs(func(ref Ref) {
+		assert.True(cvs.check(ref.TargetHash()).Hint() == l.Hash())
+	})
+}
+
 func TestCheckChunksNotInCache(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()

--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "65.5.0",
+  "version": "65.5.1",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/value-store.js
+++ b/js/noms/src/value-store.js
@@ -65,7 +65,7 @@ export default class ValueStore {
 
     const v = decodeValue(chunk, this);
     this._valueCache.add(hash, chunk.data.length, v);
-    this._knownHashes.cacheChunks(v, hash);
+    this._knownHashes.cacheChunks(v, hash, false);
     // hash is trivially a hint for v, so consider putting that in the cache.
     // If we got to v by reading some higher-level chunk, this entry gets dropped on
     // the floor because r already has a hint in the cache. If we later read some other
@@ -89,12 +89,15 @@ export default class ValueStore {
     }
     const hints = this._knownHashes.checkChunksInCache(v);
     this._bs.schedulePut(chunk, hints);
-    this._knownHashes.add(hash, new HashCacheEntry(true, t));
+
+    this._knownHashes.cacheChunks(v, hash, true);
+    this._knownHashes.add(hash, new HashCacheEntry(true, t), false);
     this._valueCache.drop(hash);
     return ref;
   }
 
   async flush(): Promise<void> {
+    this._knownHashes.mergePendingHints();
     return this._bs.flush();
   }
 
@@ -213,18 +216,33 @@ class HashCacheEntry {
 
 class HashCache {
   _cache: Map<string, HashCacheEntry>;
+  _pending: Map<string, HashCacheEntry>;
 
   constructor() {
     this._cache = new Map();
+    this._pending = new Map();
   }
 
   get(hash: Hash): ?HashCacheEntry {
     return this._cache.get(hash.toString());
   }
 
-  add(hash: Hash, entry: HashCacheEntry) {
-    this._cache.set(hash.toString(), entry);
+  add(hash: Hash, entry: HashCacheEntry, toPending: boolean) {
+    if (toPending) {
+      this._pending.set(hash.toString(), entry);
+    } else {
+      this._cache.set(hash.toString(), entry);
+    }
   }
+
+  mergePendingHints() {
+    for (const [hashStr, entry] of this._pending) {
+      this._cache.set(hashStr, entry);
+    }
+
+    this._pending = new Map();
+  }
+
 
   addIfNotPresent(hash: Hash, entry: HashCacheEntry) {
     const hashStr = hash.toString();
@@ -234,13 +252,13 @@ class HashCache {
     }
   }
 
-  cacheChunks(v: Value, hash: Hash) {
+  cacheChunks(v: Value, hash: Hash, toPending: boolean) {
     if (v instanceof ValueBase) {
       v.chunks.forEach(reachable => {
         const h = reachable.targetHash;
         const cur = this.get(h);
         if (!cur || cur.provenance.isEmpty() || cur.provenance.equals(h)) {
-          this.add(h, new HashCacheEntry(true, getTargetType(reachable), hash));
+          this.add(h, new HashCacheEntry(true, getTargetType(reachable), hash), toPending);
         }
       });
     }

--- a/js/noms/src/value-store.js
+++ b/js/noms/src/value-store.js
@@ -239,10 +239,8 @@ class HashCache {
     for (const [hashStr, entry] of this._pending) {
       this._cache.set(hashStr, entry);
     }
-
     this._pending = new Map();
   }
-
 
   addIfNotPresent(hash: Hash, entry: HashCacheEntry) {
     const hashStr = hash.toString();


### PR DESCRIPTION
Prior to this patch, ValueStore only kept a record of where referenced `Refs` originally reside in from chunks read from the server. This ignored the case of a client doing subsequent commits with the same ValueStore (for example, writing multiple states of a map). This was resulting in the server being forced to load a ton of chunks to validate.