### PR TITLE
Switch Map/Set Diff to use top-down by default

### DIFF
--- a/go/diff/diff.go
+++ b/go/diff/diff.go
@@ -165,7 +165,7 @@ func (d differ) diffMaps(p types.Path, v1, v2 types.Map) bool {
 			if d.leftRight {
 				v2.DiffLeftRight(v1, cc, sc)
 			} else {
-				v2.Diff(v1, cc, sc)
+				v2.DiffHybrid(v1, cc, sc)
 			}
 		},
 		func(k types.Value) types.Value { return k },
@@ -201,7 +201,7 @@ func (d differ) diffSets(p types.Path, v1, v2 types.Set) bool {
 			if d.leftRight {
 				v2.DiffLeftRight(v1, cc, sc)
 			} else {
-				v2.Diff(v1, cc, sc)
+				v2.DiffHybrid(v1, cc, sc)
 			}
 		},
 		func(k types.Value) types.Value { return k },

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -58,15 +58,28 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 	return outChan
 }
 
-// Computes the diff from |last| to |m| using "best" algorithm, which balances returning results early vs completing quickly.
+// Diff computes the diff from |last| to |m| using the top-down algorithm,
+// which completes as fast as possible while taking longer to return early
+// results than left-to-right.
 func (m Map) Diff(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
+	if m.Equals(last) {
+		return
+	}
+	orderedSequenceDiffTopDown(last.seq, m.seq, changes, closeChan)
+}
+
+// DiffHybrid computes the diff from |last| to |m| using a hybrid algorithm
+// which balances returning results early vs completing quickly, if possible.
+func (m Map) DiffHybrid(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	if m.Equals(last) {
 		return
 	}
 	orderedSequenceDiffBest(last.seq, m.seq, changes, closeChan)
 }
 
-// Like Diff() but uses a left-to-right streaming approach, optimised for returning results early, but not completing quickly.
+// DiffLeftRight computes the diff from |last| to |m| using a left-to-right
+// streaming approach, optimised for returning results early, but not
+// completing quickly.
 func (m Map) DiffLeftRight(last Map, changes chan<- ValueChanged, closeChan <-chan struct{}) {
 	if m.Equals(last) {
 		return


### PR DESCRIPTION
The only thing that wants what we used to call the "best" diff
algorithm is the command-line tools. Non-interactive programs all want
the algorithm that finishes up fastest, which is top-down.

Fixes https://github.com/attic-labs/attic/issues/627