### PR TITLE
NBS: clean up chunk extract error reporting

### DIFF
--- a/go/nbs/mem_table.go
+++ b/go/nbs/mem_table.go
@@ -93,7 +93,7 @@ func (mt *memTable) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg
 
 func (mt *memTable) extract(chunks chan<- extractRecord) {
 	for _, hrec := range mt.order {
-		chunks <- extractRecord{*hrec.a, mt.chunks[*hrec.a]}
+		chunks <- extractRecord{a: *hrec.a, data: mt.chunks[*hrec.a]}
 	}
 	return
 }

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -197,6 +197,7 @@ func (hs getRecordByPrefix) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
 type extractRecord struct {
 	a    addr
 	data []byte
+	err  interface{} // only set when there was a panic during extraction.
 }
 
 type chunkReader interface {

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -429,7 +429,7 @@ func (tr tableReader) extract(chunks chan<- extractRecord) {
 
 	sendChunk := func(i uint32) {
 		localOffset := tr.offsets[i] - tr.offsets[0]
-		chunks <- extractRecord{hashes[i], tr.parseChunk(buff[localOffset : localOffset+uint64(tr.lengths[i])])}
+		chunks <- extractRecord{a: hashes[i], data: tr.parseChunk(buff[localOffset : localOffset+uint64(tr.lengths[i])])}
 	}
 
 	for i := uint32(0); i < tr.chunkCount; i++ {


### PR DESCRIPTION
At one point, we had some hard-to-diagnose failures
decoding chunks. We tracked the problem down and fixed
it, but it's good to keep the error reporting. It's done
more cleanly and efficiently, now.

Fixes #3148