### PR TITLE
Make sure we flatten unions before calling simplify types

### DIFF
--- a/go/types/simplify_test.go
+++ b/go/types/simplify_test.go
@@ -16,13 +16,13 @@ import (
 //   - test cycles
 
 func simplifyRefs(ts typeset, intersectStructs bool) *Type {
-	return staticTypeCache.simplifyRefs(ts, intersectStructs)
+	return staticTypeCache.simplifyContainers(RefKind, ts, intersectStructs)
 }
 func simplifySets(ts typeset, intersectStructs bool) *Type {
-	return staticTypeCache.simplifySets(ts, intersectStructs)
+	return staticTypeCache.simplifyContainers(SetKind, ts, intersectStructs)
 }
 func simplifyLists(ts typeset, intersectStructs bool) *Type {
-	return staticTypeCache.simplifyLists(ts, intersectStructs)
+	return staticTypeCache.simplifyContainers(ListKind, ts, intersectStructs)
 }
 
 func simplifyMaps(ts typeset, intersectStructs bool) *Type {

--- a/go/types/simplify_test.go
+++ b/go/types/simplify_test.go
@@ -15,10 +15,24 @@ import (
 //   - test grouping of the various kinds
 //   - test cycles
 
+func simplifyRefs(ts typeset, intersectStructs bool) *Type {
+	return staticTypeCache.simplifyRefs(ts, intersectStructs)
+}
+func simplifySets(ts typeset, intersectStructs bool) *Type {
+	return staticTypeCache.simplifySets(ts, intersectStructs)
+}
+func simplifyLists(ts typeset, intersectStructs bool) *Type {
+	return staticTypeCache.simplifyLists(ts, intersectStructs)
+}
+
+func simplifyMaps(ts typeset, intersectStructs bool) *Type {
+	return staticTypeCache.simplifyMaps(ts, intersectStructs)
+}
+
 func TestSimplifyHelpers(t *testing.T) {
 	structSimplifier := func(n string) func(typeset, bool) *Type {
 		return func(ts typeset, intersectStructs bool) *Type {
-			return simplifyStructs(n, ts, intersectStructs)
+			return staticTypeCache.simplifyStructs(n, ts, intersectStructs)
 		}
 	}
 
@@ -252,7 +266,7 @@ func TestMakeSimplifiedUnion(t *testing.T) {
 		}
 
 		for i, c := range cases {
-			act := makeSimplifiedType(intersectStruct, c.in...)
+			act := staticTypeCache.makeSimplifiedType(intersectStruct, c.in...)
 			assert.True(t, c.out.Equals(act), "Test case as position %d - got %s, expected %s", i, act.Describe(), c.out.Describe())
 		}
 	}

--- a/go/types/type_cache.go
+++ b/go/types/type_cache.go
@@ -307,17 +307,10 @@ func checkForUnresolvedCycles(t, root *Type, parentStructTypes []*Type) {
 	}
 }
 
-// // MakeUnionType creates a new union type unless the elemTypes can be folded into a single non union type.
-// func (tc *TypeCache) makeUnionType(elemTypes ...*Type) *Type {
-// 	seenTypes := map[hash.Hash]bool{}
-// 	ts := flattenUnionTypes(typeSlice(elemTypes), &seenTypes)
-// 	if len(ts) == 1 {
-// 		return ts[0]
-// 	}
-// 	// We sort the contituent types to dedup equivalent types in memory; we may need to sort again after cycles are resolved for final encoding.
-// 	sort.Sort(ts)
-// 	return tc.getCompoundType(UnionKind, ts...)
-// }
+// MakeUnionType creates a new union type unless the elemTypes can be folded into a single non union type.
+func (tc *TypeCache) makeUnionType(elemTypes ...*Type) *Type {
+	return tc.makeSimplifiedType(false, elemTypes...)
+}
 
 func (tc *TypeCache) getCycleType(level uint32) *Type {
 	trie := tc.trieRoots[CycleKind].Traverse(level)
@@ -390,7 +383,9 @@ func MakeStructType(name string, fields ...StructField) *Type {
 }
 
 func MakeUnionType(elemTypes ...*Type) *Type {
-	return makeSimplifiedType(false, elemTypes...)
+	// staticTypeCache.Lock()
+	// defer staticTypeCache.Unlock()
+	return staticTypeCache.makeUnionType(elemTypes...)
 }
 
 // MakeUnionTypeIntersectStructs is a bit of strange function. It creates a
@@ -398,7 +393,9 @@ func MakeUnionType(elemTypes ...*Type) *Type {
 // types.
 // This function will go away so do not use it!
 func MakeUnionTypeIntersectStructs(elemTypes ...*Type) *Type {
-	return makeSimplifiedType(true, elemTypes...)
+	// staticTypeCache.Lock()
+	// defer staticTypeCache.Unlock()
+	return staticTypeCache.makeSimplifiedType(true, elemTypes...)
 }
 
 func MakeCycleType(level uint32) *Type {

--- a/go/types/type_cache.go
+++ b/go/types/type_cache.go
@@ -309,26 +309,6 @@ func checkForUnresolvedCycles(t, root *Type, parentStructTypes []*Type) {
 	}
 }
 
-// MakeUnionType creates a new union type unless the elemTypes can be folded into a single non union type.
-func (tc *TypeCache) makeUnionType(elemTypes ...*Type) *Type {
-	seenTypes := map[hash.Hash]bool{}
-	ts := flattenUnionTypes(typeSlice(elemTypes), &seenTypes)
-	if len(ts) == 1 {
-		return ts[0]
-	}
-	// We sort the contituent types to dedup equivalent types in memory; we may need to sort again after cycles are resolved for final encoding.
-	sort.Sort(ts)
-
-	// TODO: Remove this when we havew found the invalid caller.
-	for i := 1; i < len(ts); i++ {
-		if !unionLess(ts[i-1], ts[i]) {
-			panic("Invalid union order")
-		}
-	}
-
-	return tc.getCompoundType(UnionKind, ts...)
-}
-
 func (tc *TypeCache) getCycleType(level uint32) *Type {
 	trie := tc.trieRoots[CycleKind].Traverse(level)
 

--- a/go/types/type_cache.go
+++ b/go/types/type_cache.go
@@ -373,18 +373,16 @@ func (s structFields) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s structFields) Less(i, j int) bool { return s[i].Name < s[j].Name }
 
 func MakeStructType(name string, fields ...StructField) *Type {
-	staticTypeCache.Lock()
-	defer staticTypeCache.Unlock()
-
 	fs := structFields(fields)
 	sort.Sort(&fs)
+
+	staticTypeCache.Lock()
+	defer staticTypeCache.Unlock()
 
 	return staticTypeCache.makeStructType(name, fs)
 }
 
 func MakeUnionType(elemTypes ...*Type) *Type {
-	// staticTypeCache.Lock()
-	// defer staticTypeCache.Unlock()
 	return staticTypeCache.makeUnionType(elemTypes...)
 }
 
@@ -393,8 +391,6 @@ func MakeUnionType(elemTypes ...*Type) *Type {
 // types.
 // This function will go away so do not use it!
 func MakeUnionTypeIntersectStructs(elemTypes ...*Type) *Type {
-	// staticTypeCache.Lock()
-	// defer staticTypeCache.Unlock()
 	return staticTypeCache.makeSimplifiedType(true, elemTypes...)
 }
 

--- a/go/types/type_cache.go
+++ b/go/types/type_cache.go
@@ -318,6 +318,14 @@ func (tc *TypeCache) makeUnionType(elemTypes ...*Type) *Type {
 	}
 	// We sort the contituent types to dedup equivalent types in memory; we may need to sort again after cycles are resolved for final encoding.
 	sort.Sort(ts)
+
+	// TODO: Remove this when we havew found the invalid caller.
+	for i := 1; i < len(ts); i++ {
+		if !unionLess(ts[i-1], ts[i]) {
+			panic("Invalid union order")
+		}
+	}
+
 	return tc.getCompoundType(UnionKind, ts...)
 }
 


### PR DESCRIPTION
We ran into an issue where we passed non flatten types to simplify types
which lead to us having two `struct Commit` in a union.