### PR TITLE
Log error type when S3 reads fail

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -100,7 +100,7 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 
 		n, err := io.ReadFull(result.Body, p)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed ranged read from S3\n%s\nerror: %v", input.GoString(), err)
+			fmt.Fprintf(os.Stderr, "Failed ranged read from S3\n%s\nerr type: %T\nerror: %v\n", input.GoString(), err, err)
 		}
 		return n, err
 	}


### PR DESCRIPTION
Apparently, not all failures while reading get translated to
an ErrUnexpectedEOF. In order to figure out what error we see
in practice in s3_table_reader.go, log the type.