### PR TITLE
NGQL: Add work around for using a Set as a List

### DIFF
--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/attic-labs/graphql"
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
 	"github.com/attic-labs/testify/suite"
 )
 
@@ -1380,4 +1381,21 @@ func (suite *QueryGraphQLSuite) TestNameFunc() {
 	test(tc, set, expected, query, map[string]interface{}{
 		"key": map[string]interface{}{"a": 2},
 	})
+}
+
+func TestGetListElementsWithSet(t *testing.T) {
+	assert := assert.New(t)
+	v := types.NewSet(types.Number(0), types.Number(1), types.Number(2))
+	r := getListElements(v, map[string]interface{}{})
+	assert.Equal([]interface{}{float64(0), float64(1), float64(2)}, r)
+
+	r = getListElements(v, map[string]interface{}{
+		atKey: 1,
+	})
+	assert.Equal([]interface{}{float64(1), float64(2)}, r)
+
+	r = getListElements(v, map[string]interface{}{
+		countKey: 2,
+	})
+	assert.Equal([]interface{}{float64(0), float64(1)}, r)
 }

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -399,7 +399,7 @@ var listArgs = graphql.FieldConfigArgument{
 }
 
 func getListElements(v types.Value, args map[string]interface{}) interface{} {
-	l := v.(types.List)
+	l := v.(types.Collection)
 	idx := 0
 	count := int(l.Len())
 	len := count
@@ -424,7 +424,19 @@ func getListElements(v types.Value, args map[string]interface{}) interface{} {
 	}
 
 	values := make([]interface{}, count)
-	iter := l.IteratorAt(uint64(idx))
+
+	// This is a workaround for allowing types.Set as types.List.
+	type listOrSetIterator interface {
+		Next() types.Value
+	}
+
+	var iter listOrSetIterator
+	switch l := l.(type) {
+	case types.List:
+		iter = l.IteratorAt(uint64(idx))
+	case types.Set:
+		iter = l.IteratorAt(uint64(idx))
+	}
 	for i := uint64(0); i < uint64(count); i++ {
 		values[i] = MaybeGetScalar(iter.Next())
 	}


### PR DESCRIPTION
If the GraphQL schema expects a List we also allow a Set.