### PR TITLE
Fix NBS optimistic locking

### DIFF
--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -194,7 +194,7 @@ func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
 
 func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	testMaxTables := 5
-	mm := newFileManifest(suite.dir)
+	mm := fileManifest{suite.dir}
 	smallTableStore := newNomsBlockStore(mm, newFSTableSet(suite.dir, nil), 2, testMaxTables)
 	inputs := [][]byte{[]byte("ab"), []byte("cd"), []byte("ef"), []byte("gh"), []byte("ij"), []byte("kl")}
 	chunx := make([]chunks.Chunk, len(inputs))
@@ -206,7 +206,7 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	smallTableStore.PutMany(chunx[:testMaxTables])
 	suite.True(smallTableStore.UpdateRoot(chunx[0].Hash(), root)) // Commit write
 
-	exists, _, mRoot, specs := mm.LoadIfExists(nil)
+	exists, _, _, mRoot, specs := mm.ParseIfExists(nil)
 	suite.True(exists)
 	suite.Equal(chunx[0].Hash(), mRoot)
 	suite.Len(specs, testMaxTables)
@@ -215,7 +215,7 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	smallTableStore.PutMany(chunx[testMaxTables:])
 	suite.True(smallTableStore.UpdateRoot(chunx[testMaxTables].Hash(), root)) // Should compact
 
-	exists, _, mRoot, specs = mm.LoadIfExists(nil)
+	exists, _, _, mRoot, specs = mm.ParseIfExists(nil)
 	suite.True(exists)
 	suite.Equal(chunx[testMaxTables].Hash(), mRoot)
 	suite.Len(specs, testMaxTables)

--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -174,13 +174,17 @@ func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
 
 	interloper := NewLocalStore(suite.dir, testMemTableSize)
 	interloper.Put(c1)
-	interloper.UpdateRoot(c1.Hash(), interloper.Root()) // Commit write
+	interloper.Flush()
 
 	suite.store.Put(c2)
 	suite.store.Flush() // Commit write
 
-	// And reading c2 via the API should work...
+	// Reading c2 via the API should work...
 	assertInputInStore(input2, c2.Hash(), suite.store, suite.Assert())
+	// And so should reading c1 via the API
+	assertInputInStore(input1, c1.Hash(), suite.store, suite.Assert())
+
+	suite.True(interloper.UpdateRoot(c1.Hash(), interloper.Root())) // Commit root
 
 	// Updating from stale root should fail...
 	suite.False(suite.store.UpdateRoot(c2.Hash(), root))
@@ -190,7 +194,7 @@ func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
 
 func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	testMaxTables := 5
-	mm := fileManifest{suite.dir}
+	mm := newFileManifest(suite.dir)
 	smallTableStore := newNomsBlockStore(mm, newFSTableSet(suite.dir, nil), 2, testMaxTables)
 	inputs := [][]byte{[]byte("ab"), []byte("cd"), []byte("ef"), []byte("gh"), []byte("ij"), []byte("kl")}
 	chunx := make([]chunks.Chunk, len(inputs))
@@ -202,7 +206,7 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	smallTableStore.PutMany(chunx[:testMaxTables])
 	suite.True(smallTableStore.UpdateRoot(chunx[0].Hash(), root)) // Commit write
 
-	exists, _, mRoot, specs := mm.ParseIfExists(nil)
+	exists, _, mRoot, specs := mm.LoadIfExists(nil)
 	suite.True(exists)
 	suite.Equal(chunx[0].Hash(), mRoot)
 	suite.Len(specs, testMaxTables)
@@ -211,7 +215,7 @@ func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	smallTableStore.PutMany(chunx[testMaxTables:])
 	suite.True(smallTableStore.UpdateRoot(chunx[testMaxTables].Hash(), root)) // Should compact
 
-	exists, _, mRoot, specs = mm.ParseIfExists(nil)
+	exists, _, mRoot, specs = mm.LoadIfExists(nil)
 	suite.True(exists)
 	suite.Equal(chunx[testMaxTables].Hash(), mRoot)
 	suite.Len(specs, testMaxTables)

--- a/go/nbs/dynamo_manifest.go
+++ b/go/nbs/dynamo_manifest.go
@@ -19,6 +19,7 @@ import (
 const (
 	tableName      = "attic-nbs"
 	dbAttr         = "db"
+	lockAttr       = "lock"
 	rootAttr       = "root"
 	versAttr       = "vers"
 	nbsVersAttr    = "nbsVers"
@@ -26,8 +27,8 @@ const (
 )
 
 var (
-	valueEqualsExpression            = fmt.Sprintf("(%s = :prev) and (%s = :vers)", rootAttr, versAttr)
-	valueNotExistsOrEqualsExpression = fmt.Sprintf("attribute_not_exists("+rootAttr+") or %s", valueEqualsExpression)
+	valueEqualsExpression            = fmt.Sprintf("(%s = :prev) and (%s = :vers)", lockAttr, versAttr)
+	valueNotExistsOrEqualsExpression = fmt.Sprintf("attribute_not_exists("+lockAttr+") or %s", valueEqualsExpression)
 )
 
 type ddbsvc interface {
@@ -39,13 +40,14 @@ type ddbsvc interface {
 type dynamoManifest struct {
 	table, db string
 	ddbsvc    ddbsvc
+	lock      addr
 }
 
-func newDynamoManifest(table, namespace string, ddb ddbsvc) *dynamoManifest {
+func newDynamoManifest(table, namespace string, ddb ddbsvc) manifest {
 	return &dynamoManifest{table: table, db: namespace, ddbsvc: ddb}
 }
 
-func (dm dynamoManifest) ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
+func (dm *dynamoManifest) LoadIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
 	result, err := dm.ddbsvc.GetItem(&dynamodb.GetItemInput{
 		ConsistentRead: aws.Bool(true), // This doubles the cost :-(
 		TableName:      aws.String(dm.table),
@@ -64,6 +66,7 @@ func (dm dynamoManifest) ParseIfExists(readHook func()) (exists bool, vers strin
 		exists = true
 		vers = *result.Item[versAttr].S
 		root = hash.New(result.Item[rootAttr].B)
+		copy(dm.lock[:], result.Item[lockAttr].B)
 		if hasSpecs {
 			tableSpecs = parseSpecs(strings.Split(*result.Item[tableSpecsAttr].S, ":"))
 		}
@@ -76,18 +79,20 @@ func validateManifest(item map[string]*dynamodb.AttributeValue) (valid, hasSpecs
 	if item[nbsVersAttr] != nil && item[nbsVersAttr].S != nil &&
 		StorageVersion == *item[nbsVersAttr].S &&
 		item[versAttr] != nil && item[versAttr].S != nil &&
+		item[lockAttr] != nil && item[lockAttr].B != nil &&
 		item[rootAttr] != nil && item[rootAttr].B != nil {
-		if len(item) == 5 && item[tableSpecsAttr] != nil && item[tableSpecsAttr].S != nil {
+		if len(item) == 6 && item[tableSpecsAttr] != nil && item[tableSpecsAttr].S != nil {
 			return true, true
 		}
-		return len(item) == 4, false
+		return len(item) == 5, false
 	}
 	return false, false
 }
 
-func (dm dynamoManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec) {
+func (dm *dynamoManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec, err error) {
 	tableSpecs = specs
 
+	lock := generateLockHash(newRoot, specs)
 	putArgs := dynamodb.PutItemInput{
 		TableName: aws.String(dm.table),
 		Item: map[string]*dynamodb.AttributeValue{
@@ -95,6 +100,7 @@ func (dm dynamoManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writ
 			nbsVersAttr: {S: aws.String(StorageVersion)},
 			versAttr:    {S: aws.String(constants.NomsVersion)},
 			rootAttr:    {B: newRoot[:]},
+			lockAttr:    {B: lock[:]},
 		},
 	}
 	if len(specs) > 0 {
@@ -110,22 +116,25 @@ func (dm dynamoManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writ
 
 	putArgs.ConditionExpression = aws.String(expr)
 	putArgs.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
-		":prev": {B: root[:]},
+		":prev": {B: dm.lock[:]},
 		":vers": {S: aws.String(constants.NomsVersion)},
 	}
 
-	_, err := dm.ddbsvc.PutItem(&putArgs)
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
+	_, ddberr := dm.ddbsvc.PutItem(&putArgs)
+	if ddberr != nil {
+		if awsErr, ok := ddberr.(awserr.Error); ok {
 			if awsErr.Code() == "ConditionalCheckFailedException" {
-				exists, vers, actual, tableSpecs := dm.ParseIfExists(nil)
+				exists, vers, actual, tableSpecs := dm.LoadIfExists(nil)
 				d.Chk.True(exists)
 				d.Chk.True(vers == constants.NomsVersion)
-				return actual, tableSpecs
+				if root != actual {
+					return actual, tableSpecs, errOptimisticLockFailedRoot
+				}
+				return actual, tableSpecs, errOptimisticLockFailedTables
 			} // TODO handle other aws errors?
 		}
-		d.Chk.NoError(err)
+		d.Chk.NoError(ddberr)
 	}
 
-	return newRoot, tableSpecs
+	return newRoot, tableSpecs, nil
 }

--- a/go/nbs/file_manifest.go
+++ b/go/nbs/file_manifest.go
@@ -26,19 +26,24 @@ const (
 // fileManifest provides access to a NomsBlockStore manifest stored on disk in |dir|. The format
 // is currently human readable:
 //
-// |-- String --|-- String --|-------- String --------|-- String --|- String --|...|-- String --|- String --|
-// | nbs version:Noms version:Base32-encoded root hash:table 1 hash:table 1 cnt:...:table N hash:table N cnt|
+// |-- String --|-- String --|-------- String --------|-------- String --------|-- String --|- String --|...|-- String --|- String --|
+// | nbs version:Noms version:Base32-encoded lock hash:Base32-encoded root hash:table 1 hash:table 1 cnt:...:table N hash:table N cnt|
 type fileManifest struct {
-	dir string
+	dir  string
+	lock addr
 }
 
-// ParseIfExists looks for a LOCK and manifest file in fm.dir. If it finds
+func newFileManifest(dir string) manifest {
+	return &fileManifest{dir: dir}
+}
+
+// LoadIfExists looks for a LOCK and manifest file in fm.dir. If it finds
 // them, it takes the lock, parses the manifest and returns its contents,
 // setting |exists| to true. If not, it sets |exists| to false and returns. In
 // that case, the other return values are undefined. If |readHook| is non-nil,
-// it will be executed while ParseIfExists() holds the manfiest file lock.
+// it will be executed while LoadIfExists() holds the manfiest file lock.
 // This is to allow for race condition testing.
-func (fm fileManifest) ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
+func (fm *fileManifest) LoadIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
 	// !exists(lockFileName) => unitialized store
 	if l := openIfExists(filepath.Join(fm.dir, lockFileName)); l != nil {
 		var f io.ReadCloser
@@ -55,7 +60,7 @@ func (fm fileManifest) ParseIfExists(readHook func()) (exists bool, vers string,
 		if f != nil {
 			defer checkClose(f)
 			exists = true
-			vers, root, tableSpecs = parseManifest(f)
+			vers, fm.lock, root, tableSpecs = parseManifest(f)
 		}
 	}
 	return
@@ -71,37 +76,34 @@ func openIfExists(path string) *os.File {
 	return f
 }
 
-func parseManifest(r io.Reader) (string, hash.Hash, []tableSpec) {
+func parseManifest(r io.Reader) (nomsVersion string, lock addr, root hash.Hash, specs []tableSpec) {
 	manifest, err := ioutil.ReadAll(r)
 	d.PanicIfError(err)
 
 	slices := strings.Split(string(manifest), ":")
-	if len(slices) < 3 || len(slices)%2 == 0 {
+	if len(slices) < 4 || len(slices)%2 == 1 {
 		d.Chk.Fail("Malformed manifest: " + string(manifest))
 	}
 	d.PanicIfFalse(StorageVersion == string(slices[0]))
 
-	return slices[1], hash.Parse(slices[2]), parseSpecs(slices[3:])
+	return slices[1], ParseAddr([]byte(slices[2])), hash.Parse(slices[3]), parseSpecs(slices[4:])
 }
 
 // Update optimistically tries to write a new manifest, containing |newRoot|
 // and the elements of |tables|. If the existing manifest on disk doesn't
-// contain |root|, Update fails and returns the parsed contents of the
-// manifest on disk. Callers should check that |actual| == |newRoot| upon
-// return and, if not, merge any desired new table information with the
-// contents of |tableSpecs| before trying again.
+// contain |fm.lock|, Update returns an error indicating what caused the
+// optimistic lock failure along with the parsed contents of the manifest on
+// disk.
 // If writeHook is non-nil, it will be invoked wile the manifest file lock is
 // held. This is to allow for testing of race conditions.
-func (fm fileManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec) {
-	tableSpecs = specs
-
+func (fm *fileManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec, err error) {
 	// Write a temporary manifest file, to be renamed over manifestFileName upon success.
 	// The closure here ensures this file is closed before moving on.
 	tempManifestPath := func() string {
 		temp, err := ioutil.TempFile(fm.dir, "nbs_manifest_")
 		d.PanicIfError(err)
 		defer checkClose(temp)
-		writeManifest(temp, newRoot, tableSpecs)
+		writeManifest(temp, newRoot, specs)
 		return temp.Name()
 	}()
 	defer os.Remove(tempManifestPath) // If we rename below, this will be a no-op
@@ -115,31 +117,38 @@ func (fm fileManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writeH
 	}
 
 	// Read current manifest (if it exists). The closure ensures that the file is closed before moving on, so we can rename over it later if need be.
+	curLock := fm.lock
 	manifestPath := filepath.Join(fm.dir, manifestFileName)
 	func() {
 		if f := openIfExists(manifestPath); f != nil {
 			defer checkClose(f)
 
 			var mVers string
-			mVers, actual, tableSpecs = parseManifest(f)
+			mVers, fm.lock, actual, tableSpecs = parseManifest(f)
 			d.PanicIfFalse(constants.NomsVersion == mVers)
 		} else {
 			d.Chk.True(root == hash.Hash{})
 		}
 	}()
 
-	if root != actual {
-		return actual, tableSpecs
+	if curLock != fm.lock {
+		if root != actual {
+			return actual, tableSpecs, errOptimisticLockFailedRoot
+		}
+		return actual, tableSpecs, errOptimisticLockFailedTables
 	}
-	err := os.Rename(tempManifestPath, manifestPath)
-	d.PanicIfError(err)
-	return newRoot, tableSpecs
+
+	rerr := os.Rename(tempManifestPath, manifestPath)
+	d.PanicIfError(rerr)
+	return newRoot, specs, nil
 }
 
 func writeManifest(temp io.Writer, root hash.Hash, specs []tableSpec) {
-	strs := make([]string, 2*len(specs)+3)
-	strs[0], strs[1], strs[2] = StorageVersion, constants.NomsVersion, root.String()
-	tableInfo := strs[3:]
+	lock := generateLockHash(root, specs)
+
+	strs := make([]string, 2*len(specs)+4)
+	strs[0], strs[1], strs[2], strs[3] = StorageVersion, constants.NomsVersion, lock.String(), root.String()
+	tableInfo := strs[4:]
 	formatSpecs(specs, tableInfo)
 	_, err := io.WriteString(temp, strings.Join(strs, ":"))
 	d.PanicIfError(err)

--- a/go/nbs/file_manifest_test.go
+++ b/go/nbs/file_manifest_test.go
@@ -18,28 +18,29 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
-func makeFileManifestTempDir(t *testing.T) fileManifest {
+func makeFileManifestTempDir(t *testing.T) *fileManifest {
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	return fileManifest{dir}
+	return &fileManifest{dir: dir}
 }
 
-func TestFileManifestParseIfExists(t *testing.T) {
+func TestFileManifestLoadIfExists(t *testing.T) {
 	assert := assert.New(t)
 	fm := makeFileManifestTempDir(t)
 	defer os.RemoveAll(fm.dir)
 
-	exists, vers, root, tableSpecs := fm.ParseIfExists(nil)
+	exists, vers, root, tableSpecs := fm.LoadIfExists(nil)
 	assert.False(exists)
 
 	// Simulate another process writing a manifest (with an old Noms version).
+	lock := computeAddr([]byte("locker"))
 	newRoot := hash.Of([]byte("new root"))
 	tableName := hash.Of([]byte("table1"))
-	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", newRoot.String(), tableName.String(), "0"}, ":"))
+	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", lock.String(), newRoot.String(), tableName.String(), "0"}, ":"))
 	assert.NoError(err)
 
-	// ParseIfExists should now reflect the manifest written above.
-	exists, vers, root, tableSpecs = fm.ParseIfExists(nil)
+	// LoadIfExists should now reflect the manifest written above.
+	exists, vers, root, tableSpecs = fm.LoadIfExists(nil)
 	assert.True(exists)
 	assert.Equal("0", vers)
 	assert.Equal(newRoot, root)
@@ -49,22 +50,24 @@ func TestFileManifestParseIfExists(t *testing.T) {
 	}
 }
 
-func TestFileManifestParseIfExistsHoldsLock(t *testing.T) {
+func TestFileManifestLoadIfExistsHoldsLock(t *testing.T) {
 	assert := assert.New(t)
 	fm := makeFileManifestTempDir(t)
 	defer os.RemoveAll(fm.dir)
 
 	// Simulate another process writing a manifest.
+	lock := computeAddr([]byte("locker"))
 	newRoot := hash.Of([]byte("new root"))
 	tableName := hash.Of([]byte("table1"))
-	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot.String(), tableName.String(), "0"}, ":"))
+	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, lock.String(), newRoot.String(), tableName.String(), "0"}, ":"))
 	assert.NoError(err)
 
-	// ParseIfExists should now reflect the manifest written above.
-	exists, vers, root, tableSpecs := fm.ParseIfExists(func() {
+	// LoadIfExists should now reflect the manifest written above.
+	exists, vers, root, tableSpecs := fm.LoadIfExists(func() {
 		// This should fail to get the lock, and therefore _not_ clobber the manifest.
+		lock := computeAddr([]byte("newlock"))
 		badRoot := hash.Of([]byte("bad root"))
-		b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", badRoot.String(), tableName.String(), "0"}, ":"))
+		b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", lock.String(), badRoot.String(), tableName.String(), "0"}, ":"))
 		assert.NoError(err, string(b))
 	})
 
@@ -83,7 +86,7 @@ func TestFileManifestUpdateWontClobberOldVersion(t *testing.T) {
 	defer os.RemoveAll(fm.dir)
 
 	// Simulate another process having already put old Noms data in dir/.
-	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", hash.Hash{}.String()}, ":"))
+	err := clobberManifest(fm.dir, strings.Join([]string{StorageVersion, "0", addr{}.String(), hash.Hash{}.String()}, ":"))
 	assert.NoError(err)
 
 	assert.Panics(func() { fm.Update(nil, hash.Hash{}, hash.Hash{}, nil) })
@@ -94,17 +97,19 @@ func TestFileManifestUpdateEmpty(t *testing.T) {
 	fm := makeFileManifestTempDir(t)
 	defer os.RemoveAll(fm.dir)
 
-	actual, tableSpecs := fm.Update(nil, hash.Hash{}, hash.Hash{}, nil)
+	actual, tableSpecs, err := fm.Update(nil, hash.Hash{}, hash.Hash{}, nil)
+	assert.NoError(err)
 	assert.True(actual.IsEmpty())
 	assert.Empty(tableSpecs)
 
-	fm2 := fileManifest{fm.dir} // Open existent, but empty manifest
-	exists, _, root, tableSpecs := fm2.ParseIfExists(nil)
+	fm2 := newFileManifest(fm.dir) // Open existent, but empty manifest
+	exists, _, root, tableSpecs := fm2.LoadIfExists(nil)
 	assert.True(exists)
 	assert.True(root.IsEmpty())
 	assert.Empty(tableSpecs)
 
-	actual, tableSpecs = fm2.Update(nil, hash.Hash{}, hash.Hash{}, nil)
+	actual, tableSpecs, err = fm2.Update(nil, hash.Hash{}, hash.Hash{}, nil)
+	assert.NoError(err)
 	assert.True(actual.IsEmpty())
 	assert.Empty(tableSpecs)
 }
@@ -117,21 +122,39 @@ func TestFileManifestUpdate(t *testing.T) {
 	// First, test winning the race against another process.
 	newRoot := hash.Of([]byte("new root"))
 	specs := []tableSpec{{computeAddr([]byte("a")), 3}}
-	actual, tableSpecs := fm.Update(specs, hash.Hash{}, newRoot, func() {
+	actual, tableSpecs, err := fm.Update(specs, hash.Hash{}, newRoot, func() {
 		// This should fail to get the lock, and therefore _not_ clobber the manifest. So the Update should succeed.
+		lock := computeAddr([]byte("locker"))
 		newRoot2 := hash.Of([]byte("new root 2"))
-		b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, newRoot2.String()}, ":"))
+		b, err := tryClobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, lock.String(), newRoot2.String()}, ":"))
 		assert.NoError(err, string(b))
 	})
+	assert.NoError(err)
 	assert.Equal(newRoot, actual)
 	assert.Equal(specs, tableSpecs)
 
 	// Now, test the case where the optimistic lock fails, and someone else updated the root since last we checked.
 	newRoot2 := hash.Of([]byte("new root 2"))
-	actual, tableSpecs = fm.Update(nil, hash.Hash{}, newRoot2, nil)
+	actual, tableSpecs, err = fm.Update(nil, hash.Hash{}, newRoot2, nil)
+	assert.IsType(err, errOptimisticLockFailedRoot)
 	assert.Equal(newRoot, actual)
 	assert.Equal(specs, tableSpecs)
-	actual, tableSpecs = fm.Update(nil, actual, newRoot2, nil)
+	actual, tableSpecs, err = fm.Update(nil, actual, newRoot2, nil)
+	assert.NoError(err)
+	assert.Equal(newRoot2, actual)
+	assert.Empty(tableSpecs)
+
+	// Now, test the case where the optimistic lock fails because someone else updated only the tables since last we checked
+	lock := computeAddr([]byte("locker"))
+	tableName := computeAddr([]byte("table1"))
+	err = clobberManifest(fm.dir, strings.Join([]string{StorageVersion, constants.NomsVersion, lock.String(), newRoot2.String(), tableName.String(), "1"}, ":"))
+	assert.NoError(err)
+
+	newRoot3 := hash.Of([]byte("new root 3"))
+	actual, tableSpecs, err = fm.Update(nil, newRoot3, newRoot2, nil)
+	assert.IsType(err, errOptimisticLockFailedTables)
+	assert.Equal(newRoot2, actual)
+	assert.Equal([]tableSpec{{tableName, 1}}, tableSpecs)
 }
 
 // tryClobberManifest simulates another process trying to access dir/manifestFileName concurrently. To avoid deadlock, it does a non-blocking lock of dir/lockFileName. If it can get the lock, it clobbers the manifest.

--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -32,6 +32,10 @@ func (ftp fsTablePersister) persistTable(name addr, data []byte, chunkCount uint
 		d.PanicIfError(err)
 		defer checkClose(temp)
 		io.Copy(temp, bytes.NewReader(data))
+		index := parseTableIndex(data)
+		if ftp.indexCache != nil {
+			ftp.indexCache.put(name, index)
+		}
 		return temp.Name()
 	}()
 	err := os.Rename(tempName, filepath.Join(ftp.dir, name.String()))

--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -6,20 +6,14 @@ package nbs
 
 import (
 	"crypto/sha512"
-	"fmt"
 	"strconv"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 )
 
-var (
-	errOptimisticLockFailedRoot   = fmt.Errorf("Root moved")
-	errOptimisticLockFailedTables = fmt.Errorf("Tables changed")
-)
-
 type manifest interface {
-	// LoadIfExists extracts and returns values from a NomsBlockStore
+	// ParseIfExists extracts and returns values from a NomsBlockStore
 	// manifest, if one exists. Concrete implementations are responsible for
 	// defining how to find and parse the desired manifest, e.g. a
 	// particularly-named file in a given directory. Implementations are also
@@ -33,24 +27,24 @@ type manifest interface {
 	// return values are undefined. The |readHook| parameter allows race
 	// condition testing. If it is non-nil, it will be invoked while the
 	// implementation is guaranteeing exclusive access to the manifest.
-	LoadIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec)
+	ParseIfExists(readHook func()) (exists bool, vers string, lock addr, root hash.Hash, tableSpecs []tableSpec)
 
 	// Update optimistically tries to write a new manifest containing
-	// |newRoot| and the tables referenced by |specs|. If the currently
-	// persisted manifest has not changed since this instance was last loaded
-	// or updated, then Update succeeds and subsequent calls to both Update
-	// and LoadIfExists will reflect a manifest containing |newRoot| and
-	// |tables|. If not, Update fails with an error indicating what caused the
-	// optimistic lock failure. Regardless, |actual| and |tableSpecs| will
-	// reflect the current state of the world upon return. Upon error, clients
-	// should merge any desired new table information with the contents of
-	// |tableSpecs| before trying again. Concrete implementations are
-	// responsible for ensuring that concurrent Update calls (and LoadIfExists
-	// calls) are correct.
+	// |newRoot| and the tables referenced by |specs|. If |lastLock| matches
+	// the lock hash in the currently persisted manifest (logically, the lock
+	// that would be returned by ParseIfExists), then Update succeeds and
+	// subsequent calls to both Update and ParseIfExists will reflect a
+	// manifest containing |newLock|, |newRoot| and |tables|. If not, Update
+	// fails. Regardless, |lock|, |actual| and |tableSpecs| will reflect the
+	// current state of the world upon return. Callers should check that
+	// |actual| == |newRoot| and, if not, merge any desired new table
+	// information with the contents of |tableSpecs| before trying again.
+	// Concrete implementations are responsible for ensuring that concurrent
+	// Update calls (and ParseIfExists calls) are correct.
 	// If writeHook is non-nil, it will be invoked while the implementation is
 	// guaranteeing exclusive access to the manifest. This allows for testing
 	// of race conditions.
-	Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec, err error)
+	Update(lastLock, newLock addr, specs []tableSpec, newRoot hash.Hash, writeHook func()) (lock addr, actual hash.Hash, tableSpecs []tableSpec)
 }
 
 type tableSpec struct {
@@ -77,6 +71,12 @@ func formatSpecs(specs []tableSpec, tableInfo []string) {
 	}
 }
 
+// generateLockHash returns a hash of root and the names of all the tables in
+// specs, which should be included in all persisted manifests. When a client
+// attempts to update a manifest, it must check the lock hash in the currently
+// persisted manifest against the lock hash it saw last time it loaded the
+// contents of a manifest. If they do not match, the client must not update
+// the persisted manifest.
 func generateLockHash(root hash.Hash, specs []tableSpec) (lock addr) {
 	blockHash := sha512.New()
 	blockHash.Write(root[:])

--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -5,14 +5,21 @@
 package nbs
 
 import (
+	"crypto/sha512"
+	"fmt"
 	"strconv"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 )
 
+var (
+	errOptimisticLockFailedRoot   = fmt.Errorf("Root moved")
+	errOptimisticLockFailedTables = fmt.Errorf("Tables changed")
+)
+
 type manifest interface {
-	// ParseIfExists extracts and returns values from a NomsBlockStore
+	// LoadIfExists extracts and returns values from a NomsBlockStore
 	// manifest, if one exists. Concrete implementations are responsible for
 	// defining how to find and parse the desired manifest, e.g. a
 	// particularly-named file in a given directory. Implementations are also
@@ -26,24 +33,24 @@ type manifest interface {
 	// return values are undefined. The |readHook| parameter allows race
 	// condition testing. If it is non-nil, it will be invoked while the
 	// implementation is guaranteeing exclusive access to the manifest.
-	ParseIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec)
+	LoadIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec)
 
 	// Update optimistically tries to write a new manifest containing
-	// |newRoot| and the tables referenced by |specs|. If |root| matches the root
-	// hash in the currently persisted manifest (logically, the root that
-	// would be returned by ParseIfExists), then Update succeeds and
-	// subsequent calls to both Update and ParseIfExists will reflect a
-	// manifest containing |newRoot| and |tables|. If not, Update fails.
-	// Regardless, |actual| and |tableSpecs| will reflect the current state of
-	// the world upon return. Callers should check that |actual| == |newRoot|
-	// and, if not, merge any desired new table information with the contents
-	// of |tableSpecs| before trying again.
-	// Concrete implementations are responsible for ensuring that concurrent
-	// Update calls (and ParseIfExists calls) are correct.
+	// |newRoot| and the tables referenced by |specs|. If the currently
+	// persisted manifest has not changed since this instance was last loaded
+	// or updated, then Update succeeds and subsequent calls to both Update
+	// and LoadIfExists will reflect a manifest containing |newRoot| and
+	// |tables|. If not, Update fails with an error indicating what caused the
+	// optimistic lock failure. Regardless, |actual| and |tableSpecs| will
+	// reflect the current state of the world upon return. Upon error, clients
+	// should merge any desired new table information with the contents of
+	// |tableSpecs| before trying again. Concrete implementations are
+	// responsible for ensuring that concurrent Update calls (and LoadIfExists
+	// calls) are correct.
 	// If writeHook is non-nil, it will be invoked while the implementation is
 	// guaranteeing exclusive access to the manifest. This allows for testing
 	// of race conditions.
-	Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec)
+	Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec, err error)
 }
 
 type tableSpec struct {
@@ -68,4 +75,16 @@ func formatSpecs(specs []tableSpec, tableInfo []string) {
 		tableInfo[2*i] = t.name.String()
 		tableInfo[2*i+1] = strconv.FormatUint(uint64(t.chunkCount), 10)
 	}
+}
+
+func generateLockHash(root hash.Hash, specs []tableSpec) (lock addr) {
+	blockHash := sha512.New()
+	blockHash.Write(root[:])
+	for _, spec := range specs {
+		blockHash.Write(spec.name[:])
+	}
+	var h []byte
+	h = blockHash.Sum(h) // Appends hash to h
+	copy(lock[:], h)
+	return
 }

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -67,6 +67,10 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32, indexCache *index
 		buff, err = unix.Mmap(int(f.Fd()), aligned, int(fi.Size()-aligned), unix.PROT_READ, unix.MAP_SHARED)
 		d.PanicIfError(err)
 		index = parseTableIndex(buff[indexOffset-aligned:])
+
+		if indexCache != nil {
+			indexCache.put(h, index)
+		}
 	}
 	success = true
 

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -72,9 +72,9 @@ func TestChunkStoreManifestAppearsAfterConstruction(t *testing.T) {
 
 	// Simulate another process writing a manifest after construction.
 	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
-	newRoot := hash.Of([]byte("new root"))
+	newLock, newRoot := computeAddr([]byte("locker")), hash.Of([]byte("new root"))
 	src := tt.p.Compact(createMemTable(chunks), nil)
-	fm.set(constants.NomsVersion, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
+	fm.set(constants.NomsVersion, newLock, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
 
 	// state in store shouldn't change
 	assert.Equal(hash.Hash{}, store.Root())
@@ -88,9 +88,9 @@ func TestChunkStoreManifestFirstWriteByOtherProcess(t *testing.T) {
 
 	// Simulate another process having already written a manifest.
 	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
-	newRoot := hash.Of([]byte("new root"))
+	newLock, newRoot := computeAddr([]byte("locker")), hash.Of([]byte("new root"))
 	src := tt.p.Compact(createMemTable(chunks), nil)
-	fm.set(constants.NomsVersion, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
+	fm.set(constants.NomsVersion, newLock, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
 
 	store := newNomsBlockStore(fm, tt, defaultMemTableSize, defaultMaxTables)
 	defer store.Close()
@@ -107,9 +107,9 @@ func TestChunkStoreUpdateRootOptimisticLockFail(t *testing.T) {
 
 	// Simulate another process writing a manifest behind store's back.
 	chunks := [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
-	newRoot := hash.Of([]byte("new root"))
+	newLock, newRoot := computeAddr([]byte("locker")), hash.Of([]byte("new root"))
 	src := tt.p.Compact(createMemTable(chunks), nil)
-	fm.set(constants.NomsVersion, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
+	fm.set(constants.NomsVersion, newLock, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
 
 	newRoot2 := hash.Of([]byte("new root 2"))
 	assert.False(store.UpdateRoot(newRoot2, hash.Hash{}))
@@ -141,46 +141,52 @@ func assertDataInStore(slices [][]byte, store chunks.ChunkSource, assert *assert
 // fakeManifest simulates a fileManifest without touching disk.
 type fakeManifest struct {
 	version    string
+	lock       addr
 	root       hash.Hash
 	tableSpecs []tableSpec
 	mu         sync.RWMutex
 }
 
-// ParseIfExists returns any fake manifest data the caller has injected using Update() or set(). It treats an empty |fm.root| as a non-existent manifest.
-func (fm *fakeManifest) LoadIfExists(readHook func()) (exists bool, vers string, root hash.Hash, tableSpecs []tableSpec) {
+// ParseIfExists returns any fake manifest data the caller has injected using
+// Update() or set(). It treats an empty |fm.lock| as a non-existent manifest.
+func (fm *fakeManifest) ParseIfExists(readHook func()) (exists bool, vers string, lock addr, root hash.Hash, tableSpecs []tableSpec) {
 	fm.mu.RLock()
 	defer fm.mu.RUnlock()
-	if fm.root != (hash.Hash{}) {
-		return true, fm.version, fm.root, fm.tableSpecs
+	if fm.lock != (addr{}) {
+		return true, fm.version, fm.lock, fm.root, fm.tableSpecs
 	}
-	return false, "", hash.Hash{}, nil
+	return false, "", addr{}, hash.Hash{}, nil
 }
 
-// Update checks whether |root| == |fm.root| and, if so, updates internal fake manifest state as per the manifest.Update() contract: |fm.root| is set to |newRoot|, and the contents of |specs| are merged into |fm.tableSpecs|. If |root| != |fm.root|, then the update fails. Regardless of success or failure, the current state is returned.
-func (fm *fakeManifest) Update(specs []tableSpec, root, newRoot hash.Hash, writeHook func()) (actual hash.Hash, tableSpecs []tableSpec, err error) {
+// Update checks whether |lastLock| == |fm.lock| and, if so, updates internal
+// fake manifest state as per the manifest.Update() contract: |fm.lock| is set
+// to |newLock|, |fm.root| is set to |newRoot|, and the contents of |specs|
+// are merged into |fm.tableSpecs|. If |lastLock| != |fm.lock|, then the update
+// fails. Regardless of success or failure, the current state is returned.
+func (fm *fakeManifest) Update(lastLock, newLock addr, specs []tableSpec, newRoot hash.Hash, writeHook func()) (lock addr, actual hash.Hash, tableSpecs []tableSpec) {
 	fm.mu.Lock()
 	defer fm.mu.Unlock()
-	if fm.root != root {
-		return fm.root, fm.tableSpecs, errOptimisticLockFailedRoot
-	}
-	fm.version = constants.NomsVersion
-	fm.root = newRoot
+	if fm.lock == lastLock {
+		fm.version = constants.NomsVersion
+		fm.lock = newLock
+		fm.root = newRoot
 
-	known := map[addr]struct{}{}
-	for _, t := range fm.tableSpecs {
-		known[t.name] = struct{}{}
-	}
+		known := map[addr]struct{}{}
+		for _, t := range fm.tableSpecs {
+			known[t.name] = struct{}{}
+		}
 
-	for _, t := range specs {
-		if _, present := known[t.name]; !present {
-			fm.tableSpecs = append(fm.tableSpecs, t)
+		for _, t := range specs {
+			if _, present := known[t.name]; !present {
+				fm.tableSpecs = append(fm.tableSpecs, t)
+			}
 		}
 	}
-	return fm.root, fm.tableSpecs, nil
+	return fm.lock, fm.root, fm.tableSpecs
 }
 
-func (fm *fakeManifest) set(version string, root hash.Hash, specs []tableSpec) {
-	fm.version, fm.root, fm.tableSpecs = version, root, specs
+func (fm *fakeManifest) set(version string, lock addr, root hash.Hash, specs []tableSpec) {
+	fm.version, fm.lock, fm.root, fm.tableSpecs = version, lock, root, specs
 }
 
 func newFakeTableSet() tableSet {

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-2:7.6:j4m2jbcufgp97fu5gr8l5d4qq4mdvsqm:lfo8tefm1ivi3kr3muov3dfj3d9r7b4b:2:14qd0pb5311acdb1mp34ahq7thoih0f0:2
+3:7.6:j5gnegk98cbv8jm8rh13qmg4v37ktnmd:j4m2jbcufgp97fu5gr8l5d4qq4mdvsqm:lfo8tefm1ivi3kr3muov3dfj3d9r7b4b:2:14qd0pb5311acdb1mp34ahq7thoih0f0:2


### PR DESCRIPTION
Introduce a "lock" hash into NBS manifests to address the bad
interaction between Flush() and optimistic locking. Our original
design didn't include Flush(), which changes the set of tables without
updating the root. Thus... an optimistic locking strategy predicated
on checking the currently-persisted root hash is not robust to
interleaved Flush() calls from multiple clients.

Fixes #3349