### PR TITLE
Revert "Log when s3TableReader hits the rate limiter"

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -7,7 +7,6 @@ package nbs
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/aws/aws-sdk-go/aws"
@@ -80,13 +79,7 @@ func (s3tr *s3TableReader) ReadAt(p []byte, off int64) (n int, err error) {
 
 func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err error) {
 	if s3tr.readRl != nil {
-		select {
-		case s3tr.readRl <- struct{}{}:
-		// Was able to put a token in the rate limiter, great!
-		default:
-			fmt.Fprintln(os.Stderr, "*** s3TableReader rate limiting")
-			s3tr.readRl <- struct{}{} // still need to block on the rate limiter
-		}
+		s3tr.readRl <- struct{}{}
 		defer func() {
 			<-s3tr.readRl
 		}()


### PR DESCRIPTION
Reverts attic-labs/noms#3195

There doesn't seem to be any correlation between hitting the rate limit and the connection resets, so shut off this log spam