### PR TITLE
Add missing content type header to writeValue/updateRoot

### DIFF
--- a/js/noms/package.json
+++ b/js/noms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attic/noms",
   "license": "Apache-2.0",
-  "version": "69.6.1",
+  "version": "69.7.0",
   "description": "Noms JS SDK",
   "repository": "https://github.com/attic-labs/noms/tree/master/js/noms",
   "main": "dist/commonjs/noms.js",

--- a/js/noms/src/http-batch-store.js
+++ b/js/noms/src/http-batch-store.js
@@ -52,6 +52,9 @@ const readBatchOptions = {
 
 const writeBatchOptions = {
   method: 'POST',
+  headers: {
+    'Content-Type': 'application/octet-stream',
+  },
 };
 
 const updateRootOptions = {


### PR DESCRIPTION
When we do a writeValue or updateRoot we do a POST with a request body
of some binary data. Some clients (RN) do not set the content-type
header which then leads to failure on our server.