### PR TITLE
Fix NBS LocalStoreFactory

### DIFF
--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -116,7 +116,10 @@ func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxTables int) chun
 }
 
 func (lsf *LocalStoreFactory) CreateStore(ns string) chunks.ChunkStore {
-	return newLocalStore(path.Join(lsf.dir, ns), defaultMemTableSize, lsf.indexCache, lsf.maxTables)
+	path := path.Join(lsf.dir, ns)
+	err := os.MkdirAll(path, 0777)
+	d.PanicIfError(err)
+	return newLocalStore(path, defaultMemTableSize, lsf.indexCache, lsf.maxTables)
 }
 
 func (lsf *LocalStoreFactory) Shutter() {


### PR DESCRIPTION
While it's reasonable to take out the automatic directory
creation for paths that the user types, I think we want the
factory to always be able to use the paths that it authors
underneath the directory the user passed in.