### PR TITLE
Don't read chunk during ValueStore.bufferChunk()

### DIFF
--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -236,7 +236,7 @@ func (lvs *ValueStore) bufferChunk(v Value, c chunks.Chunk, height uint64) {
 		pending, isBuffered := lvs.bufferedChunks[parent]
 		if !isBuffered {
 			fmt.Fprintf(os.Stderr, "While buffering chunk for %s, encountered %s which has buffered children, but is not buffered itself.\n", h, parent)
-			pending = lvs.bs.Get(parent)
+			return
 		}
 		pv := DecodeValue(pending, lvs)
 		pv.WalkRefs(func(grandchildRef Ref) {


### PR DESCRIPTION
The last patch did this in order to allow bad-behavers
to still have a chance of succeding if they write Values
top down. This ensures that they won't, and therefore
will run afoul of lazy completeness checking.

Follow on for #3371