### PR TITLE
Close output channels in streaming collection builders

### DIFF
--- a/go/types/list.go
+++ b/go/types/list.go
@@ -43,12 +43,12 @@ func NewList(values ...Value) List {
 func NewStreamingList(vrw ValueReadWriter, values <-chan Value) <-chan List {
 	out := make(chan List)
 	go func() {
+		defer close(out)
 		ch := newEmptyListSequenceChunker(vrw, vrw)
 		for v := range values {
 			ch.Append(v)
 		}
 		out <- newList(ch.Done())
-		close(out)
 	}()
 	return out
 }

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -43,6 +43,7 @@ func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
 
 	outChan := make(chan Map)
 	go func() {
+		defer close(outChan)
 		gb := NewGraphBuilder(vrw, MapKind, false)
 		for v := range kvs {
 			if k == nil {

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -34,6 +34,7 @@ func NewSet(v ...Value) Set {
 func NewStreamingSet(vrw ValueReadWriter, vals <-chan Value) <-chan Set {
 	outChan := make(chan Set)
 	go func() {
+		defer close(outChan)
 		gb := NewGraphBuilder(vrw, SetKind, false)
 		for v := range vals {
 			gb.SetInsert(nil, v)


### PR DESCRIPTION
Since these functions return a receive-only channel, the
caller _can't_ close the channel it pulls the constructed
collection off of. Since the builder function can easily
know when it's safe to close the channel, it seems fine
to just have NewStreamingWhatever() do the close.