### PR TITLE
Add datetime.IsZero() and DateTimeNow() functions

### DIFF
--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/attic-labs/noms/cmd/util"
 	"github.com/attic-labs/noms/go/config"
@@ -19,6 +20,7 @@ import (
 	"github.com/attic-labs/noms/go/diff"
 	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/noms/go/util/datetime"
 	"github.com/attic-labs/noms/go/util/functions"
 	"github.com/attic-labs/noms/go/util/outputpager"
 	"github.com/attic-labs/noms/go/util/verbose"
@@ -260,7 +262,13 @@ func writeMetaLines(node LogNode, maxLines, lineno, maxLabelLen int, w io.Writer
 			types.TypeOf(meta).Desc.(types.StructDesc).IterFields(func(fieldName string, t *types.Type, optional bool) {
 				v := meta.Get(fieldName)
 				fmt.Fprintf(pw, "%-*s", maxLabelLen+2, strings.Title(fieldName)+":")
-				types.WriteEncodedValue(pw, v)
+				if types.TypeOf(v).Equals(datetime.DateTimeType) {
+					var dt datetime.DateTime
+					dt.UnmarshalNoms(v)
+					fmt.Fprintf(pw, time.Time(dt).Format(spec.CommitMetaDateFormat))
+				} else {
+					types.WriteEncodedValue(pw, v)
+				}
 				fmt.Fprintf(pw, "\n")
 			})
 		})

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -56,3 +56,32 @@ func (dt *DateTime) UnmarshalNoms(v types.Value) error {
 	*dt = DateTime(time.Unix(int64(s), int64(frac*1e9)))
 	return nil
 }
+
+// DateTimeNow returns a DateTime struct representing the current time. This
+// struct is created using seconds only. Since nanoseconds aren't used, it's
+// value is unchanged when Unmarshalling/Marshalling:
+//   dt1 := DateTimeNow()
+//   dt2 := DateTime{}
+//   marshal.MustUnmarshal(marshal.MustMarshal(dt1), &dt2)
+//   dt1 == dt2 // Will be true
+func DateTimeNow() DateTime {
+	return DateTime(time.Unix(time.Now().Unix(), 0))
+}
+
+// IsZero returns true if the dt is a true zero value or if it's a zero value
+// that has been marshalled into Noms and unmarshalled again.
+func (dt DateTime) IsZero() bool {
+	if time.Time(dt).IsZero() {
+		return true
+	}
+
+	dt1 := DateTime{}
+	marshal.MustUnmarshal(marshal.MustMarshal(DateTime{}), &dt1)
+	return dt == dt1
+}
+
+// String() causes DateTime structs to be printed in the same way as time.Time
+// structs.
+func (dt DateTime) String() string {
+	return time.Time(dt).String()
+}

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -30,7 +30,7 @@ var DateTimeType = types.MakeStructTypeFromFields("DateTime", types.FieldMap{
 func (dt DateTime) MarshalNoms() (types.Value, error) {
 	t := time.Time(dt)
 	return types.NewStructWithType(DateTimeType, types.ValueSlice{
-		types.Number(float64(t.UnixNano()) * 1e-9),
+		types.Number(float64(t.Unix()) + float64(t.Nanosecond())*1e-9),
 	}), nil
 }
 
@@ -55,29 +55,6 @@ func (dt *DateTime) UnmarshalNoms(v types.Value) error {
 	s, frac := math.Modf(strct.SecSinceEpoch)
 	*dt = DateTime(time.Unix(int64(s), int64(frac*1e9)))
 	return nil
-}
-
-// DateTimeNow returns a DateTime struct representing the current time. This
-// struct is created using seconds only. Since nanoseconds aren't used, it's
-// value is unchanged when Unmarshalling/Marshalling:
-//   dt1 := DateTimeNow()
-//   dt2 := DateTime{}
-//   marshal.MustUnmarshal(marshal.MustMarshal(dt1), &dt2)
-//   dt1 == dt2 // Will be true
-func DateTimeNow() DateTime {
-	return DateTime(time.Unix(time.Now().Unix(), 0))
-}
-
-// IsZero returns true if the dt is a true zero value or if it's a zero value
-// that has been marshalled into Noms and unmarshalled again.
-func (dt DateTime) IsZero() bool {
-	if time.Time(dt).IsZero() {
-		return true
-	}
-
-	dt1 := DateTime{}
-	marshal.MustUnmarshal(marshal.MustMarshal(DateTime{}), &dt1)
-	return dt == dt1
 }
 
 // String() causes DateTime structs to be printed in the same way as time.Time

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -16,7 +16,8 @@ import (
 func TestBasics(t *testing.T) {
 	assert := assert.New(t)
 
-	dt := DateTime(time.Unix(123, 456))
+	// Since we are using float64 in noms we cannot represent all possible times.
+	dt := DateTime(time.Unix(1234567, 1234567))
 
 	nomsValue, err := marshal.Marshal(dt)
 	assert.NoError(err)
@@ -108,17 +109,22 @@ func TestZeroValues(t *testing.T) {
 	assert := assert.New(t)
 
 	dt1 := DateTime{}
-	assert.True(dt1.IsZero())
+	assert.True(time.Time(dt1).IsZero())
 
 	nomsDate, _ := dt1.MarshalNoms()
 
 	dt2 := DateTime{}
 	marshal.Unmarshal(nomsDate, &dt2)
-	assert.True(dt2.IsZero())
+	assert.True(time.Time(dt2).IsZero())
 
 	dt3 := DateTime{}
 	dt3.UnmarshalNoms(nomsDate)
-	assert.True(dt3.IsZero())
+	assert.True(time.Time(dt3).IsZero())
+}
 
-	assert.False(DateTime(time.Now()).IsZero())
+func TestString(t *testing.T) {
+	assert := assert.New(t)
+	dt := DateTime(time.Unix(1234567, 1234567))
+	// Don't test the actual output since that
+	assert.IsType(dt.String(), "s")
 }

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -103,3 +103,22 @@ func TestMarshalType(t *testing.T) {
 	v := marshal.MustMarshal(dt)
 	assert.Equal(typ, types.TypeOf(v))
 }
+
+func TestZeroValues(t *testing.T) {
+	assert := assert.New(t)
+
+	dt1 := DateTime{}
+	assert.True(dt1.IsZero())
+
+	nomsDate, _ := dt1.MarshalNoms()
+
+	dt2 := DateTime{}
+	marshal.Unmarshal(nomsDate, &dt2)
+	assert.True(dt2.IsZero())
+
+	dt3 := DateTime{}
+	dt3.UnmarshalNoms(nomsDate)
+	assert.True(dt3.IsZero())
+
+	assert.False(DateTime(time.Now()).IsZero())
+}


### PR DESCRIPTION
These changes were necessary to add DateTime structs to Commit structs in attic.