### PR TITLE
Introduce walk.WalkDifferentStructs

### DIFF
--- a/go/types/walk.go
+++ b/go/types/walk.go
@@ -4,7 +4,11 @@
 
 package types
 
-import "github.com/attic-labs/noms/go/hash"
+import (
+	"sort"
+
+	"github.com/attic-labs/noms/go/hash"
+)
 
 type SkipValueCallback func(v Value) bool
 
@@ -90,4 +94,157 @@ func WalkValues(target Value, vr ValueReader, cb SkipValueCallback) {
 			}
 		}
 	}
+}
+
+func mightContainStructs(t *Type) (mightHaveStructs bool) {
+	if t.Kind() == StructKind || t.Kind() == ValueKind {
+		mightHaveStructs = true
+		return
+	}
+
+	t.WalkValues(func(v Value) {
+		mightHaveStructs = mightHaveStructs || mightContainStructs(v.(*Type))
+	})
+
+	return
+}
+
+// Efficiently returns the set of |removed| (reachable from |last|, but not |current|) and |added|
+// (reachable from |current| but not |last|) types.Structs. Internally avoids visiting chunks which
+// are common to both value graphs.
+func WalkDifferentStructs(last, current Value, vr ValueReader) (added, removed map[hash.Hash]Struct) {
+	added, removed = map[hash.Hash]Struct{}, map[hash.Hash]Struct{}
+
+	oldRefs, currentRefs := RefByHeight{}, RefByHeight{}
+	oldValues, currentValues := []Value{}, []Value{}
+	if last != nil {
+		if current != nil && last.Equals(current) {
+			return // same values
+		}
+
+		oldValues = append(oldValues, last)
+	}
+	if current != nil {
+		currentValues = append(currentValues, current)
+	}
+
+	walkLocalValues := func(values *[]Value, structs map[hash.Hash]Struct, refs *RefByHeight) {
+		for len(*values) > 0 {
+			v := (*values)[len(*values)-1]
+			*values = (*values)[:len(*values)-1]
+
+			if !mightContainStructs(v.Type()) {
+				continue
+			}
+
+			if _, ok := v.(Blob); ok {
+				continue // don't traverse into blob ptrees
+			}
+
+			if r, ok := v.(Ref); ok {
+				refs.PushBack(r)
+				continue
+			}
+
+			if col, ok := v.(Collection); ok && isMetaSequence(col.sequence()) {
+				ms := col.sequence().(metaSequence)
+				for _, mt := range ms.tuples {
+					if mt.child != nil {
+						*values = append(*values, mt.child)
+					} else if mightContainStructs(mt.ref.Type()) {
+						refs.PushBack(mt.ref)
+					}
+				}
+				continue
+			}
+
+			if s, ok := v.(Struct); ok {
+				structs[s.Hash()] = s
+			}
+
+			v.WalkValues(func(sv Value) {
+				*values = append(*values, sv)
+			})
+		}
+	}
+
+	for len(oldValues) > 0 || len(currentValues) > 0 || oldRefs.Len() > 0 || currentRefs.Len() > 0 {
+		// Iterate over all "loaded values". Record structs and refs of unloaded values.
+		walkLocalValues(&oldValues, removed, &oldRefs)
+		walkLocalValues(&currentValues, added, &currentRefs)
+
+		if len(oldRefs) == 0 && len(currentRefs) == 0 {
+			continue
+		}
+
+		sort.Sort(oldRefs)
+		sort.Sort(currentRefs)
+
+		oldRefsToLoad := hash.HashSet{}
+		currentRefsToLoad := hash.HashSet{}
+
+		oldMaxHeight := uint64(0)
+		if oldRefs.Len() > 0 {
+			oldMaxHeight = oldRefs.MaxHeight()
+		}
+		currentMaxHeight := uint64(0)
+		if currentRefs.Len() > 0 {
+			currentMaxHeight = currentRefs.MaxHeight()
+		}
+
+		for oldRefs.Len() > 0 && oldRefs.MaxHeight() > currentMaxHeight {
+			// Load all taller old refs
+			oldRefsToLoad.Insert(oldRefs.PopBack().TargetHash())
+		}
+
+		for len(oldRefsToLoad) == 0 && currentRefs.Len() > 0 && currentRefs.MaxHeight() > oldMaxHeight {
+			// Load all taller new refs
+			currentRefsToLoad.Insert(currentRefs.PopBack().TargetHash())
+		}
+
+		if len(oldRefsToLoad) == 0 && len(currentRefsToLoad) == 0 && currentMaxHeight > 0 {
+			commonHeight := currentMaxHeight
+
+			for oldRefs.Len() > 0 && oldRefs.MaxHeight() >= commonHeight {
+				// Load all taller old refs
+				oldRefsToLoad.Insert(oldRefs.PopBack().TargetHash())
+			}
+
+			for currentRefs.Len() > 0 && currentRefs.MaxHeight() >= commonHeight {
+				h := currentRefs.PopBack().TargetHash()
+				if _, ok := oldRefsToLoad[h]; ok {
+					delete(oldRefsToLoad, h)
+				} else {
+					currentRefsToLoad.Insert(h)
+				}
+			}
+		}
+
+		// oldRefsToLoad and currentRefsToLoad are fully disjoint. Insert all old into current and use
+		// oldRefs to later differentiate
+		for h, _ := range oldRefsToLoad {
+			currentRefsToLoad.Insert(h)
+		}
+
+		valueChan := make(chan Value, len(currentRefsToLoad))
+		vr.ReadManyValues(currentRefsToLoad, valueChan)
+		close(valueChan)
+		for v := range valueChan {
+			if _, ok := oldRefsToLoad[v.Hash()]; ok {
+				oldValues = append(oldValues, v)
+			} else {
+				currentValues = append(currentValues, v)
+			}
+		}
+	}
+
+	// Remove common
+	for h, _ := range added {
+		if _, ok := removed[h]; ok {
+			delete(added, h)
+			delete(removed, h)
+		}
+	}
+
+	return
 }

--- a/go/types/walk_test.go
+++ b/go/types/walk_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/testify/suite"
 )
 
@@ -248,4 +249,118 @@ func (suite *WalkTestSuite) SetupTest() {
 	suite.shouldSee = NewList(suite.shouldSeeItem)
 	suite.deadValue = Number(0xDEADBEEF)
 	suite.mustSkip = NewList(suite.deadValue)
+}
+
+type WalkDifferentStructsTestSuite struct {
+	suite.Suite
+	vs *ValueStore
+	ts *chunks.TestStore
+}
+
+func TestWalkDifferentStructsTestSuite(t *testing.T) {
+	suite.Run(t, &WalkDifferentStructsTestSuite{})
+}
+
+func (suite *WalkDifferentStructsTestSuite) SetupTest() {
+	suite.ts = chunks.NewTestStore()
+	suite.vs = NewValueStore(NewBatchStoreAdaptor(suite.ts))
+}
+
+func (suite *WalkDifferentStructsTestSuite) AssertDiffs(last, current Value, expectAdded, expectRemoved []Value) {
+	equalIgnoreOrder := func(expect []Value, actual map[hash.Hash]Struct) {
+		hashes := hash.HashSet{}
+		for _, v := range expect {
+			hashes.Insert(v.Hash())
+		}
+
+		suite.Equal(len(hashes), len(actual))
+		for h, _ := range actual {
+			_, ok := hashes[h]
+			suite.True(ok)
+		}
+	}
+
+	added, removed := WalkDifferentStructs(last, current, suite.vs)
+	equalIgnoreOrder(expectAdded, added)
+	equalIgnoreOrder(expectRemoved, removed)
+}
+
+func (suite *WalkDifferentStructsTestSuite) TestWalkStructsBasic() {
+	// Nothing plus nothing is nothing
+	suite.AssertDiffs(nil, nil, []Value{}, []Value{})
+
+	s1 := NewStruct("s", StructData{
+		"n": Number(1),
+	})
+
+	// Top level struct.
+	suite.AssertDiffs(nil, s1, []Value{s1}, []Value{})
+
+	// Same Struct
+	suite.AssertDiffs(s1, s1, []Value{}, []Value{})
+
+	// Removed.
+	suite.AssertDiffs(s1, nil, []Value{}, []Value{s1})
+
+	// Collections of structs
+	s2 := NewStruct("s", StructData{
+		"n": Number(2),
+	})
+	s3 := NewStruct("s", StructData{
+		"n": Number(3),
+	})
+	s4 := NewStruct("s", StructData{
+		"n": Number(4),
+	})
+
+	l1 := NewList(s2, s4)
+	l2 := NewList(s1, s2, s3)
+
+	suite.AssertDiffs(l1, l2, []Value{s1, s3}, []Value{s4})
+	suite.AssertDiffs(l1, l1, []Value{}, []Value{})
+	suite.AssertDiffs(l2, l1, []Value{s4}, []Value{s1, s3})
+
+	// Big, uncommitted collections of structs
+	bl := NewList()
+	i := 0
+	for NewRef(bl).Height() == 1 {
+		bl = bl.Append(Number(i))
+		i++
+	}
+
+	l1 = bl.Append(s2, s4)
+	l2 = bl.Append(s1, s2, s3)
+
+	suite.AssertDiffs(l1, l2, []Value{s1, s3}, []Value{s4})
+	suite.AssertDiffs(l1, l1, []Value{}, []Value{})
+	suite.AssertDiffs(l2, l1, []Value{s4}, []Value{s1, s3})
+
+	// Big, committed collections of structs
+	l1 = suite.vs.ReadValue(suite.vs.WriteValue(l1).TargetHash()).(List)
+	l2 = suite.vs.ReadValue(suite.vs.WriteValue(l2).TargetHash()).(List)
+
+	rc := suite.ts.Reads
+	suite.AssertDiffs(nil, l2, []Value{s1, s2, s3}, []Value{})
+	suite.Equal(1, suite.ts.Reads-rc) // Type information gets used to avoid loads
+
+	suite.AssertDiffs(l1, l2, []Value{s1, s3}, []Value{s4})
+	suite.Equal(2, suite.ts.Reads-rc) // Chunk diff gets used to avoid loading common subtrees
+
+	// Structs inside structs whose fields will be simplified away.
+	s5 := NewStruct("s", StructData{
+		"s1": s1,
+	})
+	s6 := NewStruct("s", StructData{
+		"s2": s2,
+	})
+	s7 := NewStruct("s", StructData{
+		"s3": s3,
+	})
+
+	l1 = bl.Append(s5, s6)
+	l2 = bl.Append(s6, s7)
+
+	suite.AssertDiffs(nil, l1, []Value{s5, s6, s1, s2}, []Value{})
+	suite.AssertDiffs(nil, l2, []Value{s6, s7, s2, s3}, []Value{})
+	suite.AssertDiffs(l1, l2, []Value{s7, s3}, []Value{s5, s1})
 }


### PR DESCRIPTION
This patch adds a static function which can walk graphs looking for (and diffing) two structs. It uses type information to avoid traversing sub-values which can't contain structs. It also uses a similar approach as sync to avoid visiting common sub-chunk-graphs.