### PR TITLE
Always print Bug 3156 logging

### DIFF
--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -24,7 +24,7 @@ func (ftp fsTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 	// TODO: remove when BUG 3156 is fixed
 	for h, eData := range errata {
 		func() {
-			temp, err := ioutil.TempFile(ftp.dir, h.String()+"-errata")
+			temp, err := ioutil.TempFile(ftp.dir, "errata-"+h.String())
 			d.PanicIfError(err)
 			defer checkClose(temp)
 			io.Copy(temp, bytes.NewReader(eData))

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -39,7 +39,7 @@ func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource
 	name, data, count, errata := mt.write(haver)
 	// TODO: remove when BUG 3156 is fixed
 	for h, eData := range errata {
-		s3p.multipartUpload(eData, h.String()+"-errata")
+		s3p.multipartUpload(eData, "errata-"+h.String())
 	}
 	return s3p.persistTable(name, data, count)
 }

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -141,7 +141,7 @@ func bytesToChunkSource(bs ...[]byte) chunkSource {
 	}
 	maxSize := maxTableSize(uint64(len(bs)), uint64(sum))
 	buff := make([]byte, maxSize)
-	tw := newTableWriter(buff)
+	tw := newTableWriter(buff, nil)
 	for _, b := range bs {
 		tw.addChunk(computeAddr(b), b)
 	}

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -68,7 +68,7 @@ func compactSourcesToBuffer(sources chunkSources, rl chan struct{}) (name addr, 
 
 	maxSize := maxTableSize(uint64(chunkCount), totalData)
 	buff := make([]byte, maxSize) // This can blow up RAM (BUG 3130)
-	tw := newTableWriter(buff)
+	tw := newTableWriter(buff, nil)
 
 	// Use "channel of channels" ordered-concurrency pattern so that chunks from a given table stay together, preserving whatever locality was present in that table.
 	chunkChans := make(chan chan extractRecord)

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -29,7 +29,7 @@ func buildTable(chunks [][]byte) ([]byte, addr) {
 
 	buff := make([]byte, capacity)
 
-	tw := newTableWriter(buff)
+	tw := newTableWriter(buff, nil)
 
 	for _, chunk := range chunks {
 		tw.addChunk(computeAddr(chunk), chunk)
@@ -129,7 +129,7 @@ func TestHasManySequentialPrefix(t *testing.T) {
 
 	capacity := maxTableSize(uint64(len(addrs)), totalData)
 	buff := make([]byte, capacity)
-	tw := newTableWriter(buff)
+	tw := newTableWriter(buff, nil)
 
 	for _, a := range addrs {
 		tw.addChunk(a, bogusData)
@@ -354,7 +354,7 @@ func TestEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	buff := make([]byte, footerSize)
-	tw := newTableWriter(buff)
+	tw := newTableWriter(buff, nil)
 	length, _ := tw.finish()
 	assert.Equal(length, footerSize)
 


### PR DESCRIPTION
Apparently, there's some issue running demo-server with --verbose
in prod, so we don't do it. This means that the logging info I
added isn't showing up. Change the logging code to use fmt.Fprintf()

Also, add unit test for errata functionality.

Towards #3156