### PR TITLE
Land simpler network connection logging for #3255

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -7,6 +7,8 @@ package nbs
 import (
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/aws/aws-sdk-go/aws"
@@ -106,6 +108,16 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 	n, err = io.ReadFull(result.Body, p)
 
 	if err != nil {
+		// TODO: take out this running of ss once BUG 3255 is fixed
+		cmd := exec.Command("/usr/sbin/ss", "-ntp")
+		if out, err := cmd.CombinedOutput(); err == nil {
+			if _, err = os.Stderr.Write(out); err != nil {
+				fmt.Fprintln(os.Stderr, "Failed writing network connection info", err)
+			}
+		} else {
+			fmt.Fprintln(os.Stderr, "Failed to get network connections:", err)
+		}
+
 		d.Chk.Fail("Failed ranged read from S3\n", "req %s\nreq %s\n%s\nerror: %v", reqID, reqID2, input.GoString(), err)
 	}
 


### PR DESCRIPTION
Trying to run `ss` in a background process on every request wound up
opening too many FDs. This is because, in order to read stderr and
stdout from the child process, the server process needed to open a
couple of pipes. For every single one. Unless they exited VERY
fast, that means that there'd be many of these child processes alive
at the same time, each requiring 2 FDs -- and this is in addition to
the incoming network connections the server is handling and all its
connections to S3.

Whoops.

This patch only spins up `ss` in the event that a request has already
failed during read. The downside is that we're getting a snapshot from
_after_ the failure. The upside is that it's likely to actually
function! The hope is that the situation that lead to the read failing
persists long enough that we can see it even when sampling just after
the failure. Maybe not, but hopefully it's a start on figuring out