### PR TITLE
Subtype: Make sure we continue to test after optional

### DIFF
--- a/go/types/subtype.go
+++ b/go/types/subtype.go
@@ -159,10 +159,7 @@ func IsValueSubtypeOf(v Value, t *Type) bool {
 
 		for _, f := range desc.fields {
 			fv, ok := s.MaybeGet(f.Name)
-			if !ok {
-				return f.Optional
-			}
-			if !IsValueSubtypeOf(fv, f.Type) {
+			if !ok && !f.Optional || ok && !IsValueSubtypeOf(fv, f.Type) {
 				return false
 			}
 		}

--- a/go/types/subtype.go
+++ b/go/types/subtype.go
@@ -159,7 +159,7 @@ func IsValueSubtypeOf(v Value, t *Type) bool {
 
 		for _, f := range desc.fields {
 			fv, ok := s.MaybeGet(f.Name)
-			if !ok && !f.Optional || ok && !IsValueSubtypeOf(fv, f.Type) {
+			if (!ok && !f.Optional) || (ok && !IsValueSubtypeOf(fv, f.Type)) {
 				return false
 			}
 		}

--- a/go/types/subtype_test.go
+++ b/go/types/subtype_test.go
@@ -706,4 +706,16 @@ func TestIsValueSubtypeOf(tt *testing.T) {
 		assertFalse(v, t1)
 		assertTrue(v, t2)
 	}
+
+	{
+		t := MakeStructType("A",
+			StructField{"aa", NumberType, true},
+			StructField{"bb", BoolType, false},
+		)
+		v := NewStruct("A", StructData{
+			"a": Number(1),
+			"b": Bool(true),
+		})
+		assertFalse(v, t)
+	}
 }


### PR DESCRIPTION
In the case where we have an optional field that is not present we still
need to check the remaining fields.