### PR TITLE
Rename 'lock' attribute in dynamo_manifest.go

### DIFF
--- a/go/nbs/dynamo_manifest.go
+++ b/go/nbs/dynamo_manifest.go
@@ -19,7 +19,7 @@ import (
 const (
 	tableName      = "attic-nbs"
 	dbAttr         = "db"
-	lockAttr       = "lock"
+	lockAttr       = "lck" // 'lock' is a reserved word in dynamo
 	rootAttr       = "root"
 	versAttr       = "vers"
 	nbsVersAttr    = "nbsVers"


### PR DESCRIPTION
Turns out 'lock' is a reserved word for DynamoDB attributes,
so change it.