### PR TITLE
ValueStore.Flush() no longer persists Chunks

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -46,10 +46,6 @@ type ChunkStore interface {
 	// Returns the NomsVersion with which this ChunkSource is compatible.
 	Version() string
 
-	// On return, any previously Put chunks must be durable. It is not safe to
-	// call Flush() concurrently with Put() or PutMany().
-	Flush()
-
 	// Rebase brings this ChunkStore into sync with the persistent storage's
 	// current root.
 	Rebase()

--- a/go/chunks/chunk_store_common_test.go
+++ b/go/chunks/chunk_store_common_test.go
@@ -113,7 +113,7 @@ func (suite *ChunkStoreTestSuite) TestChunkStoreVersion() {
 	suite.Equal(constants.NomsVersion, store.Version())
 }
 
-func (suite *ChunkStoreTestSuite) TestChunkStoreFlush() {
+func (suite *ChunkStoreTestSuite) TestChunkStoreCommitUnchangedRoot() {
 	store1, store2 := suite.Factory.CreateStore("ns"), suite.Factory.CreateStore("ns")
 	input := "abc"
 	c := NewChunk([]byte(input))
@@ -125,7 +125,7 @@ func (suite *ChunkStoreTestSuite) TestChunkStoreFlush() {
 	// ...but not store2.
 	assertInputNotInStore(input, h, store2, suite.Assert())
 
-	store1.Flush()
+	store1.Commit(store1.Root(), store1.Root())
 	store2.Rebase()
 	// Now, reading c from store2 via the API should work...
 	assertInputInStore(input, h, store2, suite.Assert())

--- a/go/datas/caching_chunk_haver_test.go
+++ b/go/datas/caching_chunk_haver_test.go
@@ -25,7 +25,8 @@ func TestCachingChunkHaver(t *testing.T) {
 	assert.Equal(ts.Hases, 1)
 
 	ts.Put(c)
-	ts.Flush()
+	assert.True(ts.Commit(ts.Root(), ts.Root()))
+
 	ts = storage.NewView()
 	ccs = newCachingChunkHaver(ts)
 	assert.True(ccs.Has(c.Hash()))

--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -211,7 +211,6 @@ func (dbc *databaseCommon) tryCommitChunks(currentDatasets types.Map, currentRoo
 	// TODO: This Map will be orphaned if the Commit below fails
 	newRootHash := dbc.WriteValue(currentDatasets).TargetHash()
 
-	// TODO: We've always been sorta sad that we Flush() the embedded ValueStore here, and then Commit() the composed ChunkStore below. That leads to two consecutive make-Chunks-durable operations on the underlying ChunkStore, and the latter won't actually have any novel Chunks. The problem arises from the fact that most users of ValueStore don't have access to the underlying ChunkStore, but Database _does_. ValueStore buffers Chunks, and most users who call Flush() need it to dump those Chunks into the ChunkStore and then make those Chunks durable. At this callsite, though, we only want to get those down into the ChunkStore, because we know that we're going to call Commit() later, which will make those Chunks durable. It's a conundrum :-/
 	dbc.Flush()
 
 	// If the root has been updated by another process in the short window since we read it, this call will fail. See issue #404

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -483,9 +483,6 @@ func (hcs *httpChunkStore) requestRoot(method string, current, last hash.Hash) *
 	u := *hcs.host
 	u.Path = httprouter.CleanPath(hcs.host.Path + constants.RootPath)
 	if method == "POST" {
-		if current.IsEmpty() {
-			d.Panic("Unexpected empty value")
-		}
 		params := u.Query()
 		params.Add("last", last.String())
 		params.Add("current", current.String())

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -201,6 +201,11 @@ func (suite *HTTPChunkStoreSuite) TestCommit() {
 	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
+func (suite *HTTPChunkStoreSuite) TestEmptyHashCommit() {
+	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
+	suite.Equal(hash.Hash{}, suite.serverCS.Root())
+}
+
 func (suite *HTTPChunkStoreSuite) TestCommitWithParams() {
 	u := fmt.Sprintf("http://localhost:9000?access_token=%s&other=19", testAuthToken)
 	store := newAuthenticatingHTTPChunkStoreForTest(suite.Assert(), suite.serverCS, u)
@@ -230,7 +235,7 @@ func (suite *HTTPChunkStoreSuite) TestGetMany() {
 	}
 	notPresent := chunks.NewChunk([]byte("ghi")).Hash()
 	suite.serverCS.PutMany(chnx)
-	suite.serverCS.Flush()
+	persistChunks(suite.serverCS)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), notPresent)
 	foundChunks := make(chan *chunks.Chunk)
@@ -267,7 +272,7 @@ func (suite *HTTPChunkStoreSuite) TestGetManySomeCached() {
 	}
 	cached := chunks.NewChunk([]byte("ghi"))
 	suite.serverCS.PutMany(chnx)
-	suite.serverCS.Flush()
+	persistChunks(suite.serverCS)
 	suite.http.Put(cached)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), cached.Hash())
@@ -308,7 +313,7 @@ func (suite *HTTPChunkStoreSuite) TestHasMany() {
 		chunks.NewChunk([]byte("def")),
 	}
 	suite.serverCS.PutMany(chnx)
-	suite.serverCS.Flush()
+	persistChunks(suite.serverCS)
 	notPresent := chunks.NewChunk([]byte("ghi")).Hash()
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), notPresent)
@@ -327,7 +332,7 @@ func (suite *HTTPChunkStoreSuite) TestHasManyAllCached() {
 		chunks.NewChunk([]byte("def")),
 	}
 	suite.http.PutMany(chnx)
-	suite.serverCS.Flush()
+	persistChunks(suite.serverCS)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash())
 	present := suite.http.HasMany(hashes)
@@ -345,7 +350,7 @@ func (suite *HTTPChunkStoreSuite) TestHasManySomeCached() {
 	}
 	cached := chunks.NewChunk([]byte("ghi"))
 	suite.serverCS.PutMany(chnx)
-	suite.serverCS.Flush()
+	persistChunks(suite.serverCS)
 	suite.http.Put(cached)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), cached.Hash())

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -31,7 +31,7 @@ const bytesWrittenSampleRate = .10
 // TODO: Get rid of this (BUG 2982)
 func PullWithFlush(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) {
 	Pull(srcDB, sinkDB, sourceRef, sinkHeadRef, concurrency, progressCh)
-	sinkDB.validatingChunkStore().Flush()
+	persistChunks(sinkDB.validatingChunkStore())
 }
 
 // Pull objects that descend from sourceRef from srcDB to sinkDB. sinkHeadRef

--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -158,7 +158,7 @@ func (suite *PullSuite) TestPullEverything() {
 	suite.Equal(0, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.validatingChunkStore().Flush()
+	persistChunks(suite.sink.validatingChunkStore())
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(l.Equals(v.Get(ValueField)))
@@ -202,7 +202,7 @@ func (suite *PullSuite) TestPullMultiGeneration() {
 	suite.Equal(expectedReads, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.validatingChunkStore().Flush()
+	persistChunks(suite.sink.validatingChunkStore())
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(srcL.Equals(v.Get(ValueField)))
@@ -250,7 +250,7 @@ func (suite *PullSuite) TestPullDivergentHistory() {
 	suite.Equal(preReads, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.validatingChunkStore().Flush()
+	persistChunks(suite.sink.validatingChunkStore())
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(srcL.Equals(v.Get(ValueField)))
@@ -297,7 +297,7 @@ func (suite *PullSuite) TestPullUpdates() {
 	suite.Equal(expectedReads, suite.sinkCS.Reads)
 	pt.Validate(suite)
 
-	suite.sink.validatingChunkStore().Flush()
+	persistChunks(suite.sink.validatingChunkStore())
 	v := suite.sink.ReadValue(sourceRef.TargetHash()).(types.Struct)
 	suite.NotNil(v)
 	suite.True(srcL.Equals(v.Get(ValueField)))

--- a/go/datas/validating_chunk_store.go
+++ b/go/datas/validating_chunk_store.go
@@ -51,13 +51,6 @@ func (vcs *validatingChunkStore) Commit(current, last hash.Hash) bool {
 	return vcs.ChunkStore.Commit(current, last)
 }
 
-// Flush validates pending chunks for ref-completeness before calling
-// Flush() on the underlying ChunkStore.
-func (vcs *validatingChunkStore) Flush() {
-	vcs.validate()
-	vcs.ChunkStore.Flush()
-}
-
 func (vcs *validatingChunkStore) validate() {
 	vcs.mu.Lock()
 	defer vcs.mu.Unlock()

--- a/go/diff/apply_patch_test.go
+++ b/go/diff/apply_patch_test.go
@@ -7,6 +7,7 @@ package diff
 import (
 	"testing"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/marshal"
 	"github.com/attic-labs/noms/go/types"
@@ -164,7 +165,8 @@ func TestNestedLists(t *testing.T) {
 func TestUpdateNode(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := types.NewTestValueStore()
+	storage := &chunks.MemoryStorage{}
+	vs := types.NewValueStore(storage.NewView())
 	defer vs.Close()
 
 	doTest := func(pp types.PathPart, parent, ov, nv, exp types.Value, f testFunc) {

--- a/go/merge/three_way_test.go
+++ b/go/merge/three_way_test.go
@@ -7,6 +7,7 @@ package merge
 import (
 	"testing"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/testify/assert"
 	"github.com/attic-labs/testify/suite"
@@ -24,7 +25,8 @@ type ThreeWayMergeSuite struct {
 }
 
 func (s *ThreeWayMergeSuite) SetupTest() {
-	s.vs = types.NewTestValueStore()
+	storage := &chunks.MemoryStorage{}
+	s.vs = types.NewValueStore(storage.NewView())
 }
 
 func (s *ThreeWayMergeSuite) TearDownTest() {

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/attic-labs/graphql"
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/marshal"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/test"
@@ -29,7 +30,8 @@ func TestQueryGraphQL(t *testing.T) {
 }
 
 func (suite *QueryGraphQLSuite) SetupTest() {
-	suite.vs = types.NewTestValueStore()
+	storage := &chunks.MemoryStorage{}
+	suite.vs = types.NewValueStore(storage.NewView())
 }
 
 func (suite *QueryGraphQLSuite) assertQueryResult(v types.Value, q, expect string) {

--- a/go/types/blob_test.go
+++ b/go/types/blob_test.go
@@ -237,7 +237,7 @@ func TestBlobConcat(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	reload := func(b Blob) Blob {
 		return vs.ReadValue(vs.WriteValue(b).TargetHash()).(Blob)
 	}
@@ -317,7 +317,7 @@ func TestStreamingParallelBlob(t *testing.T) {
 		readers[i] = bytes.NewReader(buff[i*chunkSize : (i+1)*chunkSize])
 	}
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	blob := NewStreamingBlob(vs, readers...)
 	outBuff := &bytes.Buffer{}
 	blob.Reader().Copy(outBuff)

--- a/go/types/collection_test.go
+++ b/go/types/collection_test.go
@@ -47,7 +47,7 @@ func (suite *collectionTestSuite) TestChunkCountAndType() {
 }
 
 func (suite *collectionTestSuite) TestRoundTripAndValidate() {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	r := vs.WriteValue(suite.col)
 	v2 := vs.ReadValue(r.TargetHash()).(Collection)
 	suite.True(v2.Equals(suite.col))

--- a/go/types/compare_test.go
+++ b/go/types/compare_test.go
@@ -57,7 +57,7 @@ func TestCompareEmpties(t *testing.T) {
 
 func TestCompareDifferentPrimitiveTypes(t *testing.T) {
 	assert := assert.New(t)
-	vrw := NewTestValueStore()
+	vrw := newTestValueStore()
 	defer vrw.Close()
 
 	nums := ValueSlice{Number(1), Number(2), Number(3)}
@@ -114,7 +114,7 @@ func TestComparePrimitives(t *testing.T) {
 func TestCompareEncodedKeys(t *testing.T) {
 	assert := assert.New(t)
 	comp := opCacheComparer{}
-	vrw := NewTestValueStore()
+	vrw := newTestValueStore()
 	defer vrw.Close()
 
 	k1 := ValueSlice{String("one"), Number(3)}

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -60,7 +60,7 @@ func TestWriteHumanReadablePrimitiveValues(t *testing.T) {
 }
 
 func TestWriteHumanReadableRef(t *testing.T) {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 
 	x := Number(42)
 	rv := vs.WriteValue(x)

--- a/go/types/encoding_test.go
+++ b/go/types/encoding_test.go
@@ -100,7 +100,7 @@ func (w *nomsTestWriter) writeHash(h hash.Hash) {
 }
 
 func assertEncoding(t *testing.T, expect []interface{}, v Value) {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	tw := &nomsTestWriter{}
 	enc := valueEncoder{tw, vs, false}
 	enc.writeValue(v)
@@ -115,7 +115,7 @@ func assertEncoding(t *testing.T, expect []interface{}, v Value) {
 
 func TestRoundTrips(t *testing.T) {
 	assertRoundTrips := func(v Value) {
-		vs := NewTestValueStore()
+		vs := newTestValueStore()
 		out := DecodeValue(EncodeValue(v, vs), vs)
 		assert.True(t, v.Equals(out))
 	}
@@ -173,7 +173,7 @@ func TestRoundTrips(t *testing.T) {
 }
 
 func TestNonFiniteNumbers(tt *testing.T) {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	t := func(f float64, s string) {
 		v := Number(f)
 		err := d.Try(func() {
@@ -320,7 +320,7 @@ func TestWriteCompoundBlob(t *testing.T) {
 			newMetaTuple(constructRef(r1, BlobType, 11), orderedKeyFromInt(20), 20, nil),
 			newMetaTuple(constructRef(r2, BlobType, 22), orderedKeyFromInt(40), 40, nil),
 			newMetaTuple(constructRef(r3, BlobType, 33), orderedKeyFromInt(60), 60, nil),
-		}, NewTestValueStore())),
+		}, newTestValueStore())),
 	)
 }
 

--- a/go/types/get_hash_test.go
+++ b/go/types/get_hash_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEnsureHash(t *testing.T) {
 	assert := assert.New(t)
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	count := byte(1)
 	mockGetRef := func(v Value) hash.Hash {
 		h := hash.Hash{}

--- a/go/types/graph_builder_test.go
+++ b/go/types/graph_builder_test.go
@@ -58,7 +58,7 @@ func SafeEquals(v1, v2 Value) bool {
 
 func TestGraphBuilderEncodeDecodeAsKey(t *testing.T) {
 	assert := assert.New(t)
-	vrw := NewTestValueStore()
+	vrw := newTestValueStore()
 	defer vrw.Close()
 
 	struct1 := NewStruct("teststruct", StructData{
@@ -94,7 +94,7 @@ func TestGraphBuilderEncodeDecodeAsKey(t *testing.T) {
 
 func TestGraphBuilderEncodeDecodeAsValue(t *testing.T) {
 	assert := assert.New(t)
-	vrw := NewTestValueStore()
+	vrw := newTestValueStore()
 	defer vrw.Close()
 
 	struct1 := NewStruct("teststruct", StructData{
@@ -125,7 +125,7 @@ func TestGraphBuilderEncodeDecodeAsValue(t *testing.T) {
 func TestGraphBuilderMapSetGraphOp(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 
 	opc := vs.opCache()
@@ -242,7 +242,7 @@ func shuffle(a []testGraphOp) {
 func TestGraphBuilderNestedMapSet(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 
 	expected := createTestMap(3, 4, valGen)
@@ -301,7 +301,7 @@ func TestGraphBuilderNestedMapSet(t *testing.T) {
 }
 
 func ExampleGraphBuilder_Build() {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 
 	gb := NewGraphBuilder(vs, MapKind, false)

--- a/go/types/incremental_test.go
+++ b/go/types/incremental_test.go
@@ -41,7 +41,7 @@ func TestIncrementalLoadList(t *testing.T) {
 
 	expected := NewList(testVals...)
 	hash := vs.WriteValue(expected).TargetHash()
-	vs.Flush()
+	vs.persist()
 
 	actualVar := vs.ReadValue(hash)
 	actual := actualVar.(List)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -257,7 +257,7 @@ func TestStreamingListCreation(t *testing.T) {
 	}
 	assert := assert.New(t)
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	simpleList := getTestList()
 
 	cl := NewList(simpleList...)
@@ -671,7 +671,7 @@ func TestListModifyAfterRead(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 
 	list := getTestList().toList()
 	// Drop chunk values.
@@ -951,7 +951,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	nums1 := generateNumbersAsValues(4000)
 	l1 := NewList(nums1...)
 	hash1 := vs1.WriteValue(l1).TargetHash()
-	vs1.Flush()
+	vs1.persist()
 	refList1 := vs1.ReadValue(hash1).(List)
 
 	cs2 := storage.NewView()
@@ -959,7 +959,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	nums2 := generateNumbersAsValuesFromToBy(5, 3550, 1)
 	l2 := NewList(nums2...)
 	hash2 := vs2.WriteValue(l2).TargetHash()
-	vs2.Flush()
+	vs2.persist()
 	refList2 := vs2.ReadValue(hash2).(List)
 
 	// diff lists without value store
@@ -1040,7 +1040,7 @@ func TestListRemoveLastWhenNotLoaded(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	reload := func(l List) List {
 		return vs.ReadValue(vs.WriteValue(l).TargetHash()).(List)
 	}
@@ -1065,7 +1065,7 @@ func TestListConcat(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	reload := func(vs *ValueStore, l List) List {
 		return vs.ReadValue(vs.WriteValue(l).TargetHash()).(List)
 	}

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -244,14 +244,14 @@ func (suite *mapTestSuite) createStreamingMap(vs *ValueStore) {
 }
 
 func (suite *mapTestSuite) TestStreamingMap() {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 	suite.createStreamingMap(vs)
 }
 
 func (suite *mapTestSuite) TestStreamingMap2() {
 	wg := sync.WaitGroup{}
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 
 	wg.Add(2)
@@ -402,7 +402,7 @@ func TestMapHas(t *testing.T) {
 
 	assert := assert.New(t)
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	doTest := func(tm testMap) {
 		m := tm.toMap()
 		m2 := vs.ReadValue(vs.WriteValue(m).TargetHash()).(Map)
@@ -462,8 +462,8 @@ func TestMapRemove(t *testing.T) {
 
 	doTest(128, getTestNativeOrderMap(32))
 	doTest(64, getTestRefValueOrderMap(4))
-	doTest(64, getTestRefToNativeOrderMap(4, NewTestValueStore()))
-	doTest(64, getTestRefToValueOrderMap(4, NewTestValueStore()))
+	doTest(64, getTestRefToNativeOrderMap(4, newTestValueStore()))
+	doTest(64, getTestRefToValueOrderMap(4, newTestValueStore()))
 }
 
 func TestMapRemoveNonexistentKey(t *testing.T) {
@@ -524,8 +524,8 @@ func TestMapFirst2(t *testing.T) {
 
 	doTest(getTestNativeOrderMap(16))
 	doTest(getTestRefValueOrderMap(2))
-	doTest(getTestRefToNativeOrderMap(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderMap(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderMap(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderMap(2, newTestValueStore()))
 }
 
 func TestMapLast(t *testing.T) {
@@ -572,8 +572,8 @@ func TestMapLast2(t *testing.T) {
 
 	doTest(getTestNativeOrderMap(16))
 	doTest(getTestRefValueOrderMap(2))
-	doTest(getTestRefToNativeOrderMap(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderMap(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderMap(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderMap(2, newTestValueStore()))
 }
 
 func TestMapSetGet(t *testing.T) {
@@ -644,8 +644,8 @@ func TestMapSet(t *testing.T) {
 	doTest(18, 3, getTestNativeOrderMap(9))
 	doTest(128, 1, getTestNativeOrderMap(32))
 	doTest(64, 1, getTestRefValueOrderMap(4))
-	doTest(64, 1, getTestRefToNativeOrderMap(4, NewTestValueStore()))
-	doTest(64, 1, getTestRefToValueOrderMap(4, NewTestValueStore()))
+	doTest(64, 1, getTestRefToNativeOrderMap(4, newTestValueStore()))
+	doTest(64, 1, getTestRefToValueOrderMap(4, newTestValueStore()))
 }
 
 func TestMapSetExistingKeyToNewValue(t *testing.T) {
@@ -721,8 +721,8 @@ func TestMapMaybeGet(t *testing.T) {
 
 	doTest(getTestNativeOrderMap(2))
 	doTest(getTestRefValueOrderMap(2))
-	doTest(getTestRefToNativeOrderMap(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderMap(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderMap(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderMap(2, newTestValueStore()))
 }
 
 func TestMapIter(t *testing.T) {
@@ -795,8 +795,8 @@ func TestMapIter2(t *testing.T) {
 
 	doTest(getTestNativeOrderMap(16))
 	doTest(getTestRefValueOrderMap(2))
-	doTest(getTestRefToNativeOrderMap(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderMap(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderMap(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderMap(2, newTestValueStore()))
 }
 
 func TestMapAny(t *testing.T) {
@@ -835,8 +835,8 @@ func TestMapIterAll(t *testing.T) {
 
 	doTest(getTestNativeOrderMap(16))
 	doTest(getTestRefValueOrderMap(2))
-	doTest(getTestRefToNativeOrderMap(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderMap(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderMap(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderMap(2, newTestValueStore()))
 }
 
 func TestMapEquals(t *testing.T) {
@@ -1096,7 +1096,7 @@ func TestMapRefOfStructFirstNNumbers(t *testing.T) {
 		t.Skip("Skipping test in short mode.")
 	}
 	assert := assert.New(t)
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 
 	kvs := []Value{}
 	for i := 0; i < testMapSize; i++ {
@@ -1118,7 +1118,7 @@ func TestMapModifyAfterRead(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	m := getTestNativeOrderMap(2).toMap()
 	// Drop chunk values.
 	m = vs.ReadValue(vs.WriteValue(m).TargetHash()).(Map)
@@ -1225,7 +1225,7 @@ func TestMapRemoveLastWhenNotLoaded(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	reload := func(m Map) Map {
 		return vs.ReadValue(vs.WriteValue(m).TargetHash()).(Map)
 	}

--- a/go/types/opcache_test.go
+++ b/go/types/opcache_test.go
@@ -23,7 +23,7 @@ type OpCacheSuite struct {
 }
 
 func (suite *OpCacheSuite) SetupTest() {
-	suite.vs = NewTestValueStore()
+	suite.vs = newTestValueStore()
 }
 
 func (suite *OpCacheSuite) TearDownTest() {

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -96,9 +96,9 @@ func (suite *diffTestSuite) TestDiff() {
 	newMapAsCol := func(vs []Value) Collection { return NewMap(vs...) }
 
 	rw := func(col Collection) Collection {
-		vs := NewTestValueStore()
+		vs := newTestValueStore()
 		h := vs.WriteValue(col).TargetHash()
-		vs.Flush()
+		vs.persist()
 		return vs.ReadValue(h).(Collection)
 	}
 	newSetAsColRw := func(vs []Value) Collection { return rw(newSetAsCol(vs)) }

--- a/go/types/path_test.go
+++ b/go/types/path_test.go
@@ -428,7 +428,7 @@ func TestPathTarget(t *testing.T) {
 	s := NewStruct("", StructData{
 		"foo": String("bar"),
 	})
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	r := vs.WriteValue(s)
 	s2 := NewStruct("", StructData{
 		"ref": r,

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -172,13 +172,13 @@ func (suite *setTestSuite) createStreamingSet(vs *ValueStore) {
 }
 
 func (suite *setTestSuite) TestStreamingSet() {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 	suite.createStreamingSet(vs)
 }
 
 func (suite *setTestSuite) TestStreamingSet2() {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	defer vs.Close()
 	wg := sync.WaitGroup{}
 	wg.Add(2)
@@ -374,7 +374,7 @@ func TestSetHas2(t *testing.T) {
 
 	assert := assert.New(t)
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	doTest := func(ts testSet) {
 		set := ts.toSet()
 		set2 := vs.ReadValue(vs.WriteValue(set).TargetHash()).(Set)
@@ -459,8 +459,8 @@ func TestSetInsert2(t *testing.T) {
 	doTest(18, 3, getTestNativeOrderSet(9))
 	doTest(64, 1, getTestNativeOrderSet(32))
 	doTest(32, 1, getTestRefValueOrderSet(4))
-	doTest(32, 1, getTestRefToNativeOrderSet(4, NewTestValueStore()))
-	doTest(32, 1, getTestRefToValueOrderSet(4, NewTestValueStore()))
+	doTest(32, 1, getTestRefToNativeOrderSet(4, newTestValueStore()))
+	doTest(32, 1, getTestRefToValueOrderSet(4, newTestValueStore()))
 }
 
 func TestSetInsertExistingValue(t *testing.T) {
@@ -527,8 +527,8 @@ func TestSetRemove2(t *testing.T) {
 	doTest(18, 3, getTestNativeOrderSet(9))
 	doTest(64, 1, getTestNativeOrderSet(32))
 	doTest(32, 1, getTestRefValueOrderSet(4))
-	doTest(32, 1, getTestRefToNativeOrderSet(4, NewTestValueStore()))
-	doTest(32, 1, getTestRefToValueOrderSet(4, NewTestValueStore()))
+	doTest(32, 1, getTestRefToNativeOrderSet(4, newTestValueStore()))
+	doTest(32, 1, getTestRefToValueOrderSet(4, newTestValueStore()))
 }
 
 func TestSetRemoveNonexistentValue(t *testing.T) {
@@ -615,8 +615,8 @@ func TestSetIter2(t *testing.T) {
 
 	doTest(getTestNativeOrderSet(16))
 	doTest(getTestRefValueOrderSet(2))
-	doTest(getTestRefToNativeOrderSet(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderSet(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderSet(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderSet(2, newTestValueStore()))
 }
 
 func TestSetIterAll(t *testing.T) {
@@ -650,8 +650,8 @@ func TestSetIterAll2(t *testing.T) {
 
 	doTest(getTestNativeOrderSet(16))
 	doTest(getTestRefValueOrderSet(2))
-	doTest(getTestRefToNativeOrderSet(2, NewTestValueStore()))
-	doTest(getTestRefToValueOrderSet(2, NewTestValueStore()))
+	doTest(getTestRefToNativeOrderSet(2, newTestValueStore()))
+	doTest(getTestRefToValueOrderSet(2, newTestValueStore()))
 }
 
 func testSetOrder(assert *assert.Assertions, valueType *Type, value []Value, expectOrdering []Value) {
@@ -820,7 +820,7 @@ func TestSetChunks2(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	doTest := func(ts testSet) {
 		set := ts.toSet()
 		set2chunks := getChunks(vs.ReadValue(vs.WriteValue(set).TargetHash()))
@@ -860,7 +860,7 @@ func TestSetModifyAfterRead(t *testing.T) {
 	defer normalProductionChunks()
 
 	assert := assert.New(t)
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	set := getTestNativeOrderSet(2).toSet()
 	// Drop chunk values.
 	set = vs.ReadValue(vs.WriteValue(set).TargetHash()).(Set)
@@ -958,7 +958,7 @@ func TestSetRemoveLastWhenNotLoaded(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	reload := func(s Set) Set {
 		return vs.ReadValue(vs.WriteValue(s).TargetHash()).(Set)
 	}

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTypes(t *testing.T) {
 	assert := assert.New(t)
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 
 	mapType := MakeMapType(StringType, NumberType)
 	setType := MakeSetType(StringType)

--- a/go/types/util_test.go
+++ b/go/types/util_test.go
@@ -66,7 +66,7 @@ func generateNumbersAsStructsFromToBy(from, to, by int) ValueSlice {
 }
 
 func generateNumbersAsRefOfStructs(n int) []Value {
-	vs := NewTestValueStore()
+	vs := newTestValueStore()
 	nums := []Value{}
 	for i := 0; i < n; i++ {
 		r := vs.WriteValue(NewStruct("num", StructData{"n": Number(i)}))

--- a/go/types/walk_test.go
+++ b/go/types/walk_test.go
@@ -328,7 +328,7 @@ func TestWalkDifferentStructsBasic(t *testing.T) {
 	// Big, committed collections of structs
 	h1 := vs.WriteValue(l1).TargetHash()
 	h2 := vs.WriteValue(l2).TargetHash()
-	vs.Flush()
+	vs.persist()
 
 	// Use a fresh value store to avoid cached chunks and ensure we're seeing the chunks persisted by the above Flush()
 	ts := storage.NewView()


### PR DESCRIPTION
ValueStore.Flush() now Puts all Chunks buffered in the ValueStore
layer into the underlying ChunkStore. The Chunks are not persistent
at this point, not until and unless the caller calls Commit() on
the ChunkStore.

This patch also removes ChunkStore.Flush(). The same effect can be
achieved by calling ChunkStore.Commit() with the current Root for both
last and current.

NB: newTestValueStore is now private to the types package.
The logic is that, now, outside the types package, callers
need to hold onto the underlying ChunkStore if they want to
persist Chunks.

Toward #3404