### PR TITLE
Remove types.Value Type() in favor of types.TypeOf()

### DIFF
--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -85,7 +85,7 @@ func runLog(args []string) int {
 	}
 
 	origCommit, ok := database.ReadValue(absPath.Hash).(types.Struct)
-	if !ok || !datas.IsCommitType(origCommit.Type()) {
+	if !ok || !datas.IsCommitType(types.TypeOf(origCommit)) {
 		d.CheckError(fmt.Errorf("%s does not reference a Commit object", args[0]))
 	}
 
@@ -139,7 +139,7 @@ func printCommit(node LogNode, path types.Path, w io.Writer, db datas.Database) 
 		maxLen := 0
 		if m, ok := commit.MaybeGet(datas.MetaField); ok {
 			meta := m.(types.Struct)
-			meta.Type().Desc.(types.StructDesc).IterFields(func(name string, t *types.Type, optional bool) {
+			types.TypeOf(meta).Desc.(types.StructDesc).IterFields(func(name string, t *types.Type, optional bool) {
 				maxLen = max(maxLen, len(name))
 			})
 		}
@@ -257,7 +257,7 @@ func writeMetaLines(node LogNode, maxLines, lineno, maxLabelLen int, w io.Writer
 		mlw := &writers.MaxLineWriter{Dest: w, MaxLines: uint32(maxLines), NumLines: uint32(lineno)}
 		pw := &writers.PrefixWriter{Dest: mlw, PrefixFunc: genPrefix, NeedsPrefix: true, NumLines: uint32(lineno)}
 		err := d.Try(func() {
-			meta.Type().Desc.(types.StructDesc).IterFields(func(fieldName string, t *types.Type, optional bool) {
+			types.TypeOf(meta).Desc.(types.StructDesc).IterFields(func(fieldName string, t *types.Type, optional bool) {
 				v := meta.Get(fieldName)
 				fmt.Fprintf(pw, "%-*s", maxLabelLen+2, strings.Title(fieldName)+":")
 				types.WriteEncodedValue(pw, v)

--- a/cmd/noms/noms_merge.go
+++ b/cmd/noms/noms_merge.go
@@ -108,7 +108,7 @@ func getCommonAncestor(r1, r2 types.Ref, vr types.ValueReader) (a types.Struct, 
 	if v == nil {
 		panic(aRef.TargetHash().String() + " not found")
 	}
-	if !datas.IsCommitType(v.Type()) {
+	if !datas.IsCommitType(types.TypeOf(v)) {
 		panic("Not a commit: " + types.EncodedValueMaxLines(v, 10) + "  ...")
 	}
 	return v.(types.Struct), true

--- a/cmd/noms/noms_migrate.go
+++ b/cmd/noms/noms_migrate.go
@@ -48,7 +48,7 @@ func runMigrate(args []string) int {
 		d.CheckErrorNoUsage(fmt.Errorf("Value not found: %s", args[0]))
 	}
 
-	isCommit := v7datas.IsCommitType(sourceValue.Type())
+	isCommit := v7datas.IsCommitType(v7types.TypeOf(sourceValue))
 
 	vNewDataset, err := spec.ForDataset(args[1])
 	d.CheckError(err)

--- a/cmd/noms/noms_root.go
+++ b/cmd/noms/noms_root.go
@@ -97,13 +97,13 @@ Continue?
 
 func validate(r types.Value) bool {
 	rootType := types.MakeMapType(types.StringType, types.MakeRefType(types.ValueType))
-	if !types.IsSubtype(rootType, r.Type()) {
-		fmt.Fprintf(os.Stderr, "Root of database must be %s, but you specified: %s\n", rootType.Describe(), r.Type().Describe())
+	if !types.IsSubtype(rootType, types.TypeOf(r)) {
+		fmt.Fprintf(os.Stderr, "Root of database must be %s, but you specified: %s\n", rootType.Describe(), types.TypeOf(r).Describe())
 		return false
 	}
 
 	return r.(types.Map).Any(func(k, v types.Value) bool {
-		if !datas.IsRefOfCommitType(v.Type()) {
+		if !datas.IsRefOfCommitType(types.TypeOf(v)) {
 			fmt.Fprintf(os.Stderr, "Invalid root map. Value for key '%s' is not a ref of commit.", string(k.(types.String)))
 			return false
 		}

--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -52,7 +52,7 @@ var valueCommitType = makeCommitType(types.ValueType, nil, types.EmptyStructType
 //
 // The new type gets combined as a union type for the value/meta of the inner commit struct.
 func NewCommit(value types.Value, parents types.Set, meta types.Struct) types.Struct {
-	t := makeCommitType(value.Type(), valueTypesFromParents(parents, ValueField), meta.Type(), valueTypesFromParents(parents, MetaField))
+	t := makeCommitType(types.TypeOf(value), valueTypesFromParents(parents, ValueField), types.TypeOf(meta), valueTypesFromParents(parents, MetaField))
 	return types.NewStructWithType(t, types.ValueSlice{meta, parents, value})
 }
 
@@ -60,11 +60,11 @@ func NewCommit(value types.Value, parents types.Set, meta types.Struct) types.St
 // one exists, setting ok to true. If there is no common ancestor, ok is set
 // to false.
 func FindCommonAncestor(c1, c2 types.Ref, vr types.ValueReader) (a types.Ref, ok bool) {
-	if !IsRefOfCommitType(c1.Type()) {
-		d.Panic("FindCommonAncestor() called on %s", c1.Type().Describe())
+	if !IsRefOfCommitType(types.TypeOf(c1)) {
+		d.Panic("FindCommonAncestor() called on %s", types.TypeOf(c1).Describe())
 	}
-	if !IsRefOfCommitType(c2.Type()) {
-		d.Panic("FindCommonAncestor() called on %s", c2.Type().Describe())
+	if !IsRefOfCommitType(types.TypeOf(c2)) {
+		d.Panic("FindCommonAncestor() called on %s", types.TypeOf(c2).Describe())
 	}
 
 	c1Q, c2Q := &types.RefByHeight{c1}, &types.RefByHeight{c2}
@@ -164,7 +164,7 @@ func makeCommitType(valueType *types.Type, parentsValueTypes []*types.Type, meta
 }
 
 func valueTypesFromParents(parents types.Set, fieldName string) []*types.Type {
-	elemType := getSetElementType(parents.Type())
+	elemType := getSetElementType(types.TypeOf(parents))
 	switch elemType.TargetKind() {
 	case types.UnionKind:
 		ts := []*types.Type{}

--- a/go/datas/commit_test.go
+++ b/go/datas/commit_test.go
@@ -22,7 +22,7 @@ func TestNewCommit(t *testing.T) {
 	}
 
 	commit := NewCommit(types.Number(1), types.NewSet(), types.EmptyStruct)
-	at := commit.Type()
+	at := types.TypeOf(commit)
 	et := makeCommitStructType(
 		types.EmptyStructType,
 		types.MakeSetType(types.MakeRefType(types.MakeCycleType(0))),
@@ -32,13 +32,13 @@ func TestNewCommit(t *testing.T) {
 
 	// Committing another Number
 	commit2 := NewCommit(types.Number(2), types.NewSet(types.NewRef(commit)), types.EmptyStruct)
-	at2 := commit2.Type()
+	at2 := types.TypeOf(commit2)
 	et2 := et
 	assertTypeEquals(et2, at2)
 
 	// Now commit a String
 	commit3 := NewCommit(types.String("Hi"), types.NewSet(types.NewRef(commit2)), types.EmptyStruct)
-	at3 := commit3.Type()
+	at3 := types.TypeOf(commit3)
 	et3 := makeCommitStructType(
 		types.EmptyStructType,
 		types.MakeSetType(types.MakeRefType(makeCommitStructType(
@@ -62,9 +62,9 @@ func TestNewCommit(t *testing.T) {
 			Type: types.NumberType,
 		},
 	)
-	assertTypeEquals(metaType, meta.Type())
+	assertTypeEquals(metaType, types.TypeOf(meta))
 	commit4 := NewCommit(types.String("Hi"), types.NewSet(types.NewRef(commit2)), meta)
-	at4 := commit4.Type()
+	at4 := types.TypeOf(commit4)
 	et4 := makeCommitStructType(
 		metaType,
 		types.MakeSetType(types.MakeRefType(makeCommitStructType(
@@ -78,7 +78,7 @@ func TestNewCommit(t *testing.T) {
 
 	// Merge-commit with different parent types
 	commit5 := NewCommit(types.String("Hi"), types.NewSet(types.NewRef(commit2), types.NewRef(commit3)), types.EmptyStruct)
-	at5 := commit5.Type()
+	at5 := types.TypeOf(commit5)
 	et5 := makeCommitStructType(
 		types.EmptyStructType,
 		types.MakeSetType(types.MakeRefType(makeCommitStructType(
@@ -98,13 +98,13 @@ func TestCommitWithoutMetaField(t *testing.T) {
 		"parents": types.NewSet(),
 		"meta":    types.EmptyStruct,
 	})
-	assert.True(IsCommitType(metaCommit.Type()))
+	assert.True(IsCommitType(types.TypeOf(metaCommit)))
 
 	noMetaCommit := types.NewStruct("Commit", types.StructData{
 		"value":   types.Number(9),
 		"parents": types.NewSet(),
 	})
-	assert.False(IsCommitType(noMetaCommit.Type()))
+	assert.False(IsCommitType(types.TypeOf(noMetaCommit)))
 }
 
 // Convert list of Struct's to Set<Ref>

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -536,7 +536,7 @@ func (suite *DatabaseSuite) TestDatabaseHeightOfCollections() {
 	everything := []types.Value{v1, v2, s1, s2, v3, v4, s3, l1, l2, s4, l3, l4, l5}
 	andMore := make([]types.Value, 0, len(everything)*3+2)
 	for _, v := range everything {
-		andMore = append(andMore, v, v.Type(), suite.db.WriteValue(v))
+		andMore = append(andMore, v, types.TypeOf(v), suite.db.WriteValue(v))
 	}
 	andMore = append(andMore, setOfStringType, setOfRefOfStringType)
 

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -286,7 +286,8 @@ func traverseSink(sinkRef types.Ref, db Database) traverseResult {
 }
 
 func traverseCommon(comRef, sinkHead types.Ref, db Database) traverseResult {
-	if comRef.Height() > 1 && IsRefOfCommitType(comRef.Type()) {
+	// TODO: Add IsRefOfCommit?
+	if comRef.Height() > 1 && IsRefOfCommitType(types.TypeOf(comRef)) {
 		commit := comRef.TargetValue(db).(types.Struct)
 		// We don't want to traverse the parents of sinkHead, but we still want to traverse its Value on the sinkDB side. We also still want to traverse all children, in both the srcDB and sinkDB, of any common Commit that is not at the Head of sinkDB.
 		exclusionSet := types.NewSet()

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -466,9 +466,10 @@ func assertMapOfStringToRefOfCommit(proposed, datasets types.Map, vr types.Value
 			val := proposed.Get(change.V)
 			ref, ok := val.(types.Ref)
 			if !ok {
-				d.Panic("Root of a Database must be a Map<String, Ref<Commit>>, but key %s maps to a %s", change.V.(types.String), val.Type().Describe())
+				d.Panic("Root of a Database must be a Map<String, Ref<Commit>>, but key %s maps to a %s", change.V.(types.String), types.TypeOf(val).Describe())
 			}
-			if targetType := ref.TargetValue(vr).Type(); !IsCommitType(targetType) {
+			// TODO: Add IsCommit
+			if targetType := types.TypeOf(ref.TargetValue(vr)); !IsCommitType(targetType) {
 				d.Panic("Root of a Database must be a Map<String, Ref<Commit>>, not the ref at key %s points to a %s", change.V.(types.String), targetType.Describe())
 			}
 		}

--- a/go/diff/summary.go
+++ b/go/diff/summary.go
@@ -15,7 +15,7 @@ import (
 
 // Summary prints a summary of the diff between two values to stdout.
 func Summary(value1, value2 types.Value) {
-	if datas.IsCommitType(value1.Type()) && datas.IsCommitType(value2.Type()) {
+	if datas.IsCommitType(types.TypeOf(value1)) && datas.IsCommitType(types.TypeOf(value2)) {
 		fmt.Println("Comparing commit values")
 		value1 = value1.(types.Struct).Get(datas.ValueField)
 		value2 = value2.(types.Struct).Get(datas.ValueField)
@@ -74,7 +74,7 @@ func diffSummary(ch chan diffSummaryProgress, v1, v2 types.Value) {
 			case types.StructKind:
 				diffSummaryStructs(ch, v1.(types.Struct), v2.(types.Struct))
 			default:
-				panic("Unrecognized type in diff function: " + v1.Type().Describe() + " and " + v2.Type().Describe())
+				panic("Unrecognized type in diff function: " + types.TypeOf(v1).Describe() + " and " + types.TypeOf(v2).Describe())
 			}
 		} else {
 			ch <- diffSummaryProgress{Adds: 1, Removes: 1, NewSize: 1, OldSize: 1}
@@ -115,8 +115,9 @@ func diffSummarySet(ch chan<- diffSummaryProgress, v1, v2 types.Set) {
 }
 
 func diffSummaryStructs(ch chan<- diffSummaryProgress, v1, v2 types.Struct) {
-	size1 := uint64(v1.Type().Desc.(types.StructDesc).Len())
-	size2 := uint64(v2.Type().Desc.(types.StructDesc).Len())
+	// TODO: Operate on values directly
+	size1 := uint64(types.TypeOf(v1).Desc.(types.StructDesc).Len())
+	size2 := uint64(types.TypeOf(v2).Desc.(types.StructDesc).Len())
 	diffSummaryValueChanged(ch, size1, size2, func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
 		v2.Diff(v1, changeChan, stopChan)
 	})

--- a/go/marshal/decode.go
+++ b/go/marshal/decode.go
@@ -144,7 +144,7 @@ func (e *UnmarshalTypeMismatchError) Error() string {
 	} else {
 		ts = e.Type.String()
 	}
-	return fmt.Sprintf("Cannot unmarshal %s into Go value of type %s%s", e.Value.Type().Describe(), ts, e.details)
+	return fmt.Sprintf("Cannot unmarshal %s into Go value of type %s%s", types.TypeOf(e.Value).Describe(), ts, e.details)
 }
 
 func overflowError(v types.Number, t reflect.Type) *UnmarshalTypeMismatchError {
@@ -532,7 +532,8 @@ func interfaceDecoder(t reflect.Type) decoderFunc {
 	}
 
 	return func(v types.Value, rv reflect.Value) {
-		t := getGoTypeForNomsType(v.Type(), rv.Type(), v)
+		// TODO: Go directly from value to go type
+		t := getGoTypeForNomsType(types.TypeOf(v), rv.Type(), v)
 		i := reflect.New(t).Elem()
 		typeDecoder(t, nomsTags{})(v, i)
 		rv.Set(i)

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -292,7 +292,7 @@ func structEncoder(t reflect.Type, parentStructTypes []reflect.Type) encoderFunc
 		e = func(v reflect.Value) types.Value {
 			fv := v.FieldByIndex(originalFieldIndex)
 			ret := fv.Interface().(types.Struct)
-			if ret.Type() == nil {
+			if ret.IsZeroValue() {
 				ret = types.NewStruct(t.Name(), nil)
 			}
 			for _, f := range fields {

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -477,7 +477,7 @@ func TestEncodeRecursive(t *testing.T) {
 			Type: types.NumberType,
 		},
 	)
-	assert.True(typ.Equals(v.Type()))
+	assert.True(typ.Equals(types.TypeOf(v)))
 
 	assert.True(types.NewStructWithType(typ, types.ValueSlice{
 		types.NewList(
@@ -707,7 +707,7 @@ func TestEncodeOriginal(t *testing.T) {
 	st2 := types.MakeStructTypeFromFields("S", types.FieldMap{
 		"foo": types.NumberType,
 	})
-	assert.True(out.Type().Equals(st2))
+	assert.True(types.TypeOf(out).Equals(st2))
 
 	// It's OK to have an empty original field
 	s = S{

--- a/go/merge/candidate.go
+++ b/go/merge/candidate.go
@@ -87,14 +87,14 @@ func (sc structCandidate) get(key types.Value) types.Value {
 		val, _ := sc.s.MaybeGet(string(field))
 		return val
 	}
-	panic(fmt.Errorf("Bad key type in diff: %s", key.Type().Describe()))
+	panic(fmt.Errorf("Bad key type in diff: %s", types.TypeOf(key).Describe()))
 }
 
 func (sc structCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
 	out = append(out, path...)
 	str, ok := change.V.(types.String)
 	if !ok {
-		d.Panic("Field names must be strings, not %s", change.V.Type().Describe())
+		d.Panic("Field names must be strings, not %s", types.TypeOf(change.V).Describe())
 	}
 	return append(out, types.NewFieldPath(string(str)))
 }

--- a/go/merge/three_way.go
+++ b/go/merge/three_way.go
@@ -136,7 +136,7 @@ func NewThreeWay(resolve ResolveFunc) Policy {
 func ThreeWay(a, b, parent types.Value, vrw types.ValueReadWriter, resolve ResolveFunc, progress chan struct{}) (merged types.Value, err error) {
 	describe := func(v types.Value) string {
 		if v != nil {
-			return v.Type().Describe()
+			return types.TypeOf(v).Describe()
 		}
 		return "nil Value"
 	}
@@ -215,9 +215,9 @@ func (m *merger) threeWay(a, b, parent types.Value, path types.Path) (merged typ
 
 	pDescription := "<nil>"
 	if parent != nil {
-		pDescription = parent.Type().Describe()
+		pDescription = types.TypeOf(parent).Describe()
 	}
-	return parent, newMergeConflict("Cannot merge %s and %s on top of %s.", a.Type().Describe(), b.Type().Describe(), pDescription)
+	return parent, newMergeConflict("Cannot merge %s and %s on top of %s.", types.TypeOf(a).Describe(), types.TypeOf(b).Describe(), pDescription)
 }
 
 func (m *merger) threeWayMapMerge(a, b, parent types.Map, path types.Path) (merged types.Value, err error) {
@@ -258,7 +258,7 @@ func (m *merger) threeWayStructMerge(a, b, parent types.Struct, path types.Path)
 		if f, ok := change.V.(types.String); ok {
 			field := string(f)
 			data := types.StructData{}
-			desc := targetVal.Type().Desc.(types.StructDesc)
+			desc := types.TypeOf(targetVal).Desc.(types.StructDesc)
 			desc.IterFields(func(name string, t *types.Type, optional bool) {
 				d.PanicIfTrue(optional) // values cannot have optional fields.
 				if name != field {
@@ -270,7 +270,7 @@ func (m *merger) threeWayStructMerge(a, b, parent types.Struct, path types.Path)
 			}
 			return structCandidate{types.NewStruct(desc.Name, data)}
 		}
-		panic(fmt.Errorf("Bad key type in diff: %s", change.V.Type().Describe()))
+		panic(fmt.Errorf("Bad key type in diff: %s", types.TypeOf(change.V).Describe()))
 	}
 	return m.threeWayOrderedSequenceMerge(structCandidate{a}, structCandidate{b}, structCandidate{parent}, apply, path)
 }
@@ -337,7 +337,7 @@ func structAssert(a, b, parent types.Value) (aStruct, bStruct, pStruct types.Str
 	aStruct, aOk = a.(types.Struct)
 	bStruct, bOk = b.(types.Struct)
 	if aOk && bOk {
-		aDesc, bDesc := a.Type().Desc.(types.StructDesc), b.Type().Desc.(types.StructDesc)
+		aDesc, bDesc := types.TypeOf(a).Desc.(types.StructDesc), types.TypeOf(b).Desc.(types.StructDesc)
 		if aDesc.Name == bDesc.Name {
 			if parent != nil {
 				pStruct, pOk = parent.(types.Struct)

--- a/go/migration/migrate.go
+++ b/go/migration/migrate.go
@@ -80,8 +80,9 @@ func MigrateFromVersion7(source v7types.Value, sourceStore v7types.ValueReadWrit
 		dest = <-sc
 		return
 	case v7types.Struct:
-		t := migrateType(source.Type())
-		sd := source.Type().Desc.(v7types.StructDesc)
+		sourceType := types.TypeOf(source)
+		t := migrateType(sourceType)
+		sd := sourceType.Desc.(v7types.StructDesc)
 		fields := make([]types.Value, 0, sd.Len())
 		sd.IterFields(func(name string, _ *v7types.Type, optional bool) {
 			d.PanicIfTrue(optional) // values cannot have optional fields

--- a/go/migration/migrate_test.go
+++ b/go/migration/migrate_test.go
@@ -107,7 +107,7 @@ func TestMigrateFromVersion7(t *testing.T) {
 	test(types.TypeType, v7types.TypeType)
 	test(types.ValueType, v7types.ValueType)
 	test(types.MakeListType(types.NumberType), v7types.MakeListType(types.NumberType))
-	test(types.MakeListType(types.NumberType).Type(), v7types.MakeListType(types.NumberType).Type())
+	test(types.TypeOf(types.MakeListType(types.NumberType)), v7types.TypeOf(v7types.MakeListType(types.NumberType)))
 
 	test(types.MakeListType(types.NumberType), v7types.MakeListType(v7types.NumberType))
 	test(types.MakeSetType(types.NumberType), v7types.MakeSetType(v7types.NumberType))

--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -44,7 +44,7 @@ func NewRootQueryObject(rootValue types.Value, tm *TypeMap) *graphql.Object {
 // NewRootQueryObject creates a "root" query object that can be used to
 // traverse the value tree of rootValue.
 func (tc *TypeConverter) NewRootQueryObject(rootValue types.Value) *graphql.Object {
-	rootNomsType := rootValue.Type()
+	rootNomsType := types.TypeOf(rootValue)
 	rootType := tc.NomsTypeToGraphQLType(rootNomsType)
 
 	return graphql.NewObject(graphql.ObjectConfig{

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -296,9 +296,9 @@ func (suite *QueryGraphQLSuite) TestListOfUnionOfStructs() {
 
 	suite.assertQueryResult(list,
 		fmt.Sprintf("{root{values{... on %s{a b} ... on %s{b} ... on %s{c}}}}",
-			GetTypeName(list.Get(0).Type()),
-			GetTypeName(list.Get(1).Type()),
-			GetTypeName(list.Get(2).Type())),
+			GetTypeName(types.TypeOf(list.Get(0))),
+			GetTypeName(types.TypeOf(list.Get(1))),
+			GetTypeName(types.TypeOf(list.Get(2)))),
 		`{"data":{"root":{"values":[{"a":28,"b":"baz"},{"b":"bar"},{"c":true}]}}}`)
 }
 
@@ -317,9 +317,9 @@ func (suite *QueryGraphQLSuite) TestListOfUnionOfStructsConflictingFieldTypes() 
 
 	suite.assertQueryResult(list,
 		fmt.Sprintf("{root{values{... on %s{a} ... on %s{b: a} ... on %s{c: a}}}}",
-			GetTypeName(list.Get(0).Type()),
-			GetTypeName(list.Get(1).Type()),
-			GetTypeName(list.Get(2).Type())),
+			GetTypeName(types.TypeOf(list.Get(0))),
+			GetTypeName(types.TypeOf(list.Get(1))),
+			GetTypeName(types.TypeOf(list.Get(2)))),
 		`{"data":{"root":{"values":[{"a":28},{"b":"bar"},{"c":true}]}}}`)
 }
 
@@ -375,7 +375,7 @@ func (suite *QueryGraphQLSuite) TestCyclicStructsWithUnion() {
 	})
 
 	suite.assertQueryResult(s1,
-		fmt.Sprintf(`{root{a b {... on %s{a}}}}`, GetTypeName(s1.Type())),
+		fmt.Sprintf(`{root{a b {... on %s{a}}}}`, GetTypeName(types.TypeOf(s1))),
 		`{"data":{"root":{"a":"aaa","b":{"a":"bbb"}}}}`)
 }
 
@@ -1062,7 +1062,7 @@ func (suite *QueryGraphQLSuite) TestSetWithComplexKeys() {
 
 func (suite *QueryGraphQLSuite) TestInputToNomsValue() {
 	test := func(expected types.Value, val interface{}) {
-		suite.True(expected.Equals(InputToNomsValue(val, expected.Type())))
+		suite.True(expected.Equals(InputToNomsValue(val, types.TypeOf(expected))))
 	}
 
 	test(types.Number(42), int(42))
@@ -1217,7 +1217,7 @@ func (suite *QueryGraphQLSuite) TestVariables() {
 		types.NewStruct("S", types.StructData{"n": types.String("c")}), types.Number(2),
 		types.NewStruct("S", types.StructData{"n": types.String("d")}), types.Number(3),
 	)
-	keyType := m2.Type().Desc.(types.CompoundDesc).ElemTypes[0]
+	keyType := types.TypeOf(m2).Desc.(types.CompoundDesc).ElemTypes[0]
 	q := fmt.Sprintf(`query Test($k: %s) { root { values(key: $k) } }`, GetInputTypeName(keyType))
 	test(m2, `{"data":{"root":{"values":[1]}}}`, q, map[string]interface{}{
 		"k": map[string]interface{}{
@@ -1277,7 +1277,7 @@ func (suite *QueryGraphQLSuite) TestVariables() {
 		types.NewMap(types.Number(0), types.String("zero")), types.Bool(false),
 		types.NewMap(types.Number(1), types.String("one")), types.Bool(true),
 	)
-	keyNomsType := m3.Type().Desc.(types.CompoundDesc).ElemTypes[0]
+	keyNomsType := types.TypeOf(m3).Desc.(types.CompoundDesc).ElemTypes[0]
 	tc := NewTypeConverter()
 	keyGraphQLInputType, err := tc.NomsTypeToGraphQLInputType(keyNomsType)
 	suite.NoError(err)
@@ -1359,10 +1359,10 @@ func (suite *QueryGraphQLSuite) TestNameFunc() {
 
 	tc := NewTypeConverter()
 	tc.NameFunc = func(nomsType *types.Type, isInputType bool) string {
-		if nomsType.Equals(aVal.Type()) {
+		if nomsType.Equals(types.TypeOf(aVal)) {
 			return "A"
 		}
-		if nomsType.Equals(bVal.Type()) {
+		if nomsType.Equals(types.TypeOf(bVal)) {
 			return "BBB"
 		}
 		return DefaultNameFunc(nomsType, isInputType)
@@ -1402,7 +1402,7 @@ func (suite *QueryGraphQLSuite) TestNameFunc() {
 	)
 	tc = NewTypeConverter()
 	tc.NameFunc = func(nomsType *types.Type, isInputType bool) string {
-		if nomsType.Equals(aVal.Type()) {
+		if nomsType.Equals(types.TypeOf(aVal)) {
 			if isInputType {
 				return "AI"
 			}

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -276,7 +276,7 @@ func (tc *TypeConverter) unionToGQLUnion(nomsType *types.Type) *graphql.Union {
 			var nomsType *types.Type
 			isScalar := false
 			if v, ok := p.Value.(types.Value); ok {
-				nomsType = v.Type()
+				nomsType = types.TypeOf(v)
 			} else {
 				switch p.Value.(type) {
 				case float64:
@@ -498,7 +498,7 @@ func getSetElements(v types.Value, args map[string]interface{}) interface{} {
 }
 
 func getCollectionArgs(col types.Collection, args map[string]interface{}, factory iteratorFactory) (iter interface{}, nomsKey, nomsThrough types.Value, count uint64, singleExactMatch bool) {
-	typ := col.Type()
+	typ := types.TypeOf(col)
 	length := col.Len()
 	nomsKeyType := typ.Desc.(types.CompoundDesc).ElemTypes[0]
 

--- a/go/spec/commit_meta_test.go
+++ b/go/spec/commit_meta_test.go
@@ -23,7 +23,7 @@ func TestCreateCommitMetaStructBasic(t *testing.T) {
 	meta, err := CreateCommitMetaStruct(nil, "", "", nil, nil)
 	assert.NoError(err)
 	assert.False(isEmptyStruct(meta))
-	assert.Equal("struct Meta {\n  date: String,\n}", meta.Type().Describe())
+	assert.Equal("struct Meta {\n  date: String,\n}", types.TypeOf(meta).Describe())
 }
 
 func TestCreateCommitMetaStructFromFlags(t *testing.T) {
@@ -34,7 +34,7 @@ func TestCreateCommitMetaStructFromFlags(t *testing.T) {
 	meta, err := CreateCommitMetaStruct(nil, "", "", nil, nil)
 	assert.NoError(err)
 	assert.Equal("struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  message: String,\n}",
-		meta.Type().Describe())
+		types.TypeOf(meta).Describe())
 	assert.Equal(types.String(commitMetaDate), meta.Get("date"))
 	assert.Equal(types.String(commitMetaMessage), meta.Get("message"))
 	assert.Equal(types.String("v1"), meta.Get("k1"))
@@ -55,7 +55,7 @@ func TestCreateCommitMetaStructFromArgs(t *testing.T) {
 	meta, err := CreateCommitMetaStruct(nil, dateArg, messageArg, keyValueArg, nil)
 	assert.NoError(err)
 	assert.Equal("struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  message: String,\n}",
-		meta.Type().Describe())
+		types.TypeOf(meta).Describe())
 	assert.Equal(types.String(dateArg), meta.Get("date"))
 	assert.Equal(types.String(messageArg), meta.Get("message"))
 	assert.Equal(types.String("v1"), meta.Get("k1"))
@@ -77,7 +77,7 @@ func TestCreateCommitMetaStructFromFlagsAndArgs(t *testing.T) {
 	meta, err := CreateCommitMetaStruct(nil, dateArg, messageArg, keyValueArg, nil)
 	assert.NoError(err)
 	assert.Equal("struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  k4: String,\n  message: String,\n}",
-		meta.Type().Describe())
+		types.TypeOf(meta).Describe())
 	assert.Equal(types.String(dateArg), meta.Get("date"))
 	assert.Equal(types.String(messageArg), meta.Get("message"))
 	assert.Equal(types.String("v1"), meta.Get("k1"))

--- a/go/types/assert_type.go
+++ b/go/types/assert_type.go
@@ -9,8 +9,8 @@ import (
 )
 
 func assertSubtype(t *Type, v Value) {
-	if !isSubtype(t, v.Type(), nil) {
-		d.Chk.Fail("Invalid type", "%s is not a subtype of %s", v.Type().Describe(), t.Describe())
+	if !isSubtype(t, TypeOf(v), nil) {
+		d.Chk.Fail("Invalid type", "%s is not a subtype of %s", TypeOf(v).Describe(), t.Describe())
 	}
 }
 

--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -111,8 +111,8 @@ func (b Blob) WalkRefs(cb RefCallback) {
 	b.seq.WalkRefs(cb)
 }
 
-func (b Blob) Type() *Type {
-	return b.seq.Type()
+func (b Blob) typeOf() *Type {
+	return b.seq.typeOf()
 }
 
 func (b Blob) Kind() NomsKind {

--- a/go/types/bool.go
+++ b/go/types/bool.go
@@ -33,7 +33,7 @@ func (v Bool) WalkValues(cb ValueCallback) {
 func (v Bool) WalkRefs(cb RefCallback) {
 }
 
-func (v Bool) Type() *Type {
+func (v Bool) typeOf() *Type {
 	return BoolType
 }
 

--- a/go/types/collection_test.go
+++ b/go/types/collection_test.go
@@ -23,7 +23,7 @@ type validateFn func(v2 Collection) bool
 type deltaFn func() Collection
 
 func (suite *collectionTestSuite) TestType() {
-	suite.True(suite.expectType.Equals(suite.col.Type()))
+	suite.True(suite.expectType.Equals(TypeOf(suite.col)))
 }
 
 func (suite *collectionTestSuite) TestLen() {
@@ -42,7 +42,7 @@ func (suite *collectionTestSuite) TestChunkCountAndType() {
 	suite.Equal(suite.expectChunkCount, len(chunks))
 	refType := MakeRefType(suite.expectType)
 	for _, r := range chunks {
-		suite.True(refType.Equals(r.Type()))
+		suite.True(refType.Equals(TypeOf(r)))
 	}
 }
 

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -196,7 +196,7 @@ func (w *hrsWriter) writeStruct(v Struct, printStructName bool) {
 }
 
 func (w *hrsWriter) WriteTagged(v Value) {
-	t := v.Type()
+	t := TypeOf(v)
 	switch t.TargetKind() {
 	case BoolKind, NumberKind, StringKind:
 		w.Write(v)
@@ -216,15 +216,10 @@ func (w *hrsWriter) WriteTagged(v Value) {
 	}
 }
 
-type lenable interface {
-	Len() uint64
-}
-
 func (w *hrsWriter) writeSize(v Value) {
-	t := v.Type()
-	switch t.TargetKind() {
+	switch v.Kind() {
 	case ListKind, MapKind, SetKind:
-		l := v.(lenable).Len()
+		l := v.(Collection).Len()
 		if l < 4 {
 			return
 		}

--- a/go/types/encoding_test.go
+++ b/go/types/encoding_test.go
@@ -607,7 +607,7 @@ func (bg bogusType) WalkRefs(cb RefCallback)     {}
 func (bg bogusType) Kind() NomsKind {
 	return CycleKind
 }
-func (bg bogusType) Type() *Type {
+func (bg bogusType) typeOf() *Type {
 	return MakeCycleType(0)
 }
 

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -10,7 +10,7 @@ func newListMetaSequence(tuples []metaTuple, vr ValueReader) metaSequence {
 	ts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<List<T>>
-		ts[i] = mt.ref.Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
+		ts[i] = TypeOf(mt.ref).Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
 	}
 	t := MakeListType(MakeUnionType(ts...))
 	return newMetaSequence(tuples, t, vr)

--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -22,7 +22,7 @@ func (seq leafSequence) valueReader() ValueReader {
 	return seq.vr
 }
 
-func (seq leafSequence) Type() *Type {
+func (seq leafSequence) typeOf() *Type {
 	return seq.t
 }
 

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -101,8 +101,8 @@ func (l List) WalkRefs(cb RefCallback) {
 	l.seq.WalkRefs(cb)
 }
 
-func (l List) Type() *Type {
-	return l.seq.Type()
+func (l List) typeOf() *Type {
+	return l.seq.typeOf()
 }
 
 func (l List) Kind() NomsKind {
@@ -137,7 +137,7 @@ func (l List) Map(mf MapFunc) []interface{} {
 }
 
 func (l List) elemType() *Type {
-	return l.seq.Type().Desc.(CompoundDesc).ElemTypes[0]
+	return l.seq.typeOf().Desc.(CompoundDesc).ElemTypes[0]
 }
 
 // Set returns a new list where the valie at the given index have been replaced with v. If idx is

--- a/go/types/list_leaf_sequence.go
+++ b/go/types/list_leaf_sequence.go
@@ -12,7 +12,7 @@ type listLeafSequence struct {
 func newListLeafSequence(vr ValueReader, v ...Value) sequence {
 	ts := make([]*Type, len(v))
 	for i, v := range v {
-		ts[i] = v.Type()
+		ts[i] = TypeOf(v)
 	}
 	t := MakeListType(MakeUnionType(ts...))
 	return listLeafSequence{leafSequence{vr, len(v), t}, v}

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -1019,17 +1019,17 @@ func TestListTypeAfterMutations(t *testing.T) {
 		l := NewList(values...)
 		assert.Equal(l.Len(), uint64(n))
 		assert.IsType(c, l.sequence())
-		assert.True(l.Type().Equals(MakeListType(NumberType)))
+		assert.True(TypeOf(l).Equals(MakeListType(NumberType)))
 
 		l = l.Append(String("a"))
 		assert.Equal(l.Len(), uint64(n+1))
 		assert.IsType(c, l.sequence())
-		assert.True(l.Type().Equals(MakeListType(MakeUnionType(NumberType, StringType))))
+		assert.True(TypeOf(l).Equals(MakeListType(MakeUnionType(NumberType, StringType))))
 
 		l = l.Splice(l.Len()-1, 1)
 		assert.Equal(l.Len(), uint64(n))
 		assert.IsType(c, l.sequence())
-		assert.True(l.Type().Equals(MakeListType(NumberType)))
+		assert.True(TypeOf(l).Equals(MakeListType(NumberType)))
 	}
 
 	test(15, listLeafSequence{})
@@ -1134,5 +1134,5 @@ func TestListWithStructShouldHaveOptionalFields(t *testing.T) {
 			StructField{"a", NumberType, false},
 			StructField{"b", StringType, true},
 		),
-		).Equals(list.Type()))
+		).Equals(TypeOf(list)))
 }

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -134,8 +134,8 @@ func (m Map) WalkRefs(cb RefCallback) {
 	m.seq.WalkRefs(cb)
 }
 
-func (m Map) Type() *Type {
-	return m.seq.Type()
+func (m Map) typeOf() *Type {
+	return m.seq.typeOf()
 }
 
 func (m Map) Kind() NomsKind {
@@ -161,7 +161,7 @@ func (m Map) Last() (Value, Value) {
 
 func (m Map) At(idx uint64) (key, value Value) {
 	if idx >= m.Len() {
-		panic(fmt.Errorf("Out of bounds: %s >= %s", idx, m.Len()))
+		panic(fmt.Errorf("Out of bounds: %d >= %d", idx, m.Len()))
 	}
 
 	cur := newCursorAtIndex(m.seq, idx, false)
@@ -300,7 +300,7 @@ func (m Map) IterFrom(start Value, cb mapIterCallback) {
 }
 
 func (m Map) elemTypes() []*Type {
-	return m.Type().Desc.(CompoundDesc).ElemTypes
+	return TypeOf(m).Desc.(CompoundDesc).ElemTypes
 }
 
 func buildMapData(values []Value) mapEntrySlice {

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -37,8 +37,8 @@ func newMapLeafSequence(vr ValueReader, data ...mapEntry) orderedSequence {
 	kts := make([]*Type, len(data))
 	vts := make([]*Type, len(data))
 	for i, e := range data {
-		kts[i] = e.key.Type()
-		vts[i] = e.value.Type()
+		kts[i] = TypeOf(e.key)
+		vts[i] = TypeOf(e.value)
 	}
 	t := MakeMapType(MakeUnionType(kts...), MakeUnionType(vts...))
 	return mapLeafSequence{leafSequence{vr, len(data), t}, data}

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -168,7 +168,7 @@ type mapTestSuite struct {
 
 func newMapTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff int, expectAppendChunkDiff int, gen genValueFn) *mapTestSuite {
 	length := 1 << size
-	keyType := gen(0).Type()
+	keyType := TypeOf(gen(0))
 	elems := newSortedTestMap(length, gen)
 	tr := MakeMapType(keyType, NumberType)
 	tmap := NewMap(elems.FlattenAll()...)
@@ -1050,22 +1050,22 @@ func TestMapType(t *testing.T) {
 
 	emptyMapType := MakeMapType(MakeUnionType(), MakeUnionType())
 	m := NewMap()
-	assert.True(m.Type().Equals(emptyMapType))
+	assert.True(TypeOf(m).Equals(emptyMapType))
 
 	m2 := m.Remove(String("B"))
-	assert.True(emptyMapType.Equals(m2.Type()))
+	assert.True(emptyMapType.Equals(TypeOf(m2)))
 
 	tr := MakeMapType(StringType, NumberType)
 	m2 = m.Set(String("A"), Number(1))
-	assert.True(tr.Equals(m2.Type()))
+	assert.True(tr.Equals(TypeOf(m2)))
 
 	m2 = m.SetM(String("B"), Number(2), String("C"), Number(2))
-	assert.True(tr.Equals(m2.Type()))
+	assert.True(tr.Equals(TypeOf(m2)))
 
 	m3 := m2.Set(String("A"), Bool(true))
-	assert.True(MakeMapType(StringType, MakeUnionType(BoolType, NumberType)).Equals(m3.Type()), m3.Type().Describe())
+	assert.True(MakeMapType(StringType, MakeUnionType(BoolType, NumberType)).Equals(TypeOf(m3)), TypeOf(m3).Describe())
 	m4 := m3.Set(Bool(true), Number(1))
-	assert.True(MakeMapType(MakeUnionType(BoolType, StringType), MakeUnionType(BoolType, NumberType)).Equals(m4.Type()))
+	assert.True(MakeMapType(MakeUnionType(BoolType, StringType), MakeUnionType(BoolType, NumberType)).Equals(TypeOf(m4)))
 }
 
 func TestMapChunks(t *testing.T) {
@@ -1155,17 +1155,17 @@ func TestMapTypeAfterMutations(t *testing.T) {
 		m := NewMap(values...)
 		assert.Equal(m.Len(), uint64(n))
 		assert.IsType(c, m.sequence())
-		assert.True(m.Type().Equals(MakeMapType(NumberType, NumberType)))
+		assert.True(TypeOf(m).Equals(MakeMapType(NumberType, NumberType)))
 
 		m = m.Set(String("a"), String("a"))
 		assert.Equal(m.Len(), uint64(n+1))
 		assert.IsType(c, m.sequence())
-		assert.True(m.Type().Equals(MakeMapType(MakeUnionType(NumberType, StringType), MakeUnionType(NumberType, StringType))))
+		assert.True(TypeOf(m).Equals(MakeMapType(MakeUnionType(NumberType, StringType), MakeUnionType(NumberType, StringType))))
 
 		m = m.Remove(String("a"))
 		assert.Equal(m.Len(), uint64(n))
 		assert.IsType(c, m.sequence())
-		assert.True(m.Type().Equals(MakeMapType(NumberType, NumberType)))
+		assert.True(TypeOf(m).Equals(MakeMapType(NumberType, NumberType)))
 	}
 
 	test(10, mapLeafSequence{})
@@ -1315,7 +1315,7 @@ func TestMapWithStructShouldHaveOptionalFields(t *testing.T) {
 				StructField{"a", NumberType, false},
 				StructField{"b", StringType, true},
 			),
-		).Equals(list.Type()))
+		).Equals(TypeOf(list)))
 
 	// transpose
 	list = NewMap(
@@ -1336,6 +1336,6 @@ func TestMapWithStructShouldHaveOptionalFields(t *testing.T) {
 				StructField{"b", StringType, true},
 			),
 			StringType,
-		).Equals(list.Type()))
+		).Equals(TypeOf(list)))
 
 }

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -130,7 +130,7 @@ func (ms metaSequence) WalkRefs(cb RefCallback) {
 	}
 }
 
-func (ms metaSequence) Type() *Type {
+func (ms metaSequence) typeOf() *Type {
 	return ms.t
 }
 
@@ -184,7 +184,7 @@ func (ms metaSequence) getCompositeChildSequence(start uint64, length uint64) se
 	}
 
 	if childIsMeta {
-		return newMetaSequence(metaItems, ms.Type(), ms.vr)
+		return newMetaSequence(metaItems, ms.typeOf(), ms.vr)
 	}
 
 	if isIndexedSequence {
@@ -295,7 +295,7 @@ func (es emptySequence) valueReader() ValueReader {
 func (es emptySequence) WalkRefs(cb RefCallback) {
 }
 
-func (es emptySequence) Type() *Type {
+func (es emptySequence) typeOf() *Type {
 	panic("empty sequence")
 }
 

--- a/go/types/number.go
+++ b/go/types/number.go
@@ -33,7 +33,7 @@ func (v Number) WalkValues(cb ValueCallback) {
 func (v Number) WalkRefs(cb RefCallback) {
 }
 
-func (v Number) Type() *Type {
+func (v Number) typeOf() *Type {
 	return NumberType
 }
 

--- a/go/types/ordered_sequences.go
+++ b/go/types/ordered_sequences.go
@@ -19,7 +19,7 @@ func newSetMetaSequence(tuples []metaTuple, vr ValueReader) metaSequence {
 	ts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<Set<T>>
-		ts[i] = mt.ref.Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
+		ts[i] = TypeOf(mt.ref).Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes[0]
 	}
 	t := MakeSetType(MakeUnionType(ts...))
 	return newMetaSequence(tuples, t, vr)
@@ -30,7 +30,7 @@ func newMapMetaSequence(tuples []metaTuple, vr ValueReader) metaSequence {
 	vts := make([]*Type, len(tuples))
 	for i, mt := range tuples {
 		// Ref<Map<K, V>>
-		ets := mt.ref.Type().Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes
+		ets := TypeOf(mt.ref).Desc.(CompoundDesc).ElemTypes[0].Desc.(CompoundDesc).ElemTypes
 		kts[i] = ets[0]
 		vts[i] = ets[1]
 	}

--- a/go/types/path.go
+++ b/go/types/path.go
@@ -422,7 +422,7 @@ type TypeAnnotation struct {
 }
 
 func (ann TypeAnnotation) Resolve(v Value) Value {
-	return v.Type()
+	return TypeOf(v)
 }
 
 func (ann TypeAnnotation) String() string {

--- a/go/types/path_test.go
+++ b/go/types/path_test.go
@@ -406,17 +406,17 @@ func TestPathType(t *testing.T) {
 
 	m.IterAll(func(k, cv Value) {
 		ks := k.(String)
-		assertResolvesTo(assert, cv.Type(), m, fmt.Sprintf("[\"%s\"]@type", ks))
+		assertResolvesTo(assert, TypeOf(cv), m, fmt.Sprintf("[\"%s\"]@type", ks))
 	})
 
 	assertResolvesTo(assert, StringType, m, `["string"]@key@type`)
-	assertResolvesTo(assert, m.Type(), m, `@type`)
+	assertResolvesTo(assert, TypeOf(m), m, `@type`)
 	s := NewStruct("", StructData{
 		"str": String("foo"),
 		"num": Number(42),
 	})
-	assertResolvesTo(assert, s.Get("str").Type(), s, ".str@type")
-	assertResolvesTo(assert, s.Get("num").Type(), s, ".num@type")
+	assertResolvesTo(assert, TypeOf(s.Get("str")), s, ".str@type")
+	assertResolvesTo(assert, TypeOf(s.Get("num")), s, ".num@type")
 }
 
 func TestPathAtAnnotation(t *testing.T) {

--- a/go/types/primitives_test.go
+++ b/go/types/primitives_test.go
@@ -38,6 +38,6 @@ func TestPrimitivesType(t *testing.T) {
 	}
 
 	for _, d := range data {
-		assert.True(t, d.v.Type().Equals(MakePrimitiveType(d.k)))
+		assert.True(t, TypeOf(d.v).Equals(MakePrimitiveType(d.k)))
 	}
 }

--- a/go/types/ref.go
+++ b/go/types/ref.go
@@ -17,7 +17,7 @@ type Ref struct {
 }
 
 func NewRef(v Value) Ref {
-	return Ref{v.Hash(), maxChunkHeight(v) + 1, MakeRefType(v.Type()), &hash.Hash{}}
+	return Ref{v.Hash(), maxChunkHeight(v) + 1, MakeRefType(TypeOf(v)), &hash.Hash{}}
 }
 
 // ToRefOfValue returns a new Ref that points to the same target as |r|, but
@@ -77,7 +77,7 @@ func (r Ref) WalkRefs(cb RefCallback) {
 	cb(r)
 }
 
-func (r Ref) Type() *Type {
+func (r Ref) typeOf() *Type {
 	return r.t
 }
 

--- a/go/types/sequence.go
+++ b/go/types/sequence.go
@@ -14,7 +14,7 @@ type sequence interface {
 	numLeaves() uint64
 	valueReader() ValueReader
 	WalkRefs(cb RefCallback)
-	Type() *Type
+	typeOf() *Type
 	Kind() NomsKind
 	getCompareFn(other sequence) compareFn
 	getChildSequence(idx int) sequence

--- a/go/types/sequence_cursor_test.go
+++ b/go/types/sequence_cursor_test.go
@@ -69,7 +69,7 @@ func (ts testSequence) WalkRefs(cb RefCallback) {
 	panic("not reached")
 }
 
-func (ts testSequence) Type() *Type {
+func (ts testSequence) typeOf() *Type {
 	panic("not reached")
 }
 

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -117,8 +117,8 @@ func (s Set) WalkRefs(cb RefCallback) {
 	s.seq.WalkRefs(cb)
 }
 
-func (s Set) Type() *Type {
-	return s.seq.Type()
+func (s Set) typeOf() *Type {
+	return s.seq.typeOf()
 }
 
 func (s Set) Kind() NomsKind {
@@ -135,7 +135,7 @@ func (s Set) First() Value {
 
 func (s Set) At(idx uint64) Value {
 	if idx >= s.Len() {
-		panic(fmt.Errorf("Out of bounds: %s >= %s", idx, s.Len()))
+		panic(fmt.Errorf("Out of bounds: %d >= %d", idx, s.Len()))
 	}
 
 	cur := newCursorAtIndex(s.seq, idx, false)
@@ -240,7 +240,7 @@ func (s Set) IteratorFrom(val Value) SetIterator {
 }
 
 func (s Set) elemType() *Type {
-	return s.Type().Desc.(CompoundDesc).ElemTypes[0]
+	return TypeOf(s).Desc.(CompoundDesc).ElemTypes[0]
 }
 
 func buildSetData(values ValueSlice) ValueSlice {

--- a/go/types/set_leaf_sequence.go
+++ b/go/types/set_leaf_sequence.go
@@ -12,7 +12,7 @@ type setLeafSequence struct {
 func newSetLeafSequence(vr ValueReader, v ...Value) orderedSequence {
 	ts := make([]*Type, len(v))
 	for i, v := range v {
-		ts[i] = v.Type()
+		ts[i] = TypeOf(v)
 	}
 	t := MakeSetType(MakeUnionType(ts...))
 	return setLeafSequence{leafSequence{vr, len(v), t}, v}

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -119,7 +119,7 @@ type setTestSuite struct {
 
 func newSetTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff int, expectAppendChunkDiff int, gen genValueFn) *setTestSuite {
 	length := 1 << size
-	elemType := gen(0).Type()
+	elemType := TypeOf(gen(0))
 	elems := newSortedTestSet(length, gen)
 	tr := MakeSetType(elemType)
 	set := NewSet(elems...)
@@ -264,17 +264,17 @@ func diffSetTest(assert *assert.Assertions, s1 Set, s2 Set, numAddsExpected int,
 func TestNewSet(t *testing.T) {
 	assert := assert.New(t)
 	s := NewSet()
-	assert.True(MakeSetType(MakeUnionType()).Equals(s.Type()))
+	assert.True(MakeSetType(MakeUnionType()).Equals(TypeOf(s)))
 	assert.Equal(uint64(0), s.Len())
 
 	s = NewSet(Number(0))
-	assert.True(MakeSetType(NumberType).Equals(s.Type()))
+	assert.True(MakeSetType(NumberType).Equals(TypeOf(s)))
 
 	s = NewSet()
-	assert.IsType(MakeSetType(NumberType), s.Type())
+	assert.IsType(MakeSetType(NumberType), TypeOf(s))
 
 	s2 := s.Remove(Number(1))
-	assert.IsType(s.Type(), s2.Type())
+	assert.IsType(TypeOf(s), TypeOf(s2))
 }
 
 func TestSetLen(t *testing.T) {
@@ -795,21 +795,21 @@ func TestSetType(t *testing.T) {
 	assert := assert.New(t)
 
 	s := NewSet()
-	assert.True(s.Type().Equals(MakeSetType(MakeUnionType())))
+	assert.True(TypeOf(s).Equals(MakeSetType(MakeUnionType())))
 
 	s = NewSet(Number(0))
-	assert.True(s.Type().Equals(MakeSetType(NumberType)))
+	assert.True(TypeOf(s).Equals(MakeSetType(NumberType)))
 
 	s2 := s.Remove(Number(1))
-	assert.True(s2.Type().Equals(MakeSetType(NumberType)))
+	assert.True(TypeOf(s2).Equals(MakeSetType(NumberType)))
 
 	s2 = s.Insert(Number(0), Number(1))
-	assert.True(s.Type().Equals(s2.Type()))
+	assert.True(TypeOf(s).Equals(TypeOf(s2)))
 
 	s3 := s.Insert(Bool(true))
-	assert.True(s3.Type().Equals(MakeSetType(MakeUnionType(BoolType, NumberType))))
+	assert.True(TypeOf(s3).Equals(MakeSetType(MakeUnionType(BoolType, NumberType))))
 	s4 := s.Insert(Number(3), Bool(true))
-	assert.True(s4.Type().Equals(MakeSetType(MakeUnionType(BoolType, NumberType))))
+	assert.True(TypeOf(s4).Equals(MakeSetType(MakeUnionType(BoolType, NumberType))))
 }
 
 func TestSetChunks(t *testing.T) {
@@ -835,7 +835,7 @@ func TestSetChunks2(t *testing.T) {
 		set := ts.toSet()
 		set2chunks := getChunks(vs.ReadValue(vs.WriteValue(set).TargetHash()))
 		for i, r := range getChunks(set) {
-			assert.True(r.Type().Equals(set2chunks[i].Type()), "%s != %s", r.Type().Describe(), set2chunks[i].Type().Describe())
+			assert.True(TypeOf(r).Equals(TypeOf(set2chunks[i])), "%s != %s", TypeOf(r).Describe(), TypeOf(set2chunks[i]).Describe())
 		}
 	}
 
@@ -895,17 +895,17 @@ func TestSetTypeAfterMutations(t *testing.T) {
 		s := NewSet(values...)
 		assert.Equal(s.Len(), uint64(n))
 		assert.IsType(c, s.sequence())
-		assert.True(s.Type().Equals(MakeSetType(NumberType)))
+		assert.True(TypeOf(s).Equals(MakeSetType(NumberType)))
 
 		s = s.Insert(String("a"))
 		assert.Equal(s.Len(), uint64(n+1))
 		assert.IsType(c, s.sequence())
-		assert.True(s.Type().Equals(MakeSetType(MakeUnionType(NumberType, StringType))))
+		assert.True(TypeOf(s).Equals(MakeSetType(MakeUnionType(NumberType, StringType))))
 
 		s = s.Remove(String("a"))
 		assert.Equal(s.Len(), uint64(n))
 		assert.IsType(c, s.sequence())
-		assert.True(s.Type().Equals(MakeSetType(NumberType)))
+		assert.True(TypeOf(s).Equals(MakeSetType(NumberType)))
 	}
 
 	test(10, setLeafSequence{})
@@ -1015,5 +1015,5 @@ func TestSetWithStructShouldHaveOptionalFields(t *testing.T) {
 			StructField{"a", NumberType, false},
 			StructField{"b", StringType, true},
 		),
-		).Equals(list.Type()))
+		).Equals(TypeOf(list)))
 }

--- a/go/types/string.go
+++ b/go/types/string.go
@@ -31,7 +31,7 @@ func (s String) WalkValues(cb ValueCallback) {
 func (s String) WalkRefs(cb RefCallback) {
 }
 
-func (s String) Type() *Type {
+func (s String) typeOf() *Type {
 	return StringType
 }
 

--- a/go/types/string_test.go
+++ b/go/types/string_test.go
@@ -33,5 +33,5 @@ func TestStringString(t *testing.T) {
 }
 
 func TestStringType(t *testing.T) {
-	assert.True(t, String("hi").Type().Equals(StringType))
+	assert.True(t, TypeOf(String("hi")).Equals(StringType))
 }

--- a/go/types/struct_test.go
+++ b/go/types/struct_test.go
@@ -81,7 +81,7 @@ func TestGenericStructSet(t *testing.T) {
 	assert.True(MakeStructType("S3",
 		StructField{"b", NumberType, false},
 		StructField{"o", StringType, false},
-	).Equals(s4.Type()))
+	).Equals(TypeOf(s4)))
 
 	// Adds a new field
 	s5 := s.Set("x", Number(42))
@@ -89,7 +89,7 @@ func TestGenericStructSet(t *testing.T) {
 		StructField{"b", BoolType, false},
 		StructField{"o", StringType, false},
 		StructField{"x", NumberType, false},
-	).Equals(s5.Type()))
+	).Equals(TypeOf(s5)))
 
 	// Subtype is not equal.
 	s6 := NewStruct("", StructData{"l": NewList(Number(0), Number(1), Bool(false), Bool(true))})
@@ -97,7 +97,7 @@ func TestGenericStructSet(t *testing.T) {
 	t7 := MakeStructTypeFromFields("", FieldMap{
 		"l": MakeListType(NumberType),
 	})
-	assert.True(t7.Equals(s7.Type()))
+	assert.True(t7.Equals(TypeOf(s7)))
 }
 
 func TestGenericStructDelete(t *testing.T) {

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -91,7 +91,7 @@ func (t *Type) WalkRefs(cb RefCallback) {
 	return
 }
 
-func (t *Type) Type() *Type {
+func (t *Type) typeOf() *Type {
 	return TypeType
 }
 
@@ -135,4 +135,10 @@ func MakePrimitiveTypeByString(p string) *Type {
 	}
 	d.Chk.Fail("invalid type string: %s", p)
 	return nil
+}
+
+// TypeOf returns the type describing the value. This is not an exact type but
+// often a simplification of the concrete type.
+func TypeOf(v Value) *Type {
+	return v.typeOf()
 }

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -34,7 +34,7 @@ func TestTypes(t *testing.T) {
 }
 
 func TestTypeType(t *testing.T) {
-	assert.True(t, BoolType.Type().Equals(TypeType))
+	assert.True(t, TypeOf(BoolType).Equals(TypeType))
 }
 
 func TestTypeRefDescribe(t *testing.T) {

--- a/go/types/validating_batching_sink.go
+++ b/go/types/validating_batching_sink.go
@@ -71,7 +71,7 @@ func (vbs *ValidatingBatchingSink) DecodeUnqueued(c *chunks.Chunk) DecodedChunk 
 	return DecodedChunk{c, &v}
 }
 
-// Enequeue adds c to the queue of Chunks waiting to be Put into vbs' backing
+// Enqueue adds c to the queue of Chunks waiting to be Put into vbs' backing
 // ChunkStore. It is assumed that v is the Value decoded from c, and so v can
 // be used to validate the ref-completeness of c.  The instance keeps an
 // internal buffer of Chunks, spilling to the ChunkStore when the buffer is
@@ -79,7 +79,7 @@ func (vbs *ValidatingBatchingSink) DecodeUnqueued(c *chunks.Chunk) DecodedChunk 
 func (vbs *ValidatingBatchingSink) Enqueue(c chunks.Chunk, v Value) {
 	h := c.Hash()
 	vbs.vs.ensureChunksInCache(v)
-	vbs.vs.set(h, hintedChunk{v.Type(), h}, false)
+	vbs.vs.set(h, hintedChunk{TypeOf(v), h}, false)
 
 	vbs.batch[vbs.count] = c
 	vbs.count++

--- a/go/types/value.go
+++ b/go/types/value.go
@@ -37,9 +37,13 @@ type Value interface {
 
 	// Type returns the type of the Noms value. All Noms values carry their runtime Noms type.
 	// DEPRECATED: https://github.com/attic-labs/noms/issues/3184
-	Type() *Type
+	// Type() *Type
 
+	// Kind is the NomsKind describing the kind of value this is.
 	Kind() NomsKind
+
+	// typeOf is the internal implementation of types.TypeOf.
+	typeOf() *Type
 }
 
 type ValueSlice []Value

--- a/go/types/value_encoder.go
+++ b/go/types/value_encoder.go
@@ -117,7 +117,7 @@ func (w *valueEncoder) maybeWriteMetaSequence(seq sequence) bool {
 }
 
 func (w *valueEncoder) writeValue(v Value) {
-	t := v.Type()
+	t := TypeOf(v)
 	w.appendType(t)
 	switch t.TargetKind() {
 	case BlobKind:

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -85,7 +85,7 @@ func TestCheckChunksInCache(t *testing.T) {
 
 	b := NewEmptyBlob()
 	cs.Put(EncodeValue(b, nil))
-	cvs.set(b.Hash(), hintedChunk{b.Type(), b.Hash()}, false)
+	cvs.set(b.Hash(), hintedChunk{TypeOf(b), b.Hash()}, false)
 
 	bref := NewRef(b)
 	assert.NotPanics(func() { cvs.chunkHintsFromCache(bref) })

--- a/go/types/walk.go
+++ b/go/types/walk.go
@@ -133,7 +133,7 @@ func WalkDifferentStructs(last, current Value, vr ValueReader) (added, removed m
 			v := (*values)[len(*values)-1]
 			*values = (*values)[:len(*values)-1]
 
-			if !mightContainStructs(v.Type()) {
+			if !mightContainStructs(TypeOf(v)) {
 				continue
 			}
 
@@ -151,7 +151,7 @@ func WalkDifferentStructs(last, current Value, vr ValueReader) (added, removed m
 				for _, mt := range ms.tuples {
 					if mt.child != nil {
 						*values = append(*values, mt.child)
-					} else if mightContainStructs(mt.ref.Type()) {
+					} else if mightContainStructs(TypeOf(mt.ref)) {
 						refs.PushBack(mt.ref)
 					}
 				}

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -101,5 +101,5 @@ func TestMarshalType(t *testing.T) {
 	assert.Equal(DateTimeType, typ)
 
 	v := marshal.MustMarshal(dt)
-	assert.Equal(typ, v.Type())
+	assert.Equal(typ, types.TypeOf(v))
 }

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -85,7 +85,7 @@ func main() {
 		}
 		blob, ok := val.(types.Blob)
 		if !ok {
-			d.CheckError(fmt.Errorf("Path %s not a Blob: %s\n", *path, types.EncodedValue(val.Type())))
+			d.CheckError(fmt.Errorf("Path %s not a Blob: %s\n", *path, types.EncodedValue(types.TypeOf(val))))
 		}
 		defer db.Close()
 		preader, pwriter := io.Pipe()

--- a/samples/go/csv/csv-import/importer_test.go
+++ b/samples/go/csv/csv-import/importer_test.go
@@ -345,7 +345,6 @@ func (s *testSuite) TestCSVImportSkipRecordsTooMany() {
 	s.Equal("", stdout)
 	s.Equal("error: skip-records skipped past EOF\n", stderr)
 	s.Equal(clienttest.ExitError{1}, recoveredErr)
-
 }
 
 func (s *testSuite) TestCSVImportSkipRecordsCustomHeader() {

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -69,7 +69,7 @@ b,2,false
 	m := ReadToMap(r, "test", headers, []string{"0"}, kinds, ds)
 
 	assert.Equal(uint64(2), m.Len())
-	assert.True(m.Type().Equals(
+	assert.True(types.TypeOf(m).Equals(
 		types.MakeMapType(types.StringType, types.MakeStructType("test",
 			types.StructField{"A", types.StringType, false},
 			types.StructField{"B", types.NumberType, false},

--- a/samples/go/csv/write.go
+++ b/samples/go/csv/write.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getElemDesc(s types.Collection, index int) types.StructDesc {
-	t := s.Type().Desc.(types.CompoundDesc).ElemTypes[index]
+	t := types.TypeOf(s).Desc.(types.CompoundDesc).ElemTypes[index]
 	if types.StructKind != t.TargetKind() {
 		d.Panic("Expected StructKind, found %s", types.KindToString[t.Kind()])
 	}
@@ -29,7 +29,7 @@ func GetListElemDesc(l types.List, vr types.ValueReader) types.StructDesc {
 // GetMapElemDesc ensures that m is a types.Map of structs, pulls the types.StructDesc that describes the elements of m out of vr, and returns the StructDesc.
 // If m is a nested types.Map of types.Map, then GetMapElemDesc will descend the levels of the enclosed types.Maps to get to a types.Struct
 func GetMapElemDesc(m types.Map, vr types.ValueReader) types.StructDesc {
-	t := m.Type().Desc.(types.CompoundDesc).ElemTypes[1]
+	t := types.TypeOf(m).Desc.(types.CompoundDesc).ElemTypes[1]
 	if types.StructKind == t.TargetKind() {
 		return t.Desc.(types.StructDesc)
 	} else if types.MapKind == t.TargetKind() {

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-2:7.4:rio54mdafn882tk79i32ggkg8q118fdb:ogs2jpuuc89u7hpliadrjfqcpc749sel:2:o9iif7sno01q3qef8qubatd1kmlsmj9t:2
+2:7.4:rio54mdafn882tk79i32ggkg8q118fdb:o9iif7sno01q3qef8qubatd1kmlsmj9t:2:ogs2jpuuc89u7hpliadrjfqcpc749sel:2

--- a/samples/go/nomdex/nomdex_find.go
+++ b/samples/go/nomdex/nomdex_find.go
@@ -39,19 +39,19 @@ with the following commands:
     nomdex up --in-path ~/nomsdb::people.value --by .name --out-ds by-name
     nomdex up --in-path ~/nomsdb::people.value --by .geopos.latitude --out-ds by-lat
     nomdex up --in-path ~/nomsdb::people.value --by .geopos.longitude --out-ds by-lng
-    
+
 The following query could be used to find all people with an address near the
 equator:
     nomdex find 'by-lat >= -1.0 and by-lat <= 1.0'
 
 We could also get a list of all people who live near the equator whose name begins with "A":
     nomdex find '(by-name >= "A" and by-name < "B") and (by-lat >= -1.0 and by-lat <= 1.0)'
-   
+
 The query language is simple. It currently supports the following relational operators:
     <, <=, >, >=, =, !=
 Relational expressions are always of the form:
     <index> <relational operator> <constant>   e.g. personId >= 2000.
-    
+
 Indexes are the name given by the --out-ds argument in the 'nomdex up' command.
 Constants are either "strings" (in quotes) or numbers (e.g. 3, 3000, -2, -2.5,
 3.147, etc).
@@ -172,7 +172,7 @@ func openIndex(idxName string, im *indexManager) error {
 		types.MakeUnionType(types.StringType, types.NumberType),
 		types.ValueType)
 
-	if !types.IsSubtype(typ, index.Type()) {
+	if !types.IsSubtype(typ, types.TypeOf(index)) {
 		return fmt.Errorf("%s does not point to a suitable index type:", idxName)
 	}
 

--- a/samples/go/nomdex/nomdex_update.go
+++ b/samples/go/nomdex/nomdex_update.go
@@ -165,7 +165,7 @@ func addElementsToGraphBuilder(gb *types.GraphBuilder, db datas.Database, rootOb
 
 	index := Index{m: IndexMap{}}
 	types.WalkValues(rootObject, db, func(v types.Value) bool {
-		typ := v.Type()
+		typ := types.TypeOf(v)
 		typeCacheMutex.Lock()
 		hasPath, ok := typeCache[typ.Hash()]
 		typeCacheMutex.Unlock()

--- a/samples/go/url-fetch/fetch_test.go
+++ b/samples/go/url-fetch/fetch_test.go
@@ -56,7 +56,7 @@ func (s *testSuite) TestImportFromStdin() {
 	ds := sp.GetDatabase().GetDataset("ds")
 	meta := ds.Head().Get(datas.MetaField).(types.Struct)
 	// The meta should only have a "date" field.
-	metaDesc := meta.Type().Desc.(types.StructDesc)
+	metaDesc := types.TypeOf(meta).Desc.(types.StructDesc)
 	assert.Equal(1, metaDesc.Len())
 	assert.NotNil(metaDesc.Field("date"))
 }
@@ -82,7 +82,7 @@ func (s *testSuite) TestImportFromFile() {
 
 	ds := sp.GetDatabase().GetDataset("ds")
 	meta := ds.Head().Get(datas.MetaField).(types.Struct)
-	metaDesc := meta.Type().Desc.(types.StructDesc)
+	metaDesc := types.TypeOf(meta).Desc.(types.StructDesc)
 	assert.Equal(2, metaDesc.Len())
 	assert.NotNil(metaDesc.Field("date"))
 	assert.Equal(f.Name(), string(meta.Get("file").(types.String)))


### PR DESCRIPTION
BREAKING CHANGE

This removes the `Type()` method from the `types.Value` interface.
Instead use the `types.TypeOf(v types.Value) bool` function.

Fixes #3324