### PR TITLE
Gather more info about Bug 3156

### DIFF
--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -88,7 +88,7 @@ func TestMemTableWrite(t *testing.T) {
 	assert.True(tr1.has(computeAddr(chunks[1])))
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
-	_, data, count := mt.write(chunkReaderGroup{tr1, tr2})
+	_, data, count, _ := mt.write(chunkReaderGroup{tr1, tr2})
 	assert.Equal(uint32(1), count)
 
 	outReader := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -197,7 +197,7 @@ type fakeTablePersister struct {
 
 func (ftp fakeTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
 	if mt.count() > 0 {
-		name, data, chunkCount := mt.write(haver)
+		name, data, chunkCount, _ := mt.write(haver)
 		if chunkCount > 0 {
 			ftp.sources[name] = newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
 			return chunkSourceAdapter{ftp.sources[name], name}

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -29,7 +29,7 @@ type EnumerationOrder uint8
 
 const (
 	// StorageVersion is the version of the on-disk Noms Chunks Store data format.
-	StorageVersion = "0"
+	StorageVersion = "1"
 
 	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
 	defaultAWSReadLimit        = 1024

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -363,12 +363,12 @@ func canReadAhead(fRec offsetRec, fLength uint32, readStart, readEnd, blockSize 
 // Fetches the byte stream of data logically encoded within the table starting at |pos|.
 func (tr tableReader) parseChunk(buff []byte) []byte {
 	dataLen := uint64(len(buff)) - checksumSize
+
+	chksum := binary.BigEndian.Uint32(buff[dataLen:])
+	d.Chk.True(chksum == crc(buff[:dataLen]))
+
 	data, err := snappy.Decode(nil, buff[:dataLen])
 	d.Chk.NoError(err)
-	buff = buff[dataLen:]
-
-	chksum := binary.BigEndian.Uint32(buff)
-	d.Chk.True(chksum == crc(data))
 
 	return data
 }


### PR DESCRIPTION
There's some case that causes chunks that compress to more than about
55k (we think these are quite big, chunks that are many hundreds of K
in size) not to wind up correctly inserted into tables. It looks like
the snappy library believes the buffer we've allocated may not be
large enough, so it allocates its own space and this screws us up.

This patch changes two things:
1) The CRC in the NBS format is now the CRC of the _compressed_ data
2) Such chunks will be manually copied into the table, so they won't
   be missing anymore

Also, when the code detects a case where the snappy library decided
to allocate its own storage, it saves the uncompressed data off to
the side, so that it can be pushed to durable storage. Such chunks
are stored on disk or in S3 named like "<chunk-hash>-errata", and
logging is dumped out so we can figure out which tables were supposed
to contain these chunks.

Towards #3156