### PR TITLE
NBS: Store total uncompressed data size in NBS tables

### DIFF
--- a/go/nbs/compacting_chunk_source.go
+++ b/go/nbs/compacting_chunk_source.go
@@ -81,10 +81,10 @@ func (ccs *compactingChunkSource) count() uint32 {
 	return ccs.cs.count()
 }
 
-func (ccs *compactingChunkSource) lens() []uint32 {
+func (ccs *compactingChunkSource) uncompressedLen() uint64 {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.lens()
+	return ccs.cs.uncompressedLen()
 }
 
 func (ccs *compactingChunkSource) hash() addr {
@@ -131,8 +131,8 @@ func (ecs emptyChunkSource) count() uint32 {
 	return 0
 }
 
-func (ecs emptyChunkSource) lens() []uint32 {
-	return nil
+func (ecs emptyChunkSource) uncompressedLen() uint64 {
+	return 0
 }
 
 func (ecs emptyChunkSource) hash() addr {

--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -50,12 +50,8 @@ func (mt *memTable) count() uint32 {
 	return uint32(len(mt.order))
 }
 
-func (mt *memTable) lens() []uint32 {
-	lengths := make([]uint32, 0, len(mt.chunks))
-	for _, data := range mt.chunks {
-		lengths = append(lengths, uint32(len(data)))
-	}
-	return lengths
+func (mt *memTable) uncompressedLen() uint64 {
+	return mt.totalData
 }
 
 func (mt *memTable) has(h addr) (has bool) {
@@ -109,7 +105,7 @@ func (mt *memTable) extract(order EnumerationOrder, chunks chan<- extractRecord)
 }
 
 func (mt *memTable) write(haver chunkReader) (name addr, data []byte, count uint32) {
-	maxSize := maxTableSize(mt.lens())
+	maxSize := maxTableSize(uint64(len(mt.order)), mt.totalData)
 	buff := make([]byte, maxSize)
 	tw := newTableWriter(buff, mt.snapper)
 

--- a/go/nbs/mem_table_test.go
+++ b/go/nbs/mem_table_test.go
@@ -98,7 +98,6 @@ func TestMemTableWrite(t *testing.T) {
 	assert.False(outReader.has(computeAddr(chunks[2])))
 }
 
-/* Temporarily disabled while we work around BUG 3156
 func TestMemTableSnappyWriteOutOfLine(t *testing.T) {
 	assert := assert.New(t)
 	mt := newMemTable(1024)
@@ -112,10 +111,10 @@ func TestMemTableSnappyWriteOutOfLine(t *testing.T) {
 	for _, c := range chunks {
 		assert.True(mt.addChunk(computeAddr(c), c))
 	}
-	mt.snapper = &outOfLineSnappy{[]bool{false, true, false}} // chunks[1] should wind up getting written "out of line"
+	mt.snapper = &outOfLineSnappy{[]bool{false, true, false}} // chunks[1] should trigger a panic
 
 	assert.Panics(func() { mt.write(nil) })
-}*/
+}
 
 type outOfLineSnappy struct {
 	policy []bool
@@ -178,9 +177,9 @@ func (crg chunkReaderGroup) count() (count uint32) {
 	return
 }
 
-func (crg chunkReaderGroup) lens() (lengths []uint32) {
+func (crg chunkReaderGroup) uncompressedLen() (data uint64) {
 	for _, haver := range crg {
-		lengths = append(lengths, haver.lens()...)
+		data += haver.uncompressedLen()
 	}
 	return
 }

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -36,7 +36,7 @@ func TestS3TablePersisterCompact(t *testing.T) {
 }
 
 func calcPartSize(rdr chunkReader, maxPartNum int) int {
-	return int(maxTableSize(rdr.lens())) / maxPartNum
+	return int(maxTableSize(uint64(rdr.count()), rdr.uncompressedLen())) / maxPartNum
 }
 
 func TestS3TablePersisterCompactSinglePart(t *testing.T) {
@@ -135,11 +135,11 @@ func TestS3TablePersisterCompactAll(t *testing.T) {
 }
 
 func bytesToChunkSource(bs ...[]byte) chunkSource {
-	lengths := []uint32{}
+	sum := 0
 	for _, b := range bs {
-		lengths = append(lengths, uint32(len(b)))
+		sum += len(b)
 	}
-	maxSize := maxTableSize(lengths)
+	maxSize := maxTableSize(uint64(len(bs)), uint64(sum))
 	buff := make([]byte, maxSize)
 	tw := newTableWriter(buff, nil)
 	for _, b := range bs {

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -29,7 +29,7 @@ type EnumerationOrder uint8
 
 const (
 	// StorageVersion is the version of the on-disk Noms Chunks Store data format.
-	StorageVersion = "1"
+	StorageVersion = "2"
 
 	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
 	defaultAWSReadLimit        = 1024

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -73,11 +73,11 @@ import (
      - Hash Suffix M must correspond to Chunk Record M for 0 <= M <= N
 
    Footer:
-   +----------------------+---------------------------+------------------+
-   | (Uint32) Chunk Count | (Uint64) Total Chunk Data | (8) Magic Number |
-   +----------------------+---------------------------+------------------+
+   +----------------------+----------------------------------------+------------------+
+   | (Uint32) Chunk Count | (Uint64) Total Uncompressed Chunk Data | (8) Magic Number |
+   +----------------------+----------------------------------------+------------------+
 
-     -Total Chunk Data is the sum of the logical byte lengths of all contained chunk byte slices.
+     -Total Uncompressed Chunk Data is the sum of the uncompressed byte lengths of all contained chunk byte slices.
      -Magic Number is the first 8 bytes of the SHA256 hash of "https://github.com/attic-labs/nbs".
 
     NOTE: Unsigned integer quanities, hashes and hash suffix are all encoded big-endian
@@ -205,7 +205,7 @@ type chunkReader interface {
 	get(h addr) []byte
 	getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool
 	count() uint32
-	lens() []uint32
+	uncompressedLen() uint64
 	extract(order EnumerationOrder, chunks chan<- extractRecord)
 }
 

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -57,16 +57,16 @@ func (csbc chunkSourcesByDescendingCount) Swap(i, j int) { csbc[i], csbc[j] = cs
 
 func compactSourcesToBuffer(sources chunkSources, rl chan struct{}) (name addr, data []byte, chunkCount uint32) {
 	d.Chk.True(rl != nil)
-
-	lengths := []uint32{}
+	totalData := uint64(0)
 	for _, src := range sources {
-		lengths = append(lengths, src.lens()...)
+		chunkCount += src.count()
+		totalData += src.uncompressedLen()
 	}
-	if len(lengths) == 0 {
+	if chunkCount == 0 {
 		return
 	}
 
-	maxSize := maxTableSize(lengths)
+	maxSize := maxTableSize(uint64(chunkCount), totalData)
 	buff := make([]byte, maxSize) // This can blow up RAM (BUG 3130)
 	tw := newTableWriter(buff, nil)
 

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -117,16 +117,14 @@ func (ts tableSet) count() uint32 {
 	return f(ts.novel) + f(ts.upstream)
 }
 
-func (ts tableSet) lens() (lengths []uint32) {
-	f := func(css chunkSources) {
+func (ts tableSet) uncompressedLen() uint64 {
+	f := func(css chunkSources) (data uint64) {
 		for _, haver := range css {
-			lengths = append(lengths, haver.lens()...)
+			data += haver.uncompressedLen()
 		}
 		return
 	}
-	f(ts.novel)
-	f(ts.upstream)
-	return
+	return f(ts.novel) + f(ts.upstream)
 }
 
 // Size returns the number of tables in this tableSet.

--- a/go/nbs/table_test.go
+++ b/go/nbs/table_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 func buildTable(chunks [][]byte) ([]byte, addr) {
-	lengths := []uint32{}
+	totalData := uint64(0)
 	for _, chunk := range chunks {
-		lengths = append(lengths, uint32(len(chunk)))
+		totalData += uint64(len(chunk))
 	}
-	capacity := maxTableSize(lengths)
+	capacity := maxTableSize(uint64(len(chunks)), totalData)
 
 	buff := make([]byte, capacity)
 
@@ -125,12 +125,9 @@ func TestHasManySequentialPrefix(t *testing.T) {
 	}
 
 	bogusData := []byte("bogus") // doesn't matter what this is. hasMany() won't check chunkRecords
-	lengths := []uint32{}
-	for range addrs {
-		lengths = append(lengths, uint32(len(bogusData)))
-	}
+	totalData := uint64(len(bogusData) * len(addrs))
 
-	capacity := maxTableSize(lengths)
+	capacity := maxTableSize(uint64(len(addrs)), totalData)
 	buff := make([]byte, capacity)
 	tw := newTableWriter(buff, nil)
 


### PR DESCRIPTION
BUG 3156 is caused by the compaction code trying to estimate the
maximum possible table size for chunk data pulled from a bunch of
existing tables. The problem was that we only had _compressed_ data
lengths for the chunks in existing tables, so we were drastically
underestimating the worst-case space that we might need during
compaction.

The fix is to have tables store the total number of _uncompressed_
bytes that were inserted, so that the compaction code can use this to
get the right estimate when putting together a bunch of tables.

Fixes #3156