### PR TITLE
GraphQL: Add support for key and through

### DIFF
--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -26,6 +26,7 @@ const (
 	sizeKey        = "size"
 	targetHashKey  = "targetHash"
 	targetValueKey = "targetValue"
+	throughKey     = "through"
 	tmKey          = "tm"
 	valueKey       = "value"
 	vrKey          = "vr"

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -201,21 +201,6 @@ func (suite *QueryGraphQLSuite) TestMapBasic() {
 
 	suite.assertQueryResult(m, "{root{elements{key value}}}", `{"data":{"root":{"elements":[{"key":"a","value":1},{"key":"b","value":2},{"key":"c","value":3},{"key":"d","value":4}]}}}`)
 	suite.assertQueryResult(m, "{root{size}}", `{"data":{"root":{"size":4}}}`)
-
-	suite.assertQueryResult(m, "{root{elements(count:0){value}}}", `{"data":{"root":{"elements":[]}}}`)
-	suite.assertQueryResult(m, "{root{elements(count:2){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(count:3){key}}}", `{"data":{"root":{"elements":[{"key":"a"},{"key":"b"},{"key":"c"}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(count: -1){key}}}", `{"data":{"root":{"elements":[]}}}`)
-	suite.assertQueryResult(m, "{root{elements(count:5){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2},{"value":3},{"value":4}]}}}`)
-
-	suite.assertQueryResult(m, "{root{elements(at:-1,count:2){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:0,count:2){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:1,count:2){value}}}", `{"data":{"root":{"elements":[{"value":2},{"value":3}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:2){value}}}", `{"data":{"root":{"elements":[{"value":3},{"value":4}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:2,count:1){value}}}", `{"data":{"root":{"elements":[{"value":3}]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:2,count:0){value}}}", `{"data":{"root":{"elements":[]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:5){value}}}", `{"data":{"root":{"elements":[]}}}`)
-	suite.assertQueryResult(m, "{root{elements(at:2,count:10){value}}}", `{"data":{"root":{"elements":[{"value":3},{"value":4}]}}}`)
 }
 
 func (suite *QueryGraphQLSuite) TestMapOfStruct() {
@@ -390,4 +375,200 @@ func (suite *QueryGraphQLSuite) TestError() {
 	Error(errors.New("Some error string"), buff)
 	suite.Equal(buff.String(), `{"data":null,"errors":[{"message":"Some error string","locations":null}]}
 `)
+}
+
+func (suite *QueryGraphQLSuite) TestMapArgs() {
+	m := types.NewMap(
+		types.String("a"), types.Number(1),
+		types.String("c"), types.Number(2),
+		types.String("e"), types.Number(3),
+		types.String("g"), types.Number(4),
+	)
+
+	// count
+	suite.assertQueryResult(m, "{root{elements(count:0){value}}}", `{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(m, "{root{elements(count:2){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(count:3){key}}}", `{"data":{"root":{"elements":[{"key":"a"},{"key":"c"},{"key":"e"}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(count: -1){key}}}", `{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(m, "{root{elements(count:5){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2},{"value":3},{"value":4}]}}}`)
+
+	// at
+	suite.assertQueryResult(m, "{root{elements(at:0){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2},{"value":3},{"value":4}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:-1){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2},{"value":3},{"value":4}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:2){value}}}", `{"data":{"root":{"elements":[{"value":3},{"value":4}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:5){value}}}", `{"data":{"root":{"elements":[]}}}`)
+
+	// at & count
+	suite.assertQueryResult(m, "{root{elements(at:0,count:2){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:-1,count:2){value}}}", `{"data":{"root":{"elements":[{"value":1},{"value":2}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:1,count:2){value}}}", `{"data":{"root":{"elements":[{"value":2},{"value":3}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:2,count:1){value}}}", `{"data":{"root":{"elements":[{"value":3}]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:2,count:0){value}}}", `{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(m, "{root{elements(at:2,count:10){value}}}", `{"data":{"root":{"elements":[{"value":3},{"value":4}]}}}`)
+
+	// key
+	suite.assertQueryResult(m, `{root{elements(key:"e"){key value}}}`,
+		`{"data":{"root":{"elements":[{"key":"e","value":3}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(key:"g"){value}}}`,
+		`{"data":{"root":{"elements":[{"value":4}]}}}`)
+	// "f" -> starts at "g"
+	suite.assertQueryResult(m, `{root{elements(key:"f"){value}}}`,
+		`{"data":{"root":{"elements":[{"value":4}]}}}`)
+	// "x" is larger than end
+	suite.assertQueryResult(m, `{root{elements(key:"x"){value}}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+
+	// key & at
+	// at is ignored when key is present
+	suite.assertQueryResult(m, `{root{elements(key:"e",at:2){key value}}}`,
+		`{"data":{"root":{"elements":[{"key":"e","value":3}]}}}`)
+
+	// key & count
+	suite.assertQueryResult(m, `{root{elements(key:"c", count: 2){key value}}}`,
+		`{"data":{"root":{"elements":[{"key":"c","value":2},{"key":"e","value":3}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(key:"c", count: 0){key value}}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(m, `{root{elements(key:"c", count: -1){key value}}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(m, `{root{elements(key:"e", count: 5){key value}}}`,
+		`{"data":{"root":{"elements":[{"key":"e","value":3},{"key":"g","value":4}]}}}`)
+
+	// through
+	suite.assertQueryResult(m, `{root{elements(through:"c"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"a"},{"key":"c"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(through:"b"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"a"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(through:"0"){key}}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+
+	// key & through
+	suite.assertQueryResult(m, `{root{elements(key:"c", through:"c"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"c"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(key:"c",through:"e"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"c"},{"key":"e"}]}}}`)
+
+	// through & count
+	suite.assertQueryResult(m, `{root{elements(through:"c",count:1){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"a"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(through:"b",count:0){key}}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(m, `{root{elements(through:"0",count:10){key}}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+
+	// at & through
+	suite.assertQueryResult(m, `{root{elements(at:0,through:"a"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"a"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(at:1,through:"e"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"c"},{"key":"e"}]}}}`)
+
+	// at & count & through
+	suite.assertQueryResult(m, `{root{elements(at:0,count:2,through:"a"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"a"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(at:0,count:2,through:"e"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"a"},{"key":"c"}]}}}`)
+
+	// key & count & through
+	suite.assertQueryResult(m, `{root{elements(key:"c",count:2,through:"c"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"c"}]}}}`)
+	suite.assertQueryResult(m, `{root{elements(key:"c",count:2,through:"g"){key}}}`,
+		`{"data":{"root":{"elements":[{"key":"c"},{"key":"e"}]}}}`)
+}
+
+func (suite *QueryGraphQLSuite) TestSetArgs() {
+	s := types.NewSet(
+		types.String("a"),
+		types.String("c"),
+		types.String("e"),
+		types.String("g"),
+	)
+
+	// count
+	suite.assertQueryResult(s, "{root{elements(count:0)}}", `{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(s, "{root{elements(count:2)}}", `{"data":{"root":{"elements":["a","c"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(count:3)}}", `{"data":{"root":{"elements":["a","c","e"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(count: -1)}}", `{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(s, "{root{elements(count:5)}}", `{"data":{"root":{"elements":["a","c","e","g"]}}}`)
+
+	// at
+	suite.assertQueryResult(s, "{root{elements(at:0)}}", `{"data":{"root":{"elements":["a","c","e","g"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:-1)}}", `{"data":{"root":{"elements":["a","c","e","g"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:2)}}", `{"data":{"root":{"elements":["e","g"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:5)}}", `{"data":{"root":{"elements":[]}}}`)
+
+	// at & count
+	suite.assertQueryResult(s, "{root{elements(at:0,count:2)}}", `{"data":{"root":{"elements":["a","c"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:-1,count:2)}}", `{"data":{"root":{"elements":["a","c"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:1,count:2)}}", `{"data":{"root":{"elements":["c","e"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:2,count:1)}}", `{"data":{"root":{"elements":["e"]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:2,count:0)}}", `{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(s, "{root{elements(at:2,count:10)}}", `{"data":{"root":{"elements":["e","g"]}}}`)
+
+	// key
+	suite.assertQueryResult(s, `{root{elements(key:"e")}}`,
+		`{"data":{"root":{"elements":["e"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"g")}}`,
+		`{"data":{"root":{"elements":["g"]}}}`)
+	// "f" -> starts at "g"
+	suite.assertQueryResult(s, `{root{elements(key:"f")}}`,
+		`{"data":{"root":{"elements":["g"]}}}`)
+	// "x" is larger than end
+	suite.assertQueryResult(s, `{root{elements(key:"x")}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+
+	// key & at
+	// at is ignored when key is present
+	suite.assertQueryResult(s, `{root{elements(key:"e",at:2)}}`,
+		`{"data":{"root":{"elements":["e"]}}}`)
+
+	// key & count
+	suite.assertQueryResult(s, `{root{elements(key:"c", count: 2)}}`,
+		`{"data":{"root":{"elements":["c","e"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"c", count: 0)}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"c", count: -1)}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"e", count: 5)}}`,
+		`{"data":{"root":{"elements":["e","g"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"0")}}`,
+		`{"data":{"root":{"elements":["a"]}}}`)
+
+	// through
+	suite.assertQueryResult(s, `{root{elements(through:"c")}}`,
+		`{"data":{"root":{"elements":["a","c"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(through:"b")}}`,
+		`{"data":{"root":{"elements":["a"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(through:"0")}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+
+	// key & through
+	suite.assertQueryResult(s, `{root{elements(key:"c", through:"c")}}`,
+		`{"data":{"root":{"elements":["c"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"c",through:"e")}}`,
+		`{"data":{"root":{"elements":["c","e"]}}}`)
+
+	// through & count
+	suite.assertQueryResult(s, `{root{elements(through:"c",count:1)}}`,
+		`{"data":{"root":{"elements":["a"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(through:"b",count:0)}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	suite.assertQueryResult(s, `{root{elements(through:"0",count:10)}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+
+	// at & through
+	suite.assertQueryResult(s, `{root{elements(at:0,through:"a")}}`,
+		`{"data":{"root":{"elements":["a"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(at:1,through:"e")}}`,
+		`{"data":{"root":{"elements":["c","e"]}}}`)
+
+	// at & count & through
+	suite.assertQueryResult(s, `{root{elements(at:0,count:2,through:"a")}}`,
+		`{"data":{"root":{"elements":["a"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(at:0,count:2,through:"e")}}`,
+		`{"data":{"root":{"elements":["a","c"]}}}`)
+
+	// key & count & through
+	suite.assertQueryResult(s, `{root{elements(key:"c",count:2,through:"c")}}`,
+		`{"data":{"root":{"elements":["c"]}}}`)
+	suite.assertQueryResult(s, `{root{elements(key:"c",count:2,through:"g")}}`,
+		`{"data":{"root":{"elements":["c","e"]}}}`)
 }

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -411,9 +411,9 @@ func (suite *QueryGraphQLSuite) TestMapArgs() {
 		`{"data":{"root":{"elements":[{"key":"e","value":3}]}}}`)
 	suite.assertQueryResult(m, `{root{elements(key:"g"){value}}}`,
 		`{"data":{"root":{"elements":[{"value":4}]}}}`)
-	// "f" -> starts at "g"
+	// "f", no count/through so asking for exact match
 	suite.assertQueryResult(m, `{root{elements(key:"f"){value}}}`,
-		`{"data":{"root":{"elements":[{"value":4}]}}}`)
+		`{"data":{"root":{"elements":[]}}}`)
 	// "x" is larger than end
 	suite.assertQueryResult(m, `{root{elements(key:"x"){value}}}`,
 		`{"data":{"root":{"elements":[]}}}`)
@@ -508,11 +508,14 @@ func (suite *QueryGraphQLSuite) TestSetArgs() {
 		`{"data":{"root":{"elements":["e"]}}}`)
 	suite.assertQueryResult(s, `{root{elements(key:"g")}}`,
 		`{"data":{"root":{"elements":["g"]}}}`)
-	// "f" -> starts at "g"
+	// "f", no count/through so asking for exact match
 	suite.assertQueryResult(s, `{root{elements(key:"f")}}`,
-		`{"data":{"root":{"elements":["g"]}}}`)
+		`{"data":{"root":{"elements":[]}}}`)
 	// "x" is larger than end
 	suite.assertQueryResult(s, `{root{elements(key:"x")}}`,
+		`{"data":{"root":{"elements":[]}}}`)
+	// exact match
+	suite.assertQueryResult(s, `{root{elements(key:"0")}}`,
 		`{"data":{"root":{"elements":[]}}}`)
 
 	// key & at
@@ -529,8 +532,6 @@ func (suite *QueryGraphQLSuite) TestSetArgs() {
 		`{"data":{"root":{"elements":[]}}}`)
 	suite.assertQueryResult(s, `{root{elements(key:"e", count: 5)}}`,
 		`{"data":{"root":{"elements":["e","g"]}}}`)
-	suite.assertQueryResult(s, `{root{elements(key:"0")}}`,
-		`{"data":{"root":{"elements":["a"]}}}`)
 
 	// through
 	suite.assertQueryResult(s, `{root{elements(through:"c")}}`,

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -108,17 +108,17 @@ func nomsTypeToGraphQLType(nomsType *types.Type, boxedIfScalar bool, tm *typeMap
 			valueType = nomsTypeToGraphQLType(nomsValueType, false, tm)
 		}
 
-		gqlType = collectionToGraphQLObject(nomsType, valueType, tm)
+		gqlType = collectionToGraphQLObject(nomsType, valueType, unpackNonNullType(valueType), tm)
 
 	case types.MapKind:
 		nomsKeyType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
 		nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[1]
-		var valueType graphql.Type
+		var entryType, keyType graphql.Type
 		if !isEmptyNomsUnion(nomsKeyType) && !isEmptyNomsUnion(nomsValueType) {
-			valueType = mapEntryToGraphQLObject(nomsKeyType, nomsValueType, tm)
+			entryType, keyType = mapEntryToGraphQLObject(nomsKeyType, nomsValueType, tm)
 		}
 
-		gqlType = collectionToGraphQLObject(nomsType, valueType, tm)
+		gqlType = collectionToGraphQLObject(nomsType, entryType, unpackNonNullType(keyType), tm)
 
 	case types.RefKind:
 		gqlType = refToGraphQLObject(nomsType, tm)
@@ -140,6 +140,13 @@ func nomsTypeToGraphQLType(nomsType *types.Type, boxedIfScalar bool, tm *typeMap
 	newNonNull := graphql.NewNonNull(gqlType)
 	(*tm)[key] = newNonNull
 	return newNonNull
+}
+
+func unpackNonNullType(t graphql.Type) graphql.Type {
+	if t, ok := t.(*graphql.NonNull); ok {
+		return t.OfType
+	}
+	return t
 }
 
 func isEmptyNomsUnion(nomsType *types.Type) bool {
@@ -222,20 +229,23 @@ var listArgs = graphql.FieldConfigArgument{
 	countKey: &graphql.ArgumentConfig{Type: graphql.Int},
 }
 
-func getBounds(l uint64, args map[string]interface{}) (uint64, uint64, bool) {
-	len := int64(l)
-	idx := int64(0)
-	count := int64(len)
+func getListValues(v types.Value, args map[string]interface{}) (interface{}, error) {
+	l := v.(types.List)
+	idx := 0
+	count := int(l.Len())
+	len := count
+
 	if at, ok := args[atKey].(int); ok {
-		idx = int64(at)
+		idx = at
 	}
+
 	if c, ok := args[countKey].(int); ok {
-		count = int64(c)
+		count = c
 	}
 
 	// Clamp ranges
 	if count <= 0 || idx >= len {
-		return 0, 0, true
+		return ([]interface{})(nil), nil
 	}
 	if idx < 0 {
 		idx = 0
@@ -243,68 +253,196 @@ func getBounds(l uint64, args map[string]interface{}) (uint64, uint64, bool) {
 	if idx+count > len {
 		count = len - idx
 	}
-	return uint64(idx), uint64(count), false
-}
-
-func getListValues(v types.Value, args map[string]interface{}) (interface{}, error) {
-	l := v.(types.List)
-	idx, count, empty := getBounds(l.Len(), args)
-	if empty {
-		return ([]interface{})(nil), nil
-	}
 
 	values := make([]interface{}, count)
-	iter := l.IteratorAt(idx)
-	for i := uint64(0); i < count; i++ {
+	iter := l.IteratorAt(uint64(idx))
+	for i := uint64(0); i < uint64(count); i++ {
 		values[i] = maybeGetScalar(iter.Next())
 	}
 
 	return values, nil
-}
-
-var setArgs = graphql.FieldConfigArgument{
-	atKey:    &graphql.ArgumentConfig{Type: graphql.Int},
-	countKey: &graphql.ArgumentConfig{Type: graphql.Int},
 }
 
 func getSetValues(v types.Value, args map[string]interface{}) (interface{}, error) {
-	// TODO: Refactor to share code between the collections.
 	s := v.(types.Set)
-	idx, count, empty := getBounds(s.Len(), args)
-	if empty {
+
+	iter, nomsThrough, count, err := getCollectionArgs(s.Type(), s.Len(), args, iteratorFactory{
+		IteratorFrom: func(from types.Value) interface{} {
+			return s.IteratorFrom(from)
+		},
+		IteratorAt: func(at uint64) interface{} {
+			return s.IteratorAt(at)
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
 		return ([]interface{})(nil), nil
 	}
 
-	values := make([]interface{}, count)
-	iter := s.IteratorAt(idx)
+	setIter := iter.(types.SetIterator)
+	values := make([]interface{}, 0, count)
 	for i := uint64(0); i < count; i++ {
-		values[i] = maybeGetScalar(iter.Next())
+		v := setIter.Next()
+		if v == nil {
+			break
+		}
+
+		if nomsThrough != nil {
+			if !nomsThrough.Less(v) {
+				values = append(values, maybeGetScalar(v))
+			} else {
+				break
+			}
+		} else {
+			values = append(values, maybeGetScalar(v))
+		}
 	}
 
 	return values, nil
 }
 
-var mapArgs = graphql.FieldConfigArgument{
-	atKey:    &graphql.ArgumentConfig{Type: graphql.Int},
-	countKey: &graphql.ArgumentConfig{Type: graphql.Int},
+func getArgValue(arg interface{}, nomsType *types.Type) (types.Value, error) {
+	var nomsVal types.Value
+	switch arg := arg.(type) {
+	case bool:
+		nomsVal = types.Bool(arg)
+	case float64:
+		nomsVal = types.Number(arg)
+	case string:
+		nomsVal = types.String(arg)
+	default:
+		return nil, fmt.Errorf("Unsupported type in GraphQL argument, %T, %s", arg, nomsType.Describe())
+	}
+
+	if types.IsSubtype(nomsType, nomsVal.Type()) {
+		return nomsVal, nil
+	}
+
+	return nil, fmt.Errorf("%s is not a subtype of %s", nomsVal.Type().Describe(), nomsType.Describe())
+}
+
+func getCollectionArgs(typ *types.Type, len uint64, args map[string]interface{}, factory iteratorFactory) (iter interface{}, nomsThrough types.Value, count uint64, err error) {
+	nomsKeyType := typ.Desc.(types.CompoundDesc).ElemTypes[0]
+
+	if key, ok := args[keyKey]; ok {
+		var nomsKey types.Value
+		nomsKey, err = getArgValue(key, nomsKeyType)
+		if err != nil {
+			return
+		}
+		iter = factory.IteratorFrom(nomsKey)
+	} else if at, ok := args[atKey]; ok {
+		idx := at.(int)
+		if idx < 0 {
+			idx = 0
+		} else if uint64(idx) > len {
+			// count is already 0
+			return
+		}
+		iter = factory.IteratorAt(uint64(idx))
+	} else {
+		iter = factory.IteratorAt(0)
+	}
+
+	// iter, err = getIterator(len, nomsKeyType, args, factory)
+	if err != nil {
+		return
+	}
+	if iter == nil {
+		// count is already 0
+		return
+	}
+
+	nomsThrough, err = getThroughArg(nomsKeyType, args)
+	if err != nil {
+		return
+	}
+
+	count = getCountArg(len, args)
+	if count == 0 {
+		return
+	}
+
+	return
 }
 
 func getMapValues(v types.Value, args map[string]interface{}) (interface{}, error) {
-	// TODO: Refactor to share code between the collections.
 	m := v.(types.Map)
-	idx, count, empty := getBounds(m.Len(), args)
-	if empty {
+
+	iter, nomsThrough, count, err := getCollectionArgs(m.Type(), m.Len(), args, iteratorFactory{
+		IteratorFrom: func(from types.Value) interface{} {
+			return m.IteratorFrom(from)
+		},
+		IteratorAt: func(at uint64) interface{} {
+			return m.IteratorAt(at)
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
 		return ([]interface{})(nil), nil
 	}
 
-	values := make([]mapEntry, count)
-	iter := m.IteratorAt(idx)
+	mapIter := iter.(types.MapIterator)
+	values := make([]mapEntry, 0, count)
 	for i := uint64(0); i < count; i++ {
-		k, v := iter.Next()
-		values[i] = mapEntry{k, v}
+		k, v := mapIter.Next()
+		if k == nil {
+			break
+		}
+
+		if nomsThrough != nil {
+			if !nomsThrough.Less(k) {
+				values = append(values, mapEntry{k, v})
+			} else {
+				break
+			}
+		} else {
+			values = append(values, mapEntry{k, v})
+		}
 	}
 
 	return values, nil
+}
+
+func getCountArg(count uint64, args map[string]interface{}) uint64 {
+	if c, ok := args[countKey]; ok {
+		c := c.(int)
+		if c <= 0 {
+			return 0
+		}
+		count = uint64(c)
+	} else {
+		// If we have key and no count/through we use count 1
+		_, hasKey := args[keyKey]
+		_, hasThrough := args[throughKey]
+		if hasKey && !hasThrough {
+			count = uint64(1)
+		}
+	}
+	return count
+}
+
+func getThroughArg(nomsKeyType *types.Type, args map[string]interface{}) (types.Value, error) {
+	var nomsThrough types.Value
+	if through, ok := args[throughKey]; ok {
+		var err error
+		nomsThrough, err = getArgValue(through, nomsKeyType)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nomsThrough, nil
+}
+
+type iteratorFactory struct {
+	IteratorFrom func(from types.Value) interface{}
+	IteratorAt   func(at uint64) interface{}
 }
 
 type mapEntry struct {
@@ -318,11 +456,11 @@ type mapEntry struct {
 //	 key: <KeyType>!
 //	 value: <ValueType>!
 // }
-func mapEntryToGraphQLObject(nomsKeyType, nomsValueType *types.Type, tm *typeMap) *graphql.Object {
+func mapEntryToGraphQLObject(nomsKeyType, nomsValueType *types.Type, tm *typeMap) (*graphql.Object, graphql.Type) {
+	keyType := nomsTypeToGraphQLType(nomsKeyType, false, tm)
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: fmt.Sprintf("%s%sEntry", getTypeName(nomsKeyType), getTypeName(nomsValueType)),
 		Fields: graphql.FieldsThunk(func() graphql.Fields {
-			keyType := nomsTypeToGraphQLType(nomsKeyType, false, tm)
 			valueType := nomsTypeToGraphQLType(nomsValueType, false, tm)
 			return graphql.Fields{
 				keyKey: &graphql.Field{
@@ -341,7 +479,7 @@ func mapEntryToGraphQLObject(nomsKeyType, nomsValueType *types.Type, tm *typeMap
 				},
 			}
 		}),
-	})
+	}), keyType
 }
 
 func getTypeName(nomsType *types.Type) string {
@@ -412,7 +550,7 @@ func getTypeName(nomsType *types.Type) string {
 	}
 }
 
-func collectionToGraphQLObject(nomsType *types.Type, listType graphql.Type, tm *typeMap) *graphql.Object {
+func collectionToGraphQLObject(nomsType *types.Type, listType, keyType graphql.Type, tm *typeMap) *graphql.Object {
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: getTypeName(nomsType),
 		Fields: graphql.FieldsThunk(func() graphql.Fields {
@@ -436,11 +574,28 @@ func collectionToGraphQLObject(nomsType *types.Type, listType graphql.Type, tm *
 					getSubvalues = getListValues
 
 				case types.SetKind:
-					args = setArgs
+					args = graphql.FieldConfigArgument{
+						atKey:    &graphql.ArgumentConfig{Type: graphql.Int},
+						countKey: &graphql.ArgumentConfig{Type: graphql.Int},
+					}
+					if graphql.IsInputType(keyType) {
+						// TODO: Should compute an graphql.InputObject from the noms type. graphql.InputObject is different from graphql.Object
+						// See graphql.IsInputType vs graphql.IsOutputType
+
+						args[keyKey] = &graphql.ArgumentConfig{Type: keyType}
+						args[throughKey] = &graphql.ArgumentConfig{Type: keyType}
+					}
 					getSubvalues = getSetValues
 
 				case types.MapKind:
-					args = mapArgs
+					args = graphql.FieldConfigArgument{
+						atKey:    &graphql.ArgumentConfig{Type: graphql.Int},
+						countKey: &graphql.ArgumentConfig{Type: graphql.Int},
+					}
+					if graphql.IsInputType(keyType) {
+						args[keyKey] = &graphql.ArgumentConfig{Type: keyType}
+						args[throughKey] = &graphql.ArgumentConfig{Type: keyType}
+					}
 					getSubvalues = getMapValues
 				}
 

--- a/go/ngql/types_test.go
+++ b/go/ngql/types_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package ngql
+
+import (
+	"testing"
+
+	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestGetArgValue(tt *testing.T) {
+	assert := assert.New(tt)
+
+	t := func(expected types.Value, arg interface{}) {
+		act, err := getArgValue(arg, expected.Type())
+		assert.NoError(err)
+		assert.True(act.Equals(expected))
+	}
+
+	t(types.Bool(true), true)
+	t(types.Number(42), float64(42))
+	t(types.String("hi"), "hi")
+
+	_, err := getArgValue(float64(42), types.BoolType)
+	assert.Equal("Number is not a subtype of Bool", err.Error())
+
+	n, err := getArgValue(float64(42), types.MakeUnionType(types.BoolType, types.NumberType))
+	assert.NoError(err)
+	assert.Equal(n, types.Number(42))
+
+	b, err := getArgValue(false, types.MakeUnionType(types.BoolType, types.NumberType))
+	assert.NoError(err)
+	assert.Equal(b, types.Bool(false))
+
+	type S struct {
+		X float64
+	}
+	_, err = getArgValue(S{42}, types.ValueType)
+	assert.Equal("Unsupported type in GraphQL argument, ngql.S, Value", err.Error())
+
+}

--- a/samples/js/graphiql/src/main.js
+++ b/samples/js/graphiql/src/main.js
@@ -104,7 +104,8 @@ class Prompt extends React.Component<void, PromptProps, void> {
 }
 
 function graphQLFetcher(graphQLParams) {
-  const url = `${params.db}/graphql/?ds=${params.ds}&query=${graphQLParams.query}`;
+  const url = `${params.db}/graphql/?ds=${params.ds}&query=${
+    encodeURIComponent(graphQLParams.query)}`;
 
   const headers = new Headers();
   if (params.auth) {
@@ -126,4 +127,3 @@ function renderPrompt(msg: string) {
 function render() {
   ReactDOM.render(<GraphiQL fetcher={graphQLFetcher}></GraphiQL>, document.body);
 }
-


### PR DESCRIPTION
If key is provided as an argument to a Map/Set elements that defines
where the collection should start iterating from.

If through is provided the iteration will end after visiting through
(or if the key is larger than through)

If both key and at are present, at is ignored.

If key is present but count and through are missing then we use a count
of 1.

Closes #3227