### PR TITLE
Test for the correct kind of error in s3_table_reader.go

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -118,7 +118,9 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 			Jitter: true,
 		}
 		for ; isConnReset(err); n, err = read() {
-			time.Sleep(b.Duration())
+			dur := b.Duration()
+			fmt.Fprintf(os.Stderr, "Retrying S3 read in %s\n", dur.String())
+			time.Sleep(dur)
 		}
 	}
 	return

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -7,8 +7,11 @@ package nbs
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/aws/aws-sdk-go/aws"
@@ -107,16 +110,21 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 
 	n, err = read()
 	// We hit the point of diminishing returns investigating #3255, so add retries. In conversations with AWS people, it's not surprising to get transient failures when talking to S3, though SDKs are intended to have their own retrying. The issue may be that, in Go, making the S3 request and reading the data are separate operations, and the SDK kind of can't do its own retrying to handle failures in the latter.
-	if err == io.ErrUnexpectedEOF {
+	if isConnReset(err) {
 		b := &backoff.Backoff{
 			Min:    128 * time.Microsecond,
 			Max:    1024 * time.Millisecond,
 			Factor: 2,
 			Jitter: true,
 		}
-		for ; err == io.ErrUnexpectedEOF; n, err = read() {
+		for ; isConnReset(err); n, err = read() {
 			time.Sleep(b.Duration())
 		}
 	}
 	return
+}
+
+func isConnReset(err error) bool {
+	nErr, ok := err.(*net.OpError)
+	return ok && nErr.Err == unix.ECONNRESET
 }


### PR DESCRIPTION
A connection reset doesn't get caught by io.ReadFull and converted to
an io.ErrUnexpectedEOF like I thought.  So, I need to try to type
assert the error I get to *net.OpError and then use that to see if it
was a connection reset.

Workaround for #3255