### PR TITLE
add 1-year Cache-Control: max-age to /getBlob/ urls

### DIFF
--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -305,6 +305,8 @@ func handleGetBlob(w http.ResponseWriter, req *http.Request, ps URLParams, cs ch
 
 	w.Header().Add("Content-Type", "application/octet-stream")
 	w.Header().Add("Content-Length", fmt.Sprintf("%d", b.Len()))
+	w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", 60*60*24*365))
+
 	b.Reader().Copy(w)
 }
 


### PR DESCRIPTION
I'm unsure how to test that this actually affects the attic client. @arv?

Fixes: #3096 