### PR TITLE
Remove ChunkStore backpressure mechanism

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -5,7 +5,6 @@
 package chunks
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/attic-labs/noms/go/hash"
@@ -62,25 +61,11 @@ type ChunkSink interface {
 	// Put writes c into the ChunkSink, blocking until the operation is complete.
 	Put(c Chunk)
 
-	// PutMany tries to write chunks into the sink. It will block as it
-	// handles as many as possible, then return a BackpressureError containing
-	// the rest (if any).
-	PutMany(chunks []Chunk) BackpressureError
+	// PutMany writes chunks into the sink, blocking until the operation is complete.
+	PutMany(chunks []Chunk)
 
 	// On return, any previously Put chunks should be durable
 	Flush()
 
 	io.Closer
-}
-
-// BackpressureError is a slice of hash.Hash that indicates some chunks could
-// not be Put(). Caller is free to try to Put them again later.
-type BackpressureError hash.HashSlice
-
-func (b BackpressureError) Error() string {
-	return fmt.Sprintf("Tried to Put %d too many Chunks", len(b))
-}
-
-func (b BackpressureError) AsHashes() hash.HashSlice {
-	return hash.HashSlice(b)
 }

--- a/go/chunks/dynamo_store.go
+++ b/go/chunks/dynamo_store.go
@@ -137,25 +137,10 @@ func (s *DynamoStore) Has(h hash.Hash) bool {
 	return <-ch
 }
 
-func (s *DynamoStore) PutMany(chunks []Chunk) (e BackpressureError) {
-	for i, c := range chunks {
-		if s.unwrittenPuts.Has(c) {
-			continue
-		}
-		select {
-		case s.writeQueue <- c:
-			s.requestWg.Add(1)
-			s.unwrittenPuts.Add(c)
-		default:
-			notPut := chunks[i:]
-			e = make(BackpressureError, len(notPut))
-			for j, np := range notPut {
-				e[j] = np.Hash()
-			}
-			return
-		}
+func (s *DynamoStore) PutMany(chunks []Chunk) {
+	for _, c := range chunks {
+		s.Put(c)
 	}
-	return
 }
 
 func (s *DynamoStore) Put(c Chunk) {

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -65,11 +65,10 @@ func (ms *MemoryStore) Put(c Chunk) {
 	ms.data[c.Hash()] = c
 }
 
-func (ms *MemoryStore) PutMany(chunks []Chunk) (e BackpressureError) {
+func (ms *MemoryStore) PutMany(chunks []Chunk) {
 	for _, c := range chunks {
 		ms.Put(c)
 	}
-	return
 }
 
 func (ms *MemoryStore) Len() int {

--- a/go/chunks/test_utils.go
+++ b/go/chunks/test_utils.go
@@ -51,11 +51,10 @@ func (s *TestStore) Put(c Chunk) {
 	s.MemoryStore.Put(c)
 }
 
-func (s *TestStore) PutMany(chunks []Chunk) (e BackpressureError) {
+func (s *TestStore) PutMany(chunks []Chunk) {
 	for _, c := range chunks {
 		s.Put(c)
 	}
-	return
 }
 
 // TestStoreFactory is public, and exposes Stores to ensure that test code can directly query instances vended by this factory.

--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -209,7 +209,7 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	}
 
 	root := smallTableStore.Root()
-	suite.NoError(smallTableStore.PutMany(chunx[:testMaxTables]))
+	smallTableStore.PutMany(chunx[:testMaxTables])
 	suite.True(smallTableStore.UpdateRoot(chunx[0].Hash(), root)) // Commit write
 
 	exists, _, mRoot, specs := mm.ParseIfExists(nil)
@@ -218,7 +218,7 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	suite.Len(specs, testMaxTables)
 
 	root = smallTableStore.Root()
-	suite.NoError(smallTableStore.PutMany(chunx[testMaxTables:]))
+	smallTableStore.PutMany(chunx[testMaxTables:])
 	suite.True(smallTableStore.UpdateRoot(chunx[testMaxTables].Hash(), root)) // Should compact
 
 	exists, _, mRoot, specs = mm.ParseIfExists(nil)

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -178,20 +178,10 @@ func (nbs *NomsBlockStore) SchedulePut(c chunks.Chunk, refHeight uint64, hints t
 	nbs.Put(c)
 }
 
-func (nbs *NomsBlockStore) PutMany(chunx []chunks.Chunk) (err chunks.BackpressureError) {
-	for ; len(chunx) > 0; chunx = chunx[1:] {
-		c := chunx[0]
-		a := addr(c.Hash())
-		if !nbs.addChunk(a, c.Data()) {
-			break
-		}
-		nbs.putCount++
-	}
+func (nbs *NomsBlockStore) PutMany(chunx []chunks.Chunk) {
 	for _, c := range chunx {
-		err = append(err, c.Hash())
+		nbs.Put(c)
 	}
-
-	return err
 }
 
 // TODO: figure out if there's a non-error reason for this to return false. If not, get rid of return value.

--- a/go/types/validating_batching_sink_test.go
+++ b/go/types/validating_batching_sink_test.go
@@ -47,7 +47,7 @@ func TestValidatingBatchingSinkDecodeAlreadyEnqueued(t *testing.T) {
 	c := EncodeValue(v, nil)
 	vbs := NewValidatingBatchingSink(chunks.NewTestStore())
 
-	assert.NoError(t, vbs.Enqueue(c, v))
+	vbs.Enqueue(c, v)
 	dc := vbs.DecodeUnqueued(&c)
 	assert.Nil(t, dc.Chunk)
 	assert.Nil(t, dc.Value)
@@ -106,8 +106,8 @@ func TestValidatingBatchingSinkEnqueueAndFlush(t *testing.T) {
 	cs := chunks.NewTestStore()
 	vbs := NewValidatingBatchingSink(cs)
 
-	assert.NoError(t, vbs.Enqueue(c, v))
-	assert.NoError(t, vbs.Flush())
+	vbs.Enqueue(c, v)
+	vbs.Flush()
 	assert.Equal(t, 1, cs.Writes)
 }
 
@@ -117,9 +117,9 @@ func TestValidatingBatchingSinkEnqueueImplicitFlush(t *testing.T) {
 
 	for i := 0; i <= batchSize; i++ {
 		v := Number(i)
-		assert.NoError(t, vbs.Enqueue(EncodeValue(v, nil), v))
+		vbs.Enqueue(EncodeValue(v, nil), v)
 	}
 	assert.Equal(t, batchSize, cs.Writes)
-	assert.NoError(t, vbs.Flush())
+	vbs.Flush()
 	assert.Equal(t, 1, cs.Writes-batchSize)
 }


### PR DESCRIPTION
This was something that evolved from the way that Dynamo stores
data, and a way to allow clients to make incremental write
progress. We never actually made the clients handle it
properly, though, and so much has changed since we wrote it
that it's only going to be in the way of building something
better.

Fixes #3234