### PR TITLE
Make server use GetMany to load hinted chunks

### DIFF
--- a/go/chunks/dynamo_store.go
+++ b/go/chunks/dynamo_store.go
@@ -122,7 +122,9 @@ func (s *DynamoStore) Get(h hash.Hash) Chunk {
 func (s *DynamoStore) GetMany(hashes hash.HashSet, foundChunks chan *Chunk) {
 	for h, _ := range hashes {
 		c := s.Get(h)
-		foundChunks <- &c
+		if !c.IsEmpty() {
+			foundChunks <- &c
+		}
 	}
 	return
 }

--- a/go/chunks/leveldb_store.go
+++ b/go/chunks/leveldb_store.go
@@ -103,7 +103,9 @@ func (l *LevelDBStore) Get(ref hash.Hash) Chunk {
 func (l *LevelDBStore) GetMany(hashes hash.HashSet, foundChunks chan *Chunk) {
 	for h, _ := range hashes {
 		c := l.Get(h)
-		foundChunks <- &c
+		if !c.IsEmpty() {
+			foundChunks <- &c
+		}
 	}
 	return
 }

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -35,7 +35,9 @@ func (ms *MemoryStore) Get(h hash.Hash) Chunk {
 func (ms *MemoryStore) GetMany(hashes hash.HashSet, foundChunks chan *Chunk) {
 	for h, _ := range hashes {
 		c := ms.Get(h)
-		foundChunks <- &c
+		if !c.IsEmpty() {
+			foundChunks <- &c
+		}
 	}
 	return
 }

--- a/go/types/batch_store.go
+++ b/go/types/batch_store.go
@@ -44,7 +44,7 @@ type BatchStore interface {
 }
 
 // Hints are a set of hashes that should be used to speed up the validation of one or more Chunks.
-type Hints map[hash.Hash]struct{}
+type Hints hash.HashSet
 
 // BatchStoreAdaptor provides a naive implementation of BatchStore should only be used with ChunkStores that can Put relatively quickly. It provides no actual batching or validation. Its intended use is for adapting a ChunkStore for use in something that requires a BatchStore.
 type BatchStoreAdaptor struct {


### PR DESCRIPTION
Now that we have GetMany, the server can use it directly to let
the chunk-fetching layer figure out the best way to batch up
requests. A small refactor allows ValidatingBatchingSink to directly
update the hint cache instead of relying on logic inside ReadValue
to do it. I made that change because ReadValue now also does a bunch
of other things around caching read values and checking a cache of
'pending Puts' that will never have anything in it when used from
the server.

Toward issue #3019