### PR TITLE
One more level of error unwrapping in s3_table_reader.go

### DIFF
--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -128,5 +128,9 @@ func (s3tr *s3TableReader) readRange(p []byte, rangeHeader string) (n int, err e
 
 func isConnReset(err error) bool {
 	nErr, ok := err.(*net.OpError)
-	return ok && nErr.Err == unix.ECONNRESET
+	if !ok {
+		return false
+	}
+	scErr, ok := nErr.Err.(*os.SyscallError)
+	return ok && scErr.Err == unix.ECONNRESET
 }

--- a/go/nbs/s3_table_reader_test.go
+++ b/go/nbs/s3_table_reader_test.go
@@ -7,6 +7,7 @@ package nbs
 import (
 	"io/ioutil"
 	"net"
+	"os"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -101,5 +102,5 @@ func (fs3 *flakyS3) GetObject(input *s3.GetObjectInput) (output *s3.GetObjectOut
 type resettingReader struct{}
 
 func (rr resettingReader) Read(p []byte) (n int, err error) {
-	return 0, &net.OpError{Op: "read", Net: "tcp", Err: unix.ECONNRESET}
+	return 0, &net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: unix.ECONNRESET}}
 }


### PR DESCRIPTION
My mistake was assuming that, when a network read error happens, the
Err field of the resulting net.OpError would directly contain a
unix.Errno. What actually happens is that there's an *os.SyscallError
in there, which is the thing that's actually wrapped around the
unix.Errno. Hence, my `IsConnReset()` function was always returning
false.

This patch has been tested in the field, so I'm confident it will
work to mitigate #3255 in practice.