### PR TITLE
Resurrect MakeUnionType2 as MakeUnionTypeIntersectStructs

### DIFF
--- a/go/types/simplify.go
+++ b/go/types/simplify.go
@@ -32,17 +32,17 @@ import "github.com/attic-labs/noms/go/d"
 //
 // Anytime any of the above cases generates a union as output, the same process
 // is applied to that union recursively.
-func makeSimplifiedType(in ...*Type) *Type {
+func makeSimplifiedType(intersectStructs bool, in ...*Type) *Type {
 	ts := make(typeset, len(in))
 	for _, t := range in {
 		// De-cycle so that we handle cycles explicitly below. Otherwise, we would implicitly crawl
 		// cycles and recurse forever.
-		t := ToUnresolvedType(t)
-		ts[t] = struct{}{}
+		ut := ToUnresolvedType(t)
+		ts[ut] = struct{}{}
 	}
 
 	// Impl de-cycles internally.
-	return makeSimplifiedTypeImpl(ts)
+	return makeSimplifiedTypeImpl(ts, intersectStructs)
 }
 
 // typeset is a helper that aggregates the unique set of input types for this algorithm, flattening
@@ -71,7 +71,7 @@ func newTypeset(t ...*Type) typeset {
 // makeSimplifiedTypeImpl is an implementation detail.
 // Warning: Do not call this directly. It assumes its input has been de-cycled using
 // ToUnresolvedType() and will infinitely recurse on cyclic types otherwise.
-func makeSimplifiedTypeImpl(in typeset) *Type {
+func makeSimplifiedTypeImpl(in typeset, intersectStructs bool) *Type {
 	type how struct {
 		k NomsKind
 		n string
@@ -109,15 +109,15 @@ func makeSimplifiedTypeImpl(in typeset) *Type {
 		var r *Type
 		switch h.k {
 		case RefKind:
-			r = simplifyRefs(ts)
+			r = simplifyRefs(ts, intersectStructs)
 		case SetKind:
-			r = simplifySets(ts)
+			r = simplifySets(ts, intersectStructs)
 		case ListKind:
-			r = simplifyLists(ts)
+			r = simplifyLists(ts, intersectStructs)
 		case MapKind:
-			r = simplifyMaps(ts)
+			r = simplifyMaps(ts, intersectStructs)
 		case StructKind:
-			r = simplifyStructs(h.n, ts)
+			r = simplifyStructs(h.n, ts, intersectStructs)
 		}
 		out = append(out, r)
 	}
@@ -136,28 +136,28 @@ func makeSimplifiedTypeImpl(in typeset) *Type {
 	return staticTypeCache.makeUnionType(out...)
 }
 
-func simplifyRefs(ts typeset) *Type {
-	return simplifyContainers(RefKind, MakeRefType, ts)
+func simplifyRefs(ts typeset, intersectStructs bool) *Type {
+	return simplifyContainers(RefKind, MakeRefType, ts, intersectStructs)
 }
 
-func simplifySets(ts typeset) *Type {
-	return simplifyContainers(SetKind, MakeSetType, ts)
+func simplifySets(ts typeset, intersectStructs bool) *Type {
+	return simplifyContainers(SetKind, MakeSetType, ts, intersectStructs)
 }
 
-func simplifyLists(ts typeset) *Type {
-	return simplifyContainers(ListKind, MakeListType, ts)
+func simplifyLists(ts typeset, intersectStructs bool) *Type {
+	return simplifyContainers(ListKind, MakeListType, ts, intersectStructs)
 }
 
-func simplifyContainers(expectedKind NomsKind, makeContainer func(elem *Type) *Type, ts typeset) *Type {
+func simplifyContainers(expectedKind NomsKind, makeContainer func(elem *Type) *Type, ts typeset, intersectStructs bool) *Type {
 	elemTypes := make(typeset, len(ts))
 	for t := range ts {
 		d.Chk.True(expectedKind == t.Kind())
 		elemTypes.Add(t.Desc.(CompoundDesc).ElemTypes[0])
 	}
-	return makeContainer(makeSimplifiedTypeImpl(elemTypes))
+	return makeContainer(makeSimplifiedTypeImpl(elemTypes, intersectStructs))
 }
 
-func simplifyMaps(ts typeset) *Type {
+func simplifyMaps(ts typeset, intersectStructs bool) *Type {
 	keyTypes := make(typeset, len(ts))
 	valTypes := make(typeset, len(ts))
 	for t := range ts {
@@ -167,19 +167,22 @@ func simplifyMaps(ts typeset) *Type {
 		valTypes.Add(desc.ElemTypes[1])
 	}
 	return MakeMapType(
-		makeSimplifiedTypeImpl(keyTypes),
-		makeSimplifiedTypeImpl(valTypes))
+		makeSimplifiedTypeImpl(keyTypes, intersectStructs),
+		makeSimplifiedTypeImpl(valTypes, intersectStructs))
 }
 
-func simplifyStructs(expectedName string, ts typeset) *Type {
+func simplifyStructs(expectedName string, ts typeset, intersectStructs bool) *Type {
 	// We gather all the fields/types into allFields. If the number of
 	// times a field name is present is less that then number of types we
 	// are simplifying then the field must be optional.
 	// If we see an optional field we do not increment the count for it and
 	// it will be treated as optional in the end.
+
+	// If intersectStructs is true we need to pick the more restrictive version (n: T over n?: T).
 	type fieldTypeInfo struct {
-		count   int
-		typeset typeset
+		anyRequired bool
+		count       int
+		typeset     typeset
 	}
 	allFields := map[string]fieldTypeInfo{}
 
@@ -198,6 +201,7 @@ func simplifyStructs(expectedName string, ts typeset) *Type {
 			fti.typeset.Add(t)
 			if !optional {
 				fti.count++
+				fti.anyRequired = true
 			}
 			allFields[name] = fti
 		})
@@ -208,8 +212,8 @@ func simplifyStructs(expectedName string, ts typeset) *Type {
 	for name, fti := range allFields {
 		fields = append(fields, StructField{
 			Name:     name,
-			Type:     makeSimplifiedTypeImpl(fti.typeset),
-			Optional: fti.count < count,
+			Type:     makeSimplifiedTypeImpl(fti.typeset, intersectStructs),
+			Optional: !(intersectStructs && fti.anyRequired) && fti.count < count,
 		})
 	}
 

--- a/go/types/simplify.go
+++ b/go/types/simplify.go
@@ -180,9 +180,9 @@ func simplifyStructs(expectedName string, ts typeset, intersectStructs bool) *Ty
 
 	// If intersectStructs is true we need to pick the more restrictive version (n: T over n?: T).
 	type fieldTypeInfo struct {
-		anyRequired bool
-		count       int
-		typeset     typeset
+		anyNonOptional bool
+		count          int
+		typeset        typeset
 	}
 	allFields := map[string]fieldTypeInfo{}
 
@@ -201,7 +201,7 @@ func simplifyStructs(expectedName string, ts typeset, intersectStructs bool) *Ty
 			fti.typeset.Add(t)
 			if !optional {
 				fti.count++
-				fti.anyRequired = true
+				fti.anyNonOptional = true
 			}
 			allFields[name] = fti
 		})
@@ -213,7 +213,7 @@ func simplifyStructs(expectedName string, ts typeset, intersectStructs bool) *Ty
 		fields = append(fields, StructField{
 			Name:     name,
 			Type:     makeSimplifiedTypeImpl(fti.typeset, intersectStructs),
-			Optional: !(intersectStructs && fti.anyRequired) && fti.count < count,
+			Optional: !(intersectStructs && fti.anyNonOptional) && fti.count < count,
 		})
 	}
 

--- a/go/types/simplify_test.go
+++ b/go/types/simplify_test.go
@@ -16,141 +16,143 @@ import (
 //   - test cycles
 
 func TestSimplifyHelpers(t *testing.T) {
-	structSimplifier := func(n string) func(typeset) *Type {
-		return func(ts typeset) *Type {
-			return simplifyStructs(n, ts)
+	structSimplifier := func(n string) func(typeset, bool) *Type {
+		return func(ts typeset, intersectStructs bool) *Type {
+			return simplifyStructs(n, ts, intersectStructs)
 		}
 	}
 
-	cases := []struct {
-		f   func(typeset) *Type
-		in  []*Type
-		out *Type
-	}{
-		// Ref<Bool> -> Ref<Bool>
-		{simplifyRefs,
-			[]*Type{MakeRefType(BoolType)},
-			MakeRefType(BoolType)},
-		// Ref<Number>|Ref<String>|Ref<blob> -> Ref<Number|String|blob>
-		{simplifyRefs,
-			[]*Type{MakeRefType(NumberType), MakeRefType(StringType), MakeRefType(BlobType)},
-			MakeRefType(MakeUnionType(NumberType, StringType, BlobType))},
-		// Ref<set<Bool>>|Ref<set<String>> -> Ref<set<Bool|String>>
-		{simplifyRefs,
-			[]*Type{MakeRefType(MakeSetType(BoolType)), MakeRefType(MakeSetType(StringType))},
-			MakeRefType(MakeSetType(MakeUnionType(BoolType, StringType)))},
-		// Ref<set<Bool>|Ref<set<String>>|Ref<Number> -> Ref<set<Bool|String>|Number>
-		{simplifyRefs,
-			[]*Type{MakeRefType(MakeSetType(BoolType)), MakeRefType(MakeSetType(StringType)), MakeRefType(NumberType)},
-			MakeRefType(MakeUnionType(MakeSetType(MakeUnionType(BoolType, StringType)), NumberType))},
+	for _, intersectStruct := range []bool{false, true} {
+		cases := []struct {
+			f   func(typeset, bool) *Type
+			in  []*Type
+			out *Type
+		}{
+			// Ref<Bool> -> Ref<Bool>
+			{simplifyRefs,
+				[]*Type{MakeRefType(BoolType)},
+				MakeRefType(BoolType)},
+			// Ref<Number>|Ref<String>|Ref<blob> -> Ref<Number|String|blob>
+			{simplifyRefs,
+				[]*Type{MakeRefType(NumberType), MakeRefType(StringType), MakeRefType(BlobType)},
+				MakeRefType(MakeUnionType(NumberType, StringType, BlobType))},
+			// Ref<set<Bool>>|Ref<set<String>> -> Ref<set<Bool|String>>
+			{simplifyRefs,
+				[]*Type{MakeRefType(MakeSetType(BoolType)), MakeRefType(MakeSetType(StringType))},
+				MakeRefType(MakeSetType(MakeUnionType(BoolType, StringType)))},
+			// Ref<set<Bool>|Ref<set<String>>|Ref<Number> -> Ref<set<Bool|String>|Number>
+			{simplifyRefs,
+				[]*Type{MakeRefType(MakeSetType(BoolType)), MakeRefType(MakeSetType(StringType)), MakeRefType(NumberType)},
+				MakeRefType(MakeUnionType(MakeSetType(MakeUnionType(BoolType, StringType)), NumberType))},
 
-		// set<Bool> -> set<Bool>
-		{simplifySets,
-			[]*Type{MakeSetType(BoolType)},
-			MakeSetType(BoolType)},
-		// set<Number>|set<String>|set<blob> -> set<Number|String|blob>
-		{simplifySets,
-			[]*Type{MakeSetType(NumberType), MakeSetType(StringType), MakeSetType(BlobType)},
-			MakeSetType(MakeUnionType(NumberType, StringType, BlobType))},
-		// set<set<Bool>>|set<set<String>> -> set<set<Bool|String>>
-		{simplifySets,
-			[]*Type{MakeSetType(MakeSetType(BoolType)), MakeSetType(MakeSetType(StringType))},
-			MakeSetType(MakeSetType(MakeUnionType(BoolType, StringType)))},
-		// set<set<Bool>|set<set<String>>|set<Number> -> set<set<Bool|String>|Number>
-		{simplifySets,
-			[]*Type{MakeSetType(MakeSetType(BoolType)), MakeSetType(MakeSetType(StringType)), MakeSetType(NumberType)},
-			MakeSetType(MakeUnionType(MakeSetType(MakeUnionType(BoolType, StringType)), NumberType))},
+			// set<Bool> -> set<Bool>
+			{simplifySets,
+				[]*Type{MakeSetType(BoolType)},
+				MakeSetType(BoolType)},
+			// set<Number>|set<String>|set<blob> -> set<Number|String|blob>
+			{simplifySets,
+				[]*Type{MakeSetType(NumberType), MakeSetType(StringType), MakeSetType(BlobType)},
+				MakeSetType(MakeUnionType(NumberType, StringType, BlobType))},
+			// set<set<Bool>>|set<set<String>> -> set<set<Bool|String>>
+			{simplifySets,
+				[]*Type{MakeSetType(MakeSetType(BoolType)), MakeSetType(MakeSetType(StringType))},
+				MakeSetType(MakeSetType(MakeUnionType(BoolType, StringType)))},
+			// set<set<Bool>|set<set<String>>|set<Number> -> set<set<Bool|String>|Number>
+			{simplifySets,
+				[]*Type{MakeSetType(MakeSetType(BoolType)), MakeSetType(MakeSetType(StringType)), MakeSetType(NumberType)},
+				MakeSetType(MakeUnionType(MakeSetType(MakeUnionType(BoolType, StringType)), NumberType))},
 
-		// list<Bool> -> list<Bool>
-		{simplifyLists,
-			[]*Type{MakeListType(BoolType)},
-			MakeListType(BoolType)},
-		// list<Number>|list<String>|list<blob> -> list<Number|String|blob>
-		{simplifyLists,
-			[]*Type{MakeListType(NumberType), MakeListType(StringType), MakeListType(BlobType)},
-			MakeListType(MakeUnionType(NumberType, StringType, BlobType))},
-		// list<set<Bool>>|list<set<String>> -> list<set<Bool|String>>
-		{simplifyLists,
-			[]*Type{MakeListType(MakeListType(BoolType)), MakeListType(MakeListType(StringType))},
-			MakeListType(MakeListType(MakeUnionType(BoolType, StringType)))},
-		// list<set<Bool>|list<set<String>>|list<Number> -> list<set<Bool|String>|Number>
-		{simplifyLists,
-			[]*Type{MakeListType(MakeListType(BoolType)), MakeListType(MakeListType(StringType)), MakeListType(NumberType)},
-			MakeListType(MakeUnionType(MakeListType(MakeUnionType(BoolType, StringType)), NumberType))},
+			// list<Bool> -> list<Bool>
+			{simplifyLists,
+				[]*Type{MakeListType(BoolType)},
+				MakeListType(BoolType)},
+			// list<Number>|list<String>|list<blob> -> list<Number|String|blob>
+			{simplifyLists,
+				[]*Type{MakeListType(NumberType), MakeListType(StringType), MakeListType(BlobType)},
+				MakeListType(MakeUnionType(NumberType, StringType, BlobType))},
+			// list<set<Bool>>|list<set<String>> -> list<set<Bool|String>>
+			{simplifyLists,
+				[]*Type{MakeListType(MakeListType(BoolType)), MakeListType(MakeListType(StringType))},
+				MakeListType(MakeListType(MakeUnionType(BoolType, StringType)))},
+			// list<set<Bool>|list<set<String>>|list<Number> -> list<set<Bool|String>|Number>
+			{simplifyLists,
+				[]*Type{MakeListType(MakeListType(BoolType)), MakeListType(MakeListType(StringType)), MakeListType(NumberType)},
+				MakeListType(MakeUnionType(MakeListType(MakeUnionType(BoolType, StringType)), NumberType))},
 
-		// map<Bool,bool> -> map<Bool,bool>
-		{simplifyMaps,
-			[]*Type{MakeMapType(BoolType, BoolType)},
-			MakeMapType(BoolType, BoolType)},
-		// map<Bool,bool>|map<Bool,string> -> map<Bool,bool|String>
-		{simplifyMaps,
-			[]*Type{MakeMapType(BoolType, BoolType), MakeMapType(BoolType, StringType)},
-			MakeMapType(BoolType, MakeUnionType(BoolType, StringType))},
-		// map<Bool,bool>|map<String,bool> -> map<Bool|String,bool>
-		{simplifyMaps,
-			[]*Type{MakeMapType(BoolType, BoolType), MakeMapType(StringType, BoolType)},
-			MakeMapType(MakeUnionType(BoolType, StringType), BoolType)},
-		// map<Bool,bool>|map<String,string> -> map<Bool|String,bool|String>
-		{simplifyMaps,
-			[]*Type{MakeMapType(BoolType, BoolType), MakeMapType(StringType, StringType)},
-			MakeMapType(MakeUnionType(BoolType, StringType), MakeUnionType(BoolType, StringType))},
-		// map<set<Bool>,bool>|map<set<String>,string> -> map<set<Bool|String>,bool|String>
-		{simplifyMaps,
-			[]*Type{MakeMapType(MakeSetType(BoolType), BoolType), MakeMapType(MakeSetType(StringType), StringType)},
-			MakeMapType(MakeSetType(MakeUnionType(BoolType, StringType)), MakeUnionType(BoolType, StringType))},
+			// map<Bool,bool> -> map<Bool,bool>
+			{simplifyMaps,
+				[]*Type{MakeMapType(BoolType, BoolType)},
+				MakeMapType(BoolType, BoolType)},
+			// map<Bool,bool>|map<Bool,string> -> map<Bool,bool|String>
+			{simplifyMaps,
+				[]*Type{MakeMapType(BoolType, BoolType), MakeMapType(BoolType, StringType)},
+				MakeMapType(BoolType, MakeUnionType(BoolType, StringType))},
+			// map<Bool,bool>|map<String,bool> -> map<Bool|String,bool>
+			{simplifyMaps,
+				[]*Type{MakeMapType(BoolType, BoolType), MakeMapType(StringType, BoolType)},
+				MakeMapType(MakeUnionType(BoolType, StringType), BoolType)},
+			// map<Bool,bool>|map<String,string> -> map<Bool|String,bool|String>
+			{simplifyMaps,
+				[]*Type{MakeMapType(BoolType, BoolType), MakeMapType(StringType, StringType)},
+				MakeMapType(MakeUnionType(BoolType, StringType), MakeUnionType(BoolType, StringType))},
+			// map<set<Bool>,bool>|map<set<String>,string> -> map<set<Bool|String>,bool|String>
+			{simplifyMaps,
+				[]*Type{MakeMapType(MakeSetType(BoolType), BoolType), MakeMapType(MakeSetType(StringType), StringType)},
+				MakeMapType(MakeSetType(MakeUnionType(BoolType, StringType)), MakeUnionType(BoolType, StringType))},
 
-		// struct{foo:Bool} -> struct{foo:Bool}
-		{structSimplifier(""),
-			[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType})},
-			MakeStructTypeFromFields("", FieldMap{"foo": BoolType})},
-		// struct{foo:Bool}|struct{foo:Number} -> struct{foo:Bool|Number}
-		{structSimplifier(""),
-			[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType}),
-				MakeStructTypeFromFields("", FieldMap{"foo": StringType})},
-			MakeStructTypeFromFields("", FieldMap{"foo": MakeUnionType(BoolType, StringType)})},
-		// struct{foo:Bool}|struct{foo:Bool,bar:Number} -> struct{foo:Bool,bar?:Number}
-		{structSimplifier(""),
-			[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType}),
-				MakeStructTypeFromFields("", FieldMap{"foo": BoolType, "bar": NumberType})},
-			MakeStructType2("",
-				StructField{"bar", NumberType, true},
-				StructField{"foo", BoolType, false},
-			)},
-		// struct{foo:Bool}|struct{bar:Number} -> struct{foo?:Bool,bar?:Number}
-		{structSimplifier(""),
-			[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType}),
-				MakeStructTypeFromFields("", FieldMap{"bar": NumberType})},
-			MakeStructType2("",
-				StructField{"bar", NumberType, true},
-				StructField{"foo", BoolType, true},
-			)},
-		// struct{foo:Ref<Bool>}|struct{foo:Ref<Number>} -> struct{foo:Ref<Bool|Number>}
-		{structSimplifier(""),
-			[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": MakeRefType(BoolType)}),
-				MakeStructTypeFromFields("", FieldMap{"foo": MakeRefType(NumberType)})},
-			MakeStructTypeFromFields("", FieldMap{"foo": MakeRefType(MakeUnionType(BoolType, NumberType))})},
+			// struct{foo:Bool} -> struct{foo:Bool}
+			{structSimplifier(""),
+				[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType})},
+				MakeStructTypeFromFields("", FieldMap{"foo": BoolType})},
+			// struct{foo:Bool}|struct{foo:Number} -> struct{foo:Bool|Number}
+			{structSimplifier(""),
+				[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType}),
+					MakeStructTypeFromFields("", FieldMap{"foo": StringType})},
+				MakeStructTypeFromFields("", FieldMap{"foo": MakeUnionType(BoolType, StringType)})},
+			// struct{foo:Bool}|struct{foo:Bool,bar:Number} -> struct{foo:Bool,bar?:Number}
+			{structSimplifier(""),
+				[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType}),
+					MakeStructTypeFromFields("", FieldMap{"foo": BoolType, "bar": NumberType})},
+				MakeStructType2("",
+					StructField{"bar", NumberType, !intersectStruct},
+					StructField{"foo", BoolType, false},
+				)},
+			// struct{foo:Bool}|struct{bar:Number} -> struct{foo?:Bool,bar?:Number}
+			{structSimplifier(""),
+				[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": BoolType}),
+					MakeStructTypeFromFields("", FieldMap{"bar": NumberType})},
+				MakeStructType2("",
+					StructField{"bar", NumberType, !intersectStruct},
+					StructField{"foo", BoolType, !intersectStruct},
+				)},
+			// struct{foo:Ref<Bool>}|struct{foo:Ref<Number>} -> struct{foo:Ref<Bool|Number>}
+			{structSimplifier(""),
+				[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": MakeRefType(BoolType)}),
+					MakeStructTypeFromFields("", FieldMap{"foo": MakeRefType(NumberType)})},
+				MakeStructTypeFromFields("", FieldMap{"foo": MakeRefType(MakeUnionType(BoolType, NumberType))})},
 
-		// struct A{foo:Bool}|struct A{foo:String} -> struct A{foo:Bool|String}
-		{structSimplifier("A"),
-			[]*Type{MakeStructTypeFromFields("A", FieldMap{"foo": BoolType}),
-				MakeStructTypeFromFields("A", FieldMap{"foo": StringType})},
-			MakeStructTypeFromFields("A", FieldMap{"foo": MakeUnionType(BoolType, StringType)})},
+			// struct A{foo:Bool}|struct A{foo:String} -> struct A{foo:Bool|String}
+			{structSimplifier("A"),
+				[]*Type{MakeStructTypeFromFields("A", FieldMap{"foo": BoolType}),
+					MakeStructTypeFromFields("A", FieldMap{"foo": StringType})},
+				MakeStructTypeFromFields("A", FieldMap{"foo": MakeUnionType(BoolType, StringType)})},
 
-		// map<String, struct A{foo:String}>,  map<String, struct A{foo:String, bar:Bool}>
-		// 	-> map<String, struct A{foo:String,bar?:Bool}>
-		{simplifyMaps,
-			[]*Type{MakeMapType(StringType, MakeStructTypeFromFields("A", FieldMap{"foo": StringType})),
-				MakeMapType(StringType, MakeStructTypeFromFields("A", FieldMap{"foo": StringType, "bar": BoolType})),
-			},
-			MakeMapType(StringType, MakeStructType2("A",
-				StructField{"foo", StringType, false},
-				StructField{"bar", BoolType, true},
-			))},
-	}
+			// map<String, struct A{foo:String}>,  map<String, struct A{foo:String, bar:Bool}>
+			// 	-> map<String, struct A{foo:String,bar?:Bool}>
+			{simplifyMaps,
+				[]*Type{MakeMapType(StringType, MakeStructTypeFromFields("A", FieldMap{"foo": StringType})),
+					MakeMapType(StringType, MakeStructTypeFromFields("A", FieldMap{"foo": StringType, "bar": BoolType})),
+				},
+				MakeMapType(StringType, MakeStructType2("A",
+					StructField{"foo", StringType, false},
+					StructField{"bar", BoolType, !intersectStruct},
+				))},
+		}
 
-	for i, c := range cases {
-		act := c.f(newTypeset(c.in...))
-		assert.True(t, c.out.Equals(act), "Test case as position %d - got %s, wanted %s", i, act.Describe(), c.out.Describe())
+		for i, c := range cases {
+			act := c.f(newTypeset(c.in...), intersectStruct)
+			assert.True(t, c.out.Equals(act), "Test case as position %d - got %s, wanted %s", i, act.Describe(), c.out.Describe())
+		}
 	}
 }
 
@@ -161,94 +163,97 @@ func TestMakeSimplifiedUnion(t *testing.T) {
 	cycleType = ToUnresolvedType(cycleType)
 	cycleType = resolveStructCycles(cycleType, nil)
 
-	cases := []struct {
-		in  []*Type
-		out *Type
-	}{
-		// {} -> <empty-union>
-		{[]*Type{},
-			MakeUnionType()},
-		// {bool} -> bool
-		{[]*Type{BoolType},
-			BoolType},
-		// {bool,bool} -> bool
-		{[]*Type{BoolType, BoolType},
-			BoolType},
-		// {bool,Number} -> bool|Number
-		{[]*Type{BoolType, NumberType},
-			MakeUnionType(BoolType, NumberType)},
-		// {bool,Number|(string|blob|Number)} -> bool|Number|String|blob
-		{[]*Type{BoolType, MakeUnionType(NumberType, MakeUnionType(StringType, BlobType, NumberType))},
-			MakeUnionType(BoolType, NumberType, StringType, BlobType)},
+	for _, intersectStruct := range []bool{false, true} {
 
-		// {Ref<Number>} -> Ref<Number>
-		{[]*Type{MakeRefType(NumberType)},
-			MakeRefType(NumberType)},
-		// {Ref<Number>,Ref<String>} -> Ref<Number|String>
-		{[]*Type{MakeRefType(NumberType), MakeRefType(StringType)},
-			MakeRefType(MakeUnionType(NumberType, StringType))},
+		cases := []struct {
+			in  []*Type
+			out *Type
+		}{
+			// {} -> <empty-union>
+			{[]*Type{},
+				MakeUnionType()},
+			// {bool} -> bool
+			{[]*Type{BoolType},
+				BoolType},
+			// {bool,bool} -> bool
+			{[]*Type{BoolType, BoolType},
+				BoolType},
+			// {bool,Number} -> bool|Number
+			{[]*Type{BoolType, NumberType},
+				MakeUnionType(BoolType, NumberType)},
+			// {bool,Number|(string|blob|Number)} -> bool|Number|String|blob
+			{[]*Type{BoolType, MakeUnionType(NumberType, MakeUnionType(StringType, BlobType, NumberType))},
+				MakeUnionType(BoolType, NumberType, StringType, BlobType)},
 
-		// {set<Number>} -> set<Number>
-		{[]*Type{MakeSetType(NumberType)},
-			MakeSetType(NumberType)},
-		// {set<Number>,set<String>} -> set<Number|String>
-		{[]*Type{MakeSetType(NumberType), MakeSetType(StringType)},
-			MakeSetType(MakeUnionType(NumberType, StringType))},
+			// {Ref<Number>} -> Ref<Number>
+			{[]*Type{MakeRefType(NumberType)},
+				MakeRefType(NumberType)},
+			// {Ref<Number>,Ref<String>} -> Ref<Number|String>
+			{[]*Type{MakeRefType(NumberType), MakeRefType(StringType)},
+				MakeRefType(MakeUnionType(NumberType, StringType))},
 
-		// {list<Number>} -> list<Number>
-		{[]*Type{MakeListType(NumberType)},
-			MakeListType(NumberType)},
-		// {list<Number>,list<String>} -> list<Number|String>
-		{[]*Type{MakeListType(NumberType), MakeListType(StringType)},
-			MakeListType(MakeUnionType(NumberType, StringType))},
+			// {set<Number>} -> set<Number>
+			{[]*Type{MakeSetType(NumberType)},
+				MakeSetType(NumberType)},
+			// {set<Number>,set<String>} -> set<Number|String>
+			{[]*Type{MakeSetType(NumberType), MakeSetType(StringType)},
+				MakeSetType(MakeUnionType(NumberType, StringType))},
 
-		// {map<Number,Number>} -> map<Number,Number>
-		{[]*Type{MakeMapType(NumberType, NumberType)},
-			MakeMapType(NumberType, NumberType)},
-		// {map<Number,Number>,map<String,string>} -> map<Number|String,Number|String>
-		{[]*Type{MakeMapType(NumberType, NumberType), MakeMapType(StringType, StringType)},
-			MakeMapType(MakeUnionType(NumberType, StringType), MakeUnionType(NumberType, StringType))},
+			// {list<Number>} -> list<Number>
+			{[]*Type{MakeListType(NumberType)},
+				MakeListType(NumberType)},
+			// {list<Number>,list<String>} -> list<Number|String>
+			{[]*Type{MakeListType(NumberType), MakeListType(StringType)},
+				MakeListType(MakeUnionType(NumberType, StringType))},
 
-		// {struct{foo:Number}} -> struct{foo:Number}
-		{[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": NumberType})},
-			MakeStructTypeFromFields("", FieldMap{"foo": NumberType})},
-		// {struct{foo:Number}, struct{foo:String}} -> struct{foo:Number|String}
-		{[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": NumberType}),
-			MakeStructTypeFromFields("", FieldMap{"foo": StringType})},
-			MakeStructTypeFromFields("", FieldMap{"foo": MakeUnionType(NumberType, StringType)})},
+			// {map<Number,Number>} -> map<Number,Number>
+			{[]*Type{MakeMapType(NumberType, NumberType)},
+				MakeMapType(NumberType, NumberType)},
+			// {map<Number,Number>,map<String,string>} -> map<Number|String,Number|String>
+			{[]*Type{MakeMapType(NumberType, NumberType), MakeMapType(StringType, StringType)},
+				MakeMapType(MakeUnionType(NumberType, StringType), MakeUnionType(NumberType, StringType))},
 
-		// {Bool,String,Ref<Bool>,Ref<String>,Ref<Set<String>>,Ref<Set<Bool>>,
-		//    struct{foo:Number},struct{bar:String},struct A{foo:Number}} ->
-		// Bool|String|Ref<Bool|String|Set<String|Bool>>|struct{foo?:Number,bar?:String}|struct A{foo:Number}
-		{
-			[]*Type{
-				BoolType, StringType,
-				MakeRefType(BoolType), MakeRefType(StringType),
-				MakeRefType(MakeSetType(BoolType)), MakeRefType(MakeSetType(StringType)),
-				MakeStructTypeFromFields("", FieldMap{"foo": NumberType}),
-				MakeStructTypeFromFields("", FieldMap{"bar": StringType}),
-				MakeStructTypeFromFields("A", FieldMap{"foo": StringType}),
-			},
-			MakeUnionType(
-				BoolType, StringType,
-				MakeRefType(MakeUnionType(BoolType, StringType,
-					MakeSetType(MakeUnionType(BoolType, StringType)))),
-				MakeStructType2("",
-					StructField{"foo", NumberType, true},
-					StructField{"bar", StringType, true},
+			// {struct{foo:Number}} -> struct{foo:Number}
+			{[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": NumberType})},
+				MakeStructTypeFromFields("", FieldMap{"foo": NumberType})},
+			// {struct{foo:Number}, struct{foo:String}} -> struct{foo:Number|String}
+			{[]*Type{MakeStructTypeFromFields("", FieldMap{"foo": NumberType}),
+				MakeStructTypeFromFields("", FieldMap{"foo": StringType})},
+				MakeStructTypeFromFields("", FieldMap{"foo": MakeUnionType(NumberType, StringType)})},
+
+			// {Bool,String,Ref<Bool>,Ref<String>,Ref<Set<String>>,Ref<Set<Bool>>,
+			//    struct{foo:Number},struct{bar:String},struct A{foo:Number}} ->
+			// Bool|String|Ref<Bool|String|Set<String|Bool>>|struct{foo?:Number,bar?:String}|struct A{foo:Number}
+			{
+				[]*Type{
+					BoolType, StringType,
+					MakeRefType(BoolType), MakeRefType(StringType),
+					MakeRefType(MakeSetType(BoolType)), MakeRefType(MakeSetType(StringType)),
+					MakeStructTypeFromFields("", FieldMap{"foo": NumberType}),
+					MakeStructTypeFromFields("", FieldMap{"bar": StringType}),
+					MakeStructTypeFromFields("A", FieldMap{"foo": StringType}),
+				},
+				MakeUnionType(
+					BoolType, StringType,
+					MakeRefType(MakeUnionType(BoolType, StringType,
+						MakeSetType(MakeUnionType(BoolType, StringType)))),
+					MakeStructType2("",
+						StructField{"foo", NumberType, !intersectStruct},
+						StructField{"bar", StringType, !intersectStruct},
+					),
+					MakeStructTypeFromFields("A", FieldMap{"foo": StringType}),
 				),
-				MakeStructTypeFromFields("A", FieldMap{"foo": StringType}),
-			),
-		},
+			},
 
-		{[]*Type{cycleType}, cycleType},
+			{[]*Type{cycleType}, cycleType},
 
-		{[]*Type{cycleType, NumberType, StringType},
-			MakeUnionType(cycleType, NumberType, StringType)},
-	}
+			{[]*Type{cycleType, NumberType, StringType},
+				MakeUnionType(cycleType, NumberType, StringType)},
+		}
 
-	for i, c := range cases {
-		act := makeSimplifiedType(c.in...)
-		assert.True(t, c.out.Equals(act), "Test case as position %d - got %s, expected %s", i, act.Describe(), c.out.Describe())
+		for i, c := range cases {
+			act := makeSimplifiedType(intersectStruct, c.in...)
+			assert.True(t, c.out.Equals(act), "Test case as position %d - got %s, expected %s", i, act.Describe(), c.out.Describe())
+		}
 	}
 }

--- a/go/types/type_cache.go
+++ b/go/types/type_cache.go
@@ -426,7 +426,15 @@ func MakeStructType2(name string, fields ...StructField) *Type {
 }
 
 func MakeUnionType(elemTypes ...*Type) *Type {
-	return makeSimplifiedType(elemTypes...)
+	return makeSimplifiedType(false, elemTypes...)
+}
+
+// MakeUnionTypeIntersectStructs is a bit of strange function. It creates a
+// simplified union type except for structs, where it creates interesection
+// types.
+// This function will go away so do not use it!
+func MakeUnionTypeIntersectStructs(elemTypes ...*Type) *Type {
+	return makeSimplifiedType(true, elemTypes...)
 }
 
 func MakeCycleType(level uint32) *Type {


### PR DESCRIPTION
This is needed by attic and it uses internal APIs so it has to be
exported 😢

A better path forward would be to fully implement intersection types
but that is a large change for an edge case feature.