### PR TITLE
Make MemoryStore come correct

### DIFF
--- a/go/chunks/chunk_serializer_test.go
+++ b/go/chunks/chunk_serializer_test.go
@@ -36,3 +36,10 @@ func TestSerializeRoundTrip(t *testing.T) {
 	}
 	assert.Len(chnx, 0)
 }
+
+func TestBadSerialization(t *testing.T) {
+	bad := []byte{0, 1} // Not enough bytes to read first length
+	ch := make(chan *Chunk)
+	defer close(ch)
+	assert.Error(t, Deserialize(bytes.NewReader(bad), ch))
+}

--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -14,7 +14,7 @@ import (
 // anyplace we have a ChunkStore implementation for.
 type ChunkStore interface {
 	// Get the Chunk for the value of the hash in the store. If the hash is
-	// absent from the store nil is returned.
+	// absent from the store EmptyChunk is returned.
 	Get(h hash.Hash) Chunk
 
 	// GetMany gets the Chunks with |hashes| from the store. On return,

--- a/go/chunks/chunk_store_common_test.go
+++ b/go/chunks/chunk_store_common_test.go
@@ -13,81 +13,88 @@ import (
 
 type ChunkStoreTestSuite struct {
 	suite.Suite
-	Store      ChunkStore
-	putCountFn func() int
+	Factory Factory
 }
 
 func (suite *ChunkStoreTestSuite) TestChunkStorePut() {
+	store := suite.Factory.CreateStore("ns")
 	input := "abc"
 	c := NewChunk([]byte(input))
-	suite.Store.Put(c)
+	store.Put(c)
 	h := c.Hash()
 
 	// See http://www.di-mgt.com.au/sha_testvectors.html
 	suite.Equal("rmnjb8cjc5tblj21ed4qs821649eduie", h.String())
 
-	suite.Store.Commit(h, suite.Store.Root()) // Commit writes
+	// Reading it via the API should work...
+	assertInputInStore(input, h, store, suite.Assert())
 
-	// And reading it via the API should work...
-	assertInputInStore(input, h, suite.Store, suite.Assert())
-	if suite.putCountFn != nil {
-		suite.Equal(1, suite.putCountFn())
-	}
-
-	// Re-writing the same data should cause a second put
-	c = NewChunk([]byte(input))
-	suite.Store.Put(c)
-	suite.Equal(h, c.Hash())
-	assertInputInStore(input, h, suite.Store, suite.Assert())
-	suite.Store.Commit(h, suite.Store.Root()) // Commit writes
-
-	if suite.putCountFn != nil {
-		suite.Equal(2, suite.putCountFn())
-	}
+	store.Commit(h, store.Root()) // Commit writes
+	// ...as well as after commit
+	assertInputInStore(input, h, store, suite.Assert())
 }
 
 func (suite *ChunkStoreTestSuite) TestChunkStorePutMany() {
+	store := suite.Factory.CreateStore("ns")
 	input1, input2 := "abc", "def"
 	c1, c2 := NewChunk([]byte(input1)), NewChunk([]byte(input2))
-	suite.Store.PutMany([]Chunk{c1, c2})
+	store.PutMany([]Chunk{c1, c2})
 
-	suite.Store.Commit(c1.Hash(), suite.Store.Root()) // Commit writes
+	store.Commit(c1.Hash(), store.Root()) // Commit writes
 
 	// And reading it via the API should work...
-	assertInputInStore(input1, c1.Hash(), suite.Store, suite.Assert())
-	assertInputInStore(input2, c2.Hash(), suite.Store, suite.Assert())
-	if suite.putCountFn != nil {
-		suite.Equal(2, suite.putCountFn())
-	}
+	assertInputInStore(input1, c1.Hash(), store, suite.Assert())
+	assertInputInStore(input2, c2.Hash(), store, suite.Assert())
 }
 
 func (suite *ChunkStoreTestSuite) TestChunkStoreRoot() {
-	oldRoot := suite.Store.Root()
+	store := suite.Factory.CreateStore("ns")
+	oldRoot := store.Root()
 	suite.True(oldRoot.IsEmpty())
 
 	bogusRoot := hash.Parse("8habda5skfek1265pc5d5l1orptn5dr0")
 	newRoot := hash.Parse("8la6qjbh81v85r6q67lqbfrkmpds14lg")
 
 	// Try to update root with bogus oldRoot
-	result := suite.Store.Commit(newRoot, bogusRoot)
+	result := store.Commit(newRoot, bogusRoot)
 	suite.False(result)
 
 	// Now do a valid root update
-	result = suite.Store.Commit(newRoot, oldRoot)
+	result = store.Commit(newRoot, oldRoot)
 	suite.True(result)
 }
 
 func (suite *ChunkStoreTestSuite) TestChunkStoreGetNonExisting() {
+	store := suite.Factory.CreateStore("ns")
 	h := hash.Parse("11111111111111111111111111111111")
-	c := suite.Store.Get(h)
+	c := store.Get(h)
 	suite.True(c.IsEmpty())
 }
 
 func (suite *ChunkStoreTestSuite) TestChunkStoreVersion() {
-	oldRoot := suite.Store.Root()
+	store := suite.Factory.CreateStore("ns")
+	oldRoot := store.Root()
 	suite.True(oldRoot.IsEmpty())
 	newRoot := hash.Parse("11111222223333344444555556666677")
-	suite.True(suite.Store.Commit(newRoot, oldRoot))
+	suite.True(store.Commit(newRoot, oldRoot))
 
-	suite.Equal(constants.NomsVersion, suite.Store.Version())
+	suite.Equal(constants.NomsVersion, store.Version())
+}
+
+func (suite *ChunkStoreTestSuite) TestChunkStoreFlush() {
+	store1, store2 := suite.Factory.CreateStore("ns"), suite.Factory.CreateStore("ns")
+	input := "abc"
+	c := NewChunk([]byte(input))
+	store1.Put(c)
+	h := c.Hash()
+
+	// Reading c from store1 via the API should work...
+	assertInputInStore(input, h, store1, suite.Assert())
+	// ...but not store2.
+	assertInputNotInStore(input, h, store2, suite.Assert())
+
+	store1.Flush()
+	store2.Rebase()
+	// Now, reading c from store2 via the API should work...
+	assertInputInStore(input, h, store2, suite.Assert())
 }

--- a/go/chunks/chunk_test.go
+++ b/go/chunks/chunk_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
+func TestChunk(t *testing.T) {
+	c := NewChunk([]byte("abc"))
+	h := c.Hash()
+	// See http://www.di-mgt.com.au/sha_testvectors.html
+	assert.Equal(t, "rmnjb8cjc5tblj21ed4qs821649eduie", h.String())
+}
+
 func TestChunkWriteAfterCloseFails(t *testing.T) {
 	assert := assert.New(t)
 	input := "abc"

--- a/go/chunks/memory_store_test.go
+++ b/go/chunks/memory_store_test.go
@@ -5,7 +5,6 @@
 package chunks
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/attic-labs/testify/suite"
@@ -20,16 +19,9 @@ type MemoryStoreTestSuite struct {
 }
 
 func (suite *MemoryStoreTestSuite) SetupTest() {
-	suite.Store = NewMemoryStore()
+	suite.Factory = newMemoryStoreFactory()
 }
 
 func (suite *MemoryStoreTestSuite) TearDownTest() {
-	suite.Store.Close()
-}
-
-func (suite *MemoryStoreTestSuite) TestBadSerialization() {
-	bad := []byte{0, 1} // Not enough bytes to read first length
-	ch := make(chan *Chunk)
-	defer close(ch)
-	suite.Error(Deserialize(bytes.NewReader(bad), ch))
+	suite.Factory.Shutter()
 }

--- a/go/datas/caching_chunk_haver_test.go
+++ b/go/datas/caching_chunk_haver_test.go
@@ -13,7 +13,8 @@ import (
 
 func TestCachingChunkHaver(t *testing.T) {
 	assert := assert.New(t)
-	ts := chunks.NewTestStore()
+	storage := &chunks.TestStorage{}
+	ts := storage.NewView()
 	ccs := newCachingChunkHaver(ts)
 	input := "abc"
 
@@ -24,9 +25,11 @@ func TestCachingChunkHaver(t *testing.T) {
 	assert.Equal(ts.Hases, 1)
 
 	ts.Put(c)
+	ts.Flush()
+	ts = storage.NewView()
 	ccs = newCachingChunkHaver(ts)
 	assert.True(ccs.Has(c.Hash()))
-	assert.Equal(ts.Hases, 2)
+	assert.Equal(ts.Hases, 1)
 	assert.True(ccs.Has(c.Hash()))
-	assert.Equal(ts.Hases, 2)
+	assert.Equal(ts.Hases, 1)
 }

--- a/go/datas/commit_test.go
+++ b/go/datas/commit_test.go
@@ -119,7 +119,8 @@ func toValuesString(refSet types.Set, vr types.ValueReader) string {
 
 func TestFindCommonAncestor(t *testing.T) {
 	assert := assert.New(t)
-	db := NewDatabase(chunks.NewTestStore())
+	storage := &chunks.TestStorage{}
+	db := NewDatabase(storage.NewView())
 	defer db.Close()
 
 	// Add a commit and return it

--- a/go/datas/completeness_checker_test.go
+++ b/go/datas/completeness_checker_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestCompletenessChecker(t *testing.T) {
+	storage := &chunks.TestStorage{}
 	b := types.Bool(true)
 	r := types.NewRef(b)
 
@@ -23,11 +24,11 @@ func TestCompletenessChecker(t *testing.T) {
 			cc := newCompletenessChecker()
 			cc.AddRefs(badRef)
 			cc.AddRefs(r)
-			assert.Panics(t, func() { cc.PanicIfDangling(chunks.NewTestStore()) })
+			assert.Panics(t, func() { cc.PanicIfDangling(storage.NewView()) })
 		})
 		t.Run("SomeBad", func(t *testing.T) {
 			t.Parallel()
-			cs := chunks.NewTestStore()
+			cs := storage.NewView()
 			cs.Put(types.EncodeValue(b, nil))
 
 			cc := newCompletenessChecker()
@@ -40,7 +41,7 @@ func TestCompletenessChecker(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Run("PendingChunk", func(t *testing.T) {
 			t.Parallel()
-			cs := chunks.NewTestStore()
+			cs := storage.NewView()
 			cs.Put(types.EncodeValue(b, nil))
 
 			cc := newCompletenessChecker()
@@ -49,7 +50,7 @@ func TestCompletenessChecker(t *testing.T) {
 		})
 		t.Run("ExistingChunk", func(t *testing.T) {
 			t.Parallel()
-			cs := chunks.NewTestStore()
+			cs := storage.NewView()
 			cs.Put(types.EncodeValue(b, nil))
 
 			cc := newCompletenessChecker()

--- a/go/datas/dataset_test.go
+++ b/go/datas/dataset_test.go
@@ -16,7 +16,8 @@ func TestExplicitBranchUsingDatasets(t *testing.T) {
 	assert := assert.New(t)
 	id1 := "testdataset"
 	id2 := "othertestdataset"
-	store := NewDatabase(chunks.NewMemoryStore())
+	stg := &chunks.MemoryStorage{}
+	store := NewDatabase(stg.NewView())
 	defer store.Close()
 
 	ds1 := store.GetDataset(id1)
@@ -63,7 +64,8 @@ func TestExplicitBranchUsingDatasets(t *testing.T) {
 func TestTwoClientsWithEmptyDataset(t *testing.T) {
 	assert := assert.New(t)
 	id1 := "testdataset"
-	store := NewDatabase(chunks.NewMemoryStore())
+	stg := &chunks.MemoryStorage{}
+	store := NewDatabase(stg.NewView())
 	defer store.Close()
 
 	dsx := store.GetDataset(id1)
@@ -91,7 +93,8 @@ func TestTwoClientsWithEmptyDataset(t *testing.T) {
 func TestTwoClientsWithNonEmptyDataset(t *testing.T) {
 	assert := assert.New(t)
 	id1 := "testdataset"
-	store := NewDatabase(chunks.NewMemoryStore())
+	stg := &chunks.MemoryStorage{}
+	store := NewDatabase(stg.NewView())
 	defer store.Close()
 
 	a := types.String("a")
@@ -128,7 +131,8 @@ func TestTwoClientsWithNonEmptyDataset(t *testing.T) {
 
 func TestIdValidation(t *testing.T) {
 	assert := assert.New(t)
-	store := NewDatabase(chunks.NewMemoryStore())
+	stg := &chunks.MemoryStorage{}
+	store := NewDatabase(stg.NewView())
 
 	invalidDatasetNames := []string{" ", "", "a ", " a", "$", "#", ":", "\n", "💩"}
 	for _, id := range invalidDatasetNames {
@@ -143,7 +147,8 @@ func TestHeadValueFunctions(t *testing.T) {
 
 	id1 := "testdataset"
 	id2 := "otherdataset"
-	store := NewDatabase(chunks.NewMemoryStore())
+	stg := &chunks.MemoryStorage{}
+	store := NewDatabase(stg.NewView())
 	defer store.Close()
 
 	ds1 := store.GetDataset(id1)

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
+	"github.com/attic-labs/testify/assert"
 	"github.com/attic-labs/testify/suite"
 	"github.com/julienschmidt/httprouter"
 )
@@ -27,8 +28,8 @@ func TestHTTPChunkStore(t *testing.T) {
 
 type HTTPChunkStoreSuite struct {
 	suite.Suite
-	cs    *chunks.TestStore
-	store *httpChunkStore
+	serverCS *chunks.TestStoreView
+	http     *httpChunkStore
 }
 
 type inlineServer struct {
@@ -48,8 +49,9 @@ func (serv inlineServer) Do(req *http.Request) (resp *http.Response, err error) 
 }
 
 func (suite *HTTPChunkStoreSuite) SetupTest() {
-	suite.cs = chunks.NewTestStore()
-	suite.store = newHTTPChunkStoreForTest(suite.cs)
+	storage := &chunks.TestStorage{}
+	suite.serverCS = storage.NewView()
+	suite.http = newHTTPChunkStoreForTest(suite.serverCS)
 }
 
 func newHTTPChunkStoreForTest(cs chunks.ChunkStore) *httpChunkStore {
@@ -87,9 +89,9 @@ func newHTTPChunkStoreForTest(cs chunks.ChunkStore) *httpChunkStore {
 	return newHTTPChunkStoreWithClient("http://localhost:9000", "", serv)
 }
 
-func newAuthenticatingHTTPChunkStoreForTest(suite *HTTPChunkStoreSuite, hostUrl string) *httpChunkStore {
+func newAuthenticatingHTTPChunkStoreForTest(assert *assert.Assertions, cs chunks.ChunkStore, hostUrl string) *httpChunkStore {
 	authenticate := func(req *http.Request) {
-		suite.Equal(testAuthToken, req.URL.Query().Get("access_token"))
+		assert.Equal(testAuthToken, req.URL.Query().Get("access_token"))
 	}
 
 	serv := inlineServer{httprouter.New()}
@@ -97,47 +99,47 @@ func newAuthenticatingHTTPChunkStoreForTest(suite *HTTPChunkStoreSuite, hostUrl 
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 			authenticate(req)
-			HandleRootPost(w, req, ps, suite.cs)
+			HandleRootPost(w, req, ps, cs)
 		},
 	)
 	serv.GET(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-			HandleRootGet(w, req, ps, suite.cs)
+			HandleRootGet(w, req, ps, cs)
 		},
 	)
 	return newHTTPChunkStoreWithClient(hostUrl, "", serv)
 }
 
-func newBadVersionHTTPChunkStoreForTest(suite *HTTPChunkStoreSuite) *httpChunkStore {
+func newBadVersionHTTPChunkStoreForTest(cs chunks.ChunkStore) *httpChunkStore {
 	serv := inlineServer{httprouter.New()}
 	serv.POST(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-			HandleRootPost(w, req, ps, suite.cs)
+			HandleRootPost(w, req, ps, cs)
 			w.Header().Set(NomsVersionHeader, "BAD")
 		},
 	)
 	serv.GET(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-			HandleRootGet(w, req, ps, suite.cs)
+			HandleRootGet(w, req, ps, cs)
 		},
 	)
 	return newHTTPChunkStoreWithClient("http://localhost", "", serv)
 }
 
 func (suite *HTTPChunkStoreSuite) TearDownTest() {
-	suite.store.Close()
-	suite.cs.Close()
+	suite.http.Close()
+	suite.serverCS.Close()
 }
 
 func (suite *HTTPChunkStoreSuite) TestPutChunk() {
 	c := types.EncodeValue(types.String("abc"), nil)
-	suite.store.Put(c)
-	suite.store.Flush()
+	suite.http.Put(c)
+	suite.http.Flush()
 
-	suite.Equal(1, suite.cs.Writes)
+	suite.Equal(1, suite.serverCS.Writes)
 }
 
 func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
@@ -147,56 +149,56 @@ func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
 	}
 	l := types.NewList()
 	for _, val := range vals {
-		suite.store.Put(types.EncodeValue(val, nil))
+		suite.http.Put(types.EncodeValue(val, nil))
 		l = l.Append(types.NewRef(val))
 	}
-	suite.store.Put(types.EncodeValue(l, nil))
-	suite.store.Flush()
+	suite.http.Put(types.EncodeValue(l, nil))
+	suite.http.Flush()
 
-	suite.Equal(3, suite.cs.Writes)
+	suite.Equal(3, suite.serverCS.Writes)
 }
 
 func (suite *HTTPChunkStoreSuite) TestRebase() {
-	suite.Equal(hash.Hash{}, suite.store.Root())
+	suite.Equal(hash.Hash{}, suite.http.Root())
 	c := types.EncodeValue(types.NewMap(), nil)
-	suite.cs.Put(c)
-	suite.True(suite.cs.Commit(c.Hash(), hash.Hash{})) // change happens behind our backs
-	suite.Equal(hash.Hash{}, suite.store.Root())       // shouldn't be visible yet
+	suite.serverCS.Put(c)
+	suite.True(suite.serverCS.Commit(c.Hash(), hash.Hash{})) // change happens behind our backs
+	suite.Equal(hash.Hash{}, suite.http.Root())              // shouldn't be visible yet
 
-	suite.store.Rebase()
-	suite.Equal(c.Hash(), suite.cs.Root())
+	suite.http.Rebase()
+	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
 func (suite *HTTPChunkStoreSuite) TestRoot() {
 	c := types.EncodeValue(types.NewMap(), nil)
-	suite.cs.Put(c)
-	suite.True(suite.store.Commit(c.Hash(), hash.Hash{}))
-	suite.Equal(c.Hash(), suite.cs.Root())
+	suite.serverCS.Put(c)
+	suite.True(suite.http.Commit(c.Hash(), hash.Hash{}))
+	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
 func (suite *HTTPChunkStoreSuite) TestVersionMismatch() {
-	store := newBadVersionHTTPChunkStoreForTest(suite)
+	store := newBadVersionHTTPChunkStoreForTest(suite.serverCS)
 	defer store.Close()
 	c := types.EncodeValue(types.NewMap(), nil)
-	suite.cs.Put(c)
+	suite.serverCS.Put(c)
 	suite.Panics(func() { store.Commit(c.Hash(), hash.Hash{}) })
 }
 
 func (suite *HTTPChunkStoreSuite) TestCommit() {
 	c := types.EncodeValue(types.NewMap(), nil)
-	suite.cs.Put(c)
-	suite.True(suite.store.Commit(c.Hash(), hash.Hash{}))
-	suite.Equal(c.Hash(), suite.cs.Root())
+	suite.serverCS.Put(c)
+	suite.True(suite.http.Commit(c.Hash(), hash.Hash{}))
+	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
 func (suite *HTTPChunkStoreSuite) TestCommitWithParams() {
 	u := fmt.Sprintf("http://localhost:9000?access_token=%s&other=19", testAuthToken)
-	store := newAuthenticatingHTTPChunkStoreForTest(suite, u)
+	store := newAuthenticatingHTTPChunkStoreForTest(suite.Assert(), suite.serverCS, u)
 	defer store.Close()
 	c := types.EncodeValue(types.NewMap(), nil)
-	suite.cs.Put(c)
+	suite.serverCS.Put(c)
 	suite.True(store.Commit(c.Hash(), hash.Hash{}))
-	suite.Equal(c.Hash(), suite.cs.Root())
+	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
 func (suite *HTTPChunkStoreSuite) TestGet() {
@@ -204,10 +206,10 @@ func (suite *HTTPChunkStoreSuite) TestGet() {
 		chunks.NewChunk([]byte("abc")),
 		chunks.NewChunk([]byte("def")),
 	}
-	suite.cs.PutMany(chnx)
-	got := suite.store.Get(chnx[0].Hash())
+	suite.serverCS.PutMany(chnx)
+	got := suite.http.Get(chnx[0].Hash())
 	suite.Equal(chnx[0].Hash(), got.Hash())
-	got = suite.store.Get(chnx[1].Hash())
+	got = suite.http.Get(chnx[1].Hash())
 	suite.Equal(chnx[1].Hash(), got.Hash())
 }
 
@@ -217,12 +219,12 @@ func (suite *HTTPChunkStoreSuite) TestGetMany() {
 		chunks.NewChunk([]byte("def")),
 	}
 	notPresent := chunks.NewChunk([]byte("ghi")).Hash()
-	suite.cs.PutMany(chnx)
-	suite.cs.Flush()
+	suite.serverCS.PutMany(chnx)
+	suite.serverCS.Flush()
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), notPresent)
 	foundChunks := make(chan *chunks.Chunk)
-	go func() { suite.store.GetMany(hashes, foundChunks); close(foundChunks) }()
+	go func() { suite.http.GetMany(hashes, foundChunks); close(foundChunks) }()
 
 	for c := range foundChunks {
 		hashes.Remove(c.Hash())
@@ -236,11 +238,11 @@ func (suite *HTTPChunkStoreSuite) TestGetManyAllCached() {
 		chunks.NewChunk([]byte("abc")),
 		chunks.NewChunk([]byte("def")),
 	}
-	suite.store.PutMany(chnx)
+	suite.http.PutMany(chnx)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash())
 	foundChunks := make(chan *chunks.Chunk)
-	go func() { suite.store.GetMany(hashes, foundChunks); close(foundChunks) }()
+	go func() { suite.http.GetMany(hashes, foundChunks); close(foundChunks) }()
 
 	for c := range foundChunks {
 		hashes.Remove(c.Hash())
@@ -254,13 +256,13 @@ func (suite *HTTPChunkStoreSuite) TestGetManySomeCached() {
 		chunks.NewChunk([]byte("def")),
 	}
 	cached := chunks.NewChunk([]byte("ghi"))
-	suite.cs.PutMany(chnx)
-	suite.cs.Flush()
-	suite.store.Put(cached)
+	suite.serverCS.PutMany(chnx)
+	suite.serverCS.Flush()
+	suite.http.Put(cached)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), cached.Hash())
 	foundChunks := make(chan *chunks.Chunk)
-	go func() { suite.store.GetMany(hashes, foundChunks); close(foundChunks) }()
+	go func() { suite.http.GetMany(hashes, foundChunks); close(foundChunks) }()
 
 	for c := range foundChunks {
 		hashes.Remove(c.Hash())
@@ -273,10 +275,10 @@ func (suite *HTTPChunkStoreSuite) TestGetSame() {
 		chunks.NewChunk([]byte("def")),
 		chunks.NewChunk([]byte("def")),
 	}
-	suite.cs.PutMany(chnx)
-	got := suite.store.Get(chnx[0].Hash())
+	suite.serverCS.PutMany(chnx)
+	got := suite.http.Get(chnx[0].Hash())
 	suite.Equal(chnx[0].Hash(), got.Hash())
-	got = suite.store.Get(chnx[1].Hash())
+	got = suite.http.Get(chnx[1].Hash())
 	suite.Equal(chnx[1].Hash(), got.Hash())
 }
 
@@ -285,9 +287,9 @@ func (suite *HTTPChunkStoreSuite) TestHas() {
 		chunks.NewChunk([]byte("abc")),
 		chunks.NewChunk([]byte("def")),
 	}
-	suite.cs.PutMany(chnx)
-	suite.True(suite.store.Has(chnx[0].Hash()))
-	suite.True(suite.store.Has(chnx[1].Hash()))
+	suite.serverCS.PutMany(chnx)
+	suite.True(suite.http.Has(chnx[0].Hash()))
+	suite.True(suite.http.Has(chnx[1].Hash()))
 }
 
 func (suite *HTTPChunkStoreSuite) TestHasMany() {
@@ -295,12 +297,12 @@ func (suite *HTTPChunkStoreSuite) TestHasMany() {
 		chunks.NewChunk([]byte("abc")),
 		chunks.NewChunk([]byte("def")),
 	}
-	suite.cs.PutMany(chnx)
-	suite.cs.Flush()
+	suite.serverCS.PutMany(chnx)
+	suite.serverCS.Flush()
 	notPresent := chunks.NewChunk([]byte("ghi")).Hash()
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), notPresent)
-	present := suite.store.HasMany(hashes)
+	present := suite.http.HasMany(hashes)
 
 	suite.Len(present, len(chnx))
 	for _, c := range chnx {
@@ -314,10 +316,11 @@ func (suite *HTTPChunkStoreSuite) TestHasManyAllCached() {
 		chunks.NewChunk([]byte("abc")),
 		chunks.NewChunk([]byte("def")),
 	}
-	suite.store.PutMany(chnx)
+	suite.http.PutMany(chnx)
+	suite.serverCS.Flush()
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash())
-	present := suite.store.HasMany(hashes)
+	present := suite.http.HasMany(hashes)
 
 	suite.Len(present, len(chnx))
 	for _, c := range chnx {
@@ -331,12 +334,12 @@ func (suite *HTTPChunkStoreSuite) TestHasManySomeCached() {
 		chunks.NewChunk([]byte("def")),
 	}
 	cached := chunks.NewChunk([]byte("ghi"))
-	suite.cs.PutMany(chnx)
-	suite.cs.Flush()
-	suite.store.Put(cached)
+	suite.serverCS.PutMany(chnx)
+	suite.serverCS.Flush()
+	suite.http.Put(cached)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), cached.Hash())
-	present := suite.store.HasMany(hashes)
+	present := suite.http.HasMany(hashes)
 
 	suite.Len(present, len(chnx)+1)
 	for _, c := range chnx {

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -55,34 +55,40 @@ func (suite *HTTPChunkStoreSuite) SetupTest() {
 }
 
 func newHTTPChunkStoreForTest(cs chunks.ChunkStore) *httpChunkStore {
+	// Ideally, this function (and its bretheren below) would take a *TestStorage and mint a fresh TestStoreView in each handler call below. That'd break a bunch of tests in pull_test.go that want to pass in a single TestStoreView and then inspect it after doing a bunch of work. The cs.Rebase() calls here are a good compromise for now, but BUG 3415 tracks Making This Right.
 	serv := inlineServer{httprouter.New()}
 	serv.POST(
 		constants.WriteValuePath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleWriteValue(w, req, ps, cs)
 		},
 	)
 	serv.POST(
 		constants.GetRefsPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleGetRefs(w, req, ps, cs)
 		},
 	)
 	serv.POST(
 		constants.HasRefsPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleHasRefs(w, req, ps, cs)
 		},
 	)
 	serv.POST(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleRootPost(w, req, ps, cs)
 		},
 	)
 	serv.GET(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleRootGet(w, req, ps, cs)
 		},
 	)
@@ -98,6 +104,7 @@ func newAuthenticatingHTTPChunkStoreForTest(assert *assert.Assertions, cs chunks
 	serv.POST(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			authenticate(req)
 			HandleRootPost(w, req, ps, cs)
 		},
@@ -105,6 +112,7 @@ func newAuthenticatingHTTPChunkStoreForTest(assert *assert.Assertions, cs chunks
 	serv.GET(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleRootGet(w, req, ps, cs)
 		},
 	)
@@ -116,6 +124,7 @@ func newBadVersionHTTPChunkStoreForTest(cs chunks.ChunkStore) *httpChunkStore {
 	serv.POST(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleRootPost(w, req, ps, cs)
 			w.Header().Set(NomsVersionHeader, "BAD")
 		},
@@ -123,6 +132,7 @@ func newBadVersionHTTPChunkStoreForTest(cs chunks.ChunkStore) *httpChunkStore {
 	serv.GET(
 		constants.RootPath,
 		func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+			cs.Rebase()
 			HandleRootGet(w, req, ps, cs)
 		},
 	)

--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -34,10 +34,15 @@ func TestRemoteToRemotePulls(t *testing.T) {
 
 type PullSuite struct {
 	suite.Suite
-	sinkCS   *chunks.TestStore
-	sourceCS *chunks.TestStore
+	sinkCS   *chunks.TestStoreView
+	sourceCS *chunks.TestStoreView
 	sink     Database
 	source   Database
+}
+
+func makeTestStoreViews() (ts1, ts2 *chunks.TestStoreView) {
+	st1, st2 := &chunks.TestStorage{}, &chunks.TestStorage{}
+	return st1.NewView(), st2.NewView()
 }
 
 type LocalToLocalSuite struct {
@@ -45,8 +50,7 @@ type LocalToLocalSuite struct {
 }
 
 func (suite *LocalToLocalSuite) SetupTest() {
-	suite.sinkCS = chunks.NewTestStore()
-	suite.sourceCS = chunks.NewTestStore()
+	suite.sinkCS, suite.sourceCS = makeTestStoreViews()
 	suite.sink = NewDatabase(suite.sinkCS)
 	suite.source = NewDatabase(suite.sourceCS)
 }
@@ -56,8 +60,7 @@ type RemoteToLocalSuite struct {
 }
 
 func (suite *RemoteToLocalSuite) SetupTest() {
-	suite.sinkCS = chunks.NewTestStore()
-	suite.sourceCS = chunks.NewTestStore()
+	suite.sinkCS, suite.sourceCS = makeTestStoreViews()
 	suite.sink = NewDatabase(suite.sinkCS)
 	suite.source = makeRemoteDb(suite.sourceCS)
 }
@@ -67,8 +70,7 @@ type LocalToRemoteSuite struct {
 }
 
 func (suite *LocalToRemoteSuite) SetupTest() {
-	suite.sinkCS = chunks.NewTestStore()
-	suite.sourceCS = chunks.NewTestStore()
+	suite.sinkCS, suite.sourceCS = makeTestStoreViews()
 	suite.sink = makeRemoteDb(suite.sinkCS)
 	suite.source = NewDatabase(suite.sourceCS)
 }
@@ -78,8 +80,7 @@ type RemoteToRemoteSuite struct {
 }
 
 func (suite *RemoteToRemoteSuite) SetupTest() {
-	suite.sinkCS = chunks.NewTestStore()
-	suite.sourceCS = chunks.NewTestStore()
+	suite.sinkCS, suite.sourceCS = makeTestStoreViews()
 	suite.sink = makeRemoteDb(suite.sinkCS)
 	suite.source = makeRemoteDb(suite.sourceCS)
 }

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -341,7 +341,6 @@ func handleRootGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt ch
 	if req.Method != "GET" {
 		d.Panic("Expected get method.")
 	}
-	rt.Rebase()
 	fmt.Fprintf(w, "%v", rt.Root().String())
 	w.Header().Add("content-type", "text/plain")
 }

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -341,7 +341,7 @@ func handleRootGet(w http.ResponseWriter, req *http.Request, ps URLParams, rt ch
 	if req.Method != "GET" {
 		d.Panic("Expected get method.")
 	}
-
+	rt.Rebase()
 	fmt.Fprintf(w, "%v", rt.Root().String())
 	w.Header().Add("content-type", "text/plain")
 }

--- a/go/perf/codec-perf-rig/main.go
+++ b/go/perf/codec-perf-rig/main.go
@@ -53,8 +53,8 @@ func main() {
 			valueFn := valueFns[j]
 
 			// Build One-Time
-			ms := chunks.NewMemoryStore()
-			db := datas.NewDatabase(ms)
+			storage := &chunks.MemoryStorage{}
+			db := datas.NewDatabase(storage.NewView())
 			ds := db.GetDataset("test")
 			t1 := time.Now()
 			col := buildFns[i](buildCount, valueFn)
@@ -69,8 +69,8 @@ func main() {
 			readDuration := time.Since(t1)
 
 			// Build Incrementally
-			ms = chunks.NewMemoryStore()
-			db = datas.NewDatabase(ms)
+			storage = &chunks.MemoryStorage{}
+			db = datas.NewDatabase(storage.NewView())
 			ds = db.GetDataset("test")
 			t1 = time.Now()
 			col = buildIncrFns[i](insertCount, valueFn)
@@ -89,8 +89,8 @@ func main() {
 
 	fmt.Printf("Testing Blob: \t\tbuild %d MB\t\t\tscan %d MB\n", *blobSize/1000000, *blobSize/1000000)
 
-	ms := chunks.NewMemoryStore()
-	db := datas.NewDatabase(ms)
+	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 	ds := db.GetDataset("test")
 
 	blobBytes := makeBlobBytes(*blobSize)
@@ -99,7 +99,7 @@ func main() {
 	db.CommitValue(ds, blob)
 	buildDuration := time.Since(t1)
 
-	db = datas.NewDatabase(ms)
+	db = datas.NewDatabase(storage.NewView())
 	ds = db.GetDataset("test")
 	t1 = time.Now()
 	blob = ds.HeadValue().(types.Blob)

--- a/go/perf/suite/suite.go
+++ b/go/perf/suite/suite.go
@@ -491,7 +491,8 @@ func (suite *PerfSuite) getGitHead(dir string) string {
 func (suite *PerfSuite) StartRemoteDatabase() (host string, stopFn func()) {
 	var chunkStore chunks.ChunkStore
 	if *perfMemFlag {
-		chunkStore = chunks.NewMemoryStore()
+		st := &chunks.MemoryStorage{}
+		chunkStore = st.NewView()
 	} else {
 		dbDir := suite.TempDir()
 		chunkStore = nbs.NewLocalStore(dbDir, 128*(1<<20))

--- a/go/spec/absolute_path_test.go
+++ b/go/spec/absolute_path_test.go
@@ -32,12 +32,13 @@ func TestAbsolutePathToAndFromString(t *testing.T) {
 
 func TestAbsolutePaths(t *testing.T) {
 	assert := assert.New(t)
+	storage := &chunks.MemoryStorage{}
 
 	s0, s1 := types.String("foo"), types.String("bar")
 	list := types.NewList(s0, s1)
 	emptySet := types.NewSet()
 
-	db := datas.NewDatabase(chunks.NewMemoryStore())
+	db := datas.NewDatabase(storage.NewView())
 	db.WriteValue(s0)
 	db.WriteValue(s1)
 	db.WriteValue(list)
@@ -82,11 +83,12 @@ func TestAbsolutePaths(t *testing.T) {
 
 func TestReadAbsolutePaths(t *testing.T) {
 	assert := assert.New(t)
+	storage := &chunks.MemoryStorage{}
 
 	s0, s1 := types.String("foo"), types.String("bar")
 	list := types.NewList(s0, s1)
 
-	db := datas.NewDatabase(chunks.NewMemoryStore())
+	db := datas.NewDatabase(storage.NewView())
 	ds := db.GetDataset("ds")
 	ds, err := db.CommitValue(ds, list)
 	assert.NoError(err)

--- a/go/spec/spec.go
+++ b/go/spec/spec.go
@@ -174,7 +174,8 @@ func (sp Spec) NewChunkStore() chunks.ChunkStore {
 	case "nbs":
 		return nbs.NewLocalStore(sp.DatabaseName, 1<<28)
 	case "mem":
-		return chunks.NewMemoryStore()
+		storage := &chunks.MemoryStorage{}
+		return storage.NewView()
 	}
 	panic("unreachable")
 }
@@ -270,7 +271,8 @@ func (sp Spec) createDatabase() datas.Database {
 		os.Mkdir(sp.DatabaseName, 0777)
 		return datas.NewDatabase(nbs.NewLocalStore(sp.DatabaseName, 1<<28))
 	case "mem":
-		return datas.NewDatabase(chunks.NewMemoryStore())
+		storage := &chunks.MemoryStorage{}
+		return datas.NewDatabase(storage.NewView())
 	}
 	panic("unreachable")
 }

--- a/go/types/incremental_test.go
+++ b/go/types/incremental_test.go
@@ -35,7 +35,8 @@ func isEncodedOutOfLine(v Value) int {
 
 func TestIncrementalLoadList(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewTestStore()
+	ts := &chunks.TestStorage{}
+	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
 	expected := NewList(testVals...)
@@ -64,7 +65,8 @@ func TestIncrementalLoadList(t *testing.T) {
 
 func SkipTestIncrementalLoadSet(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewTestStore()
+	ts := &chunks.TestStorage{}
+	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
 	expected := NewSet(testVals...)
@@ -84,7 +86,8 @@ func SkipTestIncrementalLoadSet(t *testing.T) {
 
 func SkipTestIncrementalLoadMap(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewTestStore()
+	ts := &chunks.TestStorage{}
+	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
 	expected := NewMap(testVals...)
@@ -105,7 +108,8 @@ func SkipTestIncrementalLoadMap(t *testing.T) {
 
 func SkipTestIncrementalAddRef(t *testing.T) {
 	assert := assert.New(t)
-	cs := chunks.NewTestStore()
+	ts := &chunks.TestStorage{}
+	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
 	expectedItem := Number(42)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -944,7 +944,9 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 
 	assert := assert.New(t)
 
-	cs1 := chunks.NewTestStore()
+	storage := &chunks.TestStorage{}
+
+	cs1 := storage.NewView()
 	vs1 := NewValueStore(cs1)
 	nums1 := generateNumbersAsValues(4000)
 	l1 := NewList(nums1...)
@@ -952,7 +954,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	vs1.Flush()
 	refList1 := vs1.ReadValue(hash1).(List)
 
-	cs2 := chunks.NewTestStore()
+	cs2 := storage.NewView()
 	vs2 := NewValueStore(cs2)
 	nums2 := generateNumbersAsValuesFromToBy(5, 3550, 1)
 	l2 := NewList(nums2...)

--- a/go/types/validating_decoder_test.go
+++ b/go/types/validating_decoder_test.go
@@ -14,21 +14,22 @@ import (
 func TestValidatingBatchingSinkDecode(t *testing.T) {
 	v := Number(42)
 	c := EncodeValue(v, nil)
-	vdc := NewValidatingDecoder(chunks.NewTestStore())
+	storage := &chunks.TestStorage{}
+	vdc := NewValidatingDecoder(storage.NewView())
 
 	dc := vdc.Decode(&c)
 	assert.True(t, v.Equals(*dc.Value))
 }
 
 func assertPanicsOnInvalidChunk(t *testing.T, data []interface{}) {
-	cs := chunks.NewTestStore()
-	vs := NewValueStore(cs)
+	storage := &chunks.TestStorage{}
+	vs := NewValueStore(storage.NewView())
 	r := &nomsTestReader{data, 0}
 	dec := newValueDecoder(r, vs)
 	v := dec.readValue()
 
 	c := EncodeValue(v, nil)
-	vdc := NewValidatingDecoder(cs)
+	vdc := NewValidatingDecoder(storage.NewView())
 
 	assert.Panics(t, func() {
 		vdc.Decode(&c)

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -67,7 +67,8 @@ const (
 // NewTestValueStore creates a simple struct that satisfies ValueReadWriter
 // and is backed by a chunks.TestStore.
 func NewTestValueStore() *ValueStore {
-	return NewValueStore(chunks.NewTestStore())
+	ts := &chunks.TestStorage{}
+	return NewValueStore(ts.NewView())
 }
 
 // NewValueStore returns a ValueStore instance that owns the provided

--- a/samples/go/csv/write_test.go
+++ b/samples/go/csv/write_test.go
@@ -95,22 +95,25 @@ func startReadingCsvTestExpectationFile(s *csvWriteTestSuite) (cr *csv.Reader, h
 }
 
 func createTestList(s *csvWriteTestSuite) types.List {
-	ds := datas.NewDatabase(chunks.NewMemoryStore())
+	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 	cr, headers := startReadingCsvTestExpectationFile(s)
-	l := ReadToList(cr, TEST_ROW_STRUCT_NAME, headers, typesToKinds(s.fieldTypes), ds)
+	l := ReadToList(cr, TEST_ROW_STRUCT_NAME, headers, typesToKinds(s.fieldTypes), db)
 	return l
 }
 
 func createTestMap(s *csvWriteTestSuite) types.Map {
-	ds := datas.NewDatabase(chunks.NewMemoryStore())
+	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 	cr, headers := startReadingCsvTestExpectationFile(s)
-	return ReadToMap(cr, TEST_ROW_STRUCT_NAME, headers, []string{"anid"}, typesToKinds(s.fieldTypes), ds)
+	return ReadToMap(cr, TEST_ROW_STRUCT_NAME, headers, []string{"anid"}, typesToKinds(s.fieldTypes), db)
 }
 
 func createTestNestedMap(s *csvWriteTestSuite) types.Map {
-	ds := datas.NewDatabase(chunks.NewMemoryStore())
+	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 	cr, headers := startReadingCsvTestExpectationFile(s)
-	return ReadToMap(cr, TEST_ROW_STRUCT_NAME, headers, []string{"anid", "year"}, typesToKinds(s.fieldTypes), ds)
+	return ReadToMap(cr, TEST_ROW_STRUCT_NAME, headers, []string{"anid", "year"}, typesToKinds(s.fieldTypes), db)
 }
 
 func verifyOutput(s *csvWriteTestSuite, r io.Reader) {

--- a/samples/go/nomdex/parser_test.go
+++ b/samples/go/nomdex/parser_test.go
@@ -106,7 +106,8 @@ func TestParsing(t *testing.T) {
 		{`index1 != "whassup"`, re7},
 	}
 
-	db := datas.NewDatabase(chunks.NewMemoryStore())
+	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 	_, err := db.CommitValue(db.GetDataset("index1"), types.NewMap(types.String("one"), types.NewSet(types.String("two"))))
 	assert.NoError(err)
 


### PR DESCRIPTION
It's important that MemoryStore (and, by extension TestStore)
correctly implement the new ChunkStore semantics before we go
shifting around the Flush semantics like we want to do in #3404

In order to make this a reality, I introduced a "persistence"
layer for MemoryStore called MemoryStorage, which can vend
MemoryStoreView objects that represent a snapshot of the
persistent storage and implement the ChunkStore contract.

Fixes #3400