### PR TITLE
Remove Windows instructions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Working with Noms is ***declarative***. You don't `INSERT` new data, `UPDATE` ex
 
 ## Install Noms
 
-Noms is supported on Mac OS X and Linux. While Windows isn't officially supported, you can compile a Windows build from source, and it usually works.
+Noms is supported on Mac OS X and Linux.
 
 1. [Download the latest build](https://s3-us-west-2.amazonaws.com/downloadstable.noms.io/index.html?prefix=jobs/NomsBuildGoBinaries-v7/)
 


### PR DESCRIPTION
I attempted to build and install noms in Windows and encountered the following error:

```
C:\Users\sam\go\src\github.com\attic-labs\noms\cmd>go install ./...
# github.com/attic-labs/noms/go/nbs
..\go\nbs\file_manifest.go:46: undefined: unix.Flock
..\go\nbs\file_manifest.go:46: undefined: unix.LOCK_EX
..\go\nbs\file_manifest.go:155: undefined: unix.Flock
..\go\nbs\file_manifest.go:155: undefined: unix.LOCK_EX
..\go\nbs\mmap_table_reader.go:67: undefined: unix.Mmap
..\go\nbs\mmap_table_reader.go:67: undefined: unix.PROT_READ
..\go\nbs\mmap_table_reader.go:67: undefined: unix.MAP_SHARED
..\go\nbs\mmap_table_reader.go:82: undefined: unix.Munmap
..\go\nbs\s3_table_reader.go:131: undefined: unix.ECONNRESET
```
I believe the ability to build on Windows was broken in commit https://github.com/attic-labs/noms/commit/a00a5f5611bd4ce89063706342b48c381d7af225. Since there is no intention to support Windows, I suggest removing this statement.