### PR TITLE
Work around environment variable issue.

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "67.0.0",
+  "version": "67.1.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/version.js
+++ b/js/noms/src/version.js
@@ -6,13 +6,14 @@
 
 export default '7.1';
 
-const envName = 'NOMS_VERSION_NEXT';
 const envVal = '1';
 const details = 'https://github.com/attic-labs/noms#install-noms';
 
-if (process.env[envName] !== envVal) {
+// Do not extract the environment variable name into a constant. Our build pipeline does not replace
+// the value if we do that.
+if (process.env.NOMS_VERSION_NEXT !== envVal) {
   throw new Error(
     `WARNING: This is an unstable version of Noms. Data created with it won't be supported.\n` +
     `Please see ${details} for getting the latest supported version.\n` +
-    `Or add ${envName}=${envVal} to your environment to proceed with this version.\n`);
+    `Or add NOMS_VERSION_NEXT=${envVal} to your environment to proceed with this version.\n`);
 }


### PR DESCRIPTION
We are using babel-plugin-transform-inline-environment-variables which
replaces `process.env.FOO` with the value of the `FOO` environment
variable at compile time.

However, due to our pipeline we end with something like:

```js
var NAME = 'NOMS_VERSION_NEXT';
process.env[NAME]
```

which does not get replaced in development mode. If it was a const the
transformer could replace it but var bindings can change.