### PR TITLE
Only request remaining hashes in httpBatchStore.GetMany()

### DIFF
--- a/go/datas/http_batch_store.go
+++ b/go/datas/http_batch_store.go
@@ -163,7 +163,7 @@ func (bhcs *httpBatchStore) GetMany(hashes hash.HashSet, foundChunks chan *chunk
 	wg := &sync.WaitGroup{}
 	wg.Add(len(remaining))
 	bhcs.requestWg.Add(1)
-	bhcs.getQueue <- chunks.NewGetManyRequest(hashes, wg, foundChunks)
+	bhcs.getQueue <- chunks.NewGetManyRequest(remaining, wg, foundChunks)
 	wg.Wait()
 }
 

--- a/go/datas/http_batch_store.go
+++ b/go/datas/http_batch_store.go
@@ -160,6 +160,9 @@ func (bhcs *httpBatchStore) GetMany(hashes hash.HashSet, foundChunks chan *chunk
 		foundChunks <- c
 	}
 
+	if len(remaining) == 0 {
+		return
+	}
 	wg := &sync.WaitGroup{}
 	wg.Add(len(remaining))
 	bhcs.requestWg.Add(1)

--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -292,6 +292,24 @@ func (suite *HTTPBatchStoreSuite) TestGetMany() {
 	suite.True(hashes.Has(notPresent))
 }
 
+func (suite *HTTPBatchStoreSuite) TestGetManyAllCached() {
+	chnx := []chunks.Chunk{
+		chunks.NewChunk([]byte("abc")),
+		chunks.NewChunk([]byte("def")),
+	}
+	suite.store.SchedulePut(chnx[0], 1, types.Hints{})
+	suite.store.SchedulePut(chnx[1], 1, types.Hints{})
+
+	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash())
+	foundChunks := make(chan *chunks.Chunk)
+	go func() { suite.store.GetMany(hashes, foundChunks); close(foundChunks) }()
+
+	for c := range foundChunks {
+		hashes.Remove(c.Hash())
+	}
+	suite.Len(hashes, 0)
+}
+
 func (suite *HTTPBatchStoreSuite) TestGetManySomeCached() {
 	chnx := []chunks.Chunk{
 		chunks.NewChunk([]byte("abc")),

--- a/go/datas/http_batch_store_test.go
+++ b/go/datas/http_batch_store_test.go
@@ -292,6 +292,25 @@ func (suite *HTTPBatchStoreSuite) TestGetMany() {
 	suite.True(hashes.Has(notPresent))
 }
 
+func (suite *HTTPBatchStoreSuite) TestGetManySomeCached() {
+	chnx := []chunks.Chunk{
+		chunks.NewChunk([]byte("abc")),
+		chunks.NewChunk([]byte("def")),
+	}
+	cached := chunks.NewChunk([]byte("ghi"))
+	suite.NoError(suite.cs.PutMany(chnx))
+	suite.store.SchedulePut(cached, 1, types.Hints{})
+
+	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), cached.Hash())
+	foundChunks := make(chan *chunks.Chunk)
+	go func() { suite.store.GetMany(hashes, foundChunks); close(foundChunks) }()
+
+	for c := range foundChunks {
+		hashes.Remove(c.Hash())
+	}
+	suite.Len(hashes, 0)
+}
+
 func (suite *HTTPBatchStoreSuite) TestGetSame() {
 	chnx := []chunks.Chunk{
 		chunks.NewChunk([]byte("def")),


### PR DESCRIPTION
In httpBatchStore.GetMany(), we check our unwritten
puts to see if any of the requested chunks already
exist locally. If any do, we're _supposed_ to remove
their hashes from the set slated to be requested from
the server. That logic was borked.

Fixes https://github.com/attic-labs/attic/issues/503