### PR TITLE
NBS dynamoManifest must perform a consistent read

### DIFF
--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -137,13 +137,11 @@ func handleWriteValue(w http.ResponseWriter, req *http.Request, ps URLParams, cs
 
 	// Deserialize chunks from reader in background, recovering from errors
 	errChan := make(chan error)
-	defer close(errChan)
-
 	chunkChan := make(chan *chunks.Chunk, writeValueConcurrency)
 
 	go func() {
 		var err error
-		defer func() { errChan <- err }()
+		defer func() { errChan <- err; close(errChan) }()
 		defer close(chunkChan)
 		err = chunks.Deserialize(reader, chunkChan)
 	}()

--- a/go/nbs/dynamo_manifest.go
+++ b/go/nbs/dynamo_manifest.go
@@ -47,7 +47,8 @@ func newDynamoManifest(table, namespace string, ddb ddbsvc) *dynamoManifest {
 
 func (dm dynamoManifest) ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
 	result, err := dm.ddbsvc.GetItem(&dynamodb.GetItemInput{
-		TableName: aws.String(dm.table),
+		ConsistentRead: aws.Bool(true), // This doubles the cost :-(
+		TableName:      aws.String(dm.table),
 		Key: map[string]*dynamodb.AttributeValue{
 			dbAttr: {S: aws.String(dm.db)},
 		},


### PR DESCRIPTION
DynamoDB provides eventual read-after-write consistency, unless you
ask explicitly for strong consistency. When committing over HTTP, the
code writes a bunch of Values and then attempts to UpdateRoot to point
to one of those novel chunks. The UpdateRoot call _must_ see the
result of the prior WriteValue, or it may fail.

Fixes #3084