### PR TITLE
Fix cache/value store caching

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "69.1.0",
+  "version": "69.2.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/chunk-serializer.js
+++ b/js/noms/src/chunk-serializer.js
@@ -114,16 +114,8 @@ export function deserializeChunks(buff: Uint8Array, offset: number = 0): Array<C
 
     invariant(offset + chunkLength <= totalLength, 'Invalid chunk buffer');
 
-    let chunk: Chunk;
-    if (process.env.NODE_ENV === 'production') {
-      chunk = new Chunk(Bytes.slice(buff, offset, offset + chunkLength), hash); // copy
-    } else {
-      chunk = new Chunk(Bytes.slice(buff, offset, offset + chunkLength)); // copy
-      invariant(chunk.hash.equals(hash), 'Serialized hash !== computed hash');
-    }
-
     offset += chunkLength;
-    chunks.push(chunk);
+    chunks.push(new Chunk(Bytes.slice(buff, offset, offset + chunkLength), hash)); // copy bytes
   }
 
   return chunks;

--- a/js/noms/src/chunk-serializer.js
+++ b/js/noms/src/chunk-serializer.js
@@ -114,8 +114,10 @@ export function deserializeChunks(buff: Uint8Array, offset: number = 0): Array<C
 
     invariant(offset + chunkLength <= totalLength, 'Invalid chunk buffer');
 
+    const bytesCopy = Bytes.slice(buff, offset, offset + chunkLength);
     offset += chunkLength;
-    chunks.push(new Chunk(Bytes.slice(buff, offset, offset + chunkLength), hash)); // copy bytes
+
+    chunks.push(new Chunk(bytesCopy, hash));
   }
 
   return chunks;

--- a/js/noms/src/remote-batch-store.js
+++ b/js/noms/src/remote-batch-store.js
@@ -85,7 +85,13 @@ export default class RemoteBatchStore {
     this._unsentReads = null;
     this._readScheduled = false;
 
-    await this._delegate.readBatch(reqs);
+    // Make a copy because the delegate can and does mutate the reqs object.
+    const reqsCopy = Object.create(null);
+    for (const prop in reqs) {
+      reqsCopy[prop] = reqs[prop];
+    }
+
+    await this._delegate.readBatch(reqsCopy);
 
     const self = this; // TODO: Remove this when babel bug is fixed.
     Object.keys(reqs).forEach(hashStr => {

--- a/js/noms/src/value-store-test.js
+++ b/js/noms/src/value-store-test.js
@@ -131,6 +131,9 @@ suite('ValueStore', () => {
     const v2 = await vs.readValue(r2);
     assert.equal(v2, 'world');
 
+    // Need to wait two turns for expire to have been run.
+    await Promise.resolve().then(() => {});
+
     (bs: any).get = () => { throw new Error(); };
     let ex;
     try {

--- a/js/noms/src/value-store.js
+++ b/js/noms/src/value-store.js
@@ -197,7 +197,6 @@ class SizeCache<T> {
     let entry = this._cache.get(key);
     if (entry) {
       this._cache.delete(key);
-      entry.size.then(() => this.expire());
     }
 
     entry = new CacheEntry(size, value);


### PR DESCRIPTION
* Fixes a long standing bug in which the RemoteBatchStore is accidentally caching all chunks
* ValueStore's value cache now stores `Promise<?Value>` so that concurrent `readValues` of the same value can share a single decoding
* Removes the debug-only chunk hash check which keeps tripping up perf investigations