### PR TITLE
compactingChunkStore.count() must block on compaction

### DIFF
--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -76,9 +76,9 @@ func (ccs *compactingChunkSource) close() error {
 }
 
 func (ccs *compactingChunkSource) count() uint32 {
-	cr := ccs.getReader()
-	d.Chk.True(cr != nil)
-	return cr.count()
+	ccs.wg.Wait()
+	d.Chk.True(ccs.cs != nil)
+	return ccs.cs.count()
 }
 
 func (ccs *compactingChunkSource) hash() addr {

--- a/go/nbs/compacting_chunk_source_test.go
+++ b/go/nbs/compacting_chunk_source_test.go
@@ -39,7 +39,7 @@ func TestCompactingChunkStore(t *testing.T) {
 	ccs := newCompactingChunkSource(mt, nil, pausingFakeTablePersister{newFakeTablePersister(), trigger}, make(chan struct{}, 1))
 
 	assertChunksInReader(testChunks, ccs, assert)
-	assert.EqualValues(mt.count(), ccs.count())
+	assert.EqualValues(mt.count(), ccs.getReader().count())
 	close(trigger)
 
 	assert.NotEqual(addr{}, ccs.hash())


### PR DESCRIPTION
Compaction not only persists the contents of a memTable, it also
filters out duplicate chunks. This means that calling count() on a
compactingChunkStore before and after compaction completes could lead
to different results. In the case where the memTable contains only
duplicate chunks, this is Very Bad becuase it leads to an non-existent
table winding up in the NBS manifest.

Fixes #3044