### PR TITLE
Increase Chunk locality when writing Values through ValueStore

### DIFF
--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -186,10 +186,10 @@ func (dbc *databaseCommon) getRootAndDatasets() (currentRootHash hash.Hash, curr
 
 func (dbc *databaseCommon) tryUpdateRoot(currentDatasets types.Map, currentRootHash hash.Hash) (err error) {
 	// TODO: This Map will be orphaned if the UpdateRoot below fails
-	newRootRef := dbc.WriteValue(currentDatasets).TargetHash()
-	dbc.Flush()
+	newRootHash := dbc.WriteValue(currentDatasets).TargetHash()
+	dbc.Flush(newRootHash)
 	// If the root has been updated by another process in the short window since we read it, this call will fail. See issue #404
-	if !dbc.rt.UpdateRoot(newRootRef, currentRootHash) {
+	if !dbc.rt.UpdateRoot(newRootHash, currentRootHash) {
 		err = ErrOptimisticLockFailed
 	}
 	return

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -73,24 +73,23 @@ func (suite *DatabaseSuite) TearDownTest() {
 
 func (suite *DatabaseSuite) TestReadWriteCache() {
 	var v types.Value = types.Bool(true)
-	suite.NotEqual(hash.Hash{}, suite.db.WriteValue(v))
-	r := suite.db.WriteValue(v).TargetHash()
-	ds := suite.db.GetDataset("foo")
-	_, err := suite.db.CommitValue(ds, v)
+	r := suite.db.WriteValue(v)
+	suite.NotEqual(hash.Hash{}, r.TargetHash())
+	_, err := suite.db.CommitValue(suite.db.GetDataset("foo"), r)
 	suite.NoError(err)
 	suite.Equal(1, suite.cs.Writes-writesOnCommit)
 
-	v = suite.db.ReadValue(r)
+	v = suite.db.ReadValue(r.TargetHash())
 	suite.True(v.Equals(types.Bool(true)))
 }
 
 func (suite *DatabaseSuite) TestReadWriteCachePersists() {
 	var err error
 	var v types.Value = types.Bool(true)
-	suite.NotEqual(hash.Hash{}, suite.db.WriteValue(v))
 	r := suite.db.WriteValue(v)
+	suite.NotEqual(hash.Hash{}, r.TargetHash())
 	ds := suite.db.GetDataset("foo")
-	ds, err = suite.db.CommitValue(ds, v)
+	ds, err = suite.db.CommitValue(ds, r)
 	suite.NoError(err)
 	suite.Equal(1, suite.cs.Writes-writesOnCommit)
 

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -389,12 +389,12 @@ func TestHandlePostRoot(t *testing.T) {
 	commitRef := vs.WriteValue(commit)
 	firstHead := types.NewMap(types.String("dataset1"), types.ToRefOfValue(commitRef))
 	firstHeadRef := vs.WriteValue(firstHead)
-	vs.Flush()
+	vs.Flush(firstHeadRef.TargetHash())
 
 	commit = buildTestCommit(types.String("second"), commitRef)
 	newHead := types.NewMap(types.String("dataset1"), types.ToRefOfValue(vs.WriteValue(commit)))
 	newHeadRef := vs.WriteValue(newHead)
-	vs.Flush()
+	vs.Flush(newHeadRef.TargetHash())
 
 	// First attempt should fail, as 'last' won't match.
 	u := &url.URL{}

--- a/go/merge/three_way_keyval_test.go
+++ b/go/merge/three_way_keyval_test.go
@@ -132,7 +132,6 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefMerge() {
 	ma := kvs{"r1", strRef, "r2", s.vs.WriteValue(s.create(aa1a))}
 	mb := kvs{"r1", strRef, "r2", s.vs.WriteValue(s.create(aa1b))}
 	mMerged := kvs{"r1", strRef, "r2", s.vs.WriteValue(s.create(aaMerged))}
-	s.vs.Flush()
 
 	s.tryThreeWayMerge(ma, mb, m, mMerged)
 	s.tryThreeWayMerge(mb, ma, m, mMerged)
@@ -143,7 +142,6 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RecursiveMultiLevelMerge() 
 	ma := kvs{"mm1", mm1a, "mm2", s.vs.WriteValue(s.create(mm2a))}
 	mb := kvs{"mm1", mm1b, "mm2", s.vs.WriteValue(s.create(mm2b))}
 	mMerged := kvs{"mm1", mm1Merged, "mm2", s.vs.WriteValue(s.create(mm2Merged))}
-	s.vs.Flush()
 
 	s.tryThreeWayMerge(ma, mb, m, mMerged)
 	s.tryThreeWayMerge(mb, ma, m, mMerged)
@@ -222,7 +220,6 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefConflict() {
 	m := kvs{"r2", strRef}
 	ma := kvs{"r1", strRef, "r2", strRef}
 	mb := kvs{"r1", numRef, "r2", strRef}
-	s.vs.Flush()
 
 	s.tryThreeWayConflict(s.create(ma), s.create(mb), s.create(m), "Cannot merge struct Foo")
 	s.tryThreeWayConflict(s.create(mb), s.create(ma), s.create(m), "Cannot merge Number and struct")

--- a/go/merge/three_way_set_test.go
+++ b/go/merge/three_way_set_test.go
@@ -74,7 +74,6 @@ func (s *ThreeWaySetMergeSuite) TestThreeWayMerge_Refs() {
 	ma := items{"r1", s.vs.WriteValue(s.create(flatA))}
 	mb := items{"r1", strRef, s.vs.WriteValue(s.create(flatA))}
 	mMerged := items{"r1", strRef, s.vs.WriteValue(s.create(flatA))}
-	s.vs.Flush()
 
 	s.tryThreeWayMerge(ma, mb, m, mMerged)
 	s.tryThreeWayMerge(mb, ma, m, mMerged)

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -290,7 +290,6 @@ func (tr tableReader) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, 
 		go tr.readAtOffsets(readStart, readEnd, reqs, batch, foundChunks, wg)
 		batch = nil
 	}
-
 	return
 }
 

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -290,6 +290,7 @@ func (tr tableReader) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, 
 		go tr.readAtOffsets(readStart, readEnd, reqs, batch, foundChunks, wg)
 		batch = nil
 	}
+
 	return
 }
 

--- a/go/types/incremental_test.go
+++ b/go/types/incremental_test.go
@@ -39,10 +39,10 @@ func TestIncrementalLoadList(t *testing.T) {
 	vs := newLocalValueStore(cs)
 
 	expected := NewList(testVals...)
-	ref := vs.WriteValue(expected).TargetHash()
-	vs.Flush()
+	hash := vs.WriteValue(expected).TargetHash()
+	vs.Flush(hash)
 
-	actualVar := vs.ReadValue(ref)
+	actualVar := vs.ReadValue(hash)
 	actual := actualVar.(List)
 
 	expectedCount := cs.Reads

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -958,17 +958,17 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	vs1 := newLocalValueStore(cs1)
 	nums1 := generateNumbersAsValues(4000)
 	l1 := NewList(nums1...)
-	ref1 := vs1.WriteValue(l1).TargetHash()
-	vs1.Flush()
-	refList1 := vs1.ReadValue(ref1).(List)
+	hash1 := vs1.WriteValue(l1).TargetHash()
+	vs1.Flush(hash1)
+	refList1 := vs1.ReadValue(hash1).(List)
 
 	cs2 := chunks.NewTestStore()
 	vs2 := newLocalValueStore(cs2)
 	nums2 := generateNumbersAsValuesFromToBy(5, 3550, 1)
 	l2 := NewList(nums2...)
-	ref2 := vs2.WriteValue(l2).TargetHash()
-	vs2.Flush()
-	refList2 := vs2.ReadValue(ref2).(List)
+	hash2 := vs2.WriteValue(l2).TargetHash()
+	vs2.Flush(hash2)
+	refList2 := vs2.ReadValue(hash2).(List)
 
 	// diff lists without value store
 	diff1 := accumulateDiffSplices(l2, l1)

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -190,8 +190,12 @@ func newMapTestSuite(size uint, expectRefStr string, expectChunkCount int, expec
 				idx := uint64(0)
 				l2.Iter(func(key, value Value) (stop bool) {
 					entry := elems.entries[idx]
-					if !key.Equals(entry.key) || !value.Equals(entry.value) {
-						fmt.Printf("%s != %s or %s != %s", EncodedValue(key), EncodedValue(entry.key), EncodedValue(value), EncodedValue(entry.value))
+					if !key.Equals(entry.key) {
+						fmt.Printf("%d: %s (%s)\n!=\n%s (%s)\n", idx, EncodedValueWithTags(key), key.Hash(), EncodedValueWithTags(entry.key), entry.key.Hash())
+						stop = true
+					}
+					if !value.Equals(entry.value) {
+						fmt.Printf("%s (%s) !=\n%s (%s)\n", EncodedValueWithTags(value), value.Hash(), EncodedValueWithTags(entry.value), entry.value.Hash())
 						stop = true
 					}
 					idx++

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"sort"
 	"sync"
@@ -181,12 +182,22 @@ func newMapTestSuite(size uint, expectRefStr string, expectChunkCount int, expec
 			expectPrependChunkDiff: expectPrependChunkDiff,
 			expectAppendChunkDiff:  expectAppendChunkDiff,
 			validate: func(v2 Collection) bool {
+				if v2.Len() != uint64(elems.entries.Len()) {
+					fmt.Println("lengths not equal:", v2.Len(), elems.entries.Len())
+					return false
+				}
 				l2 := v2.(Map)
-				out := ValueSlice{}
-				l2.IterAll(func(key, value Value) {
-					out = append(out, key, value)
+				idx := uint64(0)
+				l2.Iter(func(key, value Value) (stop bool) {
+					entry := elems.entries[idx]
+					if !key.Equals(entry.key) || !value.Equals(entry.value) {
+						fmt.Printf("%s != %s or %s != %s", EncodedValue(key), EncodedValue(entry.key), EncodedValue(value), EncodedValue(entry.value))
+						stop = true
+					}
+					idx++
+					return
 				})
-				return ValueSlice(elems.FlattenAll()).Equals(out)
+				return idx == v2.Len()
 			},
 			prependOne: func() Collection {
 				dup := make([]mapEntry, length+1)

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -97,9 +97,9 @@ func (suite *diffTestSuite) TestDiff() {
 
 	rw := func(col Collection) Collection {
 		vs := NewTestValueStore()
-		r := vs.WriteValue(col)
-		vs.Flush()
-		return vs.ReadValue(r.TargetHash()).(Collection)
+		h := vs.WriteValue(col).TargetHash()
+		vs.Flush(h)
+		return vs.ReadValue(h).(Collection)
 	}
 	newSetAsColRw := func(vs []Value) Collection { return rw(newSetAsCol(vs)) }
 	newMapAsColRw := func(vs []Value) Collection { return rw(newMapAsCol(vs)) }

--- a/go/types/validating_batching_sink.go
+++ b/go/types/validating_batching_sink.go
@@ -42,7 +42,7 @@ func (vbs *ValidatingBatchingSink) Prepare(hints Hints) {
 			defer vbs.pool.Put(tc)
 			for c := range foundChunks {
 				v := DecodeFromBytes(c.Data(), vbs.vs, tc.(*TypeCache))
-				vbs.vs.setHintsForReadValue(v, c.Hash())
+				vbs.vs.setHintsForReadValue(v, c.Hash(), false)
 			}
 		}()
 	}

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -45,18 +45,24 @@ type ValueReadWriter interface {
 // - all Refs in v point to a Value that can be read from this ValueStore
 // - all Refs in v point to a Value of the correct Type
 type ValueStore struct {
-	bs           BatchStore
-	cacheMu      sync.RWMutex
-	hintCache    map[hash.Hash]chunkCacheEntry
-	pendingHints map[hash.Hash]chunkCacheEntry
-	pendingMu    sync.RWMutex
-	pendingPuts  map[hash.Hash]pendingChunk
-	valueCache   *sizecache.SizeCache
-	opcStore     opCacheStore
-	once         sync.Once
+	bs             BatchStore
+	cacheMu        sync.RWMutex
+	hintCache      map[hash.Hash]chunkCacheEntry
+	pendingHints   map[hash.Hash]chunkCacheEntry
+	pendingMu      sync.RWMutex
+	pendingPuts    map[hash.Hash]pendingChunk
+	pendingPutMax  uint64
+	pendingPutSize uint64
+	pendingParents map[hash.Hash]uint64 // chunk Hash -> ref height
+	valueCache     *sizecache.SizeCache
+	opcStore       opCacheStore
+	once           sync.Once
 }
 
-const defaultValueCacheSize = 1 << 25 // 32MB
+const (
+	defaultValueCacheSize = 1 << 25 // 32MB
+	defaultPendingPutMax  = 1 << 28 // 256MB
+)
 
 type chunkCacheEntry interface {
 	Present() bool
@@ -88,15 +94,22 @@ func NewValueStore(bs BatchStore) *ValueStore {
 }
 
 func NewValueStoreWithCache(bs BatchStore, cacheSize uint64) *ValueStore {
+	return newValueStoreWithCacheAndPending(bs, cacheSize, defaultPendingPutMax)
+}
+
+func newValueStoreWithCacheAndPending(bs BatchStore, cacheSize, pendingMax uint64) *ValueStore {
 	return &ValueStore{
-		bs:           bs,
-		cacheMu:      sync.RWMutex{},
-		hintCache:    map[hash.Hash]chunkCacheEntry{},
-		pendingHints: map[hash.Hash]chunkCacheEntry{},
-		pendingMu:    sync.RWMutex{},
-		pendingPuts:  map[hash.Hash]pendingChunk{},
-		valueCache:   sizecache.New(cacheSize),
-		once:         sync.Once{},
+		bs:             bs,
+		cacheMu:        sync.RWMutex{},
+		hintCache:      map[hash.Hash]chunkCacheEntry{},
+		pendingHints:   map[hash.Hash]chunkCacheEntry{},
+		pendingMu:      sync.RWMutex{},
+		pendingPuts:    map[hash.Hash]pendingChunk{},
+		pendingPutMax:  pendingMax,
+		pendingParents: map[hash.Hash]uint64{},
+
+		valueCache: sizecache.New(cacheSize),
+		once:       sync.Once{},
 	}
 }
 
@@ -229,35 +242,115 @@ func (lvs *ValueStore) WriteValue(v Value) Ref {
 
 	// TODO: It _really_ feels like there should be some refactoring that allows us to only have to walk the refs of |v| once, but I'm hesitant to undertake that refactor right now.
 	hints := lvs.chunkHintsFromCache(v)
+	lvs.putGrandchildren(v, c, height, hints)
 
-	func() {
-		lvs.pendingMu.Lock()
-		defer lvs.pendingMu.Unlock()
-		lvs.pendingPuts[h] = pendingChunk{c, height, hints}
-		v.WalkRefs(func(reachable Ref) {
-			if pc, present := lvs.pendingPuts[reachable.TargetHash()]; present {
-				lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
-				delete(lvs.pendingPuts, reachable.TargetHash())
-			}
-		})
-	}()
-
-	lvs.setHintsForReachable(v, v.Hash(), true)
+	lvs.setHintsForReachable(v, h, true)
 	lvs.set(h, (*presentChunk)(v.Type()), false)
 	lvs.valueCache.Drop(h)
 	return r
 }
 
-func (lvs *ValueStore) Flush() {
+func (lvs *ValueStore) putGrandchildren(v Value, c chunks.Chunk, height uint64, hints Hints) {
+	lvs.pendingMu.Lock()
+	defer lvs.pendingMu.Unlock()
+	h := c.Hash()
+	d.Chk.NotZero(height)
+	lvs.pendingPuts[h] = pendingChunk{c, height, hints}
+	lvs.pendingPutSize += uint64(len(c.Data()))
+
+	putChildren := func(parent hash.Hash) (dataPut int) {
+		pc, present := lvs.pendingPuts[parent]
+		d.Chk.True(present)
+		v := DecodeValue(pc.c, lvs)
+		v.WalkRefs(func(grandchildRef Ref) {
+			if pc, present := lvs.pendingPuts[grandchildRef.TargetHash()]; present {
+				lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
+				dataPut += len(pc.c.Data())
+				delete(lvs.pendingPuts, grandchildRef.TargetHash())
+			}
+		})
+		return
+	}
+
+	if height > 1 {
+		v.WalkRefs(func(childRef Ref) {
+			childHash := childRef.TargetHash()
+			if _, present := lvs.pendingPuts[childHash]; present {
+				lvs.pendingParents[h] = height
+			} else {
+				// Shouldn't be able to be in pendingParents without being in pendingPuts
+				_, present := lvs.pendingParents[childHash]
+				d.Chk.False(present)
+			}
+
+			if _, present := lvs.pendingParents[childHash]; present {
+				lvs.pendingPutSize -= uint64(putChildren(childHash))
+				delete(lvs.pendingParents, childHash)
+			}
+		})
+	}
+
+	for lvs.pendingPutSize > lvs.pendingPutMax {
+		var tallest hash.Hash
+		var height uint64 = 0
+		for parent, ht := range lvs.pendingParents {
+			if ht > height {
+				tallest = parent
+				height = ht
+			}
+		}
+		if height == 0 { // This can happen if there are no pending parents
+			var pc pendingChunk
+			for tallest, pc = range lvs.pendingPuts {
+				// Any pendingPut is as good as another in this case, so take the first one
+				break
+			}
+			lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
+			lvs.pendingPutSize -= uint64(len(pc.c.Data()))
+			delete(lvs.pendingPuts, tallest)
+			continue
+		}
+
+		lvs.pendingPutSize -= uint64(putChildren(tallest))
+		delete(lvs.pendingParents, tallest)
+	}
+}
+
+func (lvs *ValueStore) Flush(root hash.Hash) {
 	func() {
 		lvs.pendingMu.Lock()
 		defer lvs.pendingMu.Unlock()
-		for _, pc := range lvs.pendingPuts {
-			lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
+
+		pc, present := lvs.pendingPuts[root]
+		if !present {
+			return
 		}
-		lvs.pendingPuts = map[hash.Hash]pendingChunk{}
+
+		put := func(h hash.Hash, pc pendingChunk) uint64 {
+			lvs.bs.SchedulePut(pc.c, pc.height, pc.hints)
+			delete(lvs.pendingPuts, h)
+			return uint64(len(pc.c.Data()))
+		}
+		v := DecodeValue(pc.c, lvs)
+		v.WalkRefs(func(reachable Ref) {
+			if pc, present := lvs.pendingPuts[reachable.TargetHash()]; present {
+				lvs.pendingPutSize -= put(reachable.TargetHash(), pc)
+			}
+		})
+		delete(lvs.pendingParents, root) // If not present, this is idempotent
+		lvs.pendingPutSize -= put(root, pc)
+
+		// Merge in pending hints
+		lvs.cacheMu.Lock()
+		defer lvs.cacheMu.Unlock()
+		for h, entry := range lvs.pendingHints {
+			if _, present := lvs.pendingPuts[h]; !present {
+				lvs.hintCache[h] = entry
+			} else {
+				delete(lvs.pendingHints, h)
+			}
+		}
 	}()
-	lvs.mergePendingHints()
 	lvs.bs.Flush()
 }
 
@@ -302,16 +395,6 @@ func (lvs *ValueStore) set(r hash.Hash, entry chunkCacheEntry, toPending bool) {
 	} else {
 		lvs.hintCache[r] = entry
 	}
-}
-
-func (lvs *ValueStore) mergePendingHints() {
-	lvs.cacheMu.Lock()
-	defer lvs.cacheMu.Unlock()
-
-	for h, entry := range lvs.pendingHints {
-		lvs.hintCache[h] = entry
-	}
-	lvs.pendingHints = map[hash.Hash]chunkCacheEntry{}
 }
 
 func (lvs *ValueStore) chunkHintsFromCache(v Value) Hints {

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -18,9 +18,9 @@ func TestValueReadWriteRead(t *testing.T) {
 	s := String("hello")
 	vs := NewTestValueStore()
 	assert.Nil(vs.ReadValue(s.Hash())) // nil
-	r := vs.WriteValue(s)
-	vs.Flush()
-	v := vs.ReadValue(r.TargetHash()) // non-nil
+	h := vs.WriteValue(s).TargetHash()
+	vs.Flush(h)
+	v := vs.ReadValue(h) // non-nil
 	assert.True(s.Equals(v))
 }
 
@@ -31,9 +31,10 @@ func TestValueReadMany(t *testing.T) {
 	vs := NewTestValueStore()
 	hashes := hash.HashSet{}
 	for _, v := range vals {
-		hashes.Insert(vs.WriteValue(v).TargetHash())
+		h := vs.WriteValue(v).TargetHash()
+		hashes.Insert(h)
+		vs.Flush(h)
 	}
-	vs.Flush()
 
 	// Get one Value into vs's Value cache
 	vs.ReadValue(vals[0].Hash())
@@ -60,6 +61,23 @@ func TestValueReadMany(t *testing.T) {
 	}
 }
 
+func TestValueWriteFlush(t *testing.T) {
+	assert := assert.New(t)
+
+	vals := ValueSlice{String("hello"), Bool(true), Number(42)}
+	vs := NewTestValueStore()
+	hashes := hash.HashSet{}
+	for _, v := range vals {
+		hashes.Insert(vs.WriteValue(v).TargetHash())
+	}
+	assert.NotZero(vs.pendingPutSize)
+
+	for h := range hashes {
+		vs.Flush(h)
+	}
+	assert.Zero(vs.pendingPutSize)
+}
+
 func TestCheckChunksInCache(t *testing.T) {
 	assert := assert.New(t)
 	cs := chunks.NewTestStore()
@@ -75,8 +93,7 @@ func TestCheckChunksInCache(t *testing.T) {
 
 func TestCheckChunksInCachePostCommit(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewTestStore()
-	cvs := newLocalValueStore(cs)
+	vs := NewTestValueStore()
 
 	l := NewList()
 	r := NewRef(l)
@@ -87,15 +104,15 @@ func TestCheckChunksInCachePostCommit(t *testing.T) {
 		i++
 	}
 
-	cvs.WriteValue(l)
+	h := vs.WriteValue(l).TargetHash()
 	// Hints for leaf sequences should be absent prior to Flush...
 	l.WalkRefs(func(ref Ref) {
-		assert.True(cvs.check(ref.TargetHash()).Hint().IsEmpty())
+		assert.True(vs.check(ref.TargetHash()).Hint().IsEmpty())
 	})
-	cvs.Flush()
+	vs.Flush(h)
 	// ...And present afterwards
 	l.WalkRefs(func(ref Ref) {
-		assert.True(cvs.check(ref.TargetHash()).Hint() == l.Hash())
+		assert.True(vs.check(ref.TargetHash()).Hint() == l.Hash())
 	})
 }
 
@@ -133,6 +150,82 @@ func TestCheckChunksNotInCache(t *testing.T) {
 
 	bref := NewRef(b)
 	assert.Panics(func() { cvs.chunkHintsFromCache(bref) })
+}
+
+type checkingBatchStore struct {
+	BatchStore
+	a             *assert.Assertions
+	expectedOrder hash.HashSlice
+}
+
+func (cbs *checkingBatchStore) expect(rs ...Ref) {
+	for _, r := range rs {
+		cbs.expectedOrder = append(cbs.expectedOrder, r.TargetHash())
+	}
+}
+
+func (cbs *checkingBatchStore) SchedulePut(c chunks.Chunk, refHeight uint64, hints Hints) {
+	if cbs.a.NotZero(len(cbs.expectedOrder)) {
+		cbs.a.Equal(cbs.expectedOrder[0], c.Hash())
+		cbs.expectedOrder = cbs.expectedOrder[1:]
+	}
+}
+
+func (cbs *checkingBatchStore) Flush() {
+	cbs.a.Empty(cbs.expectedOrder)
+}
+
+func TestFlushOrder(t *testing.T) {
+	assert := assert.New(t)
+	bs := &checkingBatchStore{NewBatchStoreAdaptor(chunks.NewTestStore()), assert, nil}
+	vs := NewValueStore(bs)
+	// Graph, which should be flushed grandchildren-first, bottom-up
+	//         l
+	//        / \
+	//      ml1  ml2
+	//     /   \    \
+	//    b    ml    f
+	//        /  \
+	//       s    n
+	//
+	// Expected order: s, n, b, ml, f, ml1, ml2, l
+	s := String("oy")
+	n := Number(42)
+	sr, nr := vs.WriteValue(s), vs.WriteValue(n)
+	bs.expect(sr, nr)
+	ml := NewList(sr, nr)
+
+	b := NewEmptyBlob()
+	br, mlr := vs.WriteValue(b), vs.WriteValue(ml)
+	bs.expect(br, mlr)
+	ml1 := NewList(br, mlr)
+
+	f := Bool(false)
+	fr := vs.WriteValue(f)
+	bs.expect(fr)
+	ml2 := NewList(fr)
+
+	ml1r, ml2r := vs.WriteValue(ml1), vs.WriteValue(ml2)
+	bs.expect(ml1r, ml2r)
+	l := NewList(ml1r, ml2r)
+
+	r := vs.WriteValue(l)
+	bs.expect(r)
+	vs.Flush(l.Hash())
+}
+
+func TestFlushOverSize(t *testing.T) {
+	assert := assert.New(t)
+	bs := &checkingBatchStore{NewBatchStoreAdaptor(chunks.NewTestStore()), assert, nil}
+	vs := newValueStoreWithCacheAndPending(bs, 0, 10)
+
+	s := String("oy")
+	sr := vs.WriteValue(s)
+	l := NewList(sr)
+	bs.expect(sr, NewRef(l))
+
+	vs.WriteValue(l)
+	vs.Flush(l.Hash())
 }
 
 func TestEnsureChunksInCache(t *testing.T) {
@@ -182,7 +275,7 @@ func TestCacheOnReadValue(t *testing.T) {
 	b := NewEmptyBlob()
 	bref := cvs.WriteValue(b)
 	r := cvs.WriteValue(bref)
-	cvs.Flush()
+	cvs.Flush(r.TargetHash())
 
 	cvs2 := newLocalValueStore(cs)
 	v := cvs2.ReadValue(r.TargetHash())
@@ -229,7 +322,7 @@ func TestPanicOnReadBadVersion(t *testing.T) {
 
 func TestPanicOnWriteBadVersion(t *testing.T) {
 	cvs := newLocalValueStore(&badVersionStore{chunks.NewTestStore()})
-	assert.Panics(t, func() { cvs.WriteValue(NewEmptyBlob()); cvs.Flush() })
+	assert.Panics(t, func() { r := cvs.WriteValue(NewEmptyBlob()); cvs.Flush(r.TargetHash()) })
 }
 
 type badVersionStore struct {

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -307,10 +307,8 @@ func TestHintsOnCache(t *testing.T) {
 
 		hints := cvs.chunkHintsFromCache(s2)
 		if assert.Len(hints, 1) {
-			for _, hash := range []hash.Hash{r.TargetHash()} {
-				_, present := hints[hash]
-				assert.True(present)
-			}
+			_, present := hints[r.TargetHash()]
+			assert.True(present)
 		}
 	}
 }


### PR DESCRIPTION
Readahead + NBS benefit greatly when "related" Chunks are close to
each other. The current code did a good job of writing siblings in the
Chunk graph next to each other, but "cousins" (that is, children whose
parents are siblings) might wind up spread quite far apart.  This
patch makes WriteValue hold onto novel Chunks until it sees a
_grandparent_ come through the pipeline. All of that Chunk's queued
grandchildren will be Put at that time.
    
Additionally, ValueStore.Flush() now takes a Hash and flushes all
Chunks that are reachable from the Chunk with that Hash, as opposed
to simply flushing all Chunks to the BatchStore. This means that
there's now no supported way to write orphaned Chunks/Values to a
Database.
    
Fixes #3051
