### PR TITLE
Fix bug in read ahead for sequence.iter

### DIFF
--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -223,7 +223,7 @@ func (cur *sequenceCursor) iter(cb cursorIterCallback) {
 	for ch := range curChan {
 		leafCursor := <-ch
 		for leafCursor.valid() {
-			if cb(leafCursor.getItem(cur.idx)) {
+			if cb(leafCursor.getItem(leafCursor.idx)) {
 				stopChan <- struct{}{}
 				for _ = range curChan {
 				} // ensure async loading goroutine exits before we do

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -205,7 +205,7 @@ type cursorIterCallback func(item interface{}) bool
 
 // iter iterates forward from the current position
 func (cur *sequenceCursor) iter(cb cursorIterCallback) {
-	if !cur.readAhead {
+	if cur.parent == nil || !cur.parent.readAhead {
 		for cur.valid() && !cb(cur.getItem(cur.idx)) {
 			cur.advance()
 		}


### PR DESCRIPTION
The issue is that iter() using readAheadLeafCursors is tied to whether a cursor is created with the `readAhead` flag. However, readAhead flags can *never* be set of "leaf" cursors.

Check the flag on parent cursor instead (if there is no parent, its fine since readAhead wont do anything).

TBR @ehalpern 