### PR TITLE
Hack `noms sync` to be able to support syncing from arbitrary paths

### DIFF
--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -81,7 +81,19 @@ func runSync(args []string) int {
 		lastProgressCh <- last
 	}()
 
-	sourceRef := types.NewRef(sourceObj)
+	var sourceRef types.Ref
+	if sourceObj.Type().Kind() == types.RefKind {
+		sourceRef = sourceObj.(types.Ref)
+	} else {
+		// TODO: This is ghetto. Should not have to write to source in this case, and might not
+		// even be able to do that (source might be read-only).
+		sourceRef = sourceStore.WriteValue(sourceObj)
+
+		// Need to flush here because later on Pull() pokes around at the batchstore level, so we
+		// need to get the new value out of the ValueStore cache.
+		sourceStore.Flush()
+	}
+
 	sinkRef, sinkExists := sinkDataset.MaybeHeadRef()
 	nonFF := false
 	err = d.Try(func() {

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -25,6 +25,7 @@ type ValueReader interface {
 // package that implements Value writing.
 type ValueWriter interface {
 	WriteValue(v Value) Ref
+	Flush()
 }
 
 // ValueReadWriter is an interface that knows how to read and write Noms


### PR DESCRIPTION
Before it could only sync from hashes. This is not a good long-term
approach because it assumes caller can write to source db, which
might not be true.