### PR TITLE
NGQL: Add support for meta.schema

### DIFF
--- a/go/ngql/meta.go
+++ b/go/ngql/meta.go
@@ -1,0 +1,28 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package ngql
+
+import "github.com/attic-labs/noms/go/types"
+
+const (
+	schemaField = "schema"
+	metaField   = "meta"
+)
+
+// getCommitSchema gets the schema field from the meta struct of a commit.
+func getCommitSchema(commit types.Value) *types.Type {
+	if commit, ok := commit.(types.Struct); ok {
+		if meta, ok := commit.MaybeGet(metaField); ok {
+			if meta, ok := meta.(types.Struct); ok {
+				if schema, ok := meta.MaybeGet(schemaField); ok {
+					if schema, ok := schema.(*types.Type); ok {
+						return schema
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/go/ngql/meta_test.go
+++ b/go/ngql/meta_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package ngql
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
+)
+
+func makeMetaStructWithSchema(schema types.Value) types.Struct {
+	return types.NewStruct("Meta", types.StructData{
+		SchemaField: schema,
+	})
+}
+
+// Cannot depend on datas so mock a commit.
+func makeCommit(value, meta types.Value) types.Struct {
+	return types.NewStruct("Commit", types.StructData{
+		"value":   value,
+		"parents": types.NewSet(),
+		"meta":    meta,
+	})
+}
+
+func TestCommitWithSchema(t *testing.T) {
+	assert := assert.New(t)
+
+	assertTypeEquals := func(e, a *types.Type) {
+		assert.True(a.Equals(e), "Actual: %s\nExpected %s", a.Describe(), e.Describe())
+	}
+
+	assert.Nil(getCommitSchema(types.Number(1)))
+
+	assert.Nil(getCommitSchema(types.NewStruct("", types.StructData{})))
+
+	commit := makeCommit(types.Number(1), types.EmptyStruct)
+	schemaType := getCommitSchema(commit)
+	assert.Nil(schemaType)
+
+	commit = makeCommit(types.Number(1), makeMetaStructWithSchema(types.String("abc")))
+	schemaType = getCommitSchema(commit)
+	assert.Nil(schemaType)
+
+	commit = makeCommit(types.Number(1), makeMetaStructWithSchema(types.NumberType))
+	schemaType = getCommitSchema(commit)
+	assertTypeEquals(types.NumberType, schemaType)
+}

--- a/go/ngql/meta_test.go
+++ b/go/ngql/meta_test.go
@@ -13,7 +13,7 @@ import (
 
 func makeMetaStructWithSchema(schema types.Value) types.Struct {
 	return types.NewStruct("Meta", types.StructData{
-		SchemaField: schema,
+		schemaField: schema,
 	})
 }
 

--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -32,8 +32,12 @@ const (
 )
 
 func constructQueryType(rootValue types.Value, tm *typeMap) *graphql.Object {
-	rootNomsType := rootValue.Type()
-	rootType := nomsTypeToGraphQLType(rootNomsType, false, tm)
+	nomsSchema := getCommitSchema(rootValue)
+	if nomsSchema == nil {
+		nomsSchema = rootValue.Type()
+	}
+
+	rootType := nomsTypeToGraphQLType(nomsSchema, false, tm)
 
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: rootQueryKey,

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -383,10 +383,10 @@ func (suite *QueryGraphQLSuite) TestCustomSchema() {
 	suite.assertQueryResult(commit, "{root{value{x}}}", `{"data":{"root":{"value":{"x":42}}}}`)
 	suite.assertQueryResult(commit, "{root{value{s}}}", `{"data":{"root":{"value":{"s":"hi"}}}}`)
 
-	// no s field. Gets caught in validation
 	schema = types.MakeStructTypeFromFields("Commit", types.FieldMap{
 		"value": types.MakeStructTypeFromFields("Value", types.FieldMap{
 			"x": types.NumberType,
+			"b": types.BoolType,
 		}),
 		"meta": types.MakeStructTypeFromFields("Meta", types.FieldMap{
 			"schema": types.TypeType,
@@ -396,7 +396,9 @@ func (suite *QueryGraphQLSuite) TestCustomSchema() {
 	commit = makeCommit(val, makeMetaStructWithSchema(schema))
 	suite.assertQueryResult(commit, "{root{value{x}}}", `{"data":{"root":{"value":{"x":42}}}}`)
 
-	// Should give an error message because we didn't declare s in the schema.
-	suite.assertQueryResult(commit, "{root{value{s}}}",
-		`{"data":null,"errors":[{"message":"Cannot query field \"s\" on type \"Value_bls16s\".","locations":[{"line":1,"column":13}]}]}`)
+	// s is not part of the schema but is part of the data.
+	suite.assertQueryResult(commit, "{root{value{s}}}", `{"data":{"root":{"value":{}}}}`)
+	// b is not part of the schema nor the data.
+	suite.assertQueryResult(commit, "{root{value{b}}}",
+		`{"data":null,"errors":[{"message":"\r                        \r\tError Trace:\t\n\r\tError:\t\tStruct has no field \"b\"\n\r","locations":[{"line":1,"column":13}]}]}`)
 }

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -398,7 +398,6 @@ func (suite *QueryGraphQLSuite) TestCustomSchema() {
 
 	// s is not part of the schema but is part of the data.
 	suite.assertQueryResult(commit, "{root{value{s}}}", `{"data":{"root":{"value":{}}}}`)
-	// b is not part of the schema nor the data.
-	suite.assertQueryResult(commit, "{root{value{b}}}",
-		`{"data":null,"errors":[{"message":"\r                        \r\tError Trace:\t\n\r\tError:\t\tStruct has no field \"b\"\n\r","locations":[{"line":1,"column":13}]}]}`)
+	// b is part of the schema but not part of the data.
+	suite.assertQueryResult(commit, "{root{value{b}}}", `{"data":{"root":{"value":{"b":null}}}}`)
 }

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -203,6 +203,7 @@ func structToGQLObject(nomsType *types.Type, tm *typeMap) *graphql.Object {
 			structDesc.IterFields(func(name string, nomsFieldType *types.Type) {
 				fieldType := nomsTypeToGraphQLType(nomsFieldType, false, tm)
 
+				// Unwrap NonNull...
 				if nonNull, ok := fieldType.(*graphql.NonNull); ok {
 					fieldType = nonNull.OfType
 				}

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -10,10 +10,10 @@ import (
 
 	"strings"
 
+	"github.com/attic-labs/graphql"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
-	"github.com/attic-labs/graphql"
 )
 
 type typeMap map[typeMapKey]graphql.Type
@@ -203,10 +203,17 @@ func structToGQLObject(nomsType *types.Type, tm *typeMap) *graphql.Object {
 			structDesc.IterFields(func(name string, nomsFieldType *types.Type) {
 				fieldType := nomsTypeToGraphQLType(nomsFieldType, false, tm)
 
+				if nonNull, ok := fieldType.(*graphql.NonNull); ok {
+					fieldType = nonNull.OfType
+				}
+
 				fields[name] = &graphql.Field{
 					Type: fieldType,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						field := p.Source.(types.Struct).Get(p.Info.FieldName)
+						field, ok := p.Source.(types.Struct).MaybeGet(p.Info.FieldName)
+						if !ok {
+							return nil, nil
+						}
 						return maybeGetScalar(field), nil
 					},
 				}


### PR DESCRIPTION
If the value is a commit with a meta.schema of type Type, use that to
compute the GraphQL schema.

Fixes #3213