### PR TITLE
JS: ValueStore writes chunks only when referenced

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "65.5.1",
+  "version": "65.5.2",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/database.js
+++ b/js/noms/src/database.js
@@ -140,6 +140,7 @@ export default class Database {
 
       currentDatasets = await currentDatasets.set(datasetId, commitRef);
       const newRootRef = this.writeValue(currentDatasets).targetHash;
+      await this._vs.flush();
       if (await this._rt.updateRoot(newRootRef, currentRootRef)) {
         break;
       }

--- a/js/noms/src/dataset-test.js
+++ b/js/noms/src/dataset-test.js
@@ -6,11 +6,8 @@
 
 import {suite, test} from 'mocha';
 import makeRemoteBatchStoreFake from './remote-batch-store-fake.js';
-import {emptyHash} from './hash.js';
 import {assert} from 'chai';
-import Commit from './commit.js';
 import Database from './database.js';
-import Map from './map.js';
 import {invariant} from './assert.js';
 import {equals} from './compare.js';
 
@@ -28,18 +25,14 @@ suite('Dataset', () => {
     const bs = makeRemoteBatchStoreFake();
     let db = new Database(bs);
 
-    const commit = new Commit('foo');
-
-    const commitRef = db.writeValue(commit);
-    const datasets = new Map([['foo', commitRef]]);
-    const rootRef = db.writeValue(datasets).targetHash;
-    assert.isTrue(await bs.updateRoot(rootRef, emptyHash));
+    const headVal = 'fooContent';
+    await db.commit(db.getDataset('foo'), headVal);
     db = new Database(bs); // refresh the datasets
 
     const ds = await db.getDataset('foo');
-    const fooHead = await ds.head();
+    const fooHead = await ds.headValue();
     invariant(fooHead);
-    assert.isTrue(equals(fooHead, commit));
+    assert.isTrue(equals(fooHead, headVal));
 
     const ds2 = await db.getDataset('bar');
     const barHead = await ds2.head();

--- a/js/noms/src/specs-test.js
+++ b/js/noms/src/specs-test.js
@@ -30,8 +30,9 @@ suite('Specs', () => {
     assert.strictEqual('', spec.path);
 
     const db = spec.database();
-    db.writeValue(true);
-    assert.strictEqual(true, await spec.database().readValue(getHash(true)));
+    const r = db.writeValue(true);
+    await db.commit(db.getDataset('dataset'), r);
+    assert.strictEqual(true, await spec.database().readValue(r.targetHash));
   });
 
   test('mem dataset', async () => {
@@ -54,7 +55,8 @@ suite('Specs', () => {
     let [db, value] = await spec.value();
     assert.strictEqual(null, value);
 
-    db.writeValue(true);
+    const r = db.writeValue(true);
+    await db.commit(db.getDataset('dataset'), r);
     [db, value] = await spec.value();
     assert.strictEqual(true, value);
   });


### PR DESCRIPTION
The old strategy for writing values was to recursively encode them,
putting the resulting chunks into a BatchStore from the bottom up as
they were generated.

The new strategy tries to keep chunks from the same 'level' of a
graph together by caching chunks as they're encoded and only writing
them once they're referenced by some other value. When a collection
is written, the graph representing it is encoded recursively, and
chunks are generated bottom-up. The new strategy should, in practice,
mean that the children of a given parent node in this graph will be
cached until that parent gets written, and then they'll get written
all at once.