### PR TITLE
First pass at compaction

### DIFF
--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -198,9 +198,9 @@ func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
 }
 
 func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
-	testMax := 5
+	testMaxTables := 5
 	mm := fileManifest{suite.dir}
-	smallTableStore := newNomsBlockStore(mm, newFSTableSet(suite.dir, nil), 2, testMax)
+	smallTableStore := newNomsBlockStore(mm, newFSTableSet(suite.dir, nil), 2, testMaxTables)
 	inputs := [][]byte{[]byte("ab"), []byte("cd"), []byte("ef"), []byte("gh"), []byte("ij"), []byte("kl")}
 	chunx := make([]chunks.Chunk, len(inputs))
 	for i, data := range inputs {
@@ -208,22 +208,22 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	}
 
 	root := smallTableStore.Root()
-	suite.NoError(smallTableStore.PutMany(chunx[:testMax]))
+	suite.NoError(smallTableStore.PutMany(chunx[:testMaxTables]))
 	suite.True(smallTableStore.UpdateRoot(chunx[0].Hash(), root)) // Commit write
 
 	exists, _, mRoot, specs := mm.ParseIfExists(nil)
 	suite.True(exists)
 	suite.Equal(chunx[0].Hash(), mRoot)
-	suite.Len(specs, testMax)
+	suite.Len(specs, testMaxTables)
 
 	root = smallTableStore.Root()
-	suite.NoError(smallTableStore.PutMany(chunx[testMax:]))
-	suite.True(smallTableStore.UpdateRoot(chunx[testMax].Hash(), root)) // Should compact
+	suite.NoError(smallTableStore.PutMany(chunx[testMaxTables:]))
+	suite.True(smallTableStore.UpdateRoot(chunx[testMaxTables].Hash(), root)) // Should compact
 
 	exists, _, mRoot, specs = mm.ParseIfExists(nil)
 	suite.True(exists)
-	suite.Equal(chunx[testMax].Hash(), mRoot)
-	suite.Len(specs, testMax)
+	suite.Equal(chunx[testMaxTables].Hash(), mRoot)
+	suite.Len(specs, testMaxTables)
 }
 
 func assertInputInStore(input []byte, h hash.Hash, s chunks.ChunkStore, assert *assert.Assertions) {

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -81,6 +81,12 @@ func (ccs *compactingChunkSource) count() uint32 {
 	return ccs.cs.count()
 }
 
+func (ccs *compactingChunkSource) data() uint64 {
+	ccs.wg.Wait()
+	d.Chk.True(ccs.cs != nil)
+	return ccs.cs.data()
+}
+
 func (ccs *compactingChunkSource) hash() addr {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
@@ -122,6 +128,10 @@ func (ecs emptyChunkSource) close() error {
 }
 
 func (ecs emptyChunkSource) count() uint32 {
+	return 0
+}
+
+func (ecs emptyChunkSource) data() uint64 {
 	return 0
 }
 

--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -81,10 +81,10 @@ func (ccs *compactingChunkSource) count() uint32 {
 	return ccs.cs.count()
 }
 
-func (ccs *compactingChunkSource) data() uint64 {
+func (ccs *compactingChunkSource) byteLen() uint64 {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.data()
+	return ccs.cs.byteLen()
 }
 
 func (ccs *compactingChunkSource) hash() addr {
@@ -131,7 +131,7 @@ func (ecs emptyChunkSource) count() uint32 {
 	return 0
 }
 
-func (ecs emptyChunkSource) data() uint64 {
+func (ecs emptyChunkSource) byteLen() uint64 {
 	return 0
 }
 

--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -20,10 +20,10 @@ type fsTablePersister struct {
 }
 
 func (ftp fsTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
-	return ftp.toReader(mt.write(haver))
+	return ftp.persistTable(mt.write(haver))
 }
 
-func (ftp fsTablePersister) toReader(name addr, data []byte, chunkCount uint32) chunkSource {
+func (ftp fsTablePersister) persistTable(name addr, data []byte, chunkCount uint32) chunkSource {
 	if chunkCount == 0 {
 		return emptyChunkSource{}
 	}
@@ -42,7 +42,7 @@ func (ftp fsTablePersister) toReader(name addr, data []byte, chunkCount uint32) 
 func (ftp fsTablePersister) CompactAll(sources chunkSources) chunkSource {
 	rl := make(chan struct{}, 32)
 	defer close(rl)
-	return ftp.toReader(compactSourcesToBuffer(sources, rl))
+	return ftp.persistTable(compactSourcesToBuffer(sources, rl))
 }
 
 func (ftp fsTablePersister) Open(name addr, chunkCount uint32) chunkSource {

--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -15,30 +15,36 @@ import (
 )
 
 type fsTablePersister struct {
-	dir string
+	dir        string
+	indexCache *indexCache
 }
 
 func (ftp fsTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
-	tempName, name, chunkCount := func() (string, addr, uint32) {
-		var tempName string
-		name, data, chunkCount := mt.write(haver)
-		if chunkCount > 0 {
-			temp, err := ioutil.TempFile(ftp.dir, "nbs_table_")
-			d.PanicIfError(err)
-			defer checkClose(temp)
-			io.Copy(temp, bytes.NewReader(data))
-			tempName = temp.Name()
-		}
-		return tempName, name, chunkCount
-	}()
+	return ftp.toReader(mt.write(haver))
+}
+
+func (ftp fsTablePersister) toReader(name addr, data []byte, chunkCount uint32) chunkSource {
 	if chunkCount == 0 {
 		return emptyChunkSource{}
 	}
+	tempName := func() string {
+		temp, err := ioutil.TempFile(ftp.dir, "nbs_table_")
+		d.PanicIfError(err)
+		defer checkClose(temp)
+		io.Copy(temp, bytes.NewReader(data))
+		return temp.Name()
+	}()
 	err := os.Rename(tempName, filepath.Join(ftp.dir, name.String()))
 	d.PanicIfError(err)
-	return newMmapTableReader(ftp.dir, name, chunkCount)
+	return ftp.Open(name, chunkCount)
+}
+
+func (ftp fsTablePersister) CompactAll(sources chunkSources) chunkSource {
+	rl := make(chan struct{}, 32)
+	defer close(rl)
+	return ftp.toReader(compactSourcesToBuffer(sources, rl))
 }
 
 func (ftp fsTablePersister) Open(name addr, chunkCount uint32) chunkSource {
-	return newMmapTableReader(ftp.dir, name, chunkCount)
+	return newMmapTableReader(ftp.dir, name, chunkCount, ftp.indexCache)
 }

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestFSTablePersisterCompact(t *testing.T) {
+	assert := assert.New(t)
+	mt := newMemTable(testMemTableSize)
+
+	for _, c := range testChunks {
+		assert.True(mt.addChunk(computeAddr(c), c))
+	}
+
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+	fts := fsTablePersister{dir: dir}
+
+	src := fts.Compact(mt, nil)
+	if assert.True(src.count() > 0) {
+		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
+		assert.NoError(err)
+		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
+		assertChunksInReader(testChunks, tr, assert)
+	}
+}
+
+func TestFSTablePersisterCompactNoData(t *testing.T) {
+	assert := assert.New(t)
+	mt := newMemTable(testMemTableSize)
+	existingTable := newMemTable(testMemTableSize)
+
+	for _, c := range testChunks {
+		assert.True(mt.addChunk(computeAddr(c), c))
+		assert.True(existingTable.addChunk(computeAddr(c), c))
+	}
+
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+	fts := fsTablePersister{dir: dir}
+
+	src := fts.Compact(mt, existingTable)
+	assert.True(src.count() == 0)
+
+	_, err := os.Stat(filepath.Join(dir, src.hash().String()))
+	assert.True(os.IsNotExist(err), "%v", err)
+}
+
+func TestFSTablePersisterCompactAll(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(len(testChunks) > 1, "Whoops, this test isn't meaningful")
+	sources := make(chunkSources, len(testChunks))
+
+	for i, c := range testChunks {
+		sources[i] = bytesToChunkSource(c)
+	}
+
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+	fts := fsTablePersister{dir: dir}
+	src := fts.CompactAll(sources)
+
+	if assert.True(src.count() > 0) {
+		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
+		assert.NoError(err)
+		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
+		assertChunksInReader(testChunks, tr, assert)
+	}
+}

--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -48,6 +48,10 @@ func (mt *memTable) count() uint32 {
 	return uint32(len(mt.order))
 }
 
+func (mt *memTable) data() uint64 {
+	return mt.totalData
+}
+
 func (mt *memTable) has(h addr) (has bool) {
 	_, has = mt.chunks[h]
 	return

--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -48,7 +48,7 @@ func (mt *memTable) count() uint32 {
 	return uint32(len(mt.order))
 }
 
-func (mt *memTable) data() uint64 {
+func (mt *memTable) byteLen() uint64 {
 	return mt.totalData
 }
 

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -142,6 +142,13 @@ func (crg chunkReaderGroup) count() (count uint32) {
 	return
 }
 
+func (crg chunkReaderGroup) data() (data uint64) {
+	for _, haver := range crg {
+		data += haver.data()
+	}
+	return
+}
+
 func (crg chunkReaderGroup) extract(order EnumerationOrder, chunks chan<- extractRecord) {
 	if order == InsertOrder {
 		for _, haver := range crg {

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -142,9 +142,9 @@ func (crg chunkReaderGroup) count() (count uint32) {
 	return
 }
 
-func (crg chunkReaderGroup) data() (data uint64) {
+func (crg chunkReaderGroup) byteLen() (data uint64) {
 	for _, haver := range crg {
-		data += haver.data()
+		data += haver.byteLen()
 	}
 	return
 }

--- a/go/nbs/mmap_table_reader_test.go
+++ b/go/nbs/mmap_table_reader_test.go
@@ -29,7 +29,7 @@ func TestMmapTableReader(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(dir, h.String()), tableData, 0666)
 	assert.NoError(err)
 
-	trc := newMmapTableReader(dir, h, uint32(len(chunks)))
+	trc := newMmapTableReader(dir, h, uint32(len(chunks)), nil)
 	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -36,10 +36,10 @@ type s3UploadedPart struct {
 }
 
 func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
-	return s3p.toReader(mt.write(haver))
+	return s3p.persistTable(mt.write(haver))
 }
 
-func (s3p s3TablePersister) toReader(name addr, data []byte, chunkCount uint32) chunkSource {
+func (s3p s3TablePersister) persistTable(name addr, data []byte, chunkCount uint32) chunkSource {
 	if chunkCount > 0 {
 		t1 := time.Now()
 		result, err := s3p.s3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
@@ -81,7 +81,7 @@ func (s3p s3TablePersister) toReader(name addr, data []byte, chunkCount uint32) 
 }
 
 func (s3p s3TablePersister) CompactAll(sources chunkSources) chunkSource {
-	return s3p.toReader(compactSourcesToBuffer(sources, s3p.readRl))
+	return s3p.persistTable(compactSourcesToBuffer(sources, s3p.readRl))
 }
 
 func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.CompletedMultipartUpload, error) {

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/attic-labs/noms/go/d"
-	"github.com/attic-labs/noms/go/util/sizecache"
 	"github.com/attic-labs/noms/go/util/verbose"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -23,7 +22,7 @@ type s3TablePersister struct {
 	s3         s3svc
 	bucket     string
 	partSize   int
-	indexCache *s3IndexCache
+	indexCache *indexCache
 	readRl     chan struct{}
 }
 
@@ -37,8 +36,10 @@ type s3UploadedPart struct {
 }
 
 func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
-	name, data, chunkCount := mt.write(haver)
+	return s3p.toReader(mt.write(haver))
+}
 
+func (s3p s3TablePersister) toReader(name addr, data []byte, chunkCount uint32) chunkSource {
 	if chunkCount > 0 {
 		t1 := time.Now()
 		result, err := s3p.s3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
@@ -77,6 +78,10 @@ func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 		return s3tr
 	}
 	return emptyChunkSource{}
+}
+
+func (s3p s3TablePersister) CompactAll(sources chunkSources) chunkSource {
+	return s3p.toReader(compactSourcesToBuffer(sources, s3p.readRl))
 }
 
 func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
@@ -174,27 +179,4 @@ func (s partsByPartNum) Less(i, j int) bool {
 
 func (s partsByPartNum) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
-}
-
-type s3IndexCache struct {
-	cache *sizecache.SizeCache
-}
-
-// Returns an indexCache which will burn roughly |size| bytes of memory
-func newS3IndexCache(size uint64) *s3IndexCache {
-	return &s3IndexCache{sizecache.New(size)}
-}
-
-func (sic s3IndexCache) get(name addr) (tableIndex, bool) {
-	idx, found := sic.cache.Get(name)
-	if found {
-		return idx.(tableIndex), true
-	}
-
-	return tableIndex{}, false
-}
-
-func (sic s3IndexCache) put(name addr, idx tableIndex) {
-	indexSize := uint64(idx.chunkCount) * (addrSize + ordinalSize + lengthSize + uint64Size)
-	sic.cache.Add(name, indexSize, idx)
 }

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -36,7 +36,7 @@ func TestS3TablePersisterCompact(t *testing.T) {
 }
 
 func calcPartSize(rdr chunkReader, maxPartNum int) int {
-	return int(maxTableSize(uint64(rdr.count()), rdr.data())) / maxPartNum
+	return int(maxTableSize(uint64(rdr.count()), rdr.byteLen())) / maxPartNum
 }
 
 func TestS3TablePersisterCompactSinglePart(t *testing.T) {

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -1,0 +1,152 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func TestS3TablePersisterCompact(t *testing.T) {
+	assert := assert.New(t)
+	mt := newMemTable(testMemTableSize)
+
+	for _, c := range testChunks {
+		assert.True(mt.addChunk(computeAddr(c), c))
+	}
+
+	s3svc := makeFakeS3(assert)
+	cache := newIndexCache(1024)
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 3), indexCache: cache}
+
+	src := s3p.Compact(mt, nil)
+	assert.NotNil(cache.get(src.hash()))
+
+	if assert.True(src.count() > 0) {
+		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+			assertChunksInReader(testChunks, r, assert)
+		}
+	}
+}
+
+func calcPartSize(rdr chunkReader, maxPartNum int) int {
+	return int(maxTableSize(uint64(rdr.count()), rdr.data())) / maxPartNum
+}
+
+func TestS3TablePersisterCompactSinglePart(t *testing.T) {
+	assert := assert.New(t)
+	mt := newMemTable(testMemTableSize)
+
+	for _, c := range testChunks {
+		assert.True(mt.addChunk(computeAddr(c), c))
+	}
+
+	s3svc := makeFakeS3(assert)
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 1)}
+
+	src := s3p.Compact(mt, nil)
+	if assert.True(src.count() > 0) {
+		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+			assertChunksInReader(testChunks, r, assert)
+		}
+	}
+}
+
+func TestS3TablePersisterCompactAbort(t *testing.T) {
+	assert := assert.New(t)
+	mt := newMemTable(testMemTableSize)
+
+	for _, c := range testChunks {
+		assert.True(mt.addChunk(computeAddr(c), c))
+	}
+
+	numParts := 4
+	s3svc := &failingFakeS3{makeFakeS3(assert), sync.Mutex{}, 1}
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, numParts)}
+
+	assert.Panics(func() { s3p.Compact(mt, nil) })
+}
+
+type failingFakeS3 struct {
+	*fakeS3
+	mu           sync.Mutex
+	numSuccesses int
+}
+
+func (m *failingFakeS3) UploadPart(input *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.numSuccesses > 0 {
+		m.numSuccesses--
+		return m.fakeS3.UploadPart(input)
+	}
+	return nil, mockAWSError("MalformedXML")
+}
+
+func TestS3TablePersisterCompactNoData(t *testing.T) {
+	assert := assert.New(t)
+	mt := newMemTable(testMemTableSize)
+	existingTable := newMemTable(testMemTableSize)
+
+	for _, c := range testChunks {
+		assert.True(mt.addChunk(computeAddr(c), c))
+		assert.True(existingTable.addChunk(computeAddr(c), c))
+	}
+
+	s3svc := makeFakeS3(assert)
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: 1 << 10}
+
+	src := s3p.Compact(mt, existingTable)
+	assert.True(src.count() == 0)
+
+	_, present := s3svc.data[src.hash().String()]
+	assert.False(present)
+}
+
+func TestS3TablePersisterCompactAll(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(len(testChunks) > 1, "Whoops, this test isn't meaningful")
+	sources := make(chunkSources, len(testChunks))
+
+	for i, c := range testChunks {
+		sources[i] = bytesToChunkSource(c)
+	}
+
+	s3svc := makeFakeS3(assert)
+	cache := newIndexCache(1024)
+	rl := make(chan struct{}, 8)
+	defer close(rl)
+
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: 128, indexCache: cache, readRl: rl}
+	src := s3p.CompactAll(sources)
+	assert.NotNil(cache.get(src.hash()))
+
+	if assert.True(src.count() > 0) {
+		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+			assertChunksInReader(testChunks, r, assert)
+		}
+	}
+}
+
+func bytesToChunkSource(bs ...[]byte) chunkSource {
+	sum := 0
+	for _, b := range bs {
+		sum += len(b)
+	}
+	maxSize := maxTableSize(uint64(len(bs)), uint64(sum))
+	buff := make([]byte, maxSize)
+	tw := newTableWriter(buff)
+	for _, b := range bs {
+		tw.addChunk(computeAddr(b), b)
+	}
+	tableSize, name := tw.finish()
+	data := buff[:tableSize]
+	rdr := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
+	return chunkSourceAdapter{rdr, name}
+}

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -35,7 +35,7 @@ type s3svc interface {
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
-func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *s3IndexCache, readRl chan struct{}) chunkSource {
+func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *indexCache, readRl chan struct{}) chunkSource {
 	source := &s3TableReader{s3: s3, bucket: bucket, h: h, readRl: readRl}
 
 	var index tableIndex

--- a/go/nbs/s3_table_reader_test.go
+++ b/go/nbs/s3_table_reader_test.go
@@ -43,7 +43,7 @@ func TestS3TableReaderIndexCache(t *testing.T) {
 	s3.data[h.String()] = tableData
 
 	index := parseTableIndex(tableData)
-	cache := newS3IndexCache(1024)
+	cache := newIndexCache(1024)
 	cache.put(h, index)
 
 	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), cache, nil)

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -205,6 +205,7 @@ type chunkReader interface {
 	get(h addr) []byte
 	getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool
 	count() uint32
+	data() uint64
 	extract(order EnumerationOrder, chunks chan<- extractRecord)
 }
 
@@ -213,4 +214,15 @@ type chunkSource interface {
 	close() error
 	hash() addr
 	calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool)
+}
+
+type chunkSources []chunkSource
+
+func (css chunkSources) close() (err error) {
+	for _, haver := range css {
+		if e := haver.close(); e != nil {
+			err = e // TODO: somehow coalesce these errors??
+		}
+	}
+	return
 }

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -205,7 +205,7 @@ type chunkReader interface {
 	get(h addr) []byte
 	getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool
 	count() uint32
-	data() uint64
+	byteLen() uint64
 	extract(order EnumerationOrder, chunks chan<- extractRecord)
 }
 

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -4,7 +4,94 @@
 
 package nbs
 
+import (
+	"bytes"
+	"sync"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/util/sizecache"
+)
+
 type tablePersister interface {
 	Compact(mt *memTable, haver chunkReader) chunkSource
+	CompactAll(sources chunkSources) chunkSource
 	Open(name addr, chunkCount uint32) chunkSource
+}
+
+type indexCache struct {
+	cache *sizecache.SizeCache
+}
+
+// Returns an indexCache which will burn roughly |size| bytes of memory
+func newIndexCache(size uint64) *indexCache {
+	return &indexCache{sizecache.New(size)}
+}
+
+func (sic indexCache) get(name addr) (tableIndex, bool) {
+	idx, found := sic.cache.Get(name)
+	if found {
+		return idx.(tableIndex), true
+	}
+
+	return tableIndex{}, false
+}
+
+func (sic indexCache) put(name addr, idx tableIndex) {
+	indexSize := uint64(idx.chunkCount) * (addrSize + ordinalSize + lengthSize + uint64Size)
+	sic.cache.Add(name, indexSize, idx)
+}
+
+type chunkSourcesByDescendingCount chunkSources
+
+func (csbc chunkSourcesByDescendingCount) Len() int { return len(csbc) }
+func (csbc chunkSourcesByDescendingCount) Less(i, j int) bool {
+	srcI, srcJ := csbc[i], csbc[j]
+	if srcI.count() == srcJ.count() {
+		hi, hj := srcI.hash(), srcJ.hash()
+		return bytes.Compare(hi[:], hj[:]) > 0
+	}
+	return srcI.count() > srcJ.count()
+}
+func (csbc chunkSourcesByDescendingCount) Swap(i, j int) { csbc[i], csbc[j] = csbc[j], csbc[i] }
+
+func compactSourcesToBuffer(sources chunkSources, rl chan struct{}) (name addr, data []byte, chunkCount uint32) {
+	d.Chk.True(rl != nil)
+	totalData := uint64(0)
+	for _, src := range sources {
+		chunkCount += src.count()
+		totalData += src.data()
+	}
+	if chunkCount == 0 {
+		return
+	}
+
+	maxSize := maxTableSize(uint64(chunkCount), totalData)
+	buff := make([]byte, maxSize) // This can blow up RAM (BUG 3130)
+	tw := newTableWriter(buff)
+
+	// Use "channel of channels" ordered-concurrency pattern so that chunks from a given table stay together, preserving whatever locality was present in that table.
+	chunkChans := make(chan chan extractRecord)
+	go func() {
+		defer close(chunkChans)
+		wg := sync.WaitGroup{}
+		for _, src := range sources {
+			chunks := make(chan extractRecord)
+			wg.Add(1)
+			go func(s chunkSource, c chan<- extractRecord) {
+				defer func() { close(c); wg.Done(); <-rl }()
+				rl <- struct{}{}
+				s.extract(InsertOrder, c)
+			}(src, chunks)
+			chunkChans <- chunks
+		}
+		wg.Wait()
+	}()
+
+	for chunks := range chunkChans {
+		for chunk := range chunks {
+			tw.addChunk(chunk.a, chunk.data)
+		}
+	}
+	tableSize, name := tw.finish()
+	return name, buff[:tableSize], chunkCount
 }

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -19,6 +19,7 @@ import (
 
 type tableIndex struct {
 	chunkCount        uint32
+	totalData         uint64
 	prefixes, offsets []uint64
 	lengths, ordinals []uint32
 	suffixes          []byte
@@ -39,8 +40,9 @@ func parseTableIndex(buff []byte) tableIndex {
 	pos -= magicNumberSize
 	d.Chk.True(string(buff[pos:]) == magicNumber)
 
-	// skip total chunk data
+	// total chunk data
 	pos -= uint64Size
+	totalData := binary.BigEndian.Uint64(buff[pos:])
 
 	pos -= uint32Size
 	chunkCount := binary.BigEndian.Uint32(buff[pos:])
@@ -60,7 +62,7 @@ func parseTableIndex(buff []byte) tableIndex {
 	prefixes, ordinals := computePrefixes(chunkCount, buff[pos:pos+tuplesSize])
 
 	return tableIndex{
-		chunkCount,
+		chunkCount, totalData,
 		prefixes, offsets,
 		lengths, ordinals,
 		suffixes,
@@ -184,6 +186,10 @@ func (tr tableReader) hasMany(addrs []hasRecord) (remaining bool) {
 
 func (tr tableReader) count() uint32 {
 	return tr.chunkCount
+}
+
+func (tr tableReader) data() uint64 {
+	return tr.totalData
 }
 
 // returns true iff |h| can be found in this table.

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -19,7 +19,7 @@ import (
 
 type tableIndex struct {
 	chunkCount        uint32
-	totalData         uint64
+	totalPhysicalData uint64
 	prefixes, offsets []uint64
 	lengths, ordinals []uint32
 	suffixes          []byte
@@ -42,7 +42,7 @@ func parseTableIndex(buff []byte) tableIndex {
 
 	// total chunk data
 	pos -= uint64Size
-	totalData := binary.BigEndian.Uint64(buff[pos:])
+	totalPhysicalData := binary.BigEndian.Uint64(buff[pos:])
 
 	pos -= uint32Size
 	chunkCount := binary.BigEndian.Uint32(buff[pos:])
@@ -62,7 +62,7 @@ func parseTableIndex(buff []byte) tableIndex {
 	prefixes, ordinals := computePrefixes(chunkCount, buff[pos:pos+tuplesSize])
 
 	return tableIndex{
-		chunkCount, totalData,
+		chunkCount, totalPhysicalData,
 		prefixes, offsets,
 		lengths, ordinals,
 		suffixes,
@@ -188,8 +188,8 @@ func (tr tableReader) count() uint32 {
 	return tr.chunkCount
 }
 
-func (tr tableReader) data() uint64 {
-	return tr.totalData
+func (tr tableReader) byteLen() uint64 {
+	return tr.totalPhysicalData
 }
 
 // returns true iff |h| can be found in this table.

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -5,165 +5,281 @@
 package nbs
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/d"
 )
 
 const concurrentCompactions = 5
 
-func newS3TableSet(s3 s3svc, bucket string, indexCache *s3IndexCache, readRl chan struct{}) tableSet {
+func newS3TableSet(s3 s3svc, bucket string, indexCache *indexCache, readRl chan struct{}) tableSet {
 	return tableSet{
 		p:  s3TablePersister{s3, bucket, defaultS3PartSize, indexCache, readRl},
 		rl: make(chan struct{}, concurrentCompactions),
 	}
 }
 
-func newFSTableSet(dir string) tableSet {
+func newFSTableSet(dir string, indexCache *indexCache) tableSet {
 	return tableSet{
-		p:  fsTablePersister{dir},
+		p:  fsTablePersister{dir, indexCache},
 		rl: make(chan struct{}, concurrentCompactions),
 	}
 }
 
 // tableSet is an immutable set of persistable chunkSources.
 type tableSet struct {
-	chunkSources
-	p  tablePersister
-	rl chan struct{}
+	novel, upstream chunkSources
+	p               tablePersister
+	rl              chan struct{}
 }
 
-type chunkSources []chunkSource
-
-func (css chunkSources) has(h addr) bool {
-	for _, haver := range css {
-		if haver.has(h) {
-			return true
+func (ts tableSet) has(h addr) bool {
+	f := func(css chunkSources) bool {
+		for _, haver := range css {
+			if haver.has(h) {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	return f(ts.novel) || f(ts.upstream)
 }
 
-func (css chunkSources) hasMany(addrs []hasRecord) (remaining bool) {
-	for _, haver := range css {
-		if !haver.hasMany(addrs) {
-			return false
+func (ts tableSet) hasMany(addrs []hasRecord) (remaining bool) {
+	f := func(css chunkSources) (remaining bool) {
+		for _, haver := range css {
+			if !haver.hasMany(addrs) {
+				return false
+			}
 		}
+		return true
 	}
-	return true
+	return f(ts.novel) && f(ts.upstream)
 }
 
-func (css chunkSources) get(h addr) []byte {
-	for _, haver := range css {
-		if data := haver.get(h); data != nil {
-			return data
+func (ts tableSet) get(h addr) []byte {
+	f := func(css chunkSources) []byte {
+		for _, haver := range css {
+			if data := haver.get(h); data != nil {
+				return data
+			}
 		}
+		return nil
 	}
-	return nil
+	if data := f(ts.novel); data != nil {
+		return data
+	}
+	return f(ts.upstream)
 }
 
-func (css chunkSources) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) (remaining bool) {
-	for _, haver := range css {
-		if !haver.getMany(reqs, foundChunks, wg) {
-			return false
+func (ts tableSet) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) (remaining bool) {
+	f := func(css chunkSources) (remaining bool) {
+		for _, haver := range css {
+			if !haver.getMany(reqs, foundChunks, wg) {
+				return false
+			}
 		}
+		return true
 	}
-
-	return true
+	return f(ts.novel) && f(ts.upstream)
 }
 
-func (css chunkSources) calcReads(reqs []getRecord, blockSize uint64) (reads int, split, remaining bool) {
-	for _, haver := range css {
-		rds, remaining := haver.calcReads(reqs, blockSize)
+func (ts tableSet) calcReads(reqs []getRecord, blockSize uint64) (reads int, split, remaining bool) {
+	f := func(css chunkSources) (reads int, split, remaining bool) {
+		for _, haver := range css {
+			rds, remaining := haver.calcReads(reqs, blockSize)
+			reads += rds
+			if !remaining {
+				return reads, split, remaining
+			}
+			split = true
+		}
+		return reads, split, remaining
+	}
+	reads, split, remaining = f(ts.novel)
+	if remaining {
+		var rds int
+		rds, split, remaining = f(ts.upstream)
 		reads += rds
-		if !remaining {
-			return reads, split, remaining
-		}
-		split = true
 	}
 	return reads, split, remaining
 }
 
-func (css chunkSources) count() (count uint32) {
-	for _, haver := range css {
-		count += haver.count()
+func (ts tableSet) count() (count uint32) {
+	f := func(css chunkSources) (count uint32) {
+		for _, haver := range css {
+			count += haver.count()
+		}
+		return
 	}
-	return
+	return f(ts.novel) + f(ts.upstream)
+}
+
+func (ts tableSet) data() (data uint64) {
+	f := func(css chunkSources) (data uint64) {
+		for _, haver := range css {
+			data += haver.data()
+		}
+		return
+	}
+	return f(ts.novel) + f(ts.upstream)
+}
+
+// Size returns the number of tables in this tableSet.
+func (ts tableSet) Size() int {
+	return len(ts.novel) + len(ts.upstream)
 }
 
 // Prepend adds a memTable to an existing tableSet, compacting |mt| and
 // returning a new tableSet with newly compacted table added.
 func (ts tableSet) Prepend(mt *memTable) tableSet {
-	newTables := make(chunkSources, len(ts.chunkSources)+1)
-	newTables[0] = newCompactingChunkSource(mt, ts, ts.p, ts.rl)
-	copy(newTables[1:], ts.chunkSources)
-	return tableSet{newTables, ts.p, ts.rl}
+	newTs := tableSet{
+		novel:    make(chunkSources, len(ts.novel)+1),
+		upstream: make(chunkSources, len(ts.upstream)),
+		p:        ts.p,
+		rl:       ts.rl,
+	}
+	newTs.novel[0] = newCompactingChunkSource(mt, ts, ts.p, ts.rl)
+	copy(newTs.novel[1:], ts.novel)
+	copy(newTs.upstream, ts.upstream)
+	return newTs
+}
+
+// Compact returns a new tableSet that's smaller than |ts|. It takes the
+// max(2, len(ts)/2) smallest upstream tables, compacts them into a single
+// large table, then returns a new tableSet with novel = ts.novel, and
+// upstream set to this new large table and the not-compacted members of
+// ts.upstream. The compactees are returned separately so that the caller can
+// close them if she so chooses.
+func (ts tableSet) Compact() (ns tableSet, compactees chunkSources) {
+	ns = tableSet{
+		novel:    make(chunkSources, len(ts.novel)),
+		upstream: make(chunkSources, len(ts.upstream), len(ts.upstream)+1),
+		p:        ts.p,
+		rl:       ts.rl,
+	}
+	copy(ns.novel, ts.novel)
+	copy(ns.upstream, ts.upstream)
+	sort.Sort(chunkSourcesByDescendingCount(ns.upstream))
+
+	max := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	partition := len(ns.upstream) - max(2, len(ns.upstream)/2)
+	ns.upstream = append(ns.upstream, ts.p.CompactAll(ns.upstream[partition:]))
+	// swap new table (last item) and the partition element
+	last := len(ns.upstream) - 1
+	ns.upstream[partition], ns.upstream[last] = ns.upstream[last], ns.upstream[partition]
+
+	// The new table is at partition, so make sure that's included in |ns|, as opposed to |compactees|
+	return tableSet{ts.novel, ns.upstream[:partition+1], ts.p, ts.rl}, ns.upstream[partition+1:]
 }
 
 func (ts tableSet) extract(order EnumerationOrder, chunks chan<- extractRecord) {
-	// Since new tables are _prepended_ to a tableSet, extracting chunks in ReverseOrder requires iterating ts.chunkSources from front to back, while doing insertOrder requires iterating back to front.
+	// Since new tables are _prepended_ to a tableSet, extracting chunks in ReverseOrder requires iterating ts.novel, then ts.upstream, from front to back, while doing insertOrder requires iterating ts.upstream back to front, followed by ts.novel.
 	if order == ReverseOrder {
-		for _, cs := range ts.chunkSources {
+		for _, cs := range ts.novel {
+			cs.extract(order, chunks)
+		}
+		for _, cs := range ts.upstream {
 			cs.extract(order, chunks)
 		}
 		return
 	}
-	for i := len(ts.chunkSources) - 1; i >= 0; i-- {
-		ts.chunkSources[i].extract(order, chunks)
+	for i := len(ts.upstream) - 1; i >= 0; i-- {
+		ts.upstream[i].extract(order, chunks)
+	}
+	for i := len(ts.novel) - 1; i >= 0; i-- {
+		ts.novel[i].extract(order, chunks)
 	}
 }
 
-// Union returns a new tableSet holding the union of the tables managed by
-// |ts| and those specified by |specs|.
-func (ts tableSet) Union(specs []tableSpec) tableSet {
-	newTables := make(chunkSources, 0, len(ts.chunkSources))
-	known := map[addr]struct{}{}
-	for _, t := range ts.chunkSources {
+// Flatten returns a new tableSet with |upstream| set to the union of ts.novel
+// and ts.upstream.
+func (ts tableSet) Flatten() (flattened tableSet) {
+	flattened = tableSet{
+		upstream: make(chunkSources, 0, ts.Size()),
+		p:        ts.p,
+		rl:       ts.rl,
+	}
+	flattened.upstream = append(flattened.upstream, ts.novel...)
+	flattened.upstream = append(flattened.upstream, ts.upstream...)
+	return
+}
+
+// Merge returns a new tableSet holding the novel tables managed by |ts| and
+// those specified by |specs|. Tables in |ts.upstream| that are not referenced
+// by |specs| are returned in |dropped| so that the caller can close() them
+// appropriately.
+func (ts tableSet) Merge(specs []tableSpec) (merged tableSet, dropped chunkSources) {
+	merged = tableSet{
+		novel:    make(chunkSources, 0, len(ts.novel)),
+		upstream: make(chunkSources, 0, len(specs)),
+		p:        ts.p,
+		rl:       ts.rl,
+	}
+	dropped = make(chunkSources, len(ts.upstream))
+	copy(dropped, ts.upstream)
+
+	// Merge in all novel tables, dropping those that are actually empty (usually due to de-duping during table compaction)
+	for _, t := range ts.novel {
 		if t.count() > 0 {
-			known[t.hash()] = struct{}{}
-			newTables = append(newTables, t)
+			merged.novel = append(merged.novel, t)
+		} else {
+			dropped = append(dropped, t)
 		}
 	}
 
-	// Create a list of tables to open so we can open them in parallel
-	tablesToOpen := make([]tableSpec, 0, len(specs))
-	for _, t := range specs {
-		if _, present := known[t.name]; !present {
-			tablesToOpen = append(tablesToOpen, t)
+	// Create a list of tables to open so we can open them in parallel.
+	tablesToOpen := map[addr]tableSpec{}
+	for _, spec := range specs {
+		if _, present := tablesToOpen[spec.name]; !present { // Filter out dups
+			tablesToOpen[spec.name] = spec
 		}
 	}
 
+	// Open all the new upstream tables concurrently
 	openedTables := make(chunkSources, len(tablesToOpen))
 	wg := &sync.WaitGroup{}
-
-	for i, spec := range tablesToOpen {
+	i := 0
+	for _, spec := range tablesToOpen {
 		wg.Add(1)
 		go func(idx int, spec tableSpec) {
 			openedTables[idx] = ts.p.Open(spec.name, spec.chunkCount)
 			wg.Done()
 		}(i, spec)
+		i++
 	}
 
 	wg.Wait()
-	newTables = append(newTables, openedTables...)
-
-	return tableSet{newTables, ts.p, ts.rl}
+	merged.upstream = append(merged.upstream, openedTables...)
+	return merged, dropped
 }
 
 func (ts tableSet) ToSpecs() []tableSpec {
-	tableSpecs := make([]tableSpec, 0, len(ts.chunkSources))
-	for _, src := range ts.chunkSources {
+	tableSpecs := make([]tableSpec, 0, ts.Size())
+	for _, src := range ts.novel {
 		if src.count() > 0 {
 			tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
 		}
+	}
+	for _, src := range ts.upstream {
+		d.Chk.True(src.count() > 0)
+		tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
 	}
 	return tableSpecs
 }
 
 func (ts tableSet) Close() (err error) {
-	for _, t := range ts.chunkSources {
-		err = t.close() // TODO: somehow coalesce these errors??
+	err = ts.novel.close()
+	if e := ts.upstream.close(); e != nil {
+		err = e // TODO: somehow coalesce these errors??
 	}
-	close(ts.rl)
 	return
 }

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -132,7 +132,7 @@ func TestTableSetCompact(t *testing.T) {
 	assert.NoError(compacted.close())
 
 	assert.Equal(4, ts.Size())
-	assert.Equal(bigTable.hash(), ts.upstream[0].hash())
+	assert.Contains(ts.upstream, bigTable)
 	assertChunksInReader(moreChunks, ts, assert)
 	assertChunksInReader(extraChunks, ts, assert)
 
@@ -167,7 +167,7 @@ func makeTempDir(assert *assert.Assertions) string {
 	return dir
 }
 
-func TestTableSetMerge(t *testing.T) {
+func TestTableSetRebase(t *testing.T) {
 	assert := assert.New(t)
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
@@ -191,7 +191,7 @@ func TestTableSetMerge(t *testing.T) {
 	ts = ts.Flatten()
 	ts = insert(ts, []byte("novel"))
 
-	ts, dropped := ts.Merge(fullTS.ToSpecs())
+	ts, dropped := ts.Rebase(fullTS.ToSpecs())
 	assert.Len(dropped, 1)
 	assert.Equal(4, ts.Size())
 	dropped.close()

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -5,15 +5,12 @@
 package nbs
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"sync"
+	"sort"
 	"testing"
 
 	"github.com/attic-labs/testify/assert"
-	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 var testChunks = [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
@@ -107,13 +104,70 @@ func TestTableSetExtract(t *testing.T) {
 	ts.Close()
 }
 
+func TestTableSetCompact(t *testing.T) {
+	assert := assert.New(t)
+	ts := newFakeTableSet()
+	defer ts.Close()
+	assert.Empty(ts.ToSpecs())
+
+	moreChunks := append(testChunks, []byte("booboo"))
+	for _, c := range moreChunks {
+		mt := newMemTable(testMemTableSize)
+		mt.addChunk(computeAddr(c), c)
+		ts = ts.Prepend(mt)
+	}
+
+	// Put in one larger table, to be sure that it's not selected for compaction
+	extraChunks := [][]byte{[]byte("fubu"), []byte("fubar")}
+	mt := newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(extraChunks[0]), extraChunks[0])
+	mt.addChunk(computeAddr(extraChunks[1]), extraChunks[1])
+	ts = ts.Prepend(mt)
+	ts = ts.Flatten()
+	bigTable := ts.upstream[0]
+	assert.Equal(5, ts.Size())
+
+	var compacted chunkSources
+	ts, compacted = ts.Compact() // Should compact len/2 smallest (7/2 == 3) tables into 1, leaving 4 tables
+	assert.NoError(compacted.close())
+
+	assert.Equal(4, ts.Size())
+	assert.Equal(bigTable.hash(), ts.upstream[0].hash())
+	assertChunksInReader(moreChunks, ts, assert)
+	assertChunksInReader(extraChunks, ts, assert)
+
+	ts, compacted = ts.Compact() // Should compact len/2 smallest (4/2 == 2) tables into 1, leaving 3 tables
+	assert.NoError(compacted.close())
+
+	// After two waves of compaction on a set of tables of size 2, 1, 1, 1, 1 there should be 3 tables, each with 2 chunks in it.
+	assert.Equal(3, ts.Size())
+	for _, source := range ts.upstream {
+		assert.EqualValues(2, source.count())
+	}
+	assertChunksInReader(moreChunks, ts, assert)
+	assertChunksInReader(extraChunks, ts, assert)
+
+	ts, compacted = ts.Compact() // Should compact max(2, len/2) smallest (2 > 3/2 == 2) tables into 1
+	assert.NoError(compacted.close())
+	// After one last compaction there should be 2 tables, one of size 4 and one of size 2.
+	if assert.Equal(2, ts.Size()) {
+		sources := make(chunkSources, 2)
+		copy(sources, ts.upstream)
+		sort.Sort(chunkSourcesByDescendingCount(sources))
+		assert.EqualValues(4, sources[0].count())
+		assert.EqualValues(2, sources[1].count())
+		assertChunksInReader(moreChunks, ts, assert)
+		assertChunksInReader(extraChunks, ts, assert)
+	}
+}
+
 func makeTempDir(assert *assert.Assertions) string {
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
 	return dir
 }
 
-func TestTableSetUnion(t *testing.T) {
+func TestTableSetMerge(t *testing.T) {
 	assert := assert.New(t)
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
@@ -126,156 +180,21 @@ func TestTableSetUnion(t *testing.T) {
 		}
 		return ts
 	}
-	fullTS := newFSTableSet(dir)
+	fullTS := newFSTableSet(dir, nil)
 	assert.Empty(fullTS.ToSpecs())
 	fullTS = insert(fullTS, testChunks...)
+	fullTS = fullTS.Flatten()
 
-	ts := newFSTableSet(dir)
+	ts := newFSTableSet(dir, nil)
 	ts = insert(ts, testChunks[0])
-	assert.Len(ts.ToSpecs(), 1)
+	assert.Equal(1, ts.Size())
+	ts = ts.Flatten()
+	ts = insert(ts, []byte("novel"))
 
-	ts = ts.Union(fullTS.ToSpecs())
-	assert.Len(ts.ToSpecs(), 3)
+	ts, dropped := ts.Merge(fullTS.ToSpecs())
+	assert.Len(dropped, 1)
+	assert.Equal(4, ts.Size())
+	dropped.close()
 	ts.Close()
 	fullTS.Close()
-}
-
-func TestS3TablePersisterCompact(t *testing.T) {
-	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-	}
-
-	s3svc := makeFakeS3(assert)
-	cache := newS3IndexCache(1024)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 3), indexCache: cache}
-
-	src := s3p.Compact(mt, nil)
-	assert.NotNil(cache.get(src.hash()))
-
-	if assert.True(src.count() > 0) {
-		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
-			assertChunksInReader(testChunks, r, assert)
-		}
-	}
-}
-
-func calcPartSize(mt *memTable, maxPartNum int) int {
-	return int(maxTableSize(uint64(mt.count()), mt.totalData)) / maxPartNum
-}
-
-func TestS3TablePersisterCompactSinglePart(t *testing.T) {
-	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-	}
-
-	s3svc := makeFakeS3(assert)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 1)}
-
-	src := s3p.Compact(mt, nil)
-	if assert.True(src.count() > 0) {
-		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
-			assertChunksInReader(testChunks, r, assert)
-		}
-	}
-}
-
-func TestS3TablePersisterCompactAbort(t *testing.T) {
-	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-	}
-
-	numParts := 4
-	s3svc := &failingFakeS3{makeFakeS3(assert), sync.Mutex{}, 1}
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, numParts)}
-
-	assert.Panics(func() { s3p.Compact(mt, nil) })
-}
-
-type failingFakeS3 struct {
-	*fakeS3
-	mu           sync.Mutex
-	numSuccesses int
-}
-
-func (m *failingFakeS3) UploadPart(input *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.numSuccesses > 0 {
-		m.numSuccesses--
-		return m.fakeS3.UploadPart(input)
-	}
-	return nil, mockAWSError("MalformedXML")
-}
-
-func TestS3TablePersisterCompactNoData(t *testing.T) {
-	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-	existingTable := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-		assert.True(existingTable.addChunk(computeAddr(c), c))
-	}
-
-	s3svc := makeFakeS3(assert)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: 1 << 10}
-
-	src := s3p.Compact(mt, existingTable)
-	assert.True(src.count() == 0)
-
-	_, present := s3svc.data[src.hash().String()]
-	assert.False(present)
-}
-
-func TestFSTablePersisterCompact(t *testing.T) {
-	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-	}
-
-	dir := makeTempDir(assert)
-	defer os.RemoveAll(dir)
-	fts := fsTablePersister{dir}
-
-	src := fts.Compact(mt, nil)
-	if assert.True(src.count() > 0) {
-		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
-		assert.NoError(err)
-		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
-		for _, c := range testChunks {
-			assert.True(tr.has(computeAddr(c)))
-		}
-	}
-}
-
-func TestFSTablePersisterCompactNoData(t *testing.T) {
-	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-	existingTable := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-		assert.True(existingTable.addChunk(computeAddr(c), c))
-	}
-
-	dir := makeTempDir(assert)
-	defer os.RemoveAll(dir)
-	fts := fsTablePersister{dir}
-
-	src := fts.Compact(mt, existingTable)
-	assert.True(src.count() == 0)
-
-	_, err := os.Stat(filepath.Join(dir, src.hash().String()))
-	assert.True(os.IsNotExist(err), "%v", err)
 }


### PR DESCRIPTION
The first cut at compaction blocks UpdateRoot() while it compacts n/2
tables down into a single, large table (where n == number of tables
named in the NBS manifest). It then attempts to update the manifest
with one referencing the compacted table, the novel tables from the
client, and the remaining upstream tables that were not compacted.

If the update fails, probably due to an optimistic lock failure, the
client drops the compacted table it just created, pulls in the tables
from the newly-discovered upstream manifest, and tries again.

Known flaws:
- may explode RAM (#3130)
- doesn't handle novel tables > max tables (#3142)
- may handle optimistic-lock-failures suboptimally (#3141)

Fixes #3132

Also, fixes #2944 because doing so simplifies some code.