### PR TITLE
NBS: tableSet.Flatten() must exclude empty tables

### DIFF
--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -207,7 +207,11 @@ func (ts tableSet) Flatten() (flattened tableSet) {
 		p:        ts.p,
 		rl:       ts.rl,
 	}
-	flattened.upstream = append(flattened.upstream, ts.novel...)
+	for _, src := range ts.novel {
+		if src.count() > 0 {
+			flattened.upstream = append(flattened.upstream, src)
+		}
+	}
 	flattened.upstream = append(flattened.upstream, ts.upstream...)
 	return
 }

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -42,7 +42,7 @@ func TestTableSetPrepend(t *testing.T) {
 	ts.Close()
 }
 
-func TestTableToSpecsExcludesEmptyTable(t *testing.T) {
+func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet()
 	assert.Empty(ts.ToSpecs())
@@ -60,6 +60,27 @@ func TestTableToSpecsExcludesEmptyTable(t *testing.T) {
 
 	specs := ts.ToSpecs()
 	assert.Len(specs, 2)
+	ts.Close()
+}
+
+func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
+	assert := assert.New(t)
+	ts := newFakeTableSet()
+	assert.Empty(ts.ToSpecs())
+	mt := newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
+	ts = ts.Prepend(mt)
+
+	mt = newMemTable(testMemTableSize)
+	ts = ts.Prepend(mt)
+
+	mt = newMemTable(testMemTableSize)
+	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
+	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
+	ts = ts.Prepend(mt)
+
+	ts = ts.Flatten()
+	assert.EqualValues(ts.Size(), 2)
 	ts.Close()
 }
 


### PR DESCRIPTION
I missed this in the compaction patch :-/ I caught it in another
test when the code panic'd while trying to write a manifest with
an empty table in it. So at least it got caught there?