### PR TITLE
Normalize our number encoding

### DIFF
--- a/go/constants/version.go
+++ b/go/constants/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TODO: generate this from some central thing with go generate.
-const NomsVersion = "7.7"
+const NomsVersion = "7.8"
 const NOMS_VERSION_NEXT_ENV_NAME = "NOMS_VERSION_NEXT"
 const NOMS_VERSION_NEXT_ENV_VALUE = "1"
 

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -441,7 +441,8 @@ func (suite *QueryGraphQLSuite) TestNestedCollection() {
 
 	suite.assertQueryResult(list, "{root{size}}", `{"data":{"root":{"size":2}}}`)
 	suite.assertQueryResult(list, "{root{values(count:1){size}}}", `{"data":{"root":{"values":[{"size":2}]}}}`)
-	suite.assertQueryResult(list, "{root{values(at:1,count:1){values(count:1){entries{key value}}}}}", `{"data":{"root":{"values":[{"values":[{"entries":[{"key":30,"value":"baz"}]}]}]}}}`)
+	suite.assertQueryResult(list, "{root{values(at:1,count:1){values(count:1){entries{key value}}}}}",
+		`{"data":{"root":{"values":[{"values":[{"entries":[{"key":40,"value":"bat"}]}]}]}}}`)
 }
 
 func (suite *QueryGraphQLSuite) TestLoFi() {

--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -111,7 +111,7 @@ func (b *binaryNomsReader) readNumber() Number {
 	b.offset += uint32(count)
 	exp, count2 := binary.Varint(b.buff[b.offset:])
 	b.offset += uint32(count2)
-	return Number(intExpToFloat64(i, int(exp)))
+	return Number(fracExpToFloat(i, int(exp)))
 }
 
 func (b *binaryNomsReader) readBool() bool {

--- a/go/types/codec_test.go
+++ b/go/types/codec_test.go
@@ -1,0 +1,54 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestCodecWriteNumber(t *testing.T) {
+	test := func(f float64, exp []byte) {
+		w := newBinaryNomsWriter()
+		w.writeNumber(Number(f))
+		assert.Equal(t, exp, w.data())
+	}
+
+	test(0, []byte{0, 0}) //  0 * 2 **  0
+
+	test(1, []byte{1 * 2, 0})           //  1 * 2 **  0
+	test(2, []byte{1 * 2, 1 * 2})       //  1 * 2 **  1
+	test(-2, []byte{1*2 - 1, 1 + 1})    // -1 * 2 **  1
+	test(.5, []byte{1 * 2, 1*2 - 1})    //  1 * 2 ** -1
+	test(-.5, []byte{1*2 - 1, 1*2 - 1}) // -1 * 2 ** -1
+	test(.25, []byte{1 * 2, 2*2 - 1})   //  1 * 2 ** -2
+	test(3, []byte{3 * 2, 0})           // 0b11 * 2 ** 0
+
+	test(15, []byte{15 * 2, 0})     // 0b1111 * 2**0
+	test(256, []byte{1 * 2, 8 * 2}) // 1 * 2*8
+}
+
+func TestCodecReadNumber(t *testing.T) {
+	test := func(data []byte, exp float64) {
+		r := binaryNomsReader{buff: data}
+		n := r.readNumber()
+		assert.Equal(t, exp, float64(n))
+		assert.Equal(t, len(data), int(r.offset))
+	}
+
+	test([]byte{0, 0}, 0) //  0 * 2 **  0
+
+	test([]byte{1 * 2, 0}, 1)           //  1 * 2 **  0
+	test([]byte{1 * 2, 1 * 2}, 2)       //  1 * 2 **  1
+	test([]byte{1*2 - 1, 1 + 1}, -2)    // -1 * 2 **  1
+	test([]byte{1 * 2, 1*2 - 1}, .5)    //  1 * 2 ** -1
+	test([]byte{1*2 - 1, 1*2 - 1}, -.5) // -1 * 2 ** -1
+	test([]byte{1 * 2, 2*2 - 1}, .25)   //  1 * 2 ** -2
+	test([]byte{3 * 2, 0}, 3)           // 0b11 * 2 ** 0
+
+	test([]byte{15 * 2, 0}, 15)     // 0b1111 * 2**0
+	test([]byte{1 * 2, 8 * 2}, 256) // 1 * 2*8
+}

--- a/go/types/codec_test.go
+++ b/go/types/codec_test.go
@@ -17,18 +17,20 @@ func TestCodecWriteNumber(t *testing.T) {
 		assert.Equal(t, exp, w.data())
 	}
 
+	// We use zigzag encoding for the signed bit. For positive n we do 2*n and for negative we do 2*-n - 1
 	test(0, []byte{0, 0}) //  0 * 2 **  0
 
-	test(1, []byte{1 * 2, 0})           //  1 * 2 **  0
-	test(2, []byte{1 * 2, 1 * 2})       //  1 * 2 **  1
-	test(-2, []byte{1*2 - 1, 1 + 1})    // -1 * 2 **  1
-	test(.5, []byte{1 * 2, 1*2 - 1})    //  1 * 2 ** -1
-	test(-.5, []byte{1*2 - 1, 1*2 - 1}) // -1 * 2 ** -1
-	test(.25, []byte{1 * 2, 2*2 - 1})   //  1 * 2 ** -2
-	test(3, []byte{3 * 2, 0})           // 0b11 * 2 ** 0
+	test(1, []byte{1 * 2, 0})            //  1 * 2 **  0
+	test(2, []byte{1 * 2, 1 * 2})        //  1 * 2 **  1
+	test(-2, []byte{(1 * 2) - 1, 1 * 2}) // -1 * 2 **  1
+	test(.5, []byte{1 * 2, 1*2 - 1})     //  1 * 2 ** -1
+	test(-.5, []byte{1*2 - 1, 1*2 - 1})  // -1 * 2 ** -1
+	test(.25, []byte{1 * 2, 2*2 - 1})    //  1 * 2 ** -2
+	test(3, []byte{3 * 2, 0})            // 0b11 * 2 ** 0
 
 	test(15, []byte{15 * 2, 0})     // 0b1111 * 2**0
 	test(256, []byte{1 * 2, 8 * 2}) // 1 * 2*8
+	test(-15, []byte{15*2 - 1, 0})  // -15 * 2*0
 }
 
 func TestCodecReadNumber(t *testing.T) {
@@ -51,4 +53,5 @@ func TestCodecReadNumber(t *testing.T) {
 
 	test([]byte{15 * 2, 0}, 15)     // 0b1111 * 2**0
 	test([]byte{1 * 2, 8 * 2}, 256) // 1 * 2*8
+	test([]byte{15*2 - 1, 0}, -15)  // -15 * 2*0
 }

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -152,11 +152,11 @@ func (suite *listTestSuite) TestMap() {
 }
 
 func TestListSuite4K(t *testing.T) {
-	suite.Run(t, newListTestSuite(12, 2, 2, 2))
+	suite.Run(t, newListTestSuite(12, 6, 2, 2))
 }
 
 func TestListSuite8K(t *testing.T) {
-	suite.Run(t, newListTestSuite(14, 11, 2, 2))
+	suite.Run(t, newListTestSuite(14, 23, 2, 2))
 }
 
 func TestListInsert(t *testing.T) {
@@ -972,9 +972,9 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	assert.Equal(diff1, diff2)
 
 	// should only read/write a "small & reasonably sized portion of the total"
-	assert.Equal(3, cs1.Writes)
-	assert.Equal(3, cs1.Reads)
-	assert.Equal(3, cs2.Writes)
+	assert.Equal(7, cs1.Writes)
+	assert.Equal(5, cs1.Reads)
+	assert.Equal(5, cs2.Writes)
 	assert.Equal(3, cs2.Reads)
 }
 

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -267,11 +267,11 @@ func (suite *mapTestSuite) TestStreamingMap2() {
 }
 
 func TestMapSuite4K(t *testing.T) {
-	suite.Run(t, newMapTestSuite(12, 2, 2, 2, newNumber))
+	suite.Run(t, newMapTestSuite(12, 9, 2, 2, newNumber))
 }
 
 func TestMapSuite4KStructs(t *testing.T) {
-	suite.Run(t, newMapTestSuite(12, 18, 2, 2, newNumberStruct))
+	suite.Run(t, newMapTestSuite(12, 13, 2, 2, newNumberStruct))
 }
 
 func newNumber(i int) Value {

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -194,11 +194,11 @@ func (suite *setTestSuite) TestStreamingSet2() {
 }
 
 func TestSetSuite4K(t *testing.T) {
-	suite.Run(t, newSetTestSuite(12, 2, 2, 2, newNumber))
+	suite.Run(t, newSetTestSuite(12, 6, 8, 2, newNumber))
 }
 
 func TestSetSuite4KStructs(t *testing.T) {
-	suite.Run(t, newSetTestSuite(12, 6, 2, 2, newNumberStruct))
+	suite.Run(t, newSetTestSuite(12, 6, 2, 8, newNumberStruct))
 }
 
 func getTestNativeOrderSet(scale int) testSet {

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-3:7.7:2i6mkbcajmnkkguethlmo929rif79r8r:c1uoqa08f12o0abqgv2lvavmppuc3kg4:m6j2e6jd69tbfk7d4hqf05ke2so64df3:2:e9v26bl5mov3mtp2vdvpb7q926oqn2dn:2
+3:7.8:2i6mkbcajmnkkguethlmo929rif79r8r:c1uoqa08f12o0abqgv2lvavmppuc3kg4:m6j2e6jd69tbfk7d4hqf05ke2so64df3:2:e9v26bl5mov3mtp2vdvpb7q926oqn2dn:2


### PR DESCRIPTION
Our Number encoding consists of two parts. Firsts we convert the float
into f * 2**exp, then we uvarint encode f and exp. However, we didn't
normalize f so in theory we could end up with multiple representations
of the same number.

This changes the representation to make the f the smallest possible
integer that fulfills the formula above.

For example we used to encode 256 as (0x100, 0) but with this we instead
encode it as (0x01, 8).

Fixes #2307