### PR TITLE
Revert "Drop s3 read rate limit to 768"

### DIFF
--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -33,7 +33,7 @@ const (
 	StorageVersion = "2"
 
 	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
-	defaultAWSReadLimit        = 768
+	defaultAWSReadLimit        = 1024
 	defaultMaxTables           = 128
 
 	defaultIndexCacheSize = (1 << 20) * 8 // 8MB


### PR DESCRIPTION
Reverts attic-labs/noms#3196

Based on further logging, I'm not sure this will help. So, revert for the time being.