### PR TITLE
Add ValueStore.ReadManyValues()

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -19,8 +19,9 @@ type ChunkStore interface {
 	RootTracker
 }
 
-// Factory allows the creation of namespaced ChunkStore instances. The details of how namespaces
-// are separated is left up to the particular implementation of Factory and ChunkStore.
+// Factory allows the creation of namespaced ChunkStore instances. The details
+// of how namespaces are separated is left up to the particular implementation
+// of Factory and ChunkStore.
 type Factory interface {
 	CreateStore(ns string) ChunkStore
 
@@ -28,10 +29,11 @@ type Factory interface {
 	Shutter()
 }
 
-// RootTracker allows querying and management of the root of an entire tree of references. The
-// "root" is the single mutable variable in a ChunkStore. It can store any hash, but it is
-// typically used by higher layers (such as Database) to store a hash to a value that represents
-// the current state and entire history of a database.
+// RootTracker allows querying and management of the root of an entire tree of
+// references. The "root" is the single mutable variable in a ChunkStore. It
+// can store any hash, but it is typically used by higher layers (such as
+// Database) to store a hash to a value that represents the current state and
+// entire history of a database.
 type RootTracker interface {
 	Root() hash.Hash
 	UpdateRoot(current, last hash.Hash) bool
@@ -39,12 +41,13 @@ type RootTracker interface {
 
 // ChunkSource is a place to get chunks from.
 type ChunkSource interface {
-	// Get the Chunk for the value of the hash in the store. If the hash is absent from the store nil
-	// is returned.
+	// Get the Chunk for the value of the hash in the store. If the hash is
+	// absent from the store nil is returned.
 	Get(h hash.Hash) Chunk
 
-	// On return, |foundChunks| will have been fully sent all chunks which have been found. Any
-	// non-present chunks will silently be ignored.
+	// GetMany gets the Chunks with |hashes| from the store. On return,
+	// |foundChunks| will have been fully sent all chunks which have been
+	// found. Any non-present chunks will silently be ignored.
 	GetMany(hashes hash.HashSet, foundChunks chan *Chunk)
 
 	// Returns true iff the value at the address |h| is contained in the source
@@ -59,8 +62,9 @@ type ChunkSink interface {
 	// Put writes c into the ChunkSink, blocking until the operation is complete.
 	Put(c Chunk)
 
-	// PutMany tries to write chunks into the sink. It will block as it handles as many as possible,
-	// then return a BackpressureError containing the rest (if any).
+	// PutMany tries to write chunks into the sink. It will block as it
+	// handles as many as possible, then return a BackpressureError containing
+	// the rest (if any).
 	PutMany(chunks []Chunk) BackpressureError
 
 	// On return, any previously Put chunks should be durable
@@ -69,8 +73,8 @@ type ChunkSink interface {
 	io.Closer
 }
 
-// BackpressureError is a slice of hash.Hash that indicates some chunks could not be Put(). Caller
-// is free to try to Put them again later.
+// BackpressureError is a slice of hash.Hash that indicates some chunks could
+// not be Put(). Caller is free to try to Put them again later.
 type BackpressureError hash.HashSlice
 
 func (b BackpressureError) Error() string {

--- a/go/chunks/remote_requests.go
+++ b/go/chunks/remote_requests.go
@@ -4,41 +4,63 @@
 
 package chunks
 
-import "github.com/attic-labs/noms/go/hash"
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/go/hash"
+)
 
 type ReadRequest interface {
-	Hash() hash.Hash
+	Hashes() hash.HashSet
 	Outstanding() OutstandingRequest
 }
 
-func NewGetRequest(r hash.Hash, ch chan Chunk) GetRequest {
-	return GetRequest{r, ch}
+func NewGetRequest(r hash.Hash, ch chan<- *Chunk) GetRequest {
+	return GetRequest{hash.HashSet{r: struct{}{}}, ch}
 }
 
 type GetRequest struct {
-	r  hash.Hash
-	ch chan Chunk
+	hashes hash.HashSet
+	ch     chan<- *Chunk
 }
 
-func NewHasRequest(r hash.Hash, ch chan bool) HasRequest {
-	return HasRequest{r, ch}
+func NewGetManyRequest(hashes hash.HashSet, wg *sync.WaitGroup, ch chan<- *Chunk) GetManyRequest {
+	return GetManyRequest{hashes, wg, ch}
+}
+
+type GetManyRequest struct {
+	hashes hash.HashSet
+	wg     *sync.WaitGroup
+	ch     chan<- *Chunk
+}
+
+func NewHasRequest(r hash.Hash, ch chan<- bool) HasRequest {
+	return HasRequest{hash.HashSet{r: struct{}{}}, ch}
 }
 
 type HasRequest struct {
-	r  hash.Hash
-	ch chan bool
+	hashes hash.HashSet
+	ch     chan<- bool
 }
 
-func (g GetRequest) Hash() hash.Hash {
-	return g.r
+func (g GetRequest) Hashes() hash.HashSet {
+	return g.hashes
 }
 
 func (g GetRequest) Outstanding() OutstandingRequest {
 	return OutstandingGet(g.ch)
 }
 
-func (h HasRequest) Hash() hash.Hash {
-	return h.r
+func (g GetManyRequest) Hashes() hash.HashSet {
+	return g.hashes
+}
+
+func (g GetManyRequest) Outstanding() OutstandingRequest {
+	return OutstandingGetMany{g.wg, g.ch}
+}
+
+func (h HasRequest) Hashes() hash.HashSet {
+	return h.hashes
 }
 
 func (h HasRequest) Outstanding() OutstandingRequest {
@@ -46,24 +68,37 @@ func (h HasRequest) Outstanding() OutstandingRequest {
 }
 
 type OutstandingRequest interface {
-	Satisfy(c Chunk)
+	Satisfy(c *Chunk)
 	Fail()
 }
 
-type OutstandingGet chan Chunk
-type OutstandingHas chan bool
+type OutstandingGet chan<- *Chunk
+type OutstandingGetMany struct {
+	wg *sync.WaitGroup
+	ch chan<- *Chunk
+}
+type OutstandingHas chan<- bool
 
-func (r OutstandingGet) Satisfy(c Chunk) {
+func (r OutstandingGet) Satisfy(c *Chunk) {
 	r <- c
 	close(r)
 }
 
 func (r OutstandingGet) Fail() {
-	r <- EmptyChunk
+	r <- &EmptyChunk
 	close(r)
 }
 
-func (h OutstandingHas) Satisfy(c Chunk) {
+func (ogm OutstandingGetMany) Satisfy(c *Chunk) {
+	ogm.ch <- c
+	ogm.wg.Done()
+}
+
+func (ogm OutstandingGetMany) Fail() {
+	ogm.wg.Done()
+}
+
+func (h OutstandingHas) Satisfy(c *Chunk) {
 	h <- true
 	close(h)
 }

--- a/go/datas/http_batch_store.go
+++ b/go/datas/http_batch_store.go
@@ -137,10 +137,34 @@ func (bhcs *httpBatchStore) Get(h hash.Hash) chunks.Chunk {
 		return pending
 	}
 
-	ch := make(chan chunks.Chunk)
+	ch := make(chan *chunks.Chunk)
 	bhcs.requestWg.Add(1)
 	bhcs.getQueue <- chunks.NewGetRequest(h, ch)
-	return <-ch
+	return *(<-ch)
+}
+
+func (bhcs *httpBatchStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk) {
+	cachedChunks := make(chan *chunks.Chunk)
+	go func() {
+		bhcs.cacheMu.RLock()
+		defer bhcs.cacheMu.RUnlock()
+		defer close(cachedChunks)
+		bhcs.unwrittenPuts.GetMany(hashes, cachedChunks)
+	}()
+	remaining := hash.HashSet{}
+	for h := range hashes {
+		remaining.Insert(h)
+	}
+	for c := range cachedChunks {
+		remaining.Remove(c.Hash())
+		foundChunks <- c
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(remaining))
+	bhcs.requestWg.Add(1)
+	bhcs.getQueue <- chunks.NewGetManyRequest(hashes, wg, foundChunks)
+	wg.Wait()
 }
 
 func (bhcs *httpBatchStore) batchGetRequests() {
@@ -198,9 +222,10 @@ func (bhcs *httpBatchStore) sendReadRequests(req chunks.ReadRequest, queue <-cha
 
 	count := 0
 	addReq := func(req chunks.ReadRequest) {
-		hash := req.Hash()
-		batch[hash] = append(batch[hash], req.Outstanding())
-		hashes.Insert(hash)
+		for h := range req.Hashes() {
+			batch[h] = append(batch[h], req.Outstanding())
+			hashes.Insert(h)
+		}
 		count++
 	}
 
@@ -258,7 +283,7 @@ type readBatchChunkSink struct {
 func (rb *readBatchChunkSink) Put(c chunks.Chunk) {
 	rb.mu.RLock()
 	for _, or := range (*(rb.batch))[c.Hash()] {
-		or.Satisfy(c)
+		or.Satisfy(&c)
 	}
 	rb.mu.RUnlock()
 
@@ -310,7 +335,7 @@ func (bhcs *httpBatchStore) hasRefs(hashes hash.HashSet, batch chunks.ReadBatch)
 		if scanner.Text() == "true" {
 			for _, outstanding := range batch[h] {
 				// This is a little gross, but OutstandingHas.Satisfy() expects a chunk. It ignores it, though, and just sends 'true' over the channel it's holding.
-				outstanding.Satisfy(chunks.EmptyChunk)
+				outstanding.Satisfy(&chunks.EmptyChunk)
 			}
 		} else {
 			for _, outstanding := range batch[h] {

--- a/go/hash/hash.go
+++ b/go/hash/hash.go
@@ -114,6 +114,14 @@ func (h Hash) Greater(other Hash) bool {
 // HashSet is a set of Hashes.
 type HashSet map[Hash]struct{}
 
+func NewHashSet(hashes ...Hash) HashSet {
+	out := HashSet{}
+	for _, h := range hashes {
+		out.Insert(h)
+	}
+	return out
+}
+
 // Insert adds a Hash to the set.
 func (hs HashSet) Insert(hash Hash) {
 	hs[hash] = struct{}{}

--- a/go/nbs/benchmarks/block_store_benchmarks.go
+++ b/go/nbs/benchmarks/block_store_benchmarks.go
@@ -14,12 +14,7 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
-type blockStore interface {
-	types.BatchStore
-	GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk)
-}
-
-type storeOpenFn func() blockStore
+type storeOpenFn func() types.BatchStore
 
 func benchmarkNovelWrite(refreshStore storeOpenFn, src *dataSource, t assert.TestingT) bool {
 	store := refreshStore()
@@ -28,7 +23,7 @@ func benchmarkNovelWrite(refreshStore storeOpenFn, src *dataSource, t assert.Tes
 	return true
 }
 
-func writeToEmptyStore(store blockStore, src *dataSource, t assert.TestingT) {
+func writeToEmptyStore(store types.BatchStore, src *dataSource, t assert.TestingT) {
 	root := store.Root()
 	assert.Equal(t, hash.Hash{}, root)
 

--- a/go/nbs/benchmarks/file_block_store.go
+++ b/go/nbs/benchmarks/file_block_store.go
@@ -20,7 +20,7 @@ type fileBlockStore struct {
 	w  io.WriteCloser
 }
 
-func newFileBlockStore(w io.WriteCloser) blockStore {
+func newFileBlockStore(w io.WriteCloser) types.BatchStore {
 	return fileBlockStore{bufio.NewWriterSize(w, humanize.MiByte), w}
 }
 

--- a/go/nbs/benchmarks/null_block_store.go
+++ b/go/nbs/benchmarks/null_block_store.go
@@ -14,7 +14,7 @@ type nullBlockStore struct {
 	bogus int32
 }
 
-func newNullBlockStore() blockStore {
+func newNullBlockStore() types.BatchStore {
 	return nullBlockStore{}
 }
 

--- a/go/nbs/cache.go
+++ b/go/nbs/cache.go
@@ -47,6 +47,13 @@ func (nbc *NomsBlockCache) Get(hash hash.Hash) chunks.Chunk {
 	return nbc.chunks.Get(hash)
 }
 
+// GetMany gets the Chunks with |hashes| from the store. On return,
+// |foundChunks| will have been fully sent all chunks which have been
+// found. Any non-present chunks will silently be ignored.
+func (nbc *NomsBlockCache) GetMany(hashes hash.HashSet, foundChunks chan *chunks.Chunk) {
+	nbc.chunks.GetMany(hashes, foundChunks)
+}
+
 // ExtractChunks writes the entire contents of the cache to chunkChan. The
 // chunks are extracted in insertion order.
 func (nbc *NomsBlockCache) ExtractChunks(order EnumerationOrder, chunkChan chan *chunks.Chunk) {


### PR DESCRIPTION
The more code can use GetMany(), the better performance gets on top of
NBS. To this end, add a call to ValueStore that allows code to read
many values concurrently. This can be used e.g. by read-ahead code
that's navigating prolly trees to increase performance.

Fixes #3019