### PR TITLE
Streaming Compaction

### DIFF
--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -59,10 +59,10 @@ func (ftp fsTablePersister) CompactAll(sources chunkSources) chunkSource {
 		d.PanicIfError(err)
 		defer checkClose(temp)
 
-		for i, dataLen := range plan.chunkDataLens {
-			r := plan.sources[i].reader()
-			n, err := io.CopyN(temp, r, int64(dataLen))
-			d.PanicIfFalse(uint64(n) == dataLen)
+		for _, sws := range plan.sources {
+			r := sws.source.reader()
+			n, err := io.CopyN(temp, r, int64(sws.dataLen))
+			d.PanicIfFalse(uint64(n) == sws.dataLen)
 			d.PanicIfError(err)
 		}
 		_, err = temp.Write(plan.mergedIndex)

--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -19,7 +19,7 @@ type fsTablePersister struct {
 	indexCache *indexCache
 }
 
-func (ftp fsTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
+func (ftp fsTablePersister) Persist(mt *memTable, haver chunkReader) chunkSource {
 	return ftp.persistTable(mt.write(haver))
 }
 

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
-func TestFSTablePersisterCompact(t *testing.T) {
+func TestFSTablePersisterPersist(t *testing.T) {
 	assert := assert.New(t)
 	mt := newMemTable(testMemTableSize)
 
@@ -26,7 +26,7 @@ func TestFSTablePersisterCompact(t *testing.T) {
 	defer os.RemoveAll(dir)
 	fts := fsTablePersister{dir: dir}
 
-	src := fts.Compact(mt, nil)
+	src := fts.Persist(mt, nil)
 	if assert.True(src.count() > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
 		assert.NoError(err)
@@ -35,7 +35,7 @@ func TestFSTablePersisterCompact(t *testing.T) {
 	}
 }
 
-func TestFSTablePersisterCompactNoData(t *testing.T) {
+func TestFSTablePersisterPersistNoData(t *testing.T) {
 	assert := assert.New(t)
 	mt := newMemTable(testMemTableSize)
 	existingTable := newMemTable(testMemTableSize)
@@ -49,7 +49,7 @@ func TestFSTablePersisterCompactNoData(t *testing.T) {
 	defer os.RemoveAll(dir)
 	fts := fsTablePersister{dir: dir}
 
-	src := fts.Compact(mt, existingTable)
+	src := fts.Persist(mt, existingTable)
 	assert.True(src.count() == 0)
 
 	_, err := os.Stat(filepath.Join(dir, src.hash().String()))

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -6,6 +6,7 @@ package nbs
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -62,7 +63,10 @@ func TestFSTablePersisterCompactAll(t *testing.T) {
 	sources := make(chunkSources, len(testChunks))
 
 	for i, c := range testChunks {
-		sources[i] = bytesToChunkSource(c)
+		randChunk := make([]byte, (i+1)*13)
+		_, err := rand.Read(randChunk)
+		assert.NoError(err)
+		sources[i] = bytesToChunkSource(c, randChunk)
 	}
 
 	dir := makeTempDir(assert)
@@ -80,17 +84,19 @@ func TestFSTablePersisterCompactAll(t *testing.T) {
 
 func TestFSTablePersisterCompactAllDups(t *testing.T) {
 	assert := assert.New(t)
-	assert.True(len(testChunks) > 1, "Whoops, this test isn't meaningful")
-	sources := make(chunkSources, len(testChunks))
-
-	reps := 3
-	for i := 0; i < reps; i++ {
-		sources[i] = bytesToChunkSource(testChunks...)
-	}
-
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
 	fts := fsTablePersister{dir: dir}
+
+	reps := 3
+	sources := make(chunkSources, reps)
+	for i := 0; i < reps; i++ {
+		mt := newMemTable(1 << 10)
+		for _, c := range testChunks {
+			mt.addChunk(computeAddr(c), c)
+		}
+		sources[i] = fts.Persist(mt, nil)
+	}
 	src := fts.CompactAll(sources)
 
 	if assert.True(src.count() > 0) {

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -83,7 +83,8 @@ func TestFSTablePersisterCompactAllDups(t *testing.T) {
 	assert.True(len(testChunks) > 1, "Whoops, this test isn't meaningful")
 	sources := make(chunkSources, len(testChunks))
 
-	for i := range testChunks {
+	reps := 3
+	for i := 0; i < reps; i++ {
 		sources[i] = bytesToChunkSource(testChunks...)
 	}
 
@@ -97,6 +98,6 @@ func TestFSTablePersisterCompactAllDups(t *testing.T) {
 		assert.NoError(err)
 		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
 		assertChunksInReader(testChunks, tr, assert)
-		assert.EqualValues(len(testChunks), tr.count())
+		assert.EqualValues(reps*len(testChunks), tr.count())
 	}
 }

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -5,6 +5,7 @@
 package nbs
 
 import (
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -90,4 +91,12 @@ func (mmtr *mmapTableReader) close() (err error) {
 
 func (mmtr *mmapTableReader) hash() addr {
 	return mmtr.h
+}
+
+func (mmtr *mmapTableReader) index() tableIndex {
+	return mmtr.tableIndex
+}
+
+func (mmtr *mmapTableReader) reader() io.Reader {
+	return mmtr.f
 }

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -5,7 +5,6 @@
 package nbs
 
 import (
-	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -95,8 +94,4 @@ func (mmtr *mmapTableReader) hash() addr {
 
 func (mmtr *mmapTableReader) index() tableIndex {
 	return mmtr.tableIndex
-}
-
-func (mmtr *mmapTableReader) reader() io.Reader {
-	return mmtr.f
 }

--- a/go/nbs/persisting_chunk_source.go
+++ b/go/nbs/persisting_chunk_source.go
@@ -5,6 +5,8 @@
 package nbs
 
 import (
+	"bytes"
+	"io"
 	"sync"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -93,6 +95,18 @@ func (ccs *persistingChunkSource) hash() addr {
 	return ccs.cs.hash()
 }
 
+func (ccs *persistingChunkSource) index() tableIndex {
+	ccs.wg.Wait()
+	d.Chk.True(ccs.cs != nil)
+	return ccs.cs.index()
+}
+
+func (ccs *persistingChunkSource) reader() io.Reader {
+	ccs.wg.Wait()
+	d.Chk.True(ccs.cs != nil)
+	return ccs.cs.reader()
+}
+
 func (ccs *persistingChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool) {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
@@ -136,7 +150,15 @@ func (ecs emptyChunkSource) uncompressedLen() uint64 {
 }
 
 func (ecs emptyChunkSource) hash() addr {
-	return addr{} // TODO: is this legal?
+	return addr{}
+}
+
+func (ecs emptyChunkSource) index() tableIndex {
+	return tableIndex{}
+}
+
+func (ecs emptyChunkSource) reader() io.Reader {
+	return &bytes.Buffer{}
 }
 
 func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool) {

--- a/go/nbs/persisting_chunk_source.go
+++ b/go/nbs/persisting_chunk_source.go
@@ -11,13 +11,13 @@ import (
 	"github.com/attic-labs/noms/go/d"
 )
 
-func newCompactingChunkSource(mt *memTable, haver chunkReader, p tablePersister, rl chan struct{}) *compactingChunkSource {
-	ccs := &compactingChunkSource{mt: mt}
+func newPersistingChunkSource(mt *memTable, haver chunkReader, p tablePersister, rl chan struct{}) *persistingChunkSource {
+	ccs := &persistingChunkSource{mt: mt}
 	ccs.wg.Add(1)
 	rl <- struct{}{}
 	go func() {
 		defer ccs.wg.Done()
-		cs := p.Compact(mt, haver)
+		cs := p.Persist(mt, haver)
 
 		ccs.mu.Lock()
 		defer ccs.mu.Unlock()
@@ -28,7 +28,7 @@ func newCompactingChunkSource(mt *memTable, haver chunkReader, p tablePersister,
 	return ccs
 }
 
-type compactingChunkSource struct {
+type persistingChunkSource struct {
 	mu sync.RWMutex
 	mt *memTable
 
@@ -36,7 +36,7 @@ type compactingChunkSource struct {
 	cs chunkSource
 }
 
-func (ccs *compactingChunkSource) getReader() chunkReader {
+func (ccs *persistingChunkSource) getReader() chunkReader {
 	ccs.mu.RLock()
 	defer ccs.mu.RUnlock()
 	if ccs.mt != nil {
@@ -45,61 +45,61 @@ func (ccs *compactingChunkSource) getReader() chunkReader {
 	return ccs.cs
 }
 
-func (ccs *compactingChunkSource) has(h addr) bool {
+func (ccs *persistingChunkSource) has(h addr) bool {
 	cr := ccs.getReader()
 	d.Chk.True(cr != nil)
 	return cr.has(h)
 }
 
-func (ccs *compactingChunkSource) hasMany(addrs []hasRecord) bool {
+func (ccs *persistingChunkSource) hasMany(addrs []hasRecord) bool {
 	cr := ccs.getReader()
 	d.Chk.True(cr != nil)
 	return cr.hasMany(addrs)
 }
 
-func (ccs *compactingChunkSource) get(h addr) []byte {
+func (ccs *persistingChunkSource) get(h addr) []byte {
 	cr := ccs.getReader()
 	d.Chk.True(cr != nil)
 	return cr.get(h)
 }
 
-func (ccs *compactingChunkSource) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool {
+func (ccs *persistingChunkSource) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup) bool {
 	cr := ccs.getReader()
 	d.Chk.True(cr != nil)
 	return cr.getMany(reqs, foundChunks, wg)
 }
 
-func (ccs *compactingChunkSource) close() error {
+func (ccs *persistingChunkSource) close() error {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
 	return ccs.cs.close()
 }
 
-func (ccs *compactingChunkSource) count() uint32 {
+func (ccs *persistingChunkSource) count() uint32 {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
 	return ccs.cs.count()
 }
 
-func (ccs *compactingChunkSource) uncompressedLen() uint64 {
+func (ccs *persistingChunkSource) uncompressedLen() uint64 {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
 	return ccs.cs.uncompressedLen()
 }
 
-func (ccs *compactingChunkSource) hash() addr {
+func (ccs *persistingChunkSource) hash() addr {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
 	return ccs.cs.hash()
 }
 
-func (ccs *compactingChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool) {
+func (ccs *persistingChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool) {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
 	return ccs.cs.calcReads(reqs, blockSize)
 }
 
-func (ccs *compactingChunkSource) extract(chunks chan<- extractRecord) {
+func (ccs *persistingChunkSource) extract(chunks chan<- extractRecord) {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
 	ccs.cs.extract(chunks)

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -142,7 +142,7 @@ func makeStoreWithFakes(t *testing.T) (fm *fakeManifest, tt tableSet, store *Nom
 func interloperWrite(fm *fakeManifest, tt tableSet, rootChunk []byte, chunks ...[]byte) (newRoot hash.Hash, persisted [][]byte) {
 	newLock, newRoot := computeAddr([]byte("locker")), hash.Of(rootChunk)
 	persisted = append(chunks, rootChunk)
-	src := tt.p.Compact(createMemTable(persisted), nil)
+	src := tt.p.Persist(createMemTable(persisted), nil)
 	fm.set(constants.NomsVersion, newLock, newRoot, []tableSpec{{src.hash(), uint32(len(chunks))}})
 	return
 }
@@ -224,7 +224,7 @@ type fakeTablePersister struct {
 	sources map[addr]tableReader
 }
 
-func (ftp fakeTablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
+func (ftp fakeTablePersister) Persist(mt *memTable, haver chunkReader) chunkSource {
 	if mt.count() > 0 {
 		name, data, chunkCount := mt.write(haver)
 		if chunkCount > 0 {

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -262,3 +262,7 @@ func (csa chunkSourceAdapter) close() error {
 func (csa chunkSourceAdapter) hash() addr {
 	return csa.h
 }
+
+func (csa chunkSourceAdapter) index() tableIndex {
+	return csa.tableIndex
+}

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -19,16 +19,19 @@ import (
 )
 
 const (
-	defaultS3PartSize = 5 * 1 << 20 // 5MiB, smallest allowed by S3
-	maxS3Parts        = 10000
+	minS3PartSize = 5 * 1 << 20 // 5MiB
+	maxS3PartSize = 5 * 1 << 27 // 5GiB
+	maxS3Parts    = 10000
+
+	defaultS3PartSize = minS3PartSize // smallest allowed by S3 allows for most throughput
 )
 
 type s3TablePersister struct {
-	s3         s3svc
-	bucket     string
-	partSize   int
-	indexCache *indexCache
-	readRl     chan struct{}
+	s3                                       s3svc
+	bucket                                   string
+	targetPartSize, minPartSize, maxPartSize uint64
+	indexCache                               *indexCache
+	readRl                                   chan struct{}
 }
 
 func (s3p s3TablePersister) Open(name addr, chunkCount uint32) chunkSource {
@@ -52,10 +55,10 @@ func (s3p s3TablePersister) persistTable(name addr, data []byte, chunkCount uint
 	s3p.multipartUpload(data, name.String())
 	verbose.Log("Compacted table of %d Kb in %s", len(data)/1024, time.Since(t1))
 
-	return s3p.newReaderFromIdxData(data, name)
+	return s3p.newReaderFromIndexData(data, name)
 }
 
-func (s3p s3TablePersister) newReaderFromIdxData(idxData []byte, name addr) *s3TableReader {
+func (s3p s3TablePersister) newReaderFromIndexData(idxData []byte, name addr) *s3TableReader {
 	s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name, readRl: s3p.readRl}
 	index := parseTableIndex(idxData)
 	if s3p.indexCache != nil {
@@ -106,11 +109,10 @@ func (s3p s3TablePersister) completeMultipartUpload(key, uploadID string, mpu *s
 func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
 	sent, failed, done := make(chan s3UploadedPart), make(chan error), make(chan struct{})
 
-	numParts := getNumParts(len(data), s3p.partSize)
+	numParts := getNumParts(uint64(len(data)), s3p.targetPartSize)
 	d.PanicIfTrue(numParts > maxS3Parts) // TODO: BUG 3433: handle > 10k parts
 	var wg sync.WaitGroup
-	wg.Add(numParts)
-	sendPart := func(partNum int) {
+	sendPart := func(partNum, start, end uint64) {
 		defer wg.Done()
 
 		// Check if upload has been terminated
@@ -120,9 +122,8 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 		default:
 		}
 		// Upload the desired part
-		start, end := (partNum-1)*s3p.partSize, partNum*s3p.partSize
 		if partNum == numParts { // If this is the last part, make sure it includes any overflow
-			end = len(data)
+			end = uint64(len(data))
 		}
 		etag, err := s3p.uploadPart(data[start:end], key, uploadID, int64(partNum))
 		if err != nil {
@@ -136,8 +137,11 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 			return
 		}
 	}
-	for i := 1; i <= numParts; i++ {
-		go sendPart(i)
+	for i := uint64(0); i < numParts; i++ {
+		wg.Add(1)
+		partNum := i + 1 // Parts are 1-indexed
+		start, end := i*s3p.targetPartSize, (i+1)*s3p.targetPartSize
+		go sendPart(partNum, start, end)
 	}
 	go func() {
 		wg.Wait()
@@ -173,8 +177,8 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 	return multipartUpload, firstFailure
 }
 
-func getNumParts(dataLen, partSize int) int {
-	numParts := dataLen / partSize
+func getNumParts(dataLen, minPartSize uint64) uint64 {
+	numParts := dataLen / minPartSize
 	if numParts == 0 {
 		numParts = 1
 	}
@@ -202,15 +206,15 @@ func (s3p s3TablePersister) CompactAll(sources chunkSources) chunkSource {
 	}
 	t1 := time.Now()
 	name := nameFromSuffixes(plan.suffixes())
-	s3p.multipartCopyUpload(plan, name.String())
+	s3p.executeCompactionPlan(plan, name.String())
 	verbose.Log("Compacted table of %d Kb in %s", plan.totalCompressedData/1024, time.Since(t1))
 
-	return s3p.newReaderFromIdxData(plan.mergedIndex, name)
+	return s3p.newReaderFromIndexData(plan.mergedIndex, name)
 }
 
-func (s3p s3TablePersister) multipartCopyUpload(plan compactionPlan, key string) {
+func (s3p s3TablePersister) executeCompactionPlan(plan compactionPlan, key string) {
 	uploadID := s3p.startMultipartUpload(key)
-	multipartUpload, err := s3p.uploadPartsCopy(plan, key, uploadID)
+	multipartUpload, err := s3p.assembleTable(plan, key, uploadID)
 	if err != nil {
 		s3p.abortMultipartUpload(key, uploadID)
 		d.PanicIfError(err) // TODO: Better error handling here
@@ -218,24 +222,28 @@ func (s3p s3TablePersister) multipartCopyUpload(plan compactionPlan, key string)
 	s3p.completeMultipartUpload(key, uploadID, multipartUpload)
 }
 
-func (s3p s3TablePersister) uploadPartsCopy(plan compactionPlan, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
+func (s3p s3TablePersister) assembleTable(plan compactionPlan, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
 	d.PanicIfTrue(len(plan.sources) > maxS3Parts) // TODO: BUG 3433: handle > 10k parts
 
-	copies, manuals, buff := dividePlan(plan.sources, plan)
+	// Separate plan.sources by amount of chunkData. Tables with >5MB of chunk data (copies) can be added to the new table using S3's multipart upload copy feature. Smaller tables with <5MB of chunk data (manuals) must be read, assembled into |buff|, and then re-uploaded in parts that are larger than 5MB.
+	copies, manuals, buff := dividePlan(plan, uint64(s3p.minPartSize), uint64(s3p.maxPartSize))
+
+	// Concurrently read data from small tables into |buff|
 	var readWg sync.WaitGroup
 	for _, man := range manuals {
 		readWg.Add(1)
 		go func(m manualPart) {
 			defer readWg.Done()
-			n, _ := m.r.Read(buff[m.buffStart:m.buffEnd])
-			d.PanicIfTrue(int64(n) < m.buffEnd-m.buffStart)
+			n, _ := m.srcR.Read(buff[m.dstStart:m.dstEnd])
+			d.PanicIfTrue(int64(n) < m.dstEnd-m.dstStart)
 		}(man)
 	}
 	readWg.Wait()
 
-	type uploadFn func() (etag string, err error)
+	// sendPart calls |doUpload| to send part |partNum|, forwarding errors over |failed| or success over |sent|. Closing (or sending) on |done| will cancel all in-progress calls to sendPart.
 	sent, failed, done := make(chan s3UploadedPart), make(chan error), make(chan struct{})
 	var uploadWg sync.WaitGroup
+	type uploadFn func() (etag string, err error)
 	sendPart := func(partNum int64, doUpload uploadFn) {
 		defer uploadWg.Done()
 
@@ -259,33 +267,43 @@ func (s3p s3TablePersister) uploadPartsCopy(plan compactionPlan, key, uploadID s
 		}
 	}
 
-	numCopyParts := len(copies)
-	numManualParts := getNumParts(len(buff), s3p.partSize) // TODO: What if this is too big?
-	numParts := numCopyParts + numManualParts
-	uploadWg.Add(numParts)
-	for i, cp := range copies {
-		partNum := int64(i + 1) // parts are 1-indexed
-		go sendPart(partNum, func() (etag string, err error) {
-			return s3p.uploadPartCopy(cp.name, cp.dataLen, key, uploadID, partNum)
-		})
-	}
-	for i := numCopyParts + 1; i <= numParts; i++ {
-		start, end := (i-numCopyParts-1)*s3p.partSize, (i-numCopyParts)*s3p.partSize
-		if i == numParts { // If this is the last part, make sure it includes any overflow
-			end = len(buff)
-		}
-		partNum := int64(i)
-		go sendPart(partNum, func() (etag string, err error) {
-			return s3p.uploadPart(buff[start:end], key, uploadID, partNum)
-		})
+	// Concurrently begin sending all parts using sendPart().
+	// First, kick off sending all the copyable parts.
+	partNum := int64(1) // Part numbers are 1-indexed
+	for _, cp := range copies {
+		uploadWg.Add(1)
+		go func(cp copyPart, partNum int64) {
+			sendPart(partNum, func() (etag string, err error) {
+				return s3p.uploadPartCopy(cp.name, cp.srcOffset, cp.srcLen, key, uploadID, partNum)
+			})
+		}(cp, partNum)
+		partNum++
 	}
 
+	// Then, split buff (data from |manuals| and index) into parts and upload those concurrently.
+	numManualParts := getNumParts(uint64(len(buff)), s3p.targetPartSize) // TODO: What if this is too big?
+	for i := uint64(0); i < numManualParts; i++ {
+		start, end := i*s3p.targetPartSize, (i+1)*s3p.targetPartSize
+		if i+1 == numManualParts { // If this is the last part, make sure it includes any overflow
+			end = uint64(len(buff))
+		}
+		uploadWg.Add(1)
+		go func(data []byte, partNum int64) {
+			sendPart(partNum, func() (etag string, err error) {
+				return s3p.uploadPart(data, key, uploadID, partNum)
+			})
+		}(buff[start:end], partNum)
+		partNum++
+	}
+
+	// When all the uploads started above are done, close |sent| and |failed| so that the code below will correctly detect that we're done sending parts and move forward.
 	go func() {
 		uploadWg.Wait()
 		close(sent)
 		close(failed)
 	}()
 
+	// Watch |sent| and |failed| for the results of part uploads. If ever one fails, close |done| to stop all the in-progress or pending sendPart() calls and then bail.
 	multipartUpload := &s3.CompletedMultipartUpload{}
 	var firstFailure error
 	for cont := true; cont; {
@@ -307,46 +325,85 @@ func (s3p s3TablePersister) uploadPartsCopy(plan compactionPlan, key, uploadID s
 		}
 	}
 
+	// If there was any failure detected above, |done| is already closed
 	if firstFailure == nil {
 		close(done)
 	}
-	sort.Sort(partsByPartNum(multipartUpload.Parts))
+	sort.Sort(partsByPartNum(multipartUpload.Parts)) // S3 requires that these be in part-order
 	return multipartUpload, firstFailure
 }
 
 type copyPart struct {
-	name    string
-	dataLen int64
+	name              string
+	srcOffset, srcLen int64
 }
 
 type manualPart struct {
-	r                  io.Reader
-	buffStart, buffEnd int64
+	srcR             io.Reader
+	dstStart, dstEnd int64
 }
 
-func dividePlan(sources chunkSources, plan compactionPlan) (copies []copyPart, manuals []manualPart, buff []byte) {
+func dividePlan(plan compactionPlan, minPartSize, maxPartSize uint64) (copies []copyPart, manuals []manualPart, buff []byte) {
+	// NB: if maxPartSize < 2*minPartSize, splitting large copies apart isn't solvable. S3's limits are plenty far enough apart that this isn't a problem in production, but we could violate this in tests.
+	d.PanicIfTrue(maxPartSize < 2*minPartSize)
+
 	buffSize := uint64(len(plan.mergedIndex))
-	var offset int64
-	for i, src := range sources {
-		dataLen := plan.chunkDataLens[i]
-		if dataLen >= defaultS3PartSize { // Big enough to copy part!
-			copies = append(copies, copyPart{src.hash().String(), int64(dataLen)})
-		} else {
-			manuals = append(manuals, manualPart{src.reader(), offset, offset + int64(dataLen)})
-			offset += int64(dataLen)
-			buffSize += dataLen
+	i := 0
+	for ; i < len(plan.sources); i++ {
+		sws := plan.sources[i]
+		if sws.dataLen < minPartSize {
+			// since plan.sources is sorted in descending chunk-data-length order, we know that sws and all members after it are too small to copy.
+			break
 		}
+		if sws.dataLen <= maxPartSize {
+			copies = append(copies, copyPart{sws.source.hash().String(), 0, int64(sws.dataLen)})
+			continue
+		}
+
+		// Now, we need to break the data into some number of parts such that for all parts minPartSize <= size(part) <= maxPartSize. This code tries to split the part evenly, such that all new parts satisfy the previous inequality. This gets tricky around edge cases. Consider min = 5b and max = 10b and a data length of 101b. You need to send 11 parts, but you can't just send 10 parts of 10 bytes and 1 part of 1 byte -- the last is too small. You also can't send 10 parts of 9 bytes each and 1 part of 11 bytes, because the last is too big. You have to distribute the extra bytes across all the parts so that all of them fall into the proper size range.
+		lens := calcPartLens(sws.dataLen, maxPartSize)
+
+		var srcStart int64
+		for _, length := range lens {
+			copies = append(copies, copyPart{sws.source.hash().String(), srcStart, length})
+			srcStart += length
+		}
+	}
+	var offset int64
+	for ; i < len(plan.sources); i++ {
+		sws := plan.sources[i]
+		manuals = append(manuals, manualPart{sws.source.reader(), offset, offset + int64(sws.dataLen)})
+		offset += int64(sws.dataLen)
+		buffSize += sws.dataLen
 	}
 	buff = make([]byte, buffSize)
 	copy(buff[buffSize-uint64(len(plan.mergedIndex)):], plan.mergedIndex)
 	return
 }
 
-func (s3p s3TablePersister) uploadPartCopy(src string, dataLen int64, key, uploadID string, partNum int64) (etag string, err error) {
+func calcPartLens(dataLen, maxPartSize uint64) []int64 {
+	numParts := dataLen / maxPartSize
+	if dataLen%maxPartSize > 0 {
+		numParts++
+	}
+	baseSize := int64(dataLen / numParts)
+	extraBytes := dataLen % numParts
+	sizes := make([]int64, numParts)
+	for i := range sizes {
+		sizes[i] = baseSize
+		if extraBytes > 0 {
+			sizes[i]++
+			extraBytes--
+		}
+	}
+	return sizes
+}
+
+func (s3p s3TablePersister) uploadPartCopy(src string, srcStart, srcEnd int64, key, uploadID string, partNum int64) (etag string, err error) {
 	res, err := s3p.s3.UploadPartCopy(&s3.UploadPartCopyInput{
 		// TODO: Use url.PathEscape() once we're on go 1.8
 		CopySource:      aws.String(url.QueryEscape(s3p.bucket + "/" + src)),
-		CopySourceRange: aws.String(s3RangeHeader(0, dataLen)),
+		CopySourceRange: aws.String(s3RangeHeader(srcStart, srcEnd)),
 		Bucket:          aws.String(s3p.bucket),
 		Key:             aws.String(key),
 		PartNumber:      aws.Int64(int64(partNum)),

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -6,6 +6,8 @@ package nbs
 
 import (
 	"bytes"
+	"io"
+	"net/url"
 	"sort"
 	"sync"
 	"time"
@@ -16,7 +18,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-const defaultS3PartSize = 5 * 1 << 20 // 5MiB, smallest allowed by S3
+const (
+	defaultS3PartSize = 5 * 1 << 20 // 5MiB, smallest allowed by S3
+	maxS3Parts        = 10000
+)
 
 type s3TablePersister struct {
 	s3         s3svc
@@ -40,58 +45,69 @@ func (s3p s3TablePersister) Persist(mt *memTable, haver chunkReader) chunkSource
 }
 
 func (s3p s3TablePersister) persistTable(name addr, data []byte, chunkCount uint32) chunkSource {
-	if chunkCount > 0 {
-		t1 := time.Now()
-		s3p.multipartUpload(data, name.String())
-		verbose.Log("Compacted table of %d Kb in %s", len(data)/1024, time.Since(t1))
-
-		s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name, readRl: s3p.readRl}
-		index := parseTableIndex(data)
-		if s3p.indexCache != nil {
-			s3p.indexCache.put(name, index)
-		}
-		s3tr.tableReader = newTableReader(index, s3tr, s3BlockSize)
-		return s3tr
+	if chunkCount == 0 {
+		return emptyChunkSource{}
 	}
-	return emptyChunkSource{}
+	t1 := time.Now()
+	s3p.multipartUpload(data, name.String())
+	verbose.Log("Compacted table of %d Kb in %s", len(data)/1024, time.Since(t1))
+
+	return s3p.newReaderFromIdxData(data, name)
 }
 
-func (s3p s3TablePersister) CompactAll(sources chunkSources) chunkSource {
-	return s3p.persistTable(compactSourcesToBuffer(sources, s3p.readRl))
+func (s3p s3TablePersister) newReaderFromIdxData(idxData []byte, name addr) *s3TableReader {
+	s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name, readRl: s3p.readRl}
+	index := parseTableIndex(idxData)
+	if s3p.indexCache != nil {
+		s3p.indexCache.put(name, index)
+	}
+	s3tr.tableReader = newTableReader(index, s3tr, s3BlockSize)
+	return s3tr
 }
 
 func (s3p s3TablePersister) multipartUpload(data []byte, key string) {
+	uploadID := s3p.startMultipartUpload(key)
+	multipartUpload, err := s3p.uploadParts(data, key, uploadID)
+	if err != nil {
+		s3p.abortMultipartUpload(key, uploadID)
+		d.PanicIfError(err) // TODO: Better error handling here
+	}
+	s3p.completeMultipartUpload(key, uploadID, multipartUpload)
+}
+
+func (s3p s3TablePersister) startMultipartUpload(key string) string {
 	result, err := s3p.s3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 		Bucket: aws.String(s3p.bucket),
 		Key:    aws.String(key),
 	})
-	d.Chk.NoError(err)
-	uploadID := *result.UploadId
+	d.PanicIfError(err)
+	return *result.UploadId
+}
 
-	multipartUpload, err := s3p.uploadParts(data, key, uploadID)
-	if err != nil {
-		_, abrtErr := s3p.s3.AbortMultipartUpload(&s3.AbortMultipartUploadInput{
-			Bucket:   aws.String(s3p.bucket),
-			Key:      aws.String(key),
-			UploadId: aws.String(uploadID),
-		})
-		d.Chk.NoError(abrtErr)
-		panic(err) // TODO: Better error handling here
-	}
+func (s3p s3TablePersister) abortMultipartUpload(key, uploadID string) {
+	_, abrtErr := s3p.s3.AbortMultipartUpload(&s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(s3p.bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadID),
+	})
+	d.PanicIfError(abrtErr)
+}
 
-	_, err = s3p.s3.CompleteMultipartUpload(&s3.CompleteMultipartUploadInput{
+func (s3p s3TablePersister) completeMultipartUpload(key, uploadID string, mpu *s3.CompletedMultipartUpload) {
+	_, err := s3p.s3.CompleteMultipartUpload(&s3.CompleteMultipartUploadInput{
 		Bucket:          aws.String(s3p.bucket),
 		Key:             aws.String(key),
-		MultipartUpload: multipartUpload,
+		MultipartUpload: mpu,
 		UploadId:        aws.String(uploadID),
 	})
-	d.Chk.NoError(err)
+	d.PanicIfError(err)
 }
 
 func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
 	sent, failed, done := make(chan s3UploadedPart), make(chan error), make(chan struct{})
 
 	numParts := getNumParts(len(data), s3p.partSize)
+	d.PanicIfTrue(numParts > maxS3Parts) // TODO: BUG 3433: handle > 10k parts
 	var wg sync.WaitGroup
 	wg.Add(numParts)
 	sendPart := func(partNum int) {
@@ -108,20 +124,14 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 		if partNum == numParts { // If this is the last part, make sure it includes any overflow
 			end = len(data)
 		}
-		result, err := s3p.s3.UploadPart(&s3.UploadPartInput{
-			Bucket:     aws.String(s3p.bucket),
-			Key:        aws.String(key),
-			PartNumber: aws.Int64(int64(partNum)),
-			UploadId:   aws.String(uploadID),
-			Body:       bytes.NewReader(data[start:end]),
-		})
+		etag, err := s3p.uploadPart(data[start:end], key, uploadID, int64(partNum))
 		if err != nil {
 			failed <- err
 			return
 		}
 		// Try to send along part info. In the case that the upload was aborted, reading from done allows this worker to exit correctly.
 		select {
-		case sent <- s3UploadedPart{int64(partNum), *result.ETag}:
+		case sent <- s3UploadedPart{int64(partNum), etag}:
 		case <-done:
 			return
 		}
@@ -136,7 +146,7 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 	}()
 
 	multipartUpload := &s3.CompletedMultipartUpload{}
-	var lastFailure error
+	var firstFailure error
 	for cont := true; cont; {
 		select {
 		case sentPart, open := <-sent:
@@ -149,18 +159,18 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 			cont = open
 
 		case err := <-failed:
-			if err != nil { // nil err may happen when failed gets closed
-				lastFailure = err
+			if err != nil && firstFailure == nil { // nil err may happen when failed gets closed
+				firstFailure = err
 				close(done)
 			}
 		}
 	}
 
-	if lastFailure == nil {
+	if firstFailure == nil {
 		close(done)
 	}
 	sort.Sort(partsByPartNum(multipartUpload.Parts))
-	return multipartUpload, lastFailure
+	return multipartUpload, firstFailure
 }
 
 func getNumParts(dataLen, partSize int) int {
@@ -183,4 +193,181 @@ func (s partsByPartNum) Less(i, j int) bool {
 
 func (s partsByPartNum) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
+}
+
+func (s3p s3TablePersister) CompactAll(sources chunkSources) chunkSource {
+	plan := planCompaction(sources)
+	if plan.chunkCount == 0 {
+		return emptyChunkSource{}
+	}
+	t1 := time.Now()
+	name := nameFromSuffixes(plan.suffixes())
+	s3p.multipartCopyUpload(plan, name.String())
+	verbose.Log("Compacted table of %d Kb in %s", plan.totalCompressedData/1024, time.Since(t1))
+
+	return s3p.newReaderFromIdxData(plan.mergedIndex, name)
+}
+
+func (s3p s3TablePersister) multipartCopyUpload(plan compactionPlan, key string) {
+	uploadID := s3p.startMultipartUpload(key)
+	multipartUpload, err := s3p.uploadPartsCopy(plan, key, uploadID)
+	if err != nil {
+		s3p.abortMultipartUpload(key, uploadID)
+		d.PanicIfError(err) // TODO: Better error handling here
+	}
+	s3p.completeMultipartUpload(key, uploadID, multipartUpload)
+}
+
+func (s3p s3TablePersister) uploadPartsCopy(plan compactionPlan, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
+	d.PanicIfTrue(len(plan.sources) > maxS3Parts) // TODO: BUG 3433: handle > 10k parts
+
+	copies, manuals, buff := dividePlan(plan.sources, plan)
+	var readWg sync.WaitGroup
+	for _, man := range manuals {
+		readWg.Add(1)
+		go func(m manualPart) {
+			defer readWg.Done()
+			n, _ := m.r.Read(buff[m.buffStart:m.buffEnd])
+			d.PanicIfTrue(int64(n) < m.buffEnd-m.buffStart)
+		}(man)
+	}
+	readWg.Wait()
+
+	type uploadFn func() (etag string, err error)
+	sent, failed, done := make(chan s3UploadedPart), make(chan error), make(chan struct{})
+	var uploadWg sync.WaitGroup
+	sendPart := func(partNum int64, doUpload uploadFn) {
+		defer uploadWg.Done()
+
+		// Check if upload has been terminated
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		etag, err := doUpload()
+		if err != nil {
+			failed <- err
+			return
+		}
+		// Try to send along part info. In the case that the upload was aborted, reading from done allows this worker to exit correctly.
+		select {
+		case sent <- s3UploadedPart{int64(partNum), etag}:
+		case <-done:
+			return
+		}
+	}
+
+	numCopyParts := len(copies)
+	numManualParts := getNumParts(len(buff), s3p.partSize) // TODO: What if this is too big?
+	numParts := numCopyParts + numManualParts
+	uploadWg.Add(numParts)
+	for i, cp := range copies {
+		partNum := int64(i + 1) // parts are 1-indexed
+		go sendPart(partNum, func() (etag string, err error) {
+			return s3p.uploadPartCopy(cp.name, cp.dataLen, key, uploadID, partNum)
+		})
+	}
+	for i := numCopyParts + 1; i <= numParts; i++ {
+		start, end := (i-numCopyParts-1)*s3p.partSize, (i-numCopyParts)*s3p.partSize
+		if i == numParts { // If this is the last part, make sure it includes any overflow
+			end = len(buff)
+		}
+		partNum := int64(i)
+		go sendPart(partNum, func() (etag string, err error) {
+			return s3p.uploadPart(buff[start:end], key, uploadID, partNum)
+		})
+	}
+
+	go func() {
+		uploadWg.Wait()
+		close(sent)
+		close(failed)
+	}()
+
+	multipartUpload := &s3.CompletedMultipartUpload{}
+	var firstFailure error
+	for cont := true; cont; {
+		select {
+		case sentPart, open := <-sent:
+			if open {
+				multipartUpload.Parts = append(multipartUpload.Parts, &s3.CompletedPart{
+					ETag:       aws.String(sentPart.etag),
+					PartNumber: aws.Int64(sentPart.idx),
+				})
+			}
+			cont = open
+
+		case err := <-failed:
+			if err != nil && firstFailure == nil { // nil err may happen when failed gets closed
+				firstFailure = err
+				close(done)
+			}
+		}
+	}
+
+	if firstFailure == nil {
+		close(done)
+	}
+	sort.Sort(partsByPartNum(multipartUpload.Parts))
+	return multipartUpload, firstFailure
+}
+
+type copyPart struct {
+	name    string
+	dataLen int64
+}
+
+type manualPart struct {
+	r                  io.Reader
+	buffStart, buffEnd int64
+}
+
+func dividePlan(sources chunkSources, plan compactionPlan) (copies []copyPart, manuals []manualPart, buff []byte) {
+	buffSize := uint64(len(plan.mergedIndex))
+	var offset int64
+	for i, src := range sources {
+		dataLen := plan.chunkDataLens[i]
+		if dataLen >= defaultS3PartSize { // Big enough to copy part!
+			copies = append(copies, copyPart{src.hash().String(), int64(dataLen)})
+		} else {
+			manuals = append(manuals, manualPart{src.reader(), offset, offset + int64(dataLen)})
+			offset += int64(dataLen)
+			buffSize += dataLen
+		}
+	}
+	buff = make([]byte, buffSize)
+	copy(buff[buffSize-uint64(len(plan.mergedIndex)):], plan.mergedIndex)
+	return
+}
+
+func (s3p s3TablePersister) uploadPartCopy(src string, dataLen int64, key, uploadID string, partNum int64) (etag string, err error) {
+	res, err := s3p.s3.UploadPartCopy(&s3.UploadPartCopyInput{
+		// TODO: Use url.PathEscape() once we're on go 1.8
+		CopySource:      aws.String(url.QueryEscape(s3p.bucket + "/" + src)),
+		CopySourceRange: aws.String(s3RangeHeader(0, dataLen)),
+		Bucket:          aws.String(s3p.bucket),
+		Key:             aws.String(key),
+		PartNumber:      aws.Int64(int64(partNum)),
+		UploadId:        aws.String(uploadID),
+	})
+	if err == nil {
+		etag = *res.CopyPartResult.ETag
+	}
+	return
+}
+
+func (s3p s3TablePersister) uploadPart(data []byte, key, uploadID string, partNum int64) (etag string, err error) {
+	res, err := s3p.s3.UploadPart(&s3.UploadPartInput{
+		Bucket:     aws.String(s3p.bucket),
+		Key:        aws.String(key),
+		PartNumber: aws.Int64(int64(partNum)),
+		UploadId:   aws.String(uploadID),
+		Body:       bytes.NewReader(data),
+	})
+	if err == nil {
+		etag = *res.ETag
+	}
+	return
 }

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -35,7 +35,7 @@ type s3UploadedPart struct {
 	etag string
 }
 
-func (s3p s3TablePersister) Compact(mt *memTable, haver chunkReader) chunkSource {
+func (s3p s3TablePersister) Persist(mt *memTable, haver chunkReader) chunkSource {
 	return s3p.persistTable(mt.write(haver))
 }
 

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -148,7 +148,7 @@ func TestS3TablePersisterCalcPartSizes(t *testing.T) {
 	min, max := uint64(8*1<<10), uint64(1+(16*1<<10))
 
 	testPartSizes := func(dataLen uint64) {
-		lengths := calcPartLens(dataLen, max)
+		lengths := splitOnMaxSize(dataLen, max)
 		var sum int64
 		for _, l := range lengths {
 			assert.True(uint64(l) >= min)

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -24,7 +24,8 @@ func TestS3TablePersisterPersist(t *testing.T) {
 
 	s3svc := makeFakeS3(assert)
 	cache := newIndexCache(1024)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 3), indexCache: cache}
+	sz := calcPartSize(mt, 3)
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", targetPartSize: sz, indexCache: cache}
 
 	src := s3p.Persist(mt, nil)
 	assert.NotNil(cache.get(src.hash()))
@@ -36,8 +37,8 @@ func TestS3TablePersisterPersist(t *testing.T) {
 	}
 }
 
-func calcPartSize(rdr chunkReader, maxPartNum int) int {
-	return int(maxTableSize(uint64(rdr.count()), rdr.uncompressedLen())) / maxPartNum
+func calcPartSize(rdr chunkReader, maxPartNum uint64) uint64 {
+	return maxTableSize(uint64(rdr.count()), rdr.uncompressedLen()) / maxPartNum
 }
 
 func TestS3TablePersisterPersistSinglePart(t *testing.T) {
@@ -49,7 +50,7 @@ func TestS3TablePersisterPersistSinglePart(t *testing.T) {
 	}
 
 	s3svc := makeFakeS3(assert)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, 1)}
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", targetPartSize: calcPartSize(mt, 1)}
 
 	src := s3p.Persist(mt, nil)
 	if assert.True(src.count() > 0) {
@@ -67,9 +68,8 @@ func TestS3TablePersisterPersistAbort(t *testing.T) {
 		assert.True(mt.addChunk(computeAddr(c), c))
 	}
 
-	numParts := 4
 	s3svc := &failingFakeS3{makeFakeS3(assert), sync.Mutex{}, 1}
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: calcPartSize(mt, numParts)}
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", targetPartSize: calcPartSize(mt, 4)}
 
 	assert.Panics(func() { s3p.Persist(mt, nil) })
 }
@@ -101,7 +101,7 @@ func TestS3TablePersisterCompactNoData(t *testing.T) {
 	}
 
 	s3svc := makeFakeS3(assert)
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: 1 << 10}
+	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", targetPartSize: 1 << 10}
 
 	src := s3p.Persist(mt, existingTable)
 	assert.True(src.count() == 0)
@@ -110,41 +110,228 @@ func TestS3TablePersisterCompactNoData(t *testing.T) {
 	assert.False(present)
 }
 
-func TestS3TablePersisterCompactAll(t *testing.T) {
+func TestS3TablePersisterDividePlan(t *testing.T) {
 	assert := assert.New(t)
+	minPartSize, maxPartSize := uint64(16), uint64(32)
+	tooSmall := bytesToChunkSource([]byte("a"))
+	justRight := bytesToChunkSource([]byte("123456789"), []byte("abcdefghi"))
+	bigUns := [][]byte{make([]byte, maxPartSize-1), make([]byte, maxPartSize-1)}
+	for _, b := range bigUns {
+		rand.Read(b)
+	}
+	tooBig := bytesToChunkSource(bigUns...)
 
-	s3svc := makeFakeS3(assert)
+	sources := chunkSources{justRight, tooBig, tooSmall}
+	plan := planCompaction(sources)
+	copies, manuals, _ := dividePlan(plan, minPartSize, maxPartSize)
+
+	perTableDataSize := map[string]int64{}
+	for _, c := range copies {
+		assert.True(minPartSize <= uint64(c.srcLen))
+		assert.True(uint64(c.srcLen) <= maxPartSize)
+		totalSize := perTableDataSize[c.name]
+		totalSize += c.srcLen
+		perTableDataSize[c.name] = totalSize
+	}
+	assert.Len(perTableDataSize, 2)
+	assert.Contains(perTableDataSize, justRight.hash().String())
+	assert.Contains(perTableDataSize, tooBig.hash().String())
+	assert.EqualValues(calcChunkDataLen(justRight.index()), perTableDataSize[justRight.hash().String()])
+	assert.EqualValues(calcChunkDataLen(tooBig.index()), perTableDataSize[tooBig.hash().String()])
+
+	assert.Len(manuals, 1)
+	assert.EqualValues(calcChunkDataLen(tooSmall.index()), manuals[0].dstEnd-manuals[0].dstStart)
+}
+
+func TestS3TablePersisterCalcPartSizes(t *testing.T) {
+	assert := assert.New(t)
+	min, max := uint64(8*1<<10), uint64(1+(16*1<<10))
+
+	testPartSizes := func(dataLen uint64) {
+		lengths := calcPartLens(dataLen, max)
+		var sum int64
+		for _, l := range lengths {
+			assert.True(uint64(l) >= min)
+			assert.True(uint64(l) <= max)
+			sum += l
+		}
+		assert.EqualValues(dataLen, sum)
+	}
+
+	testPartSizes(1 << 20)
+	testPartSizes(max + 1)
+	testPartSizes(10*max - 1)
+	testPartSizes(max + max/2)
+}
+
+func TestS3TablePersisterCompactAll(t *testing.T) {
+	targetPartSize := uint64(1024)
+	minPartSize, maxPartSize := targetPartSize, 5*targetPartSize
+
 	cache := newIndexCache(1024)
 	rl := make(chan struct{}, 8)
 	defer close(rl)
 
-	s3p := s3TablePersister{s3: s3svc, bucket: "bucket", partSize: defaultS3PartSize, indexCache: cache, readRl: rl}
-
-	chunx := make([][][]byte, 3)
-	sources := make(chunkSources, len(chunx))
+	smallChunks := [][]byte{}
 	rnd := rand.New(rand.NewSource(0))
-	MiB := 1 << 20
-	for i := 0; i < len(chunx); i++ {
-		chunx[i] = make([][]byte, (defaultS3PartSize/MiB)-1+i)
-		mt := newMemTable(2 * defaultS3PartSize)
-
-		for j := 0; j < len(chunx[i]); j++ {
-			chunx[i][j] = make([]byte, MiB)
-			rnd.Read(chunx[i][j])
-			mt.addChunk(computeAddr(chunx[i][j]), chunx[i][j])
-		}
-		sources[i] = s3p.Persist(mt, nil)
+	for smallChunkTotal := uint64(0); smallChunkTotal <= uint64(minPartSize); {
+		small := make([]byte, minPartSize/5)
+		rnd.Read(small)
+		src := bytesToChunkSource(small)
+		smallChunks = append(smallChunks, small)
+		smallChunkTotal += calcChunkDataLen(src.index())
 	}
-	src := s3p.CompactAll(sources)
-	assert.NotNil(cache.get(src.hash()))
 
-	if assert.True(src.count() > 0) {
-		if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
-			for _, slice := range chunx {
-				assertChunksInReader(slice, r, assert)
+	t.Run("Small", func(t *testing.T) {
+		makeSources := func(s3p s3TablePersister, chunks [][]byte) (sources chunkSources) {
+			for i := 0; i < len(chunks); i++ {
+				mt := newMemTable(uint64(2 * targetPartSize))
+				mt.addChunk(computeAddr(chunks[i]), chunks[i])
+				sources = append(sources, s3p.Persist(mt, nil))
+			}
+			return
+		}
+
+		t.Run("TotalUnderMinSize", func(t *testing.T) {
+			assert := assert.New(t)
+			s3svc := makeFakeS3(assert)
+			s3p := s3TablePersister{s3svc, "bucket", targetPartSize, minPartSize, maxPartSize, cache, rl}
+
+			chunks := smallChunks[:len(smallChunks)-1]
+			sources := makeSources(s3p, chunks)
+			src := s3p.CompactAll(sources)
+			assert.NotNil(cache.get(src.hash()))
+
+			if assert.True(src.count() > 0) {
+				if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+					assertChunksInReader(chunks, r, assert)
+				}
+			}
+		})
+
+		t.Run("TotalOverMinSize", func(t *testing.T) {
+			assert := assert.New(t)
+			s3svc := makeFakeS3(assert)
+			s3p := s3TablePersister{s3svc, "bucket", targetPartSize, minPartSize, maxPartSize, cache, rl}
+
+			sources := makeSources(s3p, smallChunks)
+			src := s3p.CompactAll(sources)
+			assert.NotNil(cache.get(src.hash()))
+
+			if assert.True(src.count() > 0) {
+				if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+					assertChunksInReader(smallChunks, r, assert)
+				}
+			}
+		})
+	})
+
+	bigUns1 := [][]byte{make([]byte, maxPartSize-1), make([]byte, maxPartSize-1)}
+	bigUns2 := [][]byte{make([]byte, maxPartSize-1), make([]byte, maxPartSize-1)}
+	for _, bu := range [][][]byte{bigUns1, bigUns2} {
+		for _, b := range bu {
+			rand.Read(b)
+		}
+	}
+
+	t.Run("AllOverMax", func(t *testing.T) {
+		assert := assert.New(t)
+		s3svc := makeFakeS3(assert)
+		s3p := s3TablePersister{s3svc, "bucket", targetPartSize, minPartSize, maxPartSize, cache, rl}
+
+		// Make 2 chunk sources that each have >maxPartSize chunk data
+		sources := make(chunkSources, 2)
+		for i, bu := range [][][]byte{bigUns1, bigUns2} {
+			mt := newMemTable(uint64(2 * maxPartSize))
+			for _, b := range bu {
+				mt.addChunk(computeAddr(b), b)
+			}
+			sources[i] = s3p.Persist(mt, nil)
+		}
+		src := s3p.CompactAll(sources)
+		assert.NotNil(cache.get(src.hash()))
+
+		if assert.True(src.count() > 0) {
+			if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+				assertChunksInReader(bigUns1, r, assert)
+				assertChunksInReader(bigUns2, r, assert)
 			}
 		}
-	}
+	})
+
+	t.Run("SomeOverMax", func(t *testing.T) {
+		assert := assert.New(t)
+		s3svc := makeFakeS3(assert)
+		s3p := s3TablePersister{s3svc, "bucket", targetPartSize, minPartSize, maxPartSize, cache, rl}
+
+		// Add one chunk source that has >maxPartSize data
+		mtb := newMemTable(uint64(2 * maxPartSize))
+		for _, b := range bigUns1 {
+			mtb.addChunk(computeAddr(b), b)
+		}
+
+		// Follow up with a chunk source where minPartSize < data size < maxPartSize
+		medChunks := make([][]byte, 2)
+		mt := newMemTable(uint64(2 * maxPartSize))
+		for i := range medChunks {
+			medChunks[i] = make([]byte, minPartSize+1)
+			rand.Read(medChunks[i])
+			mt.addChunk(computeAddr(medChunks[i]), medChunks[i])
+		}
+		sources := chunkSources{s3p.Persist(mt, nil), s3p.Persist(mtb, nil)}
+
+		src := s3p.CompactAll(sources)
+		assert.NotNil(cache.get(src.hash()))
+
+		if assert.True(src.count() > 0) {
+			if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+				assertChunksInReader(bigUns1, r, assert)
+				assertChunksInReader(medChunks, r, assert)
+			}
+		}
+	})
+
+	t.Run("Mix", func(t *testing.T) {
+		assert := assert.New(t)
+		s3svc := makeFakeS3(assert)
+		s3p := s3TablePersister{s3svc, "bucket", targetPartSize, minPartSize, maxPartSize, cache, rl}
+
+		// Start with small tables. Since total > minPartSize, will require more than one part to upload.
+		sources := make(chunkSources, len(smallChunks))
+		for i := 0; i < len(smallChunks); i++ {
+			mt := newMemTable(uint64(2 * targetPartSize))
+			mt.addChunk(computeAddr(smallChunks[i]), smallChunks[i])
+			sources[i] = s3p.Persist(mt, nil)
+		}
+
+		// Now, add a table with big chunks that will require more than one upload copy part.
+		mt := newMemTable(uint64(2 * maxPartSize))
+		for _, b := range bigUns1 {
+			mt.addChunk(computeAddr(b), b)
+		}
+		sources = append(sources, s3p.Persist(mt, nil))
+
+		// Last, some tables that should be directly upload-copyable
+		medChunks := make([][]byte, 2)
+		mt = newMemTable(uint64(2 * maxPartSize))
+		for i := range medChunks {
+			medChunks[i] = make([]byte, minPartSize+1)
+			rand.Read(medChunks[i])
+			mt.addChunk(computeAddr(medChunks[i]), medChunks[i])
+		}
+		sources = append(sources, s3p.Persist(mt, nil))
+
+		src := s3p.CompactAll(sources)
+		assert.NotNil(cache.get(src.hash()))
+
+		if assert.True(src.count() > 0) {
+			if r := s3svc.readerForTable(src.hash()); assert.NotNil(r) {
+				assertChunksInReader(smallChunks, r, assert)
+				assertChunksInReader(bigUns1, r, assert)
+				assertChunksInReader(medChunks, r, assert)
+			}
+		}
+	})
 }
 
 func bytesToChunkSource(bs ...[]byte) chunkSource {

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -214,8 +214,9 @@ type chunkSource interface {
 	hash() addr
 	calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool)
 
-	index() tableIndex
+	// opens a Reader to the first byte of the chunkData segment of this table.
 	reader() io.Reader
+	index() tableIndex
 }
 
 type chunkSources []chunkSource

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base32"
 	"encoding/binary"
 	"hash/crc32"
+	"io"
 	"sync"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -212,6 +213,9 @@ type chunkSource interface {
 	close() error
 	hash() addr
 	calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool)
+
+	index() tableIndex
+	reader() io.Reader
 }
 
 type chunkSources []chunkSource

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -14,7 +14,7 @@ import (
 )
 
 type tablePersister interface {
-	Compact(mt *memTable, haver chunkReader) chunkSource
+	Persist(mt *memTable, haver chunkReader) chunkSource
 	CompactAll(sources chunkSources) chunkSource
 	Open(name addr, chunkCount uint32) chunkSource
 }

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -113,15 +113,15 @@ func planCompaction(sources chunkSources) (plan compactionPlan) {
 
 	prefixIndexRecs := make(prefixIndexSlice, 0, plan.chunkCount)
 	var ordinalOffset uint32
-	for _, src := range sources {
-		index := src.index()
+	for _, sws := range plan.sources {
+		index := sws.source.index()
 
 		// Add all the prefix tuples from this index to the list of all prefixIndexRecs, modifying the ordinals such that all entries from the 1st item in sources come after those in the 0th and so on.
 		for j, prefix := range index.prefixes {
 			rec := prefixIndexRec{prefix: prefix, order: ordinalOffset + index.ordinals[j]}
 			prefixIndexRecs = append(prefixIndexRecs, rec)
 		}
-		ordinalOffset += src.count()
+		ordinalOffset += sws.source.count()
 
 		// TODO: copy the lengths and suffixes as a byte-copy from src BUG #3438
 		// Bring over the lengths block, in order

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -6,7 +6,10 @@ package nbs
 
 import (
 	"bytes"
+	"crypto/sha512"
+	"encoding/binary"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/attic-labs/noms/go/d"
@@ -54,6 +57,89 @@ func (csbc chunkSourcesByAscendingCount) Less(i, j int) bool {
 	return srcI.count() < srcJ.count()
 }
 func (csbc chunkSourcesByAscendingCount) Swap(i, j int) { csbc[i], csbc[j] = csbc[j], csbc[i] }
+
+type compactionPlan struct {
+	sources             chunkSources
+	chunkDataLens       []uint64
+	mergedIndex         []byte
+	chunkCount          uint32
+	totalCompressedData uint64
+}
+
+func (cp compactionPlan) lengths() []byte {
+	lengthsStart := uint64(cp.chunkCount) * prefixTupleSize
+	return cp.mergedIndex[lengthsStart : lengthsStart+uint64(cp.chunkCount)*lengthSize]
+}
+
+func (cp compactionPlan) suffixes() []byte {
+	suffixesStart := uint64(cp.chunkCount) * (prefixTupleSize + lengthSize)
+	return cp.mergedIndex[suffixesStart : suffixesStart+uint64(cp.chunkCount)*addrSuffixSize]
+}
+
+func planCompaction(sources chunkSources) (plan compactionPlan) {
+	var totalUncompressedData uint64
+	for _, src := range sources {
+		plan.chunkCount += src.count()
+		totalUncompressedData += src.uncompressedLen()
+	}
+	plan.sources = sources
+
+	lengthsPos := uint64(plan.chunkCount) * prefixTupleSize
+	suffixesPos := lengthsPos + uint64(plan.chunkCount)*lengthSize
+	plan.mergedIndex = make([]byte, indexSize(plan.chunkCount)+footerSize)
+	plan.chunkDataLens = make([]uint64, len(sources))
+
+	prefixIndexRecs := make(prefixIndexSlice, 0, plan.chunkCount)
+	var ordinalOffset uint32
+	for i, src := range sources {
+		idx := src.index()
+
+		// Add all the prefix tuples from this index to the list of all prefixIndexRecs, modifying the ordinals such that all entries from the 1st item in sources come after those in the 0th and so on.
+		for j, prefix := range idx.prefixes {
+			rec := prefixIndexRec{prefix: prefix, order: ordinalOffset + idx.ordinals[j]}
+			prefixIndexRecs = append(prefixIndexRecs, rec)
+		}
+		ordinalOffset += src.count()
+
+		// Calculate the amount of chunk data in |src|
+		plan.chunkDataLens[i] = idx.offsets[src.count()-1] + uint64(idx.lengths[src.count()-1])
+		plan.totalCompressedData += plan.chunkDataLens[i]
+
+		// Bring over the lengths block, in order
+		for _, length := range idx.lengths {
+			binary.BigEndian.PutUint32(plan.mergedIndex[lengthsPos:], length)
+			lengthsPos += lengthSize
+		}
+
+		// Bring over the suffixes block, in order
+		n := copy(plan.mergedIndex[suffixesPos:], idx.suffixes)
+		d.Chk.True(n == len(idx.suffixes))
+		suffixesPos += uint64(n)
+	}
+
+	// Sort all prefixTuples by hash and then insert them starting at the beginning of plan.mergedIndex
+	sort.Sort(prefixIndexRecs)
+	var pfxPos uint64
+	for _, pi := range prefixIndexRecs {
+		binary.BigEndian.PutUint64(plan.mergedIndex[pfxPos:], pi.prefix)
+		pfxPos += addrPrefixSize
+		binary.BigEndian.PutUint32(plan.mergedIndex[pfxPos:], pi.order)
+		pfxPos += ordinalSize
+	}
+
+	writeFooter(plan.mergedIndex[uint64(len(plan.mergedIndex))-footerSize:], plan.chunkCount, totalUncompressedData)
+	return plan
+}
+
+func nameFromSuffixes(suffixes []byte) (name addr) {
+	sha := sha512.New()
+	sha.Write(suffixes)
+
+	var h []byte
+	h = sha.Sum(h) // Appends hash to h
+	copy(name[:], h)
+	return
+}
 
 func compactSourcesToBuffer(sources chunkSources, rl chan struct{}) (name addr, data []byte, chunkCount uint32) {
 	d.Chk.True(rl != nil)

--- a/go/nbs/table_persister_test.go
+++ b/go/nbs/table_persister_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestPlanCompaction(t *testing.T) {
+	assert := assert.New(t)
+	tableContents := [][][]byte{
+		{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")},
+		{[]byte("red"), []byte("blue")},
+		{[]byte("solo")},
+	}
+
+	var sources chunkSources
+	var dataLens []uint64
+	var totalUnc uint64
+	for _, content := range tableContents {
+		for _, chnk := range content {
+			totalUnc += uint64(len(chnk))
+		}
+		data, name := buildTable(content)
+		src := chunkSourceAdapter{newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize), name}
+		dataLens = append(dataLens, uint64(len(data))-indexSize(src.count())-footerSize)
+		sources = append(sources, src)
+	}
+
+	plan := planCompaction(sources)
+
+	var totalChunks uint32
+	for i, src := range sources {
+		assert.Equal(dataLens[i], plan.chunkDataLens[i])
+		totalChunks += src.count()
+	}
+
+	idx := parseTableIndex(plan.mergedIndex)
+
+	assert.Equal(totalChunks, idx.chunkCount)
+	assert.Equal(totalUnc, idx.totalUncompressedData)
+
+	tr := newTableReader(idx, bytes.NewReader(nil), fileBlockSize)
+	for _, content := range tableContents {
+		assertChunksInReader(content, tr, assert)
+	}
+}

--- a/go/nbs/table_persister_test.go
+++ b/go/nbs/table_persister_test.go
@@ -36,7 +36,7 @@ func TestPlanCompaction(t *testing.T) {
 
 	var totalChunks uint32
 	for i, src := range sources {
-		assert.Equal(dataLens[i], plan.chunkDataLens[i])
+		assert.Equal(dataLens[i], plan.sources[i].dataLen)
 		totalChunks += src.count()
 	}
 

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -438,9 +438,6 @@ func (tr tableReader) extract(chunks chan<- extractRecord) {
 }
 
 func (tr tableReader) reader() io.Reader {
-	if rdr, ok := tr.r.(io.Reader); ok {
-		return rdr
-	}
 	return &readerAdapter{tr.r, 0}
 }
 

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -436,3 +436,21 @@ func (tr tableReader) extract(chunks chan<- extractRecord) {
 		sendChunk(i)
 	}
 }
+
+func (tr tableReader) reader() io.Reader {
+	if rdr, ok := tr.r.(io.Reader); ok {
+		return rdr
+	}
+	return &readerAdapter{tr.r, 0}
+}
+
+type readerAdapter struct {
+	rat io.ReaderAt
+	off int64
+}
+
+func (ra *readerAdapter) Read(p []byte) (n int, err error) {
+	n, err = ra.rat.ReadAt(p, ra.off)
+	ra.off += int64(n)
+	return
+}

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -16,7 +16,7 @@ const concurrentCompactions = 5
 
 func newS3TableSet(s3 s3svc, bucket string, indexCache *indexCache, readRl chan struct{}) tableSet {
 	return tableSet{
-		p:  s3TablePersister{s3, bucket, defaultS3PartSize, indexCache, readRl},
+		p:  s3TablePersister{s3, bucket, defaultS3PartSize, minS3PartSize, maxS3PartSize, indexCache, readRl},
 		rl: make(chan struct{}, concurrentCompactions),
 	}
 }

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -141,7 +141,7 @@ func (ts tableSet) Prepend(mt *memTable) tableSet {
 		p:        ts.p,
 		rl:       ts.rl,
 	}
-	newTs.novel[0] = newCompactingChunkSource(mt, ts, ts.p, ts.rl)
+	newTs.novel[0] = newPersistingChunkSource(mt, ts, ts.p, ts.rl)
 	copy(newTs.novel[1:], ts.novel)
 	copy(newTs.upstream, ts.upstream)
 	return newTs

--- a/go/nbs/table_writer.go
+++ b/go/nbs/table_writer.go
@@ -152,16 +152,20 @@ func (tw *tableWriter) writeIndex() {
 }
 
 func (tw *tableWriter) writeFooter() {
+	tw.pos += writeFooter(tw.buff[tw.pos:], uint32(len(tw.prefixes)), tw.totalUncompressedData)
+}
+
+func writeFooter(dst []byte, chunkCount uint32, uncData uint64) (pos uint64) {
 	// chunk count
-	chunkCount := uint32(len(tw.prefixes))
-	binary.BigEndian.PutUint32(tw.buff[tw.pos:], chunkCount)
-	tw.pos += uint32Size
+	binary.BigEndian.PutUint32(dst[pos:], chunkCount)
+	pos += uint32Size
 
 	// total uncompressed chunk data
-	binary.BigEndian.PutUint64(tw.buff[tw.pos:], tw.totalUncompressedData)
-	tw.pos += uint64Size
+	binary.BigEndian.PutUint64(dst[pos:], uncData)
+	pos += uint64Size
 
 	// magic number
-	copy(tw.buff[tw.pos:], magicNumber)
-	tw.pos += magicNumberSize
+	copy(dst[pos:], magicNumber)
+	pos += magicNumberSize
+	return
 }

--- a/go/nbs/table_writer.go
+++ b/go/nbs/table_writer.go
@@ -48,6 +48,14 @@ func indexSize(numChunks uint32) uint64 {
 	return uint64(numChunks) * (addrSuffixSize + lengthSize + prefixTupleSize)
 }
 
+func lengthsOffset(numChunks uint32) uint64 {
+	return uint64(numChunks) * prefixTupleSize
+}
+
+func suffixesOffset(numChunks uint32) uint64 {
+	return uint64(numChunks) * (prefixTupleSize + lengthSize)
+}
+
 // len(buff) must be >= maxTableSize(numChunks, totalData)
 func newTableWriter(buff []byte, snapper snappyEncoder) *tableWriter {
 	if snapper == nil {
@@ -123,9 +131,9 @@ func (tw *tableWriter) writeIndex() {
 
 	pfxScratch := [addrPrefixSize]byte{}
 
-	numRecords := uint64(len(tw.prefixes))
-	lengthsOffset := tw.pos + numRecords*prefixTupleSize    // skip prefix and ordinal for each record
-	suffixesOffset := lengthsOffset + numRecords*lengthSize // skip size for each record
+	numRecords := uint32(len(tw.prefixes))
+	lengthsOffset := tw.pos + lengthsOffset(numRecords)   // skip prefix and ordinal for each record
+	suffixesOffset := tw.pos + suffixesOffset(numRecords) // skip size for each record
 	for _, pi := range tw.prefixes {
 		binary.BigEndian.PutUint64(pfxScratch[:], pi.prefix)
 
@@ -147,25 +155,26 @@ func (tw *tableWriter) writeIndex() {
 		n = uint64(copy(tw.buff[offset:], pi.suffix))
 		d.Chk.True(n == addrSuffixSize)
 	}
-	tw.blockHash.Write(tw.buff[suffixesOffset : suffixesOffset+numRecords*addrSuffixSize])
-	tw.pos = suffixesOffset + numRecords*addrSuffixSize
+	suffixesLen := uint64(numRecords) * addrSuffixSize
+	tw.blockHash.Write(tw.buff[suffixesOffset : suffixesOffset+suffixesLen])
+	tw.pos = suffixesOffset + suffixesLen
 }
 
 func (tw *tableWriter) writeFooter() {
 	tw.pos += writeFooter(tw.buff[tw.pos:], uint32(len(tw.prefixes)), tw.totalUncompressedData)
 }
 
-func writeFooter(dst []byte, chunkCount uint32, uncData uint64) (pos uint64) {
+func writeFooter(dst []byte, chunkCount uint32, uncData uint64) (consumed uint64) {
 	// chunk count
-	binary.BigEndian.PutUint32(dst[pos:], chunkCount)
-	pos += uint32Size
+	binary.BigEndian.PutUint32(dst[consumed:], chunkCount)
+	consumed += uint32Size
 
 	// total uncompressed chunk data
-	binary.BigEndian.PutUint64(dst[pos:], uncData)
-	pos += uint64Size
+	binary.BigEndian.PutUint64(dst[consumed:], uncData)
+	consumed += uint64Size
 
 	// magic number
-	copy(dst[pos:], magicNumber)
-	pos += magicNumberSize
+	copy(dst[consumed:], magicNumber)
+	consumed += magicNumberSize
 	return
 }


### PR DESCRIPTION
The old compaction code loaded all chunks to be compacted into memory, assembled a compacted table, and then persisted it to backing storage. The nice thing about this was that we could de-dup chunks across the compacted tables. The bad thing was that we needed to hold all the chunks in memory at once. That turned out to be a problem, so we've moved to a new strategy that calculates only the merged index for the compacted table in memory, but streams chunk data directly from old tables to the new, big table. This should be a big win on S3 at least, because it turns out that for tables with > 5MB and < 5GB of chunk data, we can actually just tell S3 to reference a range of the existing object when building a compacted table.

Fixes #3411