### PR TITLE
webpack-config: Pick up noms version next

### DIFF
--- a/js/webpack-config/index.js
+++ b/js/webpack-config/index.js
@@ -12,6 +12,7 @@ const devMode = process.env.NODE_ENV !== 'production';
 function replaceEnv(envVars) {
   const replacements = {
     'process.env.NODE_ENV': JSON.stringify(String(process.env.NODE_ENV)),
+    'process.env.NOMS_VERSION_NEXT': JSON.stringify(String(process.env.NOMS_VERSION_NEXT)),
   };
   for (const name of envVars) {
     if (!(name in process.env)) {

--- a/js/webpack-config/package.json
+++ b/js/webpack-config/package.json
@@ -3,7 +3,7 @@
   "description": "Shared webpack config for noms",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/webpack-config",
   "license": "Apache-2.0",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "index.js",
   "dependencies": {
     "babel-loader": "^6.2.1",


### PR DESCRIPTION
Make sure we replace process.env.NOMS_VERSION_NEXT for webpack builds