### PR TITLE
Noms type to GraphQL input types

### DIFF
--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -58,10 +58,13 @@ func NewContext(vr types.ValueReader, tm *typeMap) context.Context {
 // Query takes |rootValue|, builds a GraphQL scheme from rootValue.Type() and
 // executes |query| against it, encoding the result to |w|.
 func Query(rootValue types.Value, query string, vr types.ValueReader, w io.Writer) {
+	schemaConfig := graphql.SchemaConfig{}
 	tm := NewTypeMap()
+	queryWithSchemaConfig(rootValue, query, schemaConfig, vr, tm, w)
+}
 
-	queryObj := constructQueryType(rootValue, tm)
-	schemaConfig := graphql.SchemaConfig{Query: queryObj}
+func queryWithSchemaConfig(rootValue types.Value, query string, schemaConfig graphql.SchemaConfig, vr types.ValueReader, tm *typeMap, w io.Writer) {
+	schemaConfig.Query = constructQueryType(rootValue, tm)
 	schema, _ := graphql.NewSchema(schemaConfig)
 	ctx := NewContext(vr, tm)
 
@@ -73,6 +76,7 @@ func Query(rootValue types.Value, query string, vr types.ValueReader, w io.Write
 
 	err := json.NewEncoder(w).Encode(r)
 	d.PanicIfError(err)
+
 }
 
 // Error writes an error as a GraphQL error to a writer.

--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -76,7 +76,6 @@ func queryWithSchemaConfig(rootValue types.Value, query string, schemaConfig gra
 
 	err := json.NewEncoder(w).Encode(r)
 	d.PanicIfError(err)
-
 }
 
 // Error writes an error as a GraphQL error to a writer.


### PR DESCRIPTION
We already had a way to generate GraphQL output types from Noms types
but no way to do input types. Input types are used in arguments
position.

We currently do not do any conversion from the JSON like data in
argument position. We leave it to the users to determine if they want
to convert the data into noms data structures or go to Go structures
or operate directly on the JSON like data.