### PR TITLE
Add TypeMarshaler interface

### DIFF
--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -86,14 +86,14 @@ func encodeType(t reflect.Type, parentStructTypes []reflect.Type, tags nomsTags,
 	}
 
 	if t.Implements(marshalerInterface) {
+		// There is no way to determine the noms type now. For Marshal it can be
+		// different each time MarshalNoms is called and is handled further up the
+		// stack.
 		if options.ReportErrors {
 			err := fmt.Errorf("Cannot marshal type which implements %s, perhaps implement %s for %s", marshalerInterface, typeMarshalerInterface, t)
 			panic(&marshalNomsError{err})
 		}
 
-		// There is no way to determine the noms type now. For Marshal it can be
-		// different each time MarshalNoms is called. This is handled further up the
-		// stack.
 		return nil
 	}
 

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -5,6 +5,7 @@
 package marshal
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -382,4 +383,103 @@ func TestMarshalTypeNomsTypes(t *testing.T) {
 			"type":   types.TypeType,
 		}),
 	))
+}
+
+func (t primitiveType) MarshalNomsType() (*types.Type, error) {
+	return types.NumberType, nil
+}
+
+func TestTypeMarshalerPrimitiveType(t *testing.T) {
+	assert := assert.New(t)
+
+	var u primitiveType
+	typ := MustMarshalType(u)
+	assert.Equal(types.NumberType, typ)
+}
+
+func (u primitiveSliceType) MarshalNomsType() (*types.Type, error) {
+	return types.StringType, nil
+}
+
+func TestTypeMarshalerPrimitiveSliceType(t *testing.T) {
+	assert := assert.New(t)
+
+	var u primitiveSliceType
+	typ := MustMarshalType(u)
+	assert.Equal(types.StringType, typ)
+}
+
+func (u primitiveMapType) MarshalNomsType() (*types.Type, error) {
+	return types.MakeSetType(types.StringType), nil
+}
+
+func TestTypeMarshalerPrimitiveMapType(t *testing.T) {
+	assert := assert.New(t)
+
+	var u primitiveMapType
+	typ := MustMarshalType(u)
+	assert.Equal(types.MakeSetType(types.StringType), typ)
+}
+
+func (u primitiveStructType) MarshalNomsType() (*types.Type, error) {
+	return types.NumberType, nil
+}
+
+func TestTypeMarshalerPrimitiveStructType(t *testing.T) {
+	assert := assert.New(t)
+
+	var u primitiveStructType
+	typ := MustMarshalType(u)
+	assert.Equal(types.NumberType, typ)
+}
+
+func (u builtinType) MarshalNomsType() (*types.Type, error) {
+	return types.StringType, nil
+}
+
+func TestTypeMarshalerBuiltinType(t *testing.T) {
+	assert := assert.New(t)
+
+	var u builtinType
+	typ := MustMarshalType(u)
+	assert.Equal(types.StringType, typ)
+}
+
+func (u wrappedMarshalerType) MarshalNomsType() (*types.Type, error) {
+	return types.NumberType, nil
+}
+
+func TestTypeMarshalerWrapperMarshalerType(t *testing.T) {
+	assert := assert.New(t)
+
+	var u wrappedMarshalerType
+	typ := MustMarshalType(u)
+	assert.Equal(types.NumberType, typ)
+}
+
+func (u returnsMarshalerError) MarshalNomsType() (*types.Type, error) {
+	return nil, errors.New("expected error")
+}
+
+func (u returnsMarshalerNil) MarshalNomsType() (*types.Type, error) {
+	return nil, nil
+}
+
+func (u panicsMarshaler) MarshalNomsType() (*types.Type, error) {
+	panic("panic")
+}
+
+func TestTypeMarshalerErrors(t *testing.T) {
+	assert := assert.New(t)
+
+	expErr := errors.New("expected error")
+	var m1 returnsMarshalerError
+	_, actErr := MarshalType(m1)
+	assert.Equal(expErr, actErr)
+
+	var m2 returnsMarshalerNil
+	assert.Panics(func() { MarshalType(m2) })
+
+	var m3 panicsMarshaler
+	assert.Panics(func() { MarshalType(m3) })
 }

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -107,7 +107,7 @@ func assertMarshalTypeErrorMessage(t *testing.T, v interface{}, expectedMessage 
 func TestMarshalTypeInvalidTypes(t *testing.T) {
 	assertMarshalTypeErrorMessage(t, make(chan int), "Type is not supported, type: chan int")
 	l := types.NewList()
-	assertMarshalTypeErrorMessage(t, l, "Type is not supported, type: types.List")
+	assertMarshalTypeErrorMessage(t, l, "Cannot marshal type types.List, it requires type parameters")
 }
 
 func TestMarshalTypeEmbeddedStruct(t *testing.T) {
@@ -127,10 +127,10 @@ func TestMarshalTypeEncodeNonExportedField(t *testing.T) {
 
 func TestMarshalTypeEncodeNomsTypeWithTypeParameters(t *testing.T) {
 
-	assertMarshalTypeErrorMessage(t, types.NewList(), "Type is not supported, type: types.List")
-	assertMarshalTypeErrorMessage(t, types.NewSet(), "Type is not supported, type: types.Set")
-	assertMarshalTypeErrorMessage(t, types.NewMap(), "Type is not supported, type: types.Map")
-	assertMarshalTypeErrorMessage(t, types.NewRef(types.NewSet()), "Type is not supported, type: types.Ref")
+	assertMarshalTypeErrorMessage(t, types.NewList(), "Cannot marshal type types.List, it requires type parameters")
+	assertMarshalTypeErrorMessage(t, types.NewSet(), "Cannot marshal type types.Set, it requires type parameters")
+	assertMarshalTypeErrorMessage(t, types.NewMap(), "Cannot marshal type types.Map, it requires type parameters")
+	assertMarshalTypeErrorMessage(t, types.NewRef(types.NewSet()), "Cannot marshal type types.Ref, it requires type parameters")
 }
 
 func TestMarshalTypeEncodeTaggingSkip(t *testing.T) {
@@ -421,16 +421,13 @@ func TestTypeMarshalerPrimitiveMapType(t *testing.T) {
 	assert.Equal(types.MakeSetType(types.StringType), typ)
 }
 
-func (u primitiveStructType) MarshalNomsType() (*types.Type, error) {
-	return types.NumberType, nil
-}
-
-func TestTypeMarshalerPrimitiveStructType(t *testing.T) {
+func TestTypeMarshalerPrimitiveStructTypeNoMarshalNomsType(t *testing.T) {
 	assert := assert.New(t)
 
 	var u primitiveStructType
-	typ := MustMarshalType(u)
-	assert.Equal(types.NumberType, typ)
+	_, err := MarshalType(u)
+	assert.Error(err)
+	assert.Equal("Cannot marshal type which implements marshal.Marshaler, perhaps implement marshal.TypeMarshaler for marshal.primitiveStructType", err.Error())
 }
 
 func (u builtinType) MarshalNomsType() (*types.Type, error) {

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -34,6 +34,12 @@ func (dt DateTime) MarshalNoms() (types.Value, error) {
 	}), nil
 }
 
+// MarshalNomsType makes DateTime implement marshal.TypeMarshaler and it
+// allows marshal.MarshalType to work with DateTime.
+func (dt DateTime) MarshalNomsType() (*types.Type, error) {
+	return DateTimeType, nil
+}
+
 // UnmarshalNoms makes DateTime implement marshal.Unmarshaler and it allows
 // Noms struct with type DateTimeType able to be unmarshaled onto a DateTime
 // Go struct

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -92,3 +92,14 @@ func TestMarshal(t *testing.T) {
 	test(DateTime(time.Unix(-42, -123456789)), -42.123456789)
 	test(DateTime(time.Unix(-123456789, -123456789)), -123456789.123456789)
 }
+
+func TestMarshalType(t *testing.T) {
+	assert := assert.New(t)
+
+	dt := DateTime(time.Unix(0, 0))
+	typ := marshal.MustMarshalType(dt)
+	assert.Equal(DateTimeType, typ)
+
+	v := marshal.MustMarshal(dt)
+	assert.Equal(typ, v.Type())
+}


### PR DESCRIPTION
This allows go structs to participate in the MarshalType flow even
when they implement the Marshaler interface or if they have an original
tag.