### PR TITLE
Make GraphQL struct fields nullable

### DIFF
--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -69,7 +69,8 @@ func isScalar(nomsType *types.Type) bool {
 	}
 }
 
-// Note: Always returns a graphql.NonNull() as the outer type.
+// NomsTypeToGraphQLType creates a GraphQL type from a Noms type that knows how
+// to resolve the Noms values.
 func NomsTypeToGraphQLType(nomsType *types.Type, boxedIfScalar bool, tm *typeMap) graphql.Type {
 	key := typeMapKey{nomsType.Hash(), boxedIfScalar && isScalar(nomsType)}
 	gqlType, ok := (*tm)[key]
@@ -125,16 +126,8 @@ func NomsTypeToGraphQLType(nomsType *types.Type, boxedIfScalar bool, tm *typeMap
 		panic("not reached")
 	}
 
-	newNonNull := graphql.NewNonNull(gqlType)
-	(*tm)[key] = newNonNull
-	return newNonNull
-}
-
-func unpackNonNullType(t graphql.Type) graphql.Type {
-	if t, ok := t.(*graphql.NonNull); ok {
-		return t.OfType
-	}
-	return t
+	(*tm)[key] = gqlType
+	return gqlType
 }
 
 func isEmptyNomsUnion(nomsType *types.Type) bool {
@@ -148,7 +141,7 @@ func unionToGQLUnion(nomsType *types.Type, tm *typeMap) *graphql.Union {
 
 	for i, nomsUnionType := range nomsMemberTypes {
 		// Member types cannot be non-null and must be struct (graphl.Object)
-		memberTypes[i] = NomsTypeToGraphQLType(nomsUnionType, true, tm).(*graphql.NonNull).OfType.(*graphql.Object)
+		memberTypes[i] = NomsTypeToGraphQLType(nomsUnionType, true, tm).(*graphql.Object)
 	}
 
 	return graphql.NewUnion(graphql.UnionConfig{
@@ -176,7 +169,7 @@ func unionToGQLUnion(nomsType *types.Type, tm *typeMap) *graphql.Union {
 			key := typeMapKey{nomsType.Hash(), isScalar}
 			memberType := (*tm)[key]
 			// Member types cannot be non-null and must be struct (graphl.Object)
-			return memberType.(*graphql.NonNull).OfType.(*graphql.Object)
+			return memberType.(*graphql.Object)
 		},
 	})
 }
@@ -196,7 +189,7 @@ func structToGQLObject(nomsType *types.Type, tm *typeMap) *graphql.Object {
 			}
 
 			structDesc.IterFields(func(name string, nomsFieldType *types.Type) {
-				fieldType := unpackNonNullType(NomsTypeToGraphQLType(nomsFieldType, false, tm))
+				fieldType := NomsTypeToGraphQLType(nomsFieldType, false, tm)
 
 				fields[name] = &graphql.Field{
 					Type: fieldType,
@@ -567,8 +560,8 @@ func listAndSetToGraphQLObject(nomsType *types.Type, tm *typeMap) *graphql.Objec
 	nomsValueType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
 	var listType, valueType graphql.Type
 	if !isEmptyNomsUnion(nomsValueType) {
-		listType = NomsTypeToGraphQLType(nomsValueType, false, tm)
-		valueType = unpackNonNullType(listType)
+		valueType = NomsTypeToGraphQLType(nomsValueType, false, tm)
+		listType = graphql.NewNonNull(valueType)
 	}
 
 	return graphql.NewObject(graphql.ObjectConfig{
@@ -626,9 +619,9 @@ func mapToGraphQLObject(nomsType *types.Type, tm *typeMap) *graphql.Object {
 			fields := argsWithSize()
 
 			if !isEmptyMap {
-				keyType := NomsTypeToGraphQLType(nomsKeyType, false, tm)
-				nullableKeyType := unpackNonNullType(keyType)
-				valueType := unpackNonNullType(NomsTypeToGraphQLType(nomsValueType, false, tm))
+				nullableKeyType := NomsTypeToGraphQLType(nomsKeyType, false, tm)
+				keyType := graphql.NewNonNull(nullableKeyType)
+				valueType := NomsTypeToGraphQLType(nomsValueType, false, tm)
 				entryType := mapEntryToGraphQLObject(keyType, valueType, nomsKeyType, nomsValueType, tm)
 
 				args := graphql.FieldConfigArgument{


### PR DESCRIPTION
This is needed because we do not have optional fields in noms structs.
Therefore the noms struct type has the field but the the noms struct may
not have it.