### PR TITLE
Funnel extract failure back to main goroutine

### DIFF
--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -150,3 +150,22 @@ func bytesToChunkSource(bs ...[]byte) chunkSource {
 	rdr := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
 	return chunkSourceAdapter{rdr, name}
 }
+
+func TestCompactSourcesToBufferPanic(t *testing.T) {
+	assert := assert.New(t)
+	rl := make(chan struct{}, 1)
+	defer close(rl)
+
+	src := bytesToChunkSource([]byte("hello"))
+	pcs := panicingChunkSource{src}
+
+	assert.Panics(func() { compactSourcesToBuffer(chunkSources{pcs}, rl) })
+}
+
+type panicingChunkSource struct {
+	chunkSource
+}
+
+func (pcs panicingChunkSource) extract(order EnumerationOrder, chunks chan<- extractRecord) {
+	panic("onoes")
+}


### PR DESCRIPTION
Panics on background goroutines take down the server. This patch
hacks in a mechanism to pipe failures during NBS tableReader.extract
back to the main goroutine so the server doesn't die on this failure
and I can diagnose it.