### PR TITLE
Skip "original" field when marshaling type

### DIFF
--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -427,7 +427,6 @@ func typeFields(t reflect.Type, parentStructTypes []reflect.Type, options encode
 		}
 
 		if tags.original {
-			canComputeStructType = false
 			originalFieldIndex = f.Index
 			continue
 		}

--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -20,8 +20,9 @@ import (
 // The rules for MarshalType is the same as for Marshal, except for omitempty
 // is ignored since that cannot be determined statically.
 //
-// If a Go struct contains a noms tag with original an error is returned since
-// the Noms type depends on the original Noms value which is not available.
+// If a Go struct contains a noms tag with original an error the field is
+// skipped since the Noms type depends on the original Noms value which is not
+// available.
 func MarshalType(v interface{}) (nt *types.Type, err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -20,9 +20,8 @@ import (
 // The rules for MarshalType is the same as for Marshal, except for omitempty
 // is ignored since that cannot be determined statically.
 //
-// If a Go struct contains a noms tag with original an error the field is
-// skipped since the Noms type depends on the original Noms value which is not
-// available.
+// If a Go struct contains a noms tag with original the field is skipped since
+// the Noms type depends on the original Noms value which is not available.
 func MarshalType(v interface{}) (nt *types.Type, err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -353,14 +353,19 @@ func TestMarshalTypeCanSkipUnexportedField(t *testing.T) {
 }
 
 func TestMarshalTypeOriginal(t *testing.T) {
+	assert := assert.New(t)
+
 	type S struct {
 		Foo int          `noms:",omitempty"`
 		Bar types.Struct `noms:",original"`
 	}
 
 	var s S
-	assertMarshalTypeErrorMessage(t, s, "Type is not supported, type: marshal.S")
-
+	typ, err := MarshalType(s)
+	assert.NoError(err)
+	assert.True(types.MakeStructTypeFromFields("S", types.FieldMap{
+		"foo": types.NumberType,
+	}).Equals(typ))
 }
 
 func TestMarshalTypeNomsTypes(t *testing.T) {


### PR DESCRIPTION
Instead of failing. Fixes https://github.com/attic-labs/noms/issues/3284