### PR TITLE
Clean up NBS cruft

### DIFF
--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -27,7 +27,13 @@ type manifest interface {
 	// return values are undefined. The |readHook| parameter allows race
 	// condition testing. If it is non-nil, it will be invoked while the
 	// implementation is guaranteeing exclusive access to the manifest.
-	ParseIfExists(readHook func()) (exists bool, vers string, lock addr, root hash.Hash, tableSpecs []tableSpec)
+	ParseIfExists(readHook func()) (
+		exists bool,
+		vers string,
+		lock addr,
+		root hash.Hash,
+		tableSpecs []tableSpec,
+	)
 
 	// Update optimistically tries to write a new manifest containing
 	// |newRoot| and the tables referenced by |specs|. If |lastLock| matches
@@ -44,7 +50,16 @@ type manifest interface {
 	// If writeHook is non-nil, it will be invoked while the implementation is
 	// guaranteeing exclusive access to the manifest. This allows for testing
 	// of race conditions.
-	Update(lastLock, newLock addr, specs []tableSpec, newRoot hash.Hash, writeHook func()) (lock addr, actual hash.Hash, tableSpecs []tableSpec)
+	Update(
+		lastLock, newLock addr,
+		specs []tableSpec,
+		newRoot hash.Hash,
+		writeHook func(),
+	) (
+		lock addr,
+		actual hash.Hash,
+		tableSpecs []tableSpec,
+	)
 }
 
 type tableSpec struct {

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -56,14 +56,12 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32, indexCache *index
 		index, found = indexCache.get(h)
 	}
 
-	var buff []byte
 	if !found {
 		// index. Mmap won't take an offset that's not page-aligned, so find the nearest page boundary preceding the index.
 		indexOffset := fi.Size() - int64(footerSize) - int64(indexSize(chunkCount))
 		aligned := indexOffset / pageSize * pageSize // Thanks, integer arithmetic!
 		d.PanicIfTrue(fi.Size()-aligned > maxInt)
-		var err error
-		buff, err = unix.Mmap(int(f.Fd()), aligned, int(fi.Size()-aligned), unix.PROT_READ, unix.MAP_SHARED)
+		buff, err := unix.Mmap(int(f.Fd()), aligned, int(fi.Size()-aligned), unix.PROT_READ, unix.MAP_SHARED)
 		d.PanicIfError(err)
 		index = parseTableIndex(buff[indexOffset-aligned:])
 

--- a/go/nbs/s3_table_persister_test.go
+++ b/go/nbs/s3_table_persister_test.go
@@ -350,22 +350,3 @@ func bytesToChunkSource(bs ...[]byte) chunkSource {
 	rdr := newTableReader(parseTableIndex(data), bytes.NewReader(data), fileBlockSize)
 	return chunkSourceAdapter{rdr, name}
 }
-
-func TestCompactSourcesToBufferPanic(t *testing.T) {
-	assert := assert.New(t)
-	rl := make(chan struct{}, 1)
-	defer close(rl)
-
-	src := bytesToChunkSource([]byte("hello"))
-	pcs := panicingChunkSource{src}
-
-	assert.Panics(func() { compactSourcesToBuffer(chunkSources{pcs}, rl) })
-}
-
-type panicingChunkSource struct {
-	chunkSource
-}
-
-func (pcs panicingChunkSource) extract(chunks chan<- extractRecord) {
-	panic("onoes")
-}

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -78,10 +78,6 @@ func (s3tr *s3TableReader) hash() addr {
 	return s3tr.h
 }
 
-func (s3tr *s3TableReader) index() tableIndex {
-	return s3tr.tableIndex
-}
-
 func (s3tr *s3TableReader) ReadAt(p []byte, off int64) (n int, err error) {
 	return s3tr.readRange(p, s3RangeHeader(off, int64(len(p))))
 }

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -192,6 +192,10 @@ func (tr tableReader) uncompressedLen() uint64 {
 	return tr.totalUncompressedData
 }
 
+func (tr tableReader) index() tableIndex {
+	return tr.tableIndex
+}
+
 // returns true iff |h| can be found in this table.
 func (tr tableReader) has(h addr) bool {
 	ordinal := tr.lookupOrdinal(h)


### PR DESCRIPTION
Clean up NBS cruft standing in the way of improvements:

- Unmap buffer in newMmapTableReader()
By the time this function exits, we're done with this buffer.
Hanging on to it complicates lifetime management for the file
backing the mmapTableReader, which is something I'm trying to
make simpler. So...ditch it!

- remove compactSourcesToBuffer
replace with simpler test-focused version