### PR TITLE
Make DeserializeToChan return an error, use it everywhere

### DIFF
--- a/go/chunks/chunk_serializer_test.go
+++ b/go/chunks/chunk_serializer_test.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package chunks
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestSerializeRoundTrip(t *testing.T) {
+	assert := assert.New(t)
+	inputs := [][]byte{[]byte("abc"), []byte("def")}
+	chnx := make([]Chunk, len(inputs))
+	for i, data := range inputs {
+		chnx[i] = NewChunk(data)
+	}
+
+	buf := &bytes.Buffer{}
+	Serialize(chnx[0], buf)
+	Serialize(chnx[1], buf)
+
+	chunkChan := make(chan interface{})
+	go func() {
+		defer close(chunkChan)
+		err := Deserialize(bytes.NewReader(buf.Bytes()), chunkChan)
+		assert.NoError(err)
+	}()
+
+	for i := range chunkChan {
+		assert.Equal(chnx[0].Hash(), i.(*Chunk).Hash())
+		chnx = chnx[1:]
+	}
+	assert.Len(chnx, 0)
+}

--- a/go/chunks/memory_store_test.go
+++ b/go/chunks/memory_store_test.go
@@ -29,8 +29,7 @@ func (suite *MemoryStoreTestSuite) TearDownTest() {
 
 func (suite *MemoryStoreTestSuite) TestBadSerialization() {
 	bad := []byte{0, 1} // Not enough bytes to read first length
-	ms := NewMemoryStore()
-	suite.Panics(func() {
-		Deserialize(bytes.NewReader(bad), ms, nil)
-	})
+	ch := make(chan interface{})
+	defer close(ch)
+	suite.Error(Deserialize(bytes.NewReader(bad), ch))
 }

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -162,7 +162,7 @@ func TestBuildWriteValueRequest(t *testing.T) {
 	assert.Equal(len(hints), count)
 
 	outChunkChan := make(chan interface{}, len(chnx))
-	chunks.DeserializeToChan(gr, outChunkChan)
+	chunks.Deserialize(gr, outChunkChan)
 	close(outChunkChan)
 
 	for c := range outChunkChan {
@@ -229,7 +229,7 @@ func TestHandleGetRefs(t *testing.T) {
 
 	if assert.Equal(http.StatusOK, w.Code, "Handler error:\n%s", string(w.Body.Bytes())) {
 		chunkChan := make(chan interface{}, len(chnx))
-		chunks.DeserializeToChan(w.Body, chunkChan)
+		chunks.Deserialize(w.Body, chunkChan)
 		close(chunkChan)
 
 		foundHashes := hash.HashSet{}


### PR DESCRIPTION
Chunk deserialization can run into errors sometimes if, e.g. the
client hangs up during a writeValue request. The old error strategy
worked by throwing a "catchable" error and recovering. That's OK if
you've only got one goroutine, but since the writeValue handler starts
so many goroutines, architecting the code to deal with error handling
by panic/recover is dicey.

Instead, make DeserializeToChan return an error in the more common
failure cases and handle it by passing it over a channel and raising
it from a central place.