### PR TITLE
Fix GraphQL to use unique type names

### DIFF
--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -47,7 +47,8 @@ func constructQueryType(rootValue types.Value, tm *typeMap) *graphql.Object {
 		}})
 }
 
-// Query takes |rootValue|, builds a GraphQL scheme from rootValue.Type() and executes |query| against it, encoding the result to |w|.
+// Query takes |rootValue|, builds a GraphQL scheme from rootValue.Type() and
+// executes |query| against it, encoding the result to |w|.
 func Query(rootValue types.Value, query string, vr types.ValueReader, w io.Writer) error {
 	tm := newTypeMap()
 

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -6,6 +6,7 @@ package ngql
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -240,7 +241,12 @@ func (suite *QueryGraphQLSuite) TestListOfUnionOfStructs() {
 		}),
 	)
 
-	suite.assertQueryResult(list, "{root{elements{... on FooStruct{a b} ... on BarStruct{b} ... on BazStruct{c}}}}", `{"data":{"root":{"elements":[{"a":28,"b":"baz"},{"b":"bar"},{"c":true}]}}}`)
+	suite.assertQueryResult(list,
+		fmt.Sprintf("{root{elements{... on %s{a b} ... on %s{b} ... on %s{c}}}}",
+			getTypeName(list.Get(0).Type()),
+			getTypeName(list.Get(1).Type()),
+			getTypeName(list.Get(2).Type())),
+		`{"data":{"root":{"elements":[{"a":28,"b":"baz"},{"b":"bar"},{"c":true}]}}}`)
 }
 
 func (suite *QueryGraphQLSuite) TestListOfUnionOfStructsConflictingFieldTypes() {
@@ -256,7 +262,12 @@ func (suite *QueryGraphQLSuite) TestListOfUnionOfStructsConflictingFieldTypes() 
 		}),
 	)
 
-	suite.assertQueryResult(list, "{root{elements{... on FooStruct{a} ... on BarStruct{b: a} ... on BazStruct{c: a}}}}", `{"data":{"root":{"elements":[{"a":28},{"b":"bar"},{"c":true}]}}}`)
+	suite.assertQueryResult(list,
+		fmt.Sprintf("{root{elements{... on %s{a} ... on %s{b: a} ... on %s{c: a}}}}",
+			getTypeName(list.Get(0).Type()),
+			getTypeName(list.Get(1).Type()),
+			getTypeName(list.Get(2).Type())),
+		`{"data":{"root":{"elements":[{"a":28},{"b":"bar"},{"c":true}]}}}`)
 }
 
 func (suite *QueryGraphQLSuite) TestListOfUnionOfScalars() {


### PR DESCRIPTION
The names of GraphQL types needs to be globally unique. We therefore
name struct types as NAME_HASH (where hash is the first 6 chars of
the noms hash).

Also, make sure that we always map the noms type to the same GraphQL
type, even if the boxedIfScalar is true.

Fixes #3161