### PR TITLE
Add network connection logging

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -50,12 +50,7 @@ func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexC
 		size := indexSize(chunkCount) + footerSize
 		buff := make([]byte, size)
 
-		rngHdr := fmt.Sprintf("%s=-%d", s3RangePrefix, size)
-		n, err := source.readRange(buff, rngHdr)
-		for rErr, ok := err.(readError); ok; rErr, ok = err.(readError) {
-			fmt.Fprintln(os.Stderr, "Transient read error:", rErr)
-			n, err = source.readRange(buff, rngHdr)
-		}
+		n, err := source.readRange(buff, fmt.Sprintf("%s=-%d", s3RangePrefix, size))
 		d.PanicIfError(err)
 		d.PanicIfFalse(size == uint64(n))
 		index = parseTableIndex(buff)
@@ -84,8 +79,6 @@ func (s3tr *s3TableReader) ReadAt(p []byte, off int64) (n int, err error) {
 	return s3tr.readRange(p, rangeHeader)
 }
 
-type readError error
-
 func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err error) {
 	if s3tr.readRl != nil {
 		s3tr.readRl <- struct{}{}
@@ -99,14 +92,15 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 		Key:    aws.String(s3tr.hash().String()),
 		Range:  aws.String(rangeHeader),
 	}
-	// TODO: go back to just calling GetObject once BUG 3255 is fixed
-	// TODO: take out this running of
-	ss := newBg("/usr/sbin/ss", "-ntp")
+	// TODO: take out this running of ss once BUG 3255 is fixed
 	shouldLog := make(chan struct{})
 	defer close(shouldLog)
+	ss, logFinished := newBg(shouldLog, "/usr/sbin/ss", "-ntp")
+	go ss.Run("Couldn't run ss to record network connections:")
+
+	// TODO: go back to just calling GetObject once BUG 3255 is fixed
 	result, reqID, reqID2, err := func() (*s3.GetObjectOutput, string, string, error) {
 		if impl, ok := s3tr.s3.(*s3.S3); ok {
-			ss.Run(shouldLog, "Couldn't run ss to record network connections:")
 			req, result := impl.GetObjectRequest(input)
 			err := req.Send()
 			return result, req.RequestID, req.HTTPResponse.Header.Get("x-amz-id-2"), err
@@ -120,29 +114,34 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 	n, err = io.ReadFull(result.Body, p)
 
 	if err != nil {
-		err = readError(fmt.Errorf("Failed ranged read from S3\nreqID   %s\nexReqID %s\n%s\nerror: %v", reqID, reqID2, input.GoString(), err))
 		shouldLog <- struct{}{}
+		<-logFinished
+		d.Chk.Fail("Failed ranged read from S3\n", "req %s\nreq %s\n%s\nerror: %v", reqID, reqID2, input.GoString(), err)
 	}
 
 	return n, err
 }
 
 type bgCmd struct {
-	cmd *exec.Cmd
+	cmd         *exec.Cmd
+	startLog    <-chan struct{}
+	logFinished chan<- struct{}
 }
 
-func newBg(path string, args ...string) *bgCmd {
-	cmd := exec.Command(path, args...)
-	return &bgCmd{cmd}
+func newBg(startLog <-chan struct{}, path string, args ...string) (cmd *bgCmd, finished <-chan struct{}) {
+	f := make(chan struct{})
+	cmd = &bgCmd{exec.Command(path, args...), startLog, f}
+	return cmd, f
 }
 
-func (w *bgCmd) Run(shouldLog <-chan struct{}, msg string) {
+func (w *bgCmd) Run(msg string) {
+	defer close(w.logFinished)
 	out, err := w.cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, msg, err)
 		return
 	}
-	if _, log := <-shouldLog; log {
+	if _, log := <-w.startLog; log {
 		fmt.Fprintln(os.Stderr, out)
 	}
 }


### PR DESCRIPTION
Run the `ss` tool in the background when issuing an S3 request. Only print its output when reading data from S3 fails, though. Also retry reads that fail in this way