### PR TITLE
NBS UpdateRoot() returns false when last != nbs.Root()

### DIFF
--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -281,7 +281,9 @@ func (nbs *NomsBlockStore) Root() hash.Hash {
 func (nbs *NomsBlockStore) UpdateRoot(current, last hash.Hash) bool {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
-	d.Chk.True(nbs.root == last, "UpdateRoot: last != nbs.Root(); %s != %s", last, nbs.root)
+	if nbs.root != last {
+		return false
+	}
 
 	if nbs.mt != nil && nbs.mt.count() > 0 {
 		nbs.tables = nbs.tables.Prepend(nbs.mt)


### PR DESCRIPTION
This code initially panicked in this case, because there didn't used
to be a reasonable way that a caller might wind up trying to update
away from a Root that didn't match NomsBlockStore's internal
bookkeeping. Now, given the new Flush() behavior there is. So, just
return false and allow the caller to take appropriate action.

Towards #3089