### PR TITLE
Parallelize walk.Walk

### DIFF
--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -87,6 +87,10 @@ func (b Blob) hashPointer() *hash.Hash {
 	return b.h
 }
 
+func (b Blob) IsLeaf() bool {
+	return !isMetaSequence(b.sequence())
+}
+
 // Value interface
 func (b Blob) Equals(other Value) bool {
 	return b.Hash() == other.Hash()

--- a/go/types/collection.go
+++ b/go/types/collection.go
@@ -8,5 +8,6 @@ type Collection interface {
 	Value
 	Len() uint64
 	Empty() bool
+	IsLeaf() bool
 	sequence() sequence
 }

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -73,6 +73,10 @@ func (l List) hashPointer() *hash.Hash {
 	return l.h
 }
 
+func (l List) IsLeaf() bool {
+	return !isMetaSequence(l.sequence())
+}
+
 // Value interface
 
 func (l List) Equals(other Value) bool {

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -91,6 +91,10 @@ func (m Map) hashPointer() *hash.Hash {
 	return m.h
 }
 
+func (m Map) IsLeaf() bool {
+	return !isMetaSequence(m.sequence())
+}
+
 // Value interface
 func (m Map) Equals(other Value) bool {
 	return m.Hash() == other.Hash()

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -76,6 +76,10 @@ func (s Set) hashPointer() *hash.Hash {
 	return s.h
 }
 
+func (s Set) IsLeaf() bool {
+	return !isMetaSequence(s.sequence())
+}
+
 // Value interface
 func (s Set) Equals(other Value) bool {
 	return s.Hash() == other.Hash()

--- a/go/walk/walk.go
+++ b/go/walk/walk.go
@@ -6,46 +6,84 @@
 package walk
 
 import (
-	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
 )
 
 type SkipValueCallback func(v types.Value) bool
 
+// WalkValues loads prolly trees progressively by walking down the tree. We don't wants to invoke
+// the value callback on internal sub-trees (which are valid values) because they are not logical
+// values in the graph
+type valueRec struct {
+	v  types.Value
+	cb bool
+}
+
+const maxRefCount = 1 << 12 // ~16MB of data
+
 // WalkValues recursively walks over all types. Values reachable from r and calls cb on them.
+// TODO: This will only work on graphs of data and are committed to |vr|.
 func WalkValues(target types.Value, vr types.ValueReader, cb SkipValueCallback) {
-	var processRef func(r types.Ref)
-	var processVal func(v types.Value)
-	visited := map[hash.Hash]bool{}
+	visited := hash.HashSet{}
+	refs := map[hash.Hash]bool{}
+	values := []valueRec{{target, true}}
 
-	processVal = func(v types.Value) {
-		if cb(v) {
-			return
+	for len(values) > 0 || len(refs) > 0 {
+		for len(values) > 0 {
+			rec := values[len(values)-1]
+			values = values[:len(values)-1]
+
+			if rec.cb && cb(rec.v) {
+				continue
+			}
+
+			v := rec.v
+			if r, ok := v.(types.Ref); ok {
+				refs[r.TargetHash()] = true
+				continue
+			}
+
+			if col, ok := v.(types.Collection); ok && !col.IsLeaf() {
+				col.WalkRefs(func(r types.Ref) {
+					refs[r.TargetHash()] = false
+				})
+				continue
+			}
+
+			v.WalkValues(func(sv types.Value) {
+				values = append(values, valueRec{sv, true})
+			})
 		}
-		if sr, ok := v.(types.Ref); ok {
-			processRef(sr)
-		} else {
-			v.WalkValues(processVal)
+
+		if len(refs) == 0 {
+			continue
+		}
+
+		hs := hash.HashSet{}
+		oldRefs := refs
+		refs = map[hash.Hash]bool{}
+		for h, _ := range oldRefs {
+			if _, ok := visited[h]; ok {
+				continue
+			}
+
+			if len(hs) >= maxRefCount {
+				refs[h] = oldRefs[h]
+				continue
+			}
+
+			hs.Insert(h)
+			visited.Insert(h)
+		}
+
+		if len(hs) > 0 {
+			valueChan := make(chan types.Value, len(hs))
+			vr.ReadManyValues(hs, valueChan)
+			close(valueChan)
+			for sv := range valueChan {
+				values = append(values, valueRec{sv, oldRefs[sv.Hash()]})
+			}
 		}
 	}
-
-	processRef = func(r types.Ref) {
-		target := r.TargetHash()
-		if visited[target] {
-			return
-		}
-		visited[target] = true
-		v := vr.ReadValue(target)
-		if v == nil {
-			d.Chk.Fail("Attempt to visit absent ref:%s", target.String())
-			return
-		}
-
-		processVal(v)
-	}
-
-	//Process initial value
-	processVal(target)
-
 }


### PR DESCRIPTION
This re-implements walk.Walk to traverse "down" prolly trees, loading entire subsequent levels with large batches of ReadManyValues.