### PR TITLE
Graphql empty collections and types

### DIFF
--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -275,3 +275,12 @@ func (suite *QueryGraphQLSuite) TestNestedCollection() {
 	suite.assertQueryResult(list, "{root{elements(count:1){size}}}", `{"data":{"root":{"elements":[{"size":2}]}}}`)
 	suite.assertQueryResult(list, "{root{elements(at:1,count:1){elements(count:1){elements{key value}}}}}", `{"data":{"root":{"elements":[{"elements":[{"elements":[{"key":30,"value":"baz"}]}]}]}}}`)
 }
+
+func (suite *QueryGraphQLSuite) TestLoFi() {
+	b := types.NewBlob(bytes.NewBufferString("I am a blob"))
+
+	suite.assertQueryResult(b, "{root}", `{"data":{"root":"h6jkv35uum62a7ovu14uvmhaf0sojgh6"}}`)
+
+	t := types.StringType
+	suite.assertQueryResult(t, "{root}", `{"data":{"root":"pej65tf21rubhu9cb0oi5gqrkgf26aql"}}`)
+}

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -77,7 +77,11 @@ func (suite *QueryGraphQLSuite) TestEmbeddedStruct() {
 }
 
 func (suite *QueryGraphQLSuite) TestListBasic() {
-	list := types.NewList(types.String("foo"), types.String("bar"), types.String("baz"))
+	list := types.NewList()
+	suite.assertQueryResult(list, "{root{size}}", `{"data":{"root":{"size":0}}}`)
+	suite.assertQueryResult(list, "{root{elements}}", `{"data":null,"errors":[{"message":"Cannot query field \"elements\" on type \"EmptyList\".","locations":[{"line":1,"column":7}]}]}`)
+
+	list = types.NewList(types.String("foo"), types.String("bar"), types.String("baz"))
 
 	suite.assertQueryResult(list, "{root{elements}}", `{"data":{"root":{"elements":["foo","bar","baz"]}}}`)
 	suite.assertQueryResult(list, "{root{size}}", `{"data":{"root":{"size":3}}}`)
@@ -116,7 +120,11 @@ func (suite *QueryGraphQLSuite) TestListOfStruct() {
 }
 
 func (suite *QueryGraphQLSuite) TestSetBasic() {
-	set := types.NewSet(types.String("foo"), types.String("bar"), types.String("baz"))
+	set := types.NewSet()
+	suite.assertQueryResult(set, "{root{size}}", `{"data":{"root":{"size":0}}}`)
+	suite.assertQueryResult(set, "{root{elements}}", `{"data":null,"errors":[{"message":"Cannot query field \"elements\" on type \"EmptySet\".","locations":[{"line":1,"column":7}]}]}`)
+
+	set = types.NewSet(types.String("foo"), types.String("bar"), types.String("baz"))
 
 	suite.assertQueryResult(set, "{root{elements}}", `{"data":{"root":{"elements":["bar","baz","foo"]}}}`)
 	suite.assertQueryResult(set, "{root{size}}", `{"data":{"root":{"size":3}}}`)
@@ -154,7 +162,11 @@ func (suite *QueryGraphQLSuite) TestSetOfStruct() {
 }
 
 func (suite *QueryGraphQLSuite) TestMapBasic() {
-	m := types.NewMap(
+	m := types.NewMap()
+	suite.assertQueryResult(m, "{root{size}}", `{"data":{"root":{"size":0}}}`)
+	suite.assertQueryResult(m, "{root{elements}}", `{"data":null,"errors":[{"message":"Cannot query field \"elements\" on type \"EmptyMap\".","locations":[{"line":1,"column":7}]}]}`)
+
+	m = types.NewMap(
 		types.String("foo"), types.Number(1),
 		types.String("bar"), types.Number(2),
 		types.String("baz"), types.Number(3),

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -84,7 +84,8 @@ func nomsTypeToGraphQLType(nomsType *types.Type, tm typeMap) graphql.Type {
 		newNonNull.OfType = unionToGQLUnion(nomsType, tm)
 
 	case types.BlobKind, types.ValueKind, types.TypeKind:
-		panic(fmt.Sprintf("%d: type not impemented", nomsType.Kind()))
+		// TODO: https://github.com/attic-labs/noms/issues/3155
+		newNonNull.OfType = graphql.String
 
 	case types.CycleKind:
 		panic("not reached") // we should never attempt to create a schedule for any unresolved cycle
@@ -294,6 +295,9 @@ func getTypeName(nomsType *types.Type) string {
 	case types.StringKind:
 		return "String"
 
+	case types.BlobKind:
+		return "Blob"
+
 	case types.ValueKind:
 		return "Value"
 
@@ -425,6 +429,9 @@ func maybeGetScalar(v types.Value) interface{} {
 		return float64(v.(types.Number))
 	case types.String:
 		return string(v.(types.String))
+	case *types.Type, types.Blob:
+		// TODO: https://github.com/attic-labs/noms/issues/3155
+		return v.Hash()
 	}
 
 	return v

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -10,6 +10,7 @@ import (
 
 	"strings"
 
+	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/graphql-go/graphql"
@@ -58,13 +59,23 @@ func nomsTypeToGraphQLType(nomsType *types.Type, tm typeMap) graphql.Type {
 		newNonNull.OfType = structToGQLObject(nomsType, tm)
 
 	case types.ListKind, types.SetKind:
-		valueTyp := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
-		newNonNull.OfType = collectionToGraphQLObject(nomsType, nomsTypeToGraphQLType(valueTyp, tm), tm)
+		nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
+		var valueType graphql.Type
+		if !isEmptyNomsUnion(nomsValueType) {
+			valueType = nomsTypeToGraphQLType(nomsValueType, tm)
+		}
+
+		newNonNull.OfType = collectionToGraphQLObject(nomsType, valueType, tm)
 
 	case types.MapKind:
-		keyTyp := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
-		valueTyp := nomsType.Desc.(types.CompoundDesc).ElemTypes[1]
-		newNonNull.OfType = collectionToGraphQLObject(nomsType, mapEntryToGraphQLObject(keyTyp, valueTyp, tm), tm)
+		nomsKeyType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
+		nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[1]
+		var valueType graphql.Type
+		if !isEmptyNomsUnion(nomsKeyType) && !isEmptyNomsUnion(nomsValueType) {
+			valueType = mapEntryToGraphQLObject(nomsKeyType, nomsValueType, tm)
+		}
+
+		newNonNull.OfType = collectionToGraphQLObject(nomsType, valueType, tm)
 
 	case types.RefKind:
 		newNonNull.OfType = refToGraphQLObject(nomsType, tm)
@@ -83,6 +94,10 @@ func nomsTypeToGraphQLType(nomsType *types.Type, tm typeMap) graphql.Type {
 	}
 
 	return newNonNull
+}
+
+func isEmptyNomsUnion(nomsType *types.Type) bool {
+	return nomsType.Kind() == types.UnionKind && len(nomsType.Desc.(types.CompoundDesc).ElemTypes) == 0
 }
 
 // Creates a union of structs type.
@@ -283,18 +298,32 @@ func getTypeName(nomsType *types.Type) string {
 		return "Value"
 
 	case types.ListKind:
-		return fmt.Sprintf("%sList", getTypeName(nomsType.Desc.(types.CompoundDesc).ElemTypes[0]))
+		nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
+		if isEmptyNomsUnion(nomsValueType) {
+			return "EmptyList"
+		}
+		return fmt.Sprintf("%sList", getTypeName(nomsValueType))
 
 	case types.MapKind:
-		kn := getTypeName(nomsType.Desc.(types.CompoundDesc).ElemTypes[0])
-		vn := getTypeName(nomsType.Desc.(types.CompoundDesc).ElemTypes[0])
-		return fmt.Sprintf("%sTo%sMap", kn, vn)
+		nomsKeyType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
+		nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[1]
+		if isEmptyNomsUnion(nomsKeyType) {
+			d.Chk.True(isEmptyNomsUnion(nomsValueType))
+			return "EmptyMap"
+		}
+
+		return fmt.Sprintf("%sTo%sMap", getTypeName(nomsKeyType), getTypeName(nomsValueType))
 
 	case types.RefKind:
 		return fmt.Sprintf("%sRef", getTypeName(nomsType.Desc.(types.CompoundDesc).ElemTypes[0]))
 
 	case types.SetKind:
-		return fmt.Sprintf("%sSet", getTypeName(nomsType.Desc.(types.CompoundDesc).ElemTypes[0]))
+		nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
+		if isEmptyNomsUnion(nomsValueType) {
+			return "EmptySet"
+		}
+
+		return fmt.Sprintf("%sSet", getTypeName(nomsValueType))
 
 	case types.StructKind:
 		return fmt.Sprintf("%sStruct", nomsType.Desc.(types.StructDesc).Name)
@@ -313,43 +342,48 @@ func getTypeName(nomsType *types.Type) string {
 }
 
 func collectionToGraphQLObject(nomsType *types.Type, listType graphql.Type, tm typeMap) *graphql.Object {
-	var args graphql.FieldConfigArgument
-	var getSubvalues getSubvaluesFn
+	fields := graphql.Fields{
+		sizeKey: &graphql.Field{
+			Type: graphql.Float,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				c := p.Source.(types.Collection)
+				return maybeGetScalar(types.Number(c.Len())), nil
+			},
+		},
+	}
 
-	switch nomsType.Kind() {
-	case types.ListKind:
-		args = listArgs
-		getSubvalues = getListValues
+	if listType != nil {
+		var args graphql.FieldConfigArgument
+		var getSubvalues getSubvaluesFn
 
-	case types.SetKind:
-		args = setArgs
-		getSubvalues = getSetValues
+		switch nomsType.Kind() {
+		case types.ListKind:
+			args = listArgs
+			getSubvalues = getListValues
 
-	case types.MapKind:
-		args = mapArgs
-		getSubvalues = getMapValues
+		case types.SetKind:
+			args = setArgs
+			getSubvalues = getSetValues
+
+		case types.MapKind:
+			args = mapArgs
+			getSubvalues = getMapValues
+		}
+
+		fields[elementsKey] = &graphql.Field{
+			Type: graphql.NewList(listType),
+			Args: args,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				c := p.Source.(types.Collection)
+				return getSubvalues(c, p.Args)
+			},
+		}
 	}
 
 	return graphql.NewObject(graphql.ObjectConfig{
-		Name: getTypeName(nomsType),
-		Fields: graphql.Fields{
-			sizeKey: &graphql.Field{
-				Type: graphql.Float,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					c := p.Source.(types.Collection)
-					return maybeGetScalar(types.Number(c.Len())), nil
-				},
-			},
-
-			elementsKey: &graphql.Field{
-				Type: graphql.NewList(listType),
-				Args: args,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					c := p.Source.(types.Collection)
-					return getSubvalues(c, p.Args)
-				},
-			},
-		}})
+		Name:   getTypeName(nomsType),
+		Fields: fields,
+	})
 }
 
 // Refs are represented as structs:


### PR DESCRIPTION
We need to fully map the noms types into graphql even though the mapping isn't useful, otherwise the endpoint may die when attempting to create a schema for types that aren't mapped.

Note the reference the proposed *real* solution for implementation once we're convinced this will all work now.

For now, Blobs & Types just get returned as a string representation of their hash value.

Also, a few more type naming cleanups