### PR TITLE
Fix union ordering between two cycle types

### DIFF
--- a/go/types/type_cache_test.go
+++ b/go/types/type_cache_test.go
@@ -245,3 +245,15 @@ func TestMakeUnionTypeStruct(t *testing.T) {
 	assert.True(expected.Desc.(StructDesc).fields[0].Optional)
 	assert.True(expected.Equals(actual), "Expected %s to equal %s", expected.Describe(), actual.Describe())
 }
+
+func TestUnionWithCycles(t *testing.T) {
+	assert := assert.New(t)
+	t1 := MakeUnionType(MakeCycleType(0), MakeCycleType(1))
+	t2 := MakeUnionType(MakeCycleType(1), MakeCycleType(0))
+	assert.True(t1.Equals(t2))
+	assert.Equal(t1, t2)
+
+	t3 := MakeUnionType(MakeCycleType(1), MakeCycleType(0), MakeCycleType(0))
+	assert.True(t1.Equals(t3))
+	assert.Equal(t1, t3)
+}

--- a/go/types/type_desc.go
+++ b/go/types/type_desc.go
@@ -145,6 +145,9 @@ func unionLess(ti, tj *Type) bool {
 			// Due to type simplification, the only thing that matters is the name of the struct.
 			return ti.Desc.(StructDesc).Name < tj.Desc.(StructDesc).Name
 		}
+		if ki == CycleKind {
+			return ti.Desc.(CycleDesc) < tj.Desc.(CycleDesc)
+		}
 
 		return false
 	}

--- a/go/types/type_desc.go
+++ b/go/types/type_desc.go
@@ -4,7 +4,9 @@
 
 package types
 
-import "sort"
+import (
+	"sort"
+)
 
 // TypeDesc describes a type of the kind returned by Kind(), e.g. Map, Number, or a custom type.
 type TypeDesc interface {
@@ -134,22 +136,24 @@ func (ts typeSlice) Less(i, j int) bool {
 
 func (ts typeSlice) Swap(i, j int) { ts[i], ts[j] = ts[j], ts[i] }
 
+// unionLess is used for sorting union types in a predictable order as well as
+// validating the order when reading union types from a chunk.
 func unionLess(ti, tj *Type) bool {
-	if ti == tj {
-		return false
+	if ti.Equals(tj) {
+		panic("unreachable") // unions must not contain the same type twice.
 	}
 
 	ki, kj := ti.Kind(), tj.Kind()
 	if ki == kj {
-		if ki == StructKind {
+		switch ki {
+		case StructKind:
 			// Due to type simplification, the only thing that matters is the name of the struct.
 			return ti.Desc.(StructDesc).Name < tj.Desc.(StructDesc).Name
-		}
-		if ki == CycleKind {
+		case CycleKind:
 			return ti.Desc.(CycleDesc) < tj.Desc.(CycleDesc)
+		default:
+			panic("unreachable") // We should have folded all other types into one.
 		}
-
-		return false
 	}
 	return ki < kj
 }

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -141,7 +141,7 @@ func TestVerifyStructName(t *testing.T) {
 	assertValid("a0_")
 }
 
-func TestUnionWithCycles(tt *testing.T) {
+func TestStructUnionWithCycles(tt *testing.T) {
 	inodeType := MakeStructTypeFromFields("Inode", FieldMap{
 		"attr": MakeStructTypeFromFields("Attr", FieldMap{
 			"ctime": NumberType,


### PR DESCRIPTION
We were not enforcing the order between two cycle types. In other words
the following two should be equal:

```
Cycle<0> | Cycle<1> = Cycle<1> | Cycle<0>
```