### PR TITLE
Fix typo from counter sample README.md

### DIFF
--- a/samples/js/counter/README.md
+++ b/samples/js/counter/README.md
@@ -8,7 +8,7 @@ counter uses noms/js to read and write a simple incrementing counter.
 ```
 cd samples/js/counter
 yarn
-node . http://localhost:8000:counter
+node . http://localhost:8000::counter
 ```
 
 For dev mode you might want to run `yarn run start` instead which does not obfuscate the source.


### PR DESCRIPTION
Delimiter should be `::` instead of `:`.

If not, it returns below error.


$ node . http://localhost:8000:counter
SyntaxError: Missing :: separator between database and dataset: http://localhost:8000:counter
    at splitAndParseDatabaseSpec (/home/sungguklim/work/src/github.com/attic-labs/noms/samples/js/counter/node_modules/@attic/noms/dist/commonjs/specs.js:335:11)
    at Function.parse (/home/sungguklim/work/src/github.com/attic-labs/noms/samples/js/counter/node_modules/@attic/noms/dist/commonjs/specs.js:165:35)
    at main$ (/home/sungguklim/work/src/github.com/attic-labs/noms/samples/js/counter/dist/main.js:37:36)
    at tryCatch (/home/sungguklim/work/src/github.com/attic-labs/noms/samples/js/counter/node_modules/regenerator-runtime/runtime.js:64:40)
