### PR TITLE
Add DateTime util struct

### DIFF
--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Package datetime implements marshalling of Go DateTime values into Noms structs
+// with type DateTimeType.
+package datetime
+
+import (
+	"math"
+	"time"
+
+	"github.com/attic-labs/noms/go/marshal"
+	"github.com/attic-labs/noms/go/types"
+)
+
+// DateTime is an alias for time.Time that allows us to marshal date time to
+// Noms.
+type DateTime time.Time
+
+// DateTimeType is the Noms type used to represent date time objects in Noms.
+var DateTimeType = types.MakeStructTypeFromFields("DateTime", types.FieldMap{
+	"secSinceEpoch": types.NumberType,
+})
+
+// MarshalNoms makes DateTime implement marshal.Marshaler and it makes
+// DateTime marshal into a Noms struct with type DateTimeType.
+func (dt DateTime) MarshalNoms() (types.Value, error) {
+	t := time.Time(dt)
+	return types.NewStructWithType(DateTimeType, types.ValueSlice{
+		types.Number(float64(t.UnixNano()) * 1e-9),
+	}), nil
+}
+
+// UnmarshalNoms makes DateTime implement marshal.Unmarshaler and it allows
+// Noms struct with type DateTimeType able to be unmarshaled onto a DateTime
+// Go struct
+func (dt *DateTime) UnmarshalNoms(v types.Value) error {
+	strct := struct {
+		SecSinceEpoch float64
+	}{}
+	err := marshal.Unmarshal(v, &strct)
+	if err != nil {
+		return err
+	}
+
+	s, frac := math.Modf(strct.SecSinceEpoch)
+	*dt = DateTime(time.Unix(int64(s), int64(frac*1e9)))
+	return nil
+}

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -19,6 +19,8 @@ import (
 type DateTime time.Time
 
 // DateTimeType is the Noms type used to represent date time objects in Noms.
+// The field secSinceEpoch may contain fractions in cases where seconds are
+// not sufficient.
 var DateTimeType = types.MakeStructTypeFromFields("DateTime", types.FieldMap{
 	"secSinceEpoch": types.NumberType,
 })

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package datetime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/attic-labs/noms/go/marshal"
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestBasics(t *testing.T) {
+	assert := assert.New(t)
+
+	dt := DateTime(time.Unix(123, 456))
+
+	nomsValue, err := marshal.Marshal(dt)
+	assert.NoError(err)
+
+	var dt2 DateTime
+	err = marshal.Unmarshal(nomsValue, &dt2)
+	assert.NoError(err)
+
+	assert.True(time.Time(dt).Equal(time.Time(dt2)))
+}
+
+func TestUnmarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	test := func(v types.Struct, t time.Time) {
+		var dt DateTime
+		err := marshal.Unmarshal(v, &dt)
+		assert.NoError(err)
+		assert.True(time.Time(dt).Equal(t))
+	}
+
+	for _, name := range []string{"DateTime", "Date", "xxx", ""} {
+		test(types.NewStruct(name, types.StructData{
+			"secSinceEpoch": types.Number(42),
+		}), time.Unix(42, 0))
+	}
+
+	test(types.NewStruct("", types.StructData{
+		"secSinceEpoch": types.Number(42),
+		"extra":         types.String("field"),
+	}), time.Unix(42, 0))
+}
+
+func TestUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	test := func(v types.Value) {
+		var dt DateTime
+		err := marshal.Unmarshal(v, &dt)
+		assert.Error(err)
+	}
+
+	test(types.Number(42))
+	test(types.NewStruct("DateTime", types.StructData{}))
+	test(types.NewStruct("DateTime", types.StructData{
+		"secSinceEpoch": types.String(42),
+	}))
+	test(types.NewStruct("DateTime", types.StructData{
+		"SecSinceEpoch": types.Number(42),
+	}))
+	test(types.NewStruct("DateTime", types.StructData{
+		"msSinceEpoch": types.Number(42),
+	}))
+}
+
+func TestMarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	test := func(dt DateTime, expected float64) {
+		v, err := marshal.Marshal(dt)
+		assert.NoError(err)
+
+		assert.True(types.NewStruct("DateTime", types.StructData{
+			"secSinceEpoch": types.Number(expected),
+		}).Equals(v))
+	}
+
+	test(DateTime(time.Unix(0, 0)), 0)
+	test(DateTime(time.Unix(42, 0)), 42)
+	test(DateTime(time.Unix(42, 123456789)), 42.123456789)
+	test(DateTime(time.Unix(123456789, 123456789)), 123456789.123456789)
+	test(DateTime(time.Unix(-42, 0)), -42)
+	test(DateTime(time.Unix(-42, -123456789)), -42.123456789)
+	test(DateTime(time.Unix(-123456789, -123456789)), -123456789.123456789)
+}


### PR DESCRIPTION
This allows us to consistently marshal back and forth between time.Time
and a Noms struct.

Fixes #2970