### PR TITLE
Define DateTime using struct embedding rather than type renaming.

### DIFF
--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/attic-labs/noms/cmd/util"
 	"github.com/attic-labs/noms/go/config"
@@ -265,7 +264,7 @@ func writeMetaLines(node LogNode, maxLines, lineno, maxLabelLen int, w io.Writer
 				if types.TypeOf(v).Equals(datetime.DateTimeType) {
 					var dt datetime.DateTime
 					dt.UnmarshalNoms(v)
-					fmt.Fprintf(pw, time.Time(dt).Format(spec.CommitMetaDateFormat))
+					fmt.Fprintf(pw, dt.Format(spec.CommitMetaDateFormat))
 				} else {
 					types.WriteEncodedValue(pw, v)
 				}

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -14,8 +14,7 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-// DateTime is an alias for time.Time that allows us to marshal date time to
-// Noms.
+// DateTime implements marshaling of time.Time to and from Noms.
 type DateTime struct {
 	time.Time
 }

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -16,7 +16,9 @@ import (
 
 // DateTime is an alias for time.Time that allows us to marshal date time to
 // Noms.
-type DateTime time.Time
+type DateTime struct {
+	time.Time
+}
 
 // DateTimeType is the Noms type used to represent date time objects in Noms.
 // The field secSinceEpoch may contain fractions in cases where seconds are
@@ -28,9 +30,8 @@ var DateTimeType = types.MakeStructTypeFromFields("DateTime", types.FieldMap{
 // MarshalNoms makes DateTime implement marshal.Marshaler and it makes
 // DateTime marshal into a Noms struct with type DateTimeType.
 func (dt DateTime) MarshalNoms() (types.Value, error) {
-	t := time.Time(dt)
 	return types.NewStruct("DateTime", types.StructData{
-		"secSinceEpoch": types.Number(float64(t.Unix()) + float64(t.Nanosecond())*1e-9),
+		"secSinceEpoch": types.Number(float64(dt.Unix()) + float64(dt.Nanosecond())*1e-9),
 	}), nil
 }
 
@@ -53,12 +54,6 @@ func (dt *DateTime) UnmarshalNoms(v types.Value) error {
 	}
 
 	s, frac := math.Modf(strct.SecSinceEpoch)
-	*dt = DateTime(time.Unix(int64(s), int64(frac*1e9)))
+	*dt = DateTime{time.Unix(int64(s), int64(frac*1e9))}
 	return nil
-}
-
-// String() causes DateTime structs to be printed in the same way as time.Time
-// structs.
-func (dt DateTime) String() string {
-	return time.Time(dt).String()
 }

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -17,7 +17,7 @@ func TestBasics(t *testing.T) {
 	assert := assert.New(t)
 
 	// Since we are using float64 in noms we cannot represent all possible times.
-	dt := DateTime(time.Unix(1234567, 1234567))
+	dt := DateTime{time.Unix(1234567, 1234567)}
 
 	nomsValue, err := marshal.Marshal(dt)
 	assert.NoError(err)
@@ -26,7 +26,7 @@ func TestBasics(t *testing.T) {
 	err = marshal.Unmarshal(nomsValue, &dt2)
 	assert.NoError(err)
 
-	assert.True(time.Time(dt).Equal(time.Time(dt2)))
+	assert.True(dt.Equal(dt2.Time))
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -36,7 +36,7 @@ func TestUnmarshal(t *testing.T) {
 		var dt DateTime
 		err := marshal.Unmarshal(v, &dt)
 		assert.NoError(err)
-		assert.True(time.Time(dt).Equal(t))
+		assert.True(dt.Equal(t))
 	}
 
 	for _, name := range []string{"DateTime", "Date", "xxx", ""} {
@@ -85,19 +85,19 @@ func TestMarshal(t *testing.T) {
 		}).Equals(v))
 	}
 
-	test(DateTime(time.Unix(0, 0)), 0)
-	test(DateTime(time.Unix(42, 0)), 42)
-	test(DateTime(time.Unix(42, 123456789)), 42.123456789)
-	test(DateTime(time.Unix(123456789, 123456789)), 123456789.123456789)
-	test(DateTime(time.Unix(-42, 0)), -42)
-	test(DateTime(time.Unix(-42, -123456789)), -42.123456789)
-	test(DateTime(time.Unix(-123456789, -123456789)), -123456789.123456789)
+	test(DateTime{time.Unix(0, 0)}, 0)
+	test(DateTime{time.Unix(42, 0)}, 42)
+	test(DateTime{time.Unix(42, 123456789)}, 42.123456789)
+	test(DateTime{time.Unix(123456789, 123456789)}, 123456789.123456789)
+	test(DateTime{time.Unix(-42, 0)}, -42)
+	test(DateTime{time.Unix(-42, -123456789)}, -42.123456789)
+	test(DateTime{time.Unix(-123456789, -123456789)}, -123456789.123456789)
 }
 
 func TestMarshalType(t *testing.T) {
 	assert := assert.New(t)
 
-	dt := DateTime(time.Unix(0, 0))
+	dt := DateTime{time.Unix(0, 0)}
 	typ := marshal.MustMarshalType(dt)
 	assert.Equal(DateTimeType, typ)
 
@@ -109,22 +109,22 @@ func TestZeroValues(t *testing.T) {
 	assert := assert.New(t)
 
 	dt1 := DateTime{}
-	assert.True(time.Time(dt1).IsZero())
+	assert.True(dt1.IsZero())
 
 	nomsDate, _ := dt1.MarshalNoms()
 
 	dt2 := DateTime{}
 	marshal.Unmarshal(nomsDate, &dt2)
-	assert.True(time.Time(dt2).IsZero())
+	assert.True(dt2.IsZero())
 
 	dt3 := DateTime{}
 	dt3.UnmarshalNoms(nomsDate)
-	assert.True(time.Time(dt3).IsZero())
+	assert.True(dt3.IsZero())
 }
 
 func TestString(t *testing.T) {
 	assert := assert.New(t)
-	dt := DateTime(time.Unix(1234567, 1234567))
+	dt := DateTime{time.Unix(1234567, 1234567)}
 	// Don't test the actual output since that
 	assert.IsType(dt.String(), "s")
 }


### PR DESCRIPTION
This results in us inheriting all the methods of DateTime automatically.