### PR TITLE
NBS: Remove need to manually manage chunkSource lifetime

### DIFF
--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -257,7 +257,9 @@ func (suite *BlockStoreSuite) TestChunkStorePutWithRebase() {
 func (suite *BlockStoreSuite) TestCompactOnUpdateRoot() {
 	testMaxTables := 5
 	mm := fileManifest{suite.dir}
-	smallTableStore := newNomsBlockStore(mm, newFSTableSet(suite.dir, nil), 2, testMaxTables)
+	fc := newFDCache(testMaxTables)
+	defer fc.Drop()
+	smallTableStore := newNomsBlockStore(mm, newTableSet(newFSTablePersister(suite.dir, fc, nil)), 2, testMaxTables)
 	inputs := [][]byte{[]byte("ab"), []byte("cd"), []byte("ef"), []byte("gh"), []byte("ij"), []byte("kl")}
 	chunx := make([]chunks.Chunk, len(inputs))
 	for i, data := range inputs {

--- a/go/nbs/fd_cache.go
+++ b/go/nbs/fd_cache.go
@@ -1,0 +1,131 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/attic-labs/noms/go/d"
+)
+
+func newFDCache(targetSize int) *fdCache {
+	return &fdCache{targetSize: targetSize, cache: map[string]fdCacheEntry{}}
+}
+
+// fdCache ref-counts open file descriptors, but doesn't keep a hard cap on
+// the number of open files. Once the cache's target size is exceeded, opening
+// a new file causes the cache to try to get the cache back to the target size
+// by closing fds with zero refs. If there aren't enough such fds, fdCache
+// gives up and tries again next time a caller refs a file.
+type fdCache struct {
+	targetSize int
+	mu         sync.Mutex
+	cache      map[string]fdCacheEntry
+}
+
+type fdCacheEntry struct {
+	refCount uint32
+	f        *os.File
+}
+
+// RefFile returns an opened *os.File for the file at |path|, or an error
+// indicating why the file could not be opened. If the cache already had an
+// entry for |path|, RefFile increments its refcount and returns the cached
+// pointer. If not, it opens the file and caches the pointer for others to
+// use.
+// If reffing a currently unopened file causes the cache to grow beyond
+// |fc.targetSize|, RefFile makes a best effort to shrink the
+// cache by dumping entries with a zero refcount. If there aren't enough zero
+// refcount entries to drop to get the cache back to |fc.targetSize|, the
+// cache will remain over |fc.targetSize| until the next call to RefFile().
+func (fc *fdCache) RefFile(path string) (f *os.File, err error) {
+	f, err = fc.checkCache(path)
+	if f != nil || err != nil {
+		return f, err
+	}
+
+	// Very much want this to be outside the lock
+	f, err = os.Open(path)
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	defer fc.maybeShrinkCache()
+	if err != nil {
+		return nil, err
+	}
+	fc.cache[path] = fdCacheEntry{f: f, refCount: 1}
+	return f, nil
+}
+
+func (fc *fdCache) checkCache(path string) (f *os.File, err error) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	defer fc.maybeShrinkCache()
+	if ce, present := fc.cache[path]; present {
+		ce.refCount++
+		fc.cache[path] = ce
+		return ce.f, nil
+	}
+	return nil, nil
+}
+
+// DO NOT CALL unless holding fc.mu
+func (fc *fdCache) maybeShrinkCache() {
+	if len(fc.cache) > fc.targetSize {
+		// Sadly, we can't remove items from a map while iterating, so we'll record the stuff we want to drop and then do it after
+		needed := len(fc.cache) - fc.targetSize
+		toDrop := make([]string, 0, needed)
+		for p, ce := range fc.cache {
+			if ce.refCount != 0 {
+				continue
+			}
+			toDrop = append(toDrop, p)
+			err := ce.f.Close()
+			d.PanicIfError(err)
+			needed--
+			if needed == 0 {
+				break
+			}
+		}
+		for _, p := range toDrop {
+			delete(fc.cache, p)
+		}
+	}
+}
+
+// UnrefFile reduces the refcount of the entry at |path|. Does not try to
+// shrink the cache if it's over |fc.targetSize|.
+func (fc *fdCache) UnrefFile(path string) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if ce, present := fc.cache[path]; present {
+		ce.refCount--
+		fc.cache[path] = ce
+	}
+}
+
+// Drop dumps the entire cache and closes all currently open files.
+func (fc *fdCache) Drop() {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	for _, ce := range fc.cache {
+		ce.f.Close()
+	}
+	fc.cache = map[string]fdCacheEntry{}
+}
+
+// reportEntries is meant for testing.
+func (fc *fdCache) reportEntries() sort.StringSlice {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	ret := make(sort.StringSlice, 0, len(fc.cache))
+	for p := range fc.cache {
+		ret = append(ret, p)
+	}
+	sort.Sort(ret)
+	return ret
+}

--- a/go/nbs/fd_cache_test.go
+++ b/go/nbs/fd_cache_test.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestFDCache(t *testing.T) {
+	dir := makeTempDir(assert.New(t))
+	defer os.RemoveAll(dir)
+
+	paths := [3]string{}
+	for i := range paths {
+		name := fmt.Sprintf("file%d", i)
+		paths[i] = filepath.Join(dir, name)
+		err := ioutil.WriteFile(paths[i], []byte(name), 0644)
+		assert.NoError(t, err)
+	}
+
+	refNoError := func(fc *fdCache, p string, assert *assert.Assertions) *os.File {
+		f, err := fc.RefFile(p)
+		assert.NoError(err)
+		assert.NotNil(f)
+		return f
+	}
+
+	t.Run("NoEvictions", func(t *testing.T) {
+		assert := assert.New(t)
+		fc := newFDCache(2)
+		defer fc.Drop()
+		f := refNoError(fc, paths[0], assert)
+
+		f2 := refNoError(fc, paths[1], assert)
+		assert.NotEqual(f, f2)
+
+		dup := refNoError(fc, paths[0], assert)
+		assert.Equal(f, dup)
+	})
+
+	t.Run("Evictions", func(t *testing.T) {
+		assert := assert.New(t)
+		fc := newFDCache(1)
+		defer fc.Drop()
+
+		f := refNoError(fc, paths[0], assert)
+		f2 := refNoError(fc, paths[1], assert)
+		assert.NotEqual(f, f2)
+
+		// f wasn't evicted, because it's still reffed
+		dup := refNoError(fc, paths[0], assert)
+		assert.Equal(f, dup)
+
+		expected := sort.StringSlice(paths[:2])
+		sort.Sort(expected)
+		assert.EqualValues(expected, fc.reportEntries())
+
+		fc.UnrefFile(paths[0])
+		fc.UnrefFile(paths[0])
+		fc.UnrefFile(paths[1])
+
+		// NOW, we should be able to evict both f and f2
+		f3 := refNoError(fc, paths[2], assert)
+		assert.NotEqual(f, f2)
+		assert.NotEqual(f2, f3)
+
+		assert.EqualValues(paths[2:], fc.reportEntries())
+	})
+}

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -7,33 +7,113 @@ package nbs
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/attic-labs/testify/assert"
 )
 
-func TestFSTablePersisterPersist(t *testing.T) {
+func TestFSTableCacheOnOpen(t *testing.T) {
 	assert := assert.New(t)
-	mt := newMemTable(testMemTableSize)
-
-	for _, c := range testChunks {
-		assert.True(mt.addChunk(computeAddr(c), c))
-	}
-
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
-	fts := fsTablePersister{dir: dir}
 
-	src := fts.Persist(mt, nil, &Stats{})
+	names := []addr{}
+	cacheSize := 2
+	fc := newFDCache(cacheSize)
+	defer fc.Drop()
+	fts := newFSTablePersister(dir, fc, nil)
+
+	// Create some tables manually, load them into the cache, and then blow them away
+	func() {
+		for i := 0; i < cacheSize; i++ {
+			name, err := writeTableData(dir, []byte{byte(i)})
+			assert.NoError(err)
+			names = append(names, name)
+		}
+		for _, name := range names {
+			fts.Open(name, 1)
+		}
+		removeTables(dir, names...)
+	}()
+
+	// Tables should still be cached, even though they're gone from disk
+	for i, name := range names {
+		src := fts.Open(name, 1)
+		h := computeAddr([]byte{byte(i)})
+		assert.True(src.has(h))
+	}
+
+	// Kick a table out of the cache
+	name, err := writeTableData(dir, []byte{0xff})
+	assert.NoError(err)
+	fts.Open(name, 1)
+
+	present := fc.reportEntries()
+	assert.Contains(present, filepath.Join(dir, name.String()))
+
+	for _, name := range names {
+		if !contains(present, filepath.Join(dir, name.String())) {
+			assert.Panics(func() { fts.Open(name, 1) })
+		}
+	}
+}
+
+func writeTableData(dir string, chunx ...[]byte) (name addr, err error) {
+	var tableData []byte
+	tableData, name = buildTable(chunx)
+	err = ioutil.WriteFile(filepath.Join(dir, name.String()), tableData, 0666)
+	return
+}
+
+func removeTables(dir string, names ...addr) error {
+	for _, name := range names {
+		if err := os.Remove(filepath.Join(dir, name.String())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func contains(s sort.StringSlice, e string) bool {
+	for _, c := range s {
+		if c == e {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFSTablePersisterPersist(t *testing.T) {
+	assert := assert.New(t)
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+	fc := newFDCache(defaultMaxTables)
+	defer fc.Drop()
+	fts := newFSTablePersister(dir, fc, nil)
+
+	src, err := persistTableData(fts, testChunks...)
+	assert.NoError(err)
 	if assert.True(src.count() > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
 		assert.NoError(err)
 		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
 		assertChunksInReader(testChunks, tr, assert)
 	}
+}
+
+func persistTableData(p tablePersister, chunx ...[]byte) (src chunkSource, err error) {
+	mt := newMemTable(testMemTableSize)
+	for _, c := range chunx {
+		if !mt.addChunk(computeAddr(c), c) {
+			return nil, fmt.Errorf("memTable too full to add %s", computeAddr(c))
+		}
+	}
+	return p.Persist(mt, nil, &Stats{}), nil
 }
 
 func TestFSTablePersisterPersistNoData(t *testing.T) {
@@ -48,7 +128,9 @@ func TestFSTablePersisterPersistNoData(t *testing.T) {
 
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
-	fts := fsTablePersister{dir: dir}
+	fc := newFDCache(defaultMaxTables)
+	defer fc.Drop()
+	fts := newFSTablePersister(dir, fc, nil)
 
 	src := fts.Persist(mt, existingTable, &Stats{})
 	assert.True(src.count() == 0)
@@ -57,21 +139,56 @@ func TestFSTablePersisterPersistNoData(t *testing.T) {
 	assert.True(os.IsNotExist(err), "%v", err)
 }
 
+func TestFSTablePersisterCacheOnPersist(t *testing.T) {
+	assert := assert.New(t)
+	dir := makeTempDir(assert)
+	fc := newFDCache(1)
+	defer fc.Drop()
+	fts := newFSTablePersister(dir, fc, nil)
+	defer os.RemoveAll(dir)
+
+	var name addr
+	func() {
+		src, err := persistTableData(fts, testChunks...)
+		assert.NoError(err)
+		name = src.hash()
+		removeTables(dir, name)
+	}()
+
+	// Table should still be cached, even though it's gone from disk
+	src := fts.Open(name, uint32(len(testChunks)))
+	assertChunksInReader(testChunks, src, assert)
+
+	// Evict |name| from cache
+	src, err := persistTableData(fts, []byte{0xff})
+	assert.NoError(err)
+
+	present := fc.reportEntries()
+	assert.Contains(present, filepath.Join(dir, src.hash().String()))
+
+	assert.Panics(func() { fts.Open(name, uint32(len(testChunks))) })
+}
+
 func TestFSTablePersisterCompactAll(t *testing.T) {
 	assert := assert.New(t)
 	assert.True(len(testChunks) > 1, "Whoops, this test isn't meaningful")
 	sources := make(chunkSources, len(testChunks))
 
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+	fc := newFDCache(len(sources))
+	defer fc.Drop()
+	fts := newFSTablePersister(dir, fc, nil)
+
 	for i, c := range testChunks {
 		randChunk := make([]byte, (i+1)*13)
 		_, err := rand.Read(randChunk)
 		assert.NoError(err)
-		sources[i] = bytesToChunkSource(c, randChunk)
+		name, err := writeTableData(dir, c, randChunk)
+		assert.NoError(err)
+		sources[i] = fts.Open(name, 2)
 	}
 
-	dir := makeTempDir(assert)
-	defer os.RemoveAll(dir)
-	fts := fsTablePersister{dir: dir}
 	src := fts.CompactAll(sources, &Stats{})
 
 	if assert.True(src.count() > 0) {
@@ -80,13 +197,25 @@ func TestFSTablePersisterCompactAll(t *testing.T) {
 		tr := newTableReader(parseTableIndex(buff), bytes.NewReader(buff), fileBlockSize)
 		assertChunksInReader(testChunks, tr, assert)
 	}
+
+	// The compacted table should have evicted only one table from the cache.
+	inCache := fc.reportEntries()
+	notInCache := chunkSources{}
+	for _, src := range sources {
+		if !contains(inCache, filepath.Join(dir, src.hash().String())) {
+			notInCache = append(notInCache, src)
+		}
+	}
+	assert.Len(notInCache, 1)
 }
 
 func TestFSTablePersisterCompactAllDups(t *testing.T) {
 	assert := assert.New(t)
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
-	fts := fsTablePersister{dir: dir}
+	fc := newFDCache(defaultMaxTables)
+	defer fc.Drop()
+	fts := newFSTablePersister(dir, fc, nil)
 
 	reps := 3
 	sources := make(chunkSources, reps)

--- a/go/nbs/mmap_table_reader_test.go
+++ b/go/nbs/mmap_table_reader_test.go
@@ -19,6 +19,9 @@ func TestMmapTableReader(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
+	fc := newFDCache(1)
+	defer fc.Drop()
+
 	chunks := [][]byte{
 		[]byte("hello2"),
 		[]byte("goodbye2"),
@@ -29,7 +32,6 @@ func TestMmapTableReader(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(dir, h.String()), tableData, 0666)
 	assert.NoError(err)
 
-	trc := newMmapTableReader(dir, h, uint32(len(chunks)), nil)
-	defer trc.close()
+	trc := newMmapTableReader(dir, h, uint32(len(chunks)), nil, fc)
 	assertChunksInReader(chunks, trc, assert)
 }

--- a/go/nbs/persisting_chunk_source.go
+++ b/go/nbs/persisting_chunk_source.go
@@ -78,12 +78,6 @@ func (ccs *persistingChunkSource) getMany(reqs []getRecord, foundChunks chan *ch
 	return cr.getMany(reqs, foundChunks, wg, stats)
 }
 
-func (ccs *persistingChunkSource) close() error {
-	ccs.wg.Wait()
-	d.Chk.True(ccs.cs != nil)
-	return ccs.cs.close()
-}
-
 func (ccs *persistingChunkSource) count() uint32 {
 	ccs.wg.Wait()
 	d.Chk.True(ccs.cs != nil)
@@ -142,10 +136,6 @@ func (ecs emptyChunkSource) get(h addr, stats *Stats) []byte {
 
 func (ecs emptyChunkSource) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg *sync.WaitGroup, stats *Stats) bool {
 	return true
-}
-
-func (ecs emptyChunkSource) close() error {
-	return nil
 }
 
 func (ecs emptyChunkSource) count() uint32 {

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -70,10 +70,6 @@ func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexC
 	return source
 }
 
-func (s3tr *s3TableReader) close() error {
-	return nil
-}
-
 func (s3tr *s3TableReader) hash() addr {
 	return s3tr.h
 }

--- a/go/nbs/s3_table_reader_test.go
+++ b/go/nbs/s3_table_reader_test.go
@@ -30,7 +30,6 @@ func TestS3TableReader(t *testing.T) {
 	s3.data[h.String()] = tableData
 
 	trc := newS3TableReader(s3, "bucket", h, uint32(len(chunks)), nil, nil)
-	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }
 
@@ -56,7 +55,6 @@ func TestS3TableReaderIndexCache(t *testing.T) {
 
 	assert.Equal(0, s3.getCount) // constructing the table shouldn't have resulted in any reads
 
-	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }
 
@@ -77,7 +75,6 @@ func TestS3TableReaderFails(t *testing.T) {
 	trc := newS3TableReader(makeFlakyS3(fake), "bucket", h, uint32(len(chunks)), nil, nil)
 	assert.Equal(2, fake.getCount) // constructing the table should have resulted in 2 reads
 
-	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }
 

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -40,11 +40,15 @@ const (
 )
 
 var (
-	indexCacheOnce   = sync.Once{}
+	cacheOnce        = sync.Once{}
 	globalIndexCache *indexCache
+	globalFDCache    *fdCache
 )
 
-func makeGlobalIndexCache() { globalIndexCache = newIndexCache(defaultIndexCacheSize) }
+func makeGlobalCaches() {
+	globalIndexCache = newIndexCache(defaultIndexCacheSize)
+	globalFDCache = newFDCache(defaultMaxTables)
+}
 
 type NomsBlockStore struct {
 	mm           manifest
@@ -64,11 +68,9 @@ type NomsBlockStore struct {
 }
 
 type AWSStoreFactory struct {
-	s3            s3svc
-	ddb           ddbsvc
-	table, bucket string
-	indexCache    *indexCache
-	readRl        chan struct{}
+	ddb       ddbsvc
+	persister tablePersister
+	table     string
 }
 
 func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheSize uint64) chunks.Factory {
@@ -76,20 +78,33 @@ func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheS
 	if indexCacheSize > 0 {
 		indexCache = newIndexCache(indexCacheSize)
 	}
-	return &AWSStoreFactory{s3.New(sess), dynamodb.New(sess), table, bucket, indexCache, make(chan struct{}, defaultAWSReadLimit)}
+	return &AWSStoreFactory{
+		dynamodb.New(sess),
+		&s3TablePersister{
+			s3.New(sess),
+			bucket,
+			defaultS3PartSize,
+			minS3PartSize,
+			maxS3PartSize,
+			indexCache,
+			make(chan struct{}, defaultAWSReadLimit),
+		},
+		table,
+	}
 }
 
 func (asf *AWSStoreFactory) CreateStore(ns string) chunks.ChunkStore {
-	return newAWSStore(asf.table, ns, asf.bucket, asf.s3, asf.ddb, defaultMemTableSize, asf.indexCache, asf.readRl)
+	return newAWSStore(asf.table, ns, asf.ddb, asf.persister, defaultMemTableSize, defaultMaxTables)
 }
 
 func (asf *AWSStoreFactory) Shutter() {
 }
 
 type LocalStoreFactory struct {
-	dir        string
-	indexCache *indexCache
-	maxTables  int
+	dir       string
+	persister tablePersister
+	maxTables int
+	fc        *fdCache
 }
 
 func CheckDir(dir string) error {
@@ -111,40 +126,52 @@ func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxTables int) chun
 	if indexCacheSize > 0 {
 		indexCache = newIndexCache(indexCacheSize)
 	}
-	return &LocalStoreFactory{dir, indexCache, maxTables}
+	fc := newFDCache(maxTables)
+	return &LocalStoreFactory{dir, newFSTablePersister(dir, fc, indexCache), maxTables, fc}
 }
 
 func (lsf *LocalStoreFactory) CreateStore(ns string) chunks.ChunkStore {
 	path := path.Join(lsf.dir, ns)
 	err := os.MkdirAll(path, 0777)
 	d.PanicIfError(err)
-	return newLocalStore(path, defaultMemTableSize, lsf.indexCache, lsf.maxTables)
+	return newLocalStore(path, defaultMemTableSize, lsf.persister, lsf.maxTables)
 }
 
 func (lsf *LocalStoreFactory) Shutter() {
+	lsf.fc.Drop()
 }
 
 func NewAWSStore(table, ns, bucket string, s3 s3svc, ddb ddbsvc, memTableSize uint64) *NomsBlockStore {
-	indexCacheOnce.Do(makeGlobalIndexCache)
-	return newAWSStore(table, ns, bucket, s3, ddb, memTableSize, globalIndexCache, make(chan struct{}, 32))
+	cacheOnce.Do(makeGlobalCaches)
+	p := &s3TablePersister{
+		s3,
+		bucket,
+		defaultS3PartSize,
+		minS3PartSize,
+		maxS3PartSize,
+		globalIndexCache,
+		make(chan struct{}, 32),
+	}
+	return newAWSStore(table, ns, ddb, p, memTableSize, defaultMaxTables)
 }
 
-func newAWSStore(table, ns, bucket string, s3 s3svc, ddb ddbsvc, memTableSize uint64, indexCache *indexCache, readRl chan struct{}) *NomsBlockStore {
+func newAWSStore(table, ns string, ddb ddbsvc, p tablePersister, memTableSize uint64, maxTables int) *NomsBlockStore {
 	d.PanicIfTrue(ns == "")
 	mm := newDynamoManifest(table, ns, ddb)
-	ts := newS3TableSet(s3, bucket, indexCache, readRl)
-	return newNomsBlockStore(mm, ts, memTableSize, defaultMaxTables)
+	ts := newTableSet(p)
+	return newNomsBlockStore(mm, ts, memTableSize, maxTables)
 }
 
 func NewLocalStore(dir string, memTableSize uint64) *NomsBlockStore {
-	indexCacheOnce.Do(makeGlobalIndexCache)
-	return newLocalStore(dir, memTableSize, globalIndexCache, defaultMaxTables)
+	cacheOnce.Do(makeGlobalCaches)
+	p := newFSTablePersister(dir, globalFDCache, globalIndexCache)
+	return newLocalStore(dir, memTableSize, p, defaultMaxTables)
 }
 
-func newLocalStore(dir string, memTableSize uint64, indexCache *indexCache, maxTables int) *NomsBlockStore {
+func newLocalStore(dir string, memTableSize uint64, p tablePersister, maxTables int) *NomsBlockStore {
 	err := CheckDir(dir)
 	d.PanicIfError(err)
-	return newNomsBlockStore(fileManifest{dir}, newFSTableSet(dir, indexCache), memTableSize, maxTables)
+	return newNomsBlockStore(fileManifest{dir}, newTableSet(p), memTableSize, maxTables)
 }
 
 func newNomsBlockStore(mm manifest, ts tableSet, memTableSize uint64, maxTables int) *NomsBlockStore {
@@ -162,7 +189,7 @@ func newNomsBlockStore(mm manifest, ts tableSet, memTableSize uint64, maxTables 
 
 	if exists, vers, lock, root, tableSpecs := nbs.mm.ParseIfExists(nil); exists {
 		nbs.nomsVersion, nbs.manifestLock, nbs.root = vers, lock, root
-		nbs.tables, _ = nbs.tables.Rebase(tableSpecs)
+		nbs.tables = nbs.tables.Rebase(tableSpecs)
 	}
 
 	return nbs
@@ -175,6 +202,16 @@ func (nbs *NomsBlockStore) Put(c chunks.Chunk) {
 	nbs.putCount++
 
 	nbs.stats.PutLatency.SampleTime(time.Since(t1))
+}
+
+func (nbs *NomsBlockStore) SchedulePut(c chunks.Chunk) {
+	nbs.Put(c)
+}
+
+func (nbs *NomsBlockStore) PutMany(chunx []chunks.Chunk) {
+	for _, c := range chunx {
+		nbs.Put(c)
+	}
 }
 
 // TODO: figure out if there's a non-error reason for this to return false. If not, get rid of return value.
@@ -389,9 +426,7 @@ func (nbs *NomsBlockStore) Rebase() {
 		nbs.mu.Lock()
 		defer nbs.mu.Unlock()
 		nbs.nomsVersion, nbs.manifestLock, nbs.root = vers, lock, root
-		var dropped chunkSources
-		nbs.tables, dropped = nbs.tables.Rebase(tableSpecs)
-		dropped.close()
+		nbs.tables = nbs.tables.Rebase(tableSpecs)
 	}
 }
 
@@ -450,7 +485,6 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	}
 
 	candidate := nbs.tables
-	var compactees chunkSources
 
 	shouldCompact := func() bool {
 		// As the number of tables grows from 1 to maxTables, the probability of compacting, grows from 0 to 1
@@ -459,7 +493,8 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	}
 
 	if shouldCompact() {
-		candidate, compactees = candidate.Compact(nbs.stats) // Compact() must only compact upstream tables (BUG 3142)
+		// TODO: the 'compactees' return value will be useful in the next stage of BUG 3462
+		candidate, _ = candidate.Compact(nbs.stats) // Compact() must only compact upstream tables (BUG 3142)
 	}
 
 	specs := candidate.ToSpecs()
@@ -468,12 +503,9 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	if nl != lock {
 		// Optimistic lock failure. Someone else moved to the root, the set of tables, or both out from under us.
 		// Regardless of what happened, we're going to start fresh by re-opening all the new tables from upstream, and re-calculating which tables to compact, so close all the compactees as well as any chunkSources that are dropped during Rebase().
-		compactees.close()
-		var dropped chunkSources
 		nbs.manifestLock = lock
 		nbs.root = actual
-		nbs.tables, dropped = candidate.Rebase(tableNames)
-		dropped.close()
+		nbs.tables = candidate.Rebase(tableNames)
 
 		if last != actual {
 			return errOptimisticLockFailedRoot
@@ -482,7 +514,6 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	}
 
 	nbs.tables = candidate.Flatten()
-	compactees.close()
 	nbs.nomsVersion, nbs.manifestLock, nbs.root = constants.NomsVersion, lock, current
 	return nil
 }
@@ -492,9 +523,7 @@ func (nbs *NomsBlockStore) Version() string {
 }
 
 func (nbs *NomsBlockStore) Close() (err error) {
-	nbs.mu.Lock()
-	defer nbs.mu.Unlock()
-	return nbs.tables.Close()
+	return
 }
 
 func (nbs *NomsBlockStore) Stats() Stats {

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -204,16 +204,6 @@ func (nbs *NomsBlockStore) Put(c chunks.Chunk) {
 	nbs.stats.PutLatency.SampleTime(time.Since(t1))
 }
 
-func (nbs *NomsBlockStore) SchedulePut(c chunks.Chunk) {
-	nbs.Put(c)
-}
-
-func (nbs *NomsBlockStore) PutMany(chunx []chunks.Chunk) {
-	for _, c := range chunx {
-		nbs.Put(c)
-	}
-}
-
 // TODO: figure out if there's a non-error reason for this to return false. If not, get rid of return value.
 func (nbs *NomsBlockStore) addChunk(h addr, data []byte) bool {
 	nbs.mu.Lock()

--- a/go/nbs/table.go
+++ b/go/nbs/table.go
@@ -210,7 +210,6 @@ type chunkReader interface {
 
 type chunkSource interface {
 	chunkReader
-	close() error
 	hash() addr
 	calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool)
 
@@ -220,12 +219,3 @@ type chunkSource interface {
 }
 
 type chunkSources []chunkSource
-
-func (css chunkSources) close() (err error) {
-	for _, haver := range css {
-		if e := haver.close(); e != nil {
-			err = e // TODO: somehow coalesce these errors??
-		}
-	}
-	return
-}

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -14,9 +14,22 @@ import (
 	"github.com/attic-labs/noms/go/util/sizecache"
 )
 
+// tablePersister allows interaction with persistent storage. It provides
+// primitives for pushing the contents of a memTable to persistent storage,
+// opening persistent tables for reading, and conjoining a number of existing
+// chunkSources into one.
 type tablePersister interface {
+	// Persist makes the contents of mt durable. Chunks already present in
+	// |haver| may be dropped in the process.
 	Persist(mt *memTable, haver chunkReader, stats *Stats) chunkSource
+
+	// CompactAll conjoins all chunks in |sources| into a single, new
+	// chunkSource.
 	CompactAll(sources chunkSources, stats *Stats) chunkSource
+
+	// Open a table named |name|, containing |chunkCount| chunks. The
+	// tablePersister is responsible for managing the lifetime of the returned
+	// chunkSource. TODO: Is that actually true? Or can we get rid of explicit 'close'
 	Open(name addr, chunkCount uint32) chunkSource
 }
 


### PR DESCRIPTION
For file-backed NBS, it's important that chunkSources get closed at
some point, to free up limited resources like file descriptors.
Previously, whenever a caller compacted or rebased a tableSet, the
caller had to manually close the chunkSources that were no longer
needed. This complicates logic around retrying in the event of an
optimistic lock failure.

This patch introduces a cache for open file descriptors, which
the fsTablePersister uses to manage the lifetime of files
automatically. The fdCache ref-counts open file descriptors,
but doesn't keep a hard cap on the number of open files. Once
the cache's target size is exceeded, opening a new file causes
the cache to look for fds with zero refs to close. It closes
as many of those as needed to get back under the target size.

Towards #3462