### PR TITLE
Log when s3TableReader hits the rate limiter

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -7,6 +7,7 @@ package nbs
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/aws/aws-sdk-go/aws"
@@ -79,7 +80,13 @@ func (s3tr *s3TableReader) ReadAt(p []byte, off int64) (n int, err error) {
 
 func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err error) {
 	if s3tr.readRl != nil {
-		s3tr.readRl <- struct{}{}
+		select {
+		case s3tr.readRl <- struct{}{}:
+		// Was able to put a token in the rate limiter, great!
+		default:
+			fmt.Fprintln(os.Stderr, "*** s3TableReader rate limiting")
+			s3tr.readRl <- struct{}{} // still need to block on the rate limiter
+		}
 		defer func() {
 			<-s3tr.readRl
 		}()


### PR DESCRIPTION
We're getting some TCP hangups when trying to talk to S3.
We have an S3 reading rate limiter that's supposed to
prevent issues like this, so the question is whether that's
set too high. Rather than just turning the knob and seeing
if things are OK, this patch adds some logging to verify
that we're actually hitting the rate limiter.