### PR TITLE
Add Database.Rebase()

### DIFF
--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -41,6 +41,9 @@ type Database interface {
 	// datasetID in the above Datasets Map.
 	GetDataset(datasetID string) Dataset
 
+	// Rebase brings this Database's view of the world inline with upstream.
+	Rebase()
+
 	// Commit updates the Commit that ds.ID() in this database points at. All
 	// Values that have been written to this Database are guaranteed to be
 	// persistent after Commit() returns.


### PR DESCRIPTION
All this really does is tell the underlying ChunkStore
to go fetch the current root from persistent storage
and drops the now-out-of-date Dataset map on the floor.

Fixes https://github.com/attic-labs/attic/issues/1157