### PR TITLE
NBS: Calculate maxTableSize precisely

### DIFF
--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -81,10 +81,10 @@ func (ccs *compactingChunkSource) count() uint32 {
 	return ccs.cs.count()
 }
 
-func (ccs *compactingChunkSource) byteLen() uint64 {
+func (ccs *compactingChunkSource) lens() []uint32 {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.byteLen()
+	return ccs.cs.lens()
 }
 
 func (ccs *compactingChunkSource) hash() addr {
@@ -131,8 +131,8 @@ func (ecs emptyChunkSource) count() uint32 {
 	return 0
 }
 
-func (ecs emptyChunkSource) byteLen() uint64 {
-	return 0
+func (ecs emptyChunkSource) lens() []uint32 {
+	return nil
 }
 
 func (ecs emptyChunkSource) hash() addr {

--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -20,17 +20,7 @@ type fsTablePersister struct {
 }
 
 func (ftp fsTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
-	name, data, count, errata := mt.write(haver)
-	// TODO: remove when BUG 3156 is fixed
-	for h, eData := range errata {
-		func() {
-			temp, err := ioutil.TempFile(ftp.dir, "errata-"+h.String())
-			d.PanicIfError(err)
-			defer checkClose(temp)
-			io.Copy(temp, bytes.NewReader(eData))
-		}()
-	}
-	return ftp.persistTable(name, data, count)
+	return ftp.persistTable(mt.write(haver))
 }
 
 func (ftp fsTablePersister) persistTable(name addr, data []byte, chunkCount uint32) chunkSource {

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -197,7 +197,7 @@ type fakeTablePersister struct {
 
 func (ftp fakeTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
 	if mt.count() > 0 {
-		name, data, chunkCount, _ := mt.write(haver)
+		name, data, chunkCount := mt.write(haver)
 		if chunkCount > 0 {
 			ftp.sources[name] = newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
 			return chunkSourceAdapter{ftp.sources[name], name}

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -36,12 +36,7 @@ type s3UploadedPart struct {
 }
 
 func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
-	name, data, count, errata := mt.write(haver)
-	// TODO: remove when BUG 3156 is fixed
-	for h, eData := range errata {
-		s3p.multipartUpload(eData, "errata-"+h.String())
-	}
-	return s3p.persistTable(name, data, count)
+	return s3p.persistTable(mt.write(haver))
 }
 
 func (s3p s3TablePersister) persistTable(name addr, data []byte, chunkCount uint32) chunkSource {

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -36,7 +36,7 @@ func TestS3TablePersisterCompact(t *testing.T) {
 }
 
 func calcPartSize(rdr chunkReader, maxPartNum int) int {
-	return int(maxTableSize(uint64(rdr.count()), rdr.byteLen())) / maxPartNum
+	return int(maxTableSize(rdr.lens())) / maxPartNum
 }
 
 func TestS3TablePersisterCompactSinglePart(t *testing.T) {
@@ -135,11 +135,11 @@ func TestS3TablePersisterCompactAll(t *testing.T) {
 }
 
 func bytesToChunkSource(bs ...[]byte) chunkSource {
-	sum := 0
+	lengths := []uint32{}
 	for _, b := range bs {
-		sum += len(b)
+		lengths = append(lengths, uint32(len(b)))
 	}
-	maxSize := maxTableSize(uint64(len(bs)), uint64(sum))
+	maxSize := maxTableSize(lengths)
 	buff := make([]byte, maxSize)
 	tw := newTableWriter(buff, nil)
 	for _, b := range bs {

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -205,7 +205,7 @@ type chunkReader interface {
 	get(h addr) []byte
 	getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool
 	count() uint32
-	byteLen() uint64
+	lens() []uint32
 	extract(order EnumerationOrder, chunks chan<- extractRecord)
 }
 

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -57,16 +57,16 @@ func (csbc chunkSourcesByDescendingCount) Swap(i, j int) { csbc[i], csbc[j] = cs
 
 func compactSourcesToBuffer(sources chunkSources, rl chan struct{}) (name addr, data []byte, chunkCount uint32) {
 	d.Chk.True(rl != nil)
-	totalData := uint64(0)
+
+	lengths := []uint32{}
 	for _, src := range sources {
-		chunkCount += src.count()
-		totalData += src.byteLen()
+		lengths = append(lengths, src.lens()...)
 	}
-	if chunkCount == 0 {
+	if len(lengths) == 0 {
 		return
 	}
 
-	maxSize := maxTableSize(uint64(chunkCount), totalData)
+	maxSize := maxTableSize(lengths)
 	buff := make([]byte, maxSize) // This can blow up RAM (BUG 3130)
 	tw := newTableWriter(buff, nil)
 

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -19,7 +19,6 @@ import (
 
 type tableIndex struct {
 	chunkCount        uint32
-	totalPhysicalData uint64
 	prefixes, offsets []uint64
 	lengths, ordinals []uint32
 	suffixes          []byte
@@ -40,9 +39,8 @@ func parseTableIndex(buff []byte) tableIndex {
 	pos -= magicNumberSize
 	d.Chk.True(string(buff[pos:]) == magicNumber)
 
-	// total chunk data
+	// Ignore total chunk data
 	pos -= uint64Size
-	totalPhysicalData := binary.BigEndian.Uint64(buff[pos:])
 
 	pos -= uint32Size
 	chunkCount := binary.BigEndian.Uint32(buff[pos:])
@@ -62,7 +60,7 @@ func parseTableIndex(buff []byte) tableIndex {
 	prefixes, ordinals := computePrefixes(chunkCount, buff[pos:pos+tuplesSize])
 
 	return tableIndex{
-		chunkCount, totalPhysicalData,
+		chunkCount,
 		prefixes, offsets,
 		lengths, ordinals,
 		suffixes,
@@ -188,8 +186,8 @@ func (tr tableReader) count() uint32 {
 	return tr.chunkCount
 }
 
-func (tr tableReader) byteLen() uint64 {
-	return tr.totalPhysicalData
+func (tr tableReader) lens() []uint32 {
+	return tr.lengths
 }
 
 // returns true iff |h| can be found in this table.

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -117,14 +117,16 @@ func (ts tableSet) count() uint32 {
 	return f(ts.novel) + f(ts.upstream)
 }
 
-func (ts tableSet) byteLen() uint64 {
-	f := func(css chunkSources) (data uint64) {
+func (ts tableSet) lens() (lengths []uint32) {
+	f := func(css chunkSources) {
 		for _, haver := range css {
-			data += haver.byteLen()
+			lengths = append(lengths, haver.lens()...)
 		}
 		return
 	}
-	return f(ts.novel) + f(ts.upstream)
+	f(ts.novel)
+	f(ts.upstream)
+	return
 }
 
 // Size returns the number of tables in this tableSet.

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 func buildTable(chunks [][]byte) ([]byte, addr) {
-	totalData := uint64(0)
+	lengths := []uint32{}
 	for _, chunk := range chunks {
-		totalData += uint64(len(chunk))
+		lengths = append(lengths, uint32(len(chunk)))
 	}
-	capacity := maxTableSize(uint64(len(chunks)), totalData)
+	capacity := maxTableSize(lengths)
 
 	buff := make([]byte, capacity)
 
@@ -125,9 +125,12 @@ func TestHasManySequentialPrefix(t *testing.T) {
 	}
 
 	bogusData := []byte("bogus") // doesn't matter what this is. hasMany() won't check chunkRecords
-	totalData := uint64(len(bogusData) * len(addrs))
+	lengths := []uint32{}
+	for range addrs {
+		lengths = append(lengths, uint32(len(bogusData)))
+	}
 
-	capacity := maxTableSize(uint64(len(addrs)), totalData)
+	capacity := maxTableSize(lengths)
 	buff := make([]byte, capacity)
 	tw := newTableWriter(buff, nil)
 


### PR DESCRIPTION
Though Raf and I can't figure out how, it's clear that the method we
initially used for calculating the max amount of space for
snappy-compressed chunk data was incorrect. That's the root cause of
of all the chunks to be written and summing the snappy.MaxEncodedLen()
for each.

Fixes #3156