### PR TITLE
Add types.MakeStructTemplate

### DIFF
--- a/go/datas/commit.go
+++ b/go/datas/commit.go
@@ -20,6 +20,8 @@ const (
 	commitName   = "Commit"
 )
 
+var commitTemplate = types.MakeStructTemplate(commitName, []string{MetaField, ParentsField, ValueField})
+
 var valueCommitType = nomdl.MustParseType(`struct Commit {
         meta: struct {},
         parents: Set<Ref<Cycle<Commit>>>,
@@ -39,11 +41,7 @@ var valueCommitType = nomdl.MustParseType(`struct Commit {
 // ```
 // where M is a struct type and T is any type.
 func NewCommit(value types.Value, parents types.Set, meta types.Struct) types.Struct {
-	return types.NewStruct(commitName, types.StructData{
-		MetaField:    meta,
-		ParentsField: parents,
-		ValueField:   value,
-	})
+	return commitTemplate.NewStruct([]types.Value{meta, parents, value})
 }
 
 // FindCommonAncestor returns the most recent common ancestor of c1 and c2, if

--- a/go/perf/codec-perf-rig/main.go
+++ b/go/perf/codec-perf-rig/main.go
@@ -152,11 +152,13 @@ var structType = types.MakeStructType("S1",
 	},
 )
 
+var structTemplate = types.MakeStructTemplate("S1", []string{"bool", "num", "str"})
+
 func createStruct(i uint64) types.Value {
-	return types.NewStruct("S1", types.StructData{
-		"bool": types.Bool(i%2 == 0),
-		"num":  types.Number(i),
-		"str":  types.String(fmt.Sprintf("i am a 55 bytes............................%12d", i)),
+	return structTemplate.NewStruct([]types.Value{
+		types.Bool(i%2 == 0), // "bool"
+		types.Number(i),      // "num"
+		types.String(fmt.Sprintf("i am a 55 bytes............................%12d", i)), // "str"
 	})
 }
 

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -74,14 +74,14 @@ type StructTemplate struct {
 func MakeStructTemplate(name string, fieldNames []string) (t StructTemplate) {
 	t = StructTemplate{name, fieldNames}
 
-	verifyStructName(t.name)
-	if len(t.fieldNames) == 0 {
+	verifyStructName(name)
+	if len(fieldNames) == 0 {
 		return
 	}
-	verifyFieldName(t.fieldNames[0])
-	for i := 1; i < len(t.fieldNames); i++ {
-		verifyFieldName(t.fieldNames[i])
-		d.PanicIfFalse(t.fieldNames[i] > t.fieldNames[i-1])
+	verifyFieldName(fieldNames[0])
+	for i := 1; i < len(fieldNames); i++ {
+		verifyFieldName(fieldNames[i])
+		d.PanicIfFalse(fieldNames[i] > fieldNames[i-1])
 	}
 	return
 }

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -71,12 +71,19 @@ type StructTemplate struct {
 	fieldNames []string
 }
 
-func MakeStructTemplate(name string, fieldNames []string) StructTemplate {
-	st := StructTemplate{name, fieldNames}
-	for i := 0; i < len(st.fieldNames); i++ {
-		verifyFieldName(st.fieldNames[i])
+func MakeStructTemplate(name string, fieldNames []string) (t StructTemplate) {
+	t = StructTemplate{name, fieldNames}
+
+	verifyStructName(t.name)
+	if len(t.fieldNames) == 0 {
+		return
 	}
-	return st
+	verifyFieldName(t.fieldNames[0])
+	for i := 1; i < len(t.fieldNames); i++ {
+		verifyFieldName(t.fieldNames[i])
+		d.PanicIfFalse(t.fieldNames[i] > t.fieldNames[i-1])
+	}
+	return
 }
 
 func (st StructTemplate) NewStruct(values []Value) Struct {

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -66,6 +66,24 @@ func NewStruct(name string, data StructData) Struct {
 	return validateStruct(newStruct(name, fieldNames, values))
 }
 
+type StructTemplate struct {
+	name       string
+	fieldNames []string
+}
+
+func MakeStructTemplate(name string, fieldNames []string) StructTemplate {
+	st := StructTemplate{name, fieldNames}
+	for i := 0; i < len(st.fieldNames); i++ {
+		verifyFieldName(st.fieldNames[i])
+	}
+	return st
+}
+
+func (st StructTemplate) NewStruct(values []Value) Struct {
+	d.PanicIfFalse(len(st.fieldNames) == len(values))
+	return newStruct(st.name, st.fieldNames, values)
+}
+
 func (s Struct) hashPointer() *hash.Hash {
 	return s.h
 }

--- a/go/types/struct_test.go
+++ b/go/types/struct_test.go
@@ -204,3 +204,76 @@ func TestEscStructField(t *testing.T) {
 		assert.Equal(expected, EscapeStructField(orig))
 	}
 }
+
+func TestMakeStructTemplate(t *testing.T) {
+	assert := assert.New(t)
+
+	assertInvalidStructName := func(n string) {
+		assert.Panics(func() {
+			MakeStructTemplate(n, []string{})
+		})
+	}
+
+	assertInvalidStructName(" ")
+	assertInvalidStructName(" a")
+	assertInvalidStructName("a ")
+	assertInvalidStructName("0")
+	assertInvalidStructName("_")
+	assertInvalidStructName("0a")
+	assertInvalidStructName("_a")
+	assertInvalidStructName("💩")
+
+	assertValidStructName := func(n string) {
+		MakeStructTemplate(n, []string{})
+	}
+
+	assertValidStructName("")
+	assertValidStructName("a")
+	assertValidStructName("A")
+	assertValidStructName("a0")
+	assertValidStructName("a_")
+	assertValidStructName("a0_")
+
+	assertInvalidFieldName := func(n string) {
+		assert.Panics(func() {
+			MakeStructTemplate("", []string{n})
+		})
+	}
+
+	assertInvalidFieldName("")
+	assertInvalidFieldName(" ")
+	assertInvalidFieldName(" a")
+	assertInvalidFieldName("a ")
+	assertInvalidFieldName("0")
+	assertInvalidFieldName("_")
+	assertInvalidFieldName("0a")
+	assertInvalidFieldName("_a")
+	assertInvalidFieldName("💩")
+
+	assertValidFieldName := func(n string) {
+		MakeStructTemplate("", []string{n})
+	}
+
+	assertValidFieldName("a")
+	assertValidFieldName("A")
+	assertValidFieldName("a0")
+	assertValidFieldName("a_")
+	assertValidFieldName("a0_")
+
+	assertInvalidFieldOrder := func(n []string) {
+		assert.Panics(func() {
+			MakeStructTemplate("", n)
+		})
+	}
+
+	assertInvalidFieldOrder([]string{"a", "a"})
+	assertInvalidFieldOrder([]string{"b", "a"})
+	assertInvalidFieldOrder([]string{"a", "c", "b"})
+
+	assertValidFieldOrder := func(n []string) {
+		MakeStructTemplate("", n)
+	}
+
+	assertValidFieldOrder([]string{"a", "b"})
+	assertValidFieldOrder([]string{"a", "b", "c"})
+}

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -26,12 +26,12 @@ var DateTimeType = types.MakeStructTypeFromFields("DateTime", types.FieldMap{
 	"secSinceEpoch": types.NumberType,
 })
 
+var dateTimeTemplate = types.MakeStructTemplate("DateTime", []string{"secSinceEpoch"})
+
 // MarshalNoms makes DateTime implement marshal.Marshaler and it makes
 // DateTime marshal into a Noms struct with type DateTimeType.
 func (dt DateTime) MarshalNoms() (types.Value, error) {
-	return types.NewStruct("DateTime", types.StructData{
-		"secSinceEpoch": types.Number(float64(dt.Unix()) + float64(dt.Nanosecond())*1e-9),
-	}), nil
+	return dateTimeTemplate.NewStruct([]types.Value{types.Number(float64(dt.Unix()) + float64(dt.Nanosecond())*1e-9)}), nil
 }
 
 // MarshalNomsType makes DateTime implement marshal.TypeMarshaler and it

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -169,7 +169,7 @@ func main() {
 
 	var value types.Value
 	if dest == destList {
-		value, _ = csv.ReadToList(cr, *name, headers, kinds, db)
+		value = csv.ReadToList(cr, *name, headers, kinds, db)
 	} else {
 		value = csv.ReadToMap(cr, *name, headers, strPks, kinds, db)
 	}

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -26,24 +26,9 @@ b,2,false
 
 	headers := []string{"A", "B", "C"}
 	kinds := KindSlice{types.StringKind, types.NumberKind, types.BoolKind}
-	l, typ := ReadToList(r, "test", headers, kinds, ds)
+	l := ReadToList(r, "test", headers, kinds, ds)
 
 	assert.Equal(uint64(2), l.Len())
-
-	assert.Equal(types.StructKind, typ.TargetKind())
-
-	desc, ok := typ.Desc.(types.StructDesc)
-	assert.True(ok)
-	assert.Equal(desc.Len(), 3)
-
-	assertNotOptional := func(t *types.Type, optional bool) *types.Type {
-		assert.False(optional)
-		return t
-	}
-
-	assert.Equal(types.StringKind, assertNotOptional(desc.Field("A")).TargetKind())
-	assert.Equal(types.NumberKind, assertNotOptional(desc.Field("B")).TargetKind())
-	assert.Equal(types.BoolKind, assertNotOptional(desc.Field("C")).TargetKind())
 
 	assert.True(l.Get(0).(types.Struct).Get("A").Equals(types.String("a")))
 	assert.True(l.Get(1).(types.Struct).Get("A").Equals(types.String("b")))
@@ -97,21 +82,8 @@ func testTrailingHelper(t *testing.T, dataString string) {
 
 	headers := []string{"A", "B"}
 	kinds := KindSlice{types.StringKind, types.StringKind}
-	l, typ := ReadToList(r, "test", headers, kinds, ds1)
+	l := ReadToList(r, "test", headers, kinds, ds1)
 	assert.Equal(uint64(3), l.Len())
-	assert.Equal(types.StructKind, typ.TargetKind())
-
-	desc, ok := typ.Desc.(types.StructDesc)
-	assert.True(ok)
-	assert.Equal(desc.Len(), 2)
-
-	assertNotOptional := func(t *types.Type, optional bool) *types.Type {
-		assert.False(optional)
-		return t
-	}
-
-	assert.Equal(types.StringKind, assertNotOptional(desc.Field("A")).TargetKind())
-	assert.Equal(types.StringKind, assertNotOptional(desc.Field("B")).TargetKind())
 
 	ds2 := datas.NewDatabase(chunks.NewMemoryStore())
 	defer ds2.Close()
@@ -207,7 +179,7 @@ func TestEscapeFieldNames(t *testing.T) {
 	headers := []string{"A A", "B"}
 	kinds := KindSlice{types.NumberKind, types.NumberKind}
 
-	l, _ := ReadToList(r, "test", headers, kinds, ds)
+	l := ReadToList(r, "test", headers, kinds, ds)
 	assert.Equal(uint64(1), l.Len())
 	assert.Equal(types.Number(1), l.Get(0).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 
@@ -225,7 +197,7 @@ func TestDefaults(t *testing.T) {
 	headers := []string{"A", "B", "C", "D"}
 	kinds := KindSlice{types.NumberKind, types.NumberKind, types.BoolKind, types.StringKind}
 
-	l, _ := ReadToList(r, "test", headers, kinds, ds)
+	l := ReadToList(r, "test", headers, kinds, ds)
 	assert.Equal(uint64(1), l.Len())
 	row := l.Get(0).(types.Struct)
 	assert.Equal(types.Number(42), row.Get("A"))
@@ -242,7 +214,7 @@ func TestBooleanStrings(t *testing.T) {
 	headers := []string{"T", "F"}
 	kinds := KindSlice{types.BoolKind, types.BoolKind}
 
-	l, _ := ReadToList(r, "test", headers, kinds, ds)
+	l := ReadToList(r, "test", headers, kinds, ds)
 	assert.Equal(uint64(5), l.Len())
 	for i := uint64(0); i < l.Len(); i++ {
 		row := l.Get(i).(types.Struct)

--- a/samples/go/csv/write_test.go
+++ b/samples/go/csv/write_test.go
@@ -97,7 +97,7 @@ func startReadingCsvTestExpectationFile(s *csvWriteTestSuite) (cr *csv.Reader, h
 func createTestList(s *csvWriteTestSuite) types.List {
 	ds := datas.NewDatabase(chunks.NewMemoryStore())
 	cr, headers := startReadingCsvTestExpectationFile(s)
-	l, _ := ReadToList(cr, TEST_ROW_STRUCT_NAME, headers, typesToKinds(s.fieldTypes), ds)
+	l := ReadToList(cr, TEST_ROW_STRUCT_NAME, headers, typesToKinds(s.fieldTypes), ds)
 	return l
 }
 


### PR DESCRIPTION
`types.MakeStructTemplate` creates a "template" whose struct & field names have been validated. It allows cases of rapidly creating struct with the same names/fieldNames to avoid the cost of allocating a map for passing field data and validating names.

Fixes #3347

