### PR TITLE
NBS: Tolerate other clients writing novel tables during compaction

### DIFF
--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -483,8 +483,7 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	}
 
 	if shouldCompact() {
-		// TODO: the 'compactees' return value will be useful in the next stage of BUG 3462
-		candidate, _ = candidate.Compact(nbs.stats) // Compact() must only compact upstream tables (BUG 3142)
+		candidate = candidate.Compact(nbs.stats) // Compact() must only compact upstream tables (BUG 3142)
 	}
 
 	specs := candidate.ToSpecs()
@@ -492,7 +491,6 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	lock, actual, tableNames := nbs.mm.Update(nbs.manifestLock, nl, specs, current, nil)
 	if nl != lock {
 		// Optimistic lock failure. Someone else moved to the root, the set of tables, or both out from under us.
-		// Regardless of what happened, we're going to start fresh by re-opening all the new tables from upstream, and re-calculating which tables to compact, so close all the compactees as well as any chunkSources that are dropped during Rebase().
 		nbs.manifestLock = lock
 		nbs.root = actual
 		nbs.tables = candidate.Rebase(tableNames)

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -24,7 +24,7 @@ type tableSet struct {
 	// novel chunkSources contain chunks that have not yet been pushed upstream
 	novel chunkSources
 
-	// When Compact() conjoins upstream tables into larger tables, the results are stored in |compacted| until the next call to Flatten(). The tables that were conjoined are put into |compactees|, so they can be correctly handled during a Rebase()
+	// compactees holds precisely the chunkSources that were conjoined to build the members of compacted. If compacted is empty, compactees is also. The members of compactees are split out of upstream during Compact(), though they still represent actual persisted tables.
 	compacted  chunkSources
 	compactees chunkSources
 

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -21,9 +21,9 @@ func newTableSet(persister tablePersister) tableSet {
 
 // tableSet is an immutable set of persistable chunkSources.
 type tableSet struct {
-	novel, upstream chunkSources
-	p               tablePersister
-	rl              chan struct{}
+	novel, compacted, compactees, upstream chunkSources
+	p                                      tablePersister
+	rl                                     chan struct{}
 }
 
 func (ts tableSet) has(h addr) bool {
@@ -35,7 +35,7 @@ func (ts tableSet) has(h addr) bool {
 		}
 		return false
 	}
-	return f(ts.novel) || f(ts.upstream)
+	return f(ts.novel) || f(ts.compacted) || f(ts.upstream)
 }
 
 func (ts tableSet) hasMany(addrs []hasRecord) (remaining bool) {
@@ -47,7 +47,7 @@ func (ts tableSet) hasMany(addrs []hasRecord) (remaining bool) {
 		}
 		return true
 	}
-	return f(ts.novel) && f(ts.upstream)
+	return f(ts.novel) && f(ts.compacted) && f(ts.upstream)
 }
 
 func (ts tableSet) get(h addr, stats *Stats) []byte {
@@ -62,6 +62,9 @@ func (ts tableSet) get(h addr, stats *Stats) []byte {
 	if data := f(ts.novel); data != nil {
 		return data
 	}
+	if data := f(ts.compacted); data != nil {
+		return data
+	}
 	return f(ts.upstream)
 }
 
@@ -74,7 +77,7 @@ func (ts tableSet) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg 
 		}
 		return true
 	}
-	return f(ts.novel) && f(ts.upstream)
+	return f(ts.novel) && f(ts.compacted) && f(ts.upstream)
 }
 
 func (ts tableSet) calcReads(reqs []getRecord, blockSize uint64) (reads int, split, remaining bool) {
@@ -92,6 +95,11 @@ func (ts tableSet) calcReads(reqs []getRecord, blockSize uint64) (reads int, spl
 	reads, split, remaining = f(ts.novel)
 	if remaining {
 		var rds int
+		rds, split, remaining = f(ts.compacted)
+		reads += rds
+	}
+	if remaining {
+		var rds int
 		rds, split, remaining = f(ts.upstream)
 		reads += rds
 	}
@@ -105,7 +113,7 @@ func (ts tableSet) count() uint32 {
 		}
 		return
 	}
-	return f(ts.novel) + f(ts.upstream)
+	return f(ts.novel) + f(ts.compacted) + f(ts.upstream)
 }
 
 func (ts tableSet) uncompressedLen() uint64 {
@@ -115,25 +123,29 @@ func (ts tableSet) uncompressedLen() uint64 {
 		}
 		return
 	}
-	return f(ts.novel) + f(ts.upstream)
+	return f(ts.novel) + f(ts.compacted) + f(ts.upstream)
 }
 
 // Size returns the number of tables in this tableSet.
 func (ts tableSet) Size() int {
-	return len(ts.novel) + len(ts.upstream)
+	return len(ts.novel) + len(ts.compacted) + len(ts.upstream)
 }
 
 // Prepend adds a memTable to an existing tableSet, compacting |mt| and
 // returning a new tableSet with newly compacted table added.
 func (ts tableSet) Prepend(mt *memTable, stats *Stats) tableSet {
 	newTs := tableSet{
-		novel:    make(chunkSources, len(ts.novel)+1),
-		upstream: make(chunkSources, len(ts.upstream)),
-		p:        ts.p,
-		rl:       ts.rl,
+		novel:      make(chunkSources, len(ts.novel)+1),
+		compacted:  make(chunkSources, len(ts.compacted)),
+		compactees: make(chunkSources, len(ts.compactees)),
+		upstream:   make(chunkSources, len(ts.upstream)),
+		p:          ts.p,
+		rl:         ts.rl,
 	}
 	newTs.novel[0] = newPersistingChunkSource(mt, ts, ts.p, ts.rl, stats)
 	copy(newTs.novel[1:], ts.novel)
+	copy(newTs.compacted, ts.compacted)
+	copy(newTs.compactees, ts.compactees)
 	copy(newTs.upstream, ts.upstream)
 	return newTs
 }
@@ -142,15 +154,19 @@ func (ts tableSet) Prepend(mt *memTable, stats *Stats) tableSet {
 // compact the N smallest (by number of chunks) tables which can be compacted
 // into a new table such that upon replacing the N input tables, the
 // resulting table will still have the fewest chunks in the tableSet.
-func (ts tableSet) Compact(stats *Stats) (ns tableSet, compactees chunkSources) {
+func (ts tableSet) Compact(stats *Stats) tableSet {
 	t1 := time.Now()
 
-	ns = tableSet{
-		novel: make(chunkSources, len(ts.novel)),
-		p:     ts.p,
-		rl:    ts.rl,
+	ns := tableSet{
+		novel:      make(chunkSources, len(ts.novel)),
+		compacted:  make(chunkSources, len(ts.compacted)+1),
+		compactees: make(chunkSources, len(ts.compactees)),
+		p:          ts.p,
+		rl:         ts.rl,
 	}
 	copy(ns.novel, ts.novel)
+	copy(ns.compacted[1:], ts.compacted) // leave the first slot for the newly compacted table
+	copy(ns.compactees, ts.compactees)
 
 	sortedUpstream := make(chunkSources, len(ts.upstream))
 	copy(sortedUpstream, ts.upstream)
@@ -165,51 +181,63 @@ func (ts tableSet) Compact(stats *Stats) (ns tableSet, compactees chunkSources) 
 
 	toCompact := sortedUpstream[:partition]
 
-	compacted := ts.p.CompactAll(toCompact, stats)
-	ns.upstream = append(chunkSources{compacted}, sortedUpstream[partition:]...)
+	ns.compacted[0] = ts.p.CompactAll(toCompact, stats)
+	ns.upstream = append(ns.upstream, sortedUpstream[partition:]...)
+	ns.compactees = append(ns.compactees, toCompact...)
 
 	stats.ConjoinLatency.SampleTime(time.Since(t1))
 	stats.TablesPerConjoin.SampleLen(len(toCompact))
-	stats.ChunksPerConjoin.Sample(uint64(compacted.count()))
+	stats.ChunksPerConjoin.Sample(uint64(ns.compacted[0].count()))
 
-	return ns, toCompact
+	return ns
 }
 
 func (ts tableSet) extract(chunks chan<- extractRecord) {
-	// Since new tables are _prepended_ to a tableSet, extracting chunks in insertOrder requires iterating ts.upstream back to front, followed by ts.novel.
+	// Since new tables are _prepended_ to a tableSet, extracting chunks in insertOrder requires iterating ts.upstream, followed by ts.compacted, followed by ts.novel in back to front order.
 	for i := len(ts.upstream) - 1; i >= 0; i-- {
 		ts.upstream[i].extract(chunks)
+	}
+	for i := len(ts.compacted) - 1; i >= 0; i-- {
+		ts.compacted[i].extract(chunks)
 	}
 	for i := len(ts.novel) - 1; i >= 0; i-- {
 		ts.novel[i].extract(chunks)
 	}
 }
 
-// Flatten returns a new tableSet with |upstream| set to the union of ts.novel
-// and ts.upstream.
+// Flatten returns a new tableSet with |upstream| set to the union of ts.novel,
+// |ts.compacted|, and |ts.upstream|. |ts.compactees| is dropped.
 func (ts tableSet) Flatten() (flattened tableSet) {
 	flattened = tableSet{
 		upstream: make(chunkSources, 0, ts.Size()),
 		p:        ts.p,
 		rl:       ts.rl,
 	}
-	for _, src := range ts.novel {
-		if src.count() > 0 {
-			flattened.upstream = append(flattened.upstream, src)
+	f := func(srcs chunkSources) {
+		for _, src := range srcs {
+			if src.count() > 0 {
+				flattened.upstream = append(flattened.upstream, src)
+			}
 		}
 	}
+	f(ts.novel)
+	flattened.upstream = append(flattened.upstream, ts.compacted...)
 	flattened.upstream = append(flattened.upstream, ts.upstream...)
 	return
 }
 
 // Rebase returns a new tableSet holding the novel tables managed by |ts| and
-// those specified by |specs|.
+// those specified by |specs|. If |ts.compacted| is not nil, Rebase runs
+// through |ts.compactees| and checks to see if every element is still
+// mentioned in |specs|. If all of them are still there, Rebase copies
+// compaction state from |ts| to the new tableSet. Specifically,
+// |ts.compacted| and |ts.compactees| are copied to the new tableSet, while
+// the compactees are dropped from the new set of upstream tables.
 func (ts tableSet) Rebase(specs []tableSpec) tableSet {
 	merged := tableSet{
-		novel:    make(chunkSources, 0, len(ts.novel)),
-		upstream: make(chunkSources, 0, len(specs)),
-		p:        ts.p,
-		rl:       ts.rl,
+		novel: make(chunkSources, 0, len(ts.novel)),
+		p:     ts.p,
+		rl:    ts.rl,
 	}
 
 	// Rebase the novel tables, skipping those that are actually empty (usually due to de-duping during table compaction)
@@ -217,6 +245,26 @@ func (ts tableSet) Rebase(specs []tableSpec) tableSet {
 		if t.count() > 0 {
 			merged.novel = append(merged.novel, t)
 		}
+	}
+
+	// Only keep locally-performed compactions if ALL compactees are still present upstream
+	keepCompactions := func() bool {
+		specsNames := map[addr]struct{}{}
+		for _, spec := range specs {
+			specsNames[spec.name] = struct{}{}
+		}
+		for _, compactee := range ts.compactees {
+			if _, present := specsNames[compactee.hash()]; !present {
+				return false
+			}
+		}
+		return true
+	}()
+	if keepCompactions {
+		merged.compacted = make(chunkSources, len(ts.compacted))
+		merged.compactees = make(chunkSources, len(ts.compactees))
+		copy(merged.compacted, ts.compacted)
+		copy(merged.compactees, ts.compactees)
 	}
 
 	// Create a list of tables to open so we can open them in parallel.
@@ -228,20 +276,19 @@ func (ts tableSet) Rebase(specs []tableSpec) tableSet {
 	}
 
 	// Open all the new upstream tables concurrently
-	openedTables := make(chunkSources, len(tablesToOpen))
+	merged.upstream = make(chunkSources, len(tablesToOpen))
 	wg := &sync.WaitGroup{}
 	i := 0
 	for _, spec := range tablesToOpen {
 		wg.Add(1)
 		go func(idx int, spec tableSpec) {
-			openedTables[idx] = ts.p.Open(spec.name, spec.chunkCount)
+			merged.upstream[idx] = ts.p.Open(spec.name, spec.chunkCount)
 			wg.Done()
 		}(i, spec)
 		i++
 	}
-
 	wg.Wait()
-	merged.upstream = append(merged.upstream, openedTables...)
+
 	return merged
 }
 
@@ -251,6 +298,10 @@ func (ts tableSet) ToSpecs() []tableSpec {
 		if src.count() > 0 {
 			tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
 		}
+	}
+	for _, src := range ts.compacted {
+		d.Chk.True(src.count() > 0)
+		tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
 	}
 	for _, src := range ts.upstream {
 		d.Chk.True(src.count() > 0)

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -224,6 +224,9 @@ func TestTableSetRebase(t *testing.T) {
 			for _, upstream := range prebased.upstream {
 				assert.Contains(specs, tableSpec{upstream.hash(), upstream.count()})
 			}
+			for _, compactee := range prebased.compactees {
+				assert.NotContains(specs, tableSpec{compactee.hash(), compactee.count()})
+			}
 			for _, crasher := range crashers {
 				assert.Contains(specs, tableSpec{crasher.hash(), crasher.count()})
 			}

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -6,7 +6,6 @@ package nbs
 
 import (
 	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 
@@ -112,34 +111,14 @@ func TestTableSetExtract(t *testing.T) {
 }
 
 func TestTableSetCompact(t *testing.T) {
-	// Makes a tableSet with len(tableSizes) upstream tables containing tableSizes[N] unique chunks
-	makeTestTableSet := func(tableSizes []uint32) tableSet {
-		count := uint32(0)
-		nextChunk := func() (chunk []byte) {
-			chunk = make([]byte, 4)
-			binary.BigEndian.PutUint32(chunk, count)
-			count++
-			return chunk
-		}
-
-		ts := newFakeTableSet()
-		for _, s := range tableSizes {
-			mt := newMemTable(testMemTableSize)
-			for i := uint32(0); i < s; i++ {
-				c := nextChunk()
-				mt.addChunk(computeAddr(c), c)
-			}
-			ts = ts.Prepend(mt, &Stats{})
-		}
-		return ts
-	}
-
-	// Returns the set of and chunk count upstream tables
+	// Returns the chunk counts of the tables in ts.compacted & ts.upstream in ascending order
 	getSortedSizes := func(ts tableSet) (sorted []uint32) {
-		sort.Sort(chunkSourcesByAscendingCount(ts.upstream))
-		sorted = make([]uint32, len(ts.upstream))
+		all := append(chunkSources{}, ts.compacted...)
+		all = append(all, ts.upstream...)
+		sort.Sort(chunkSourcesByAscendingCount(all))
+		sorted = make([]uint32, len(all))
 		for i := 0; i < len(sorted); i++ {
-			sorted[i] = ts.upstream[i].count()
+			sorted[i] = all[i].count()
 		}
 		return
 	}
@@ -161,11 +140,33 @@ func TestTableSetCompact(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			assert := assert.New(t)
 			ts := makeTestTableSet(c.precompact)
-			ts2, _ := ts.Flatten().Compact(&Stats{})
+			ts2 := ts.Compact(&Stats{})
 			assert.Equal(c.postcompact, getSortedSizes(ts2))
 			assertContainAll(t, ts, ts2)
 		})
 	}
+}
+
+// Makes a tableSet with len(tableSizes) upstream tables containing tableSizes[N] unique chunks
+func makeTestTableSet(tableSizes []uint32) tableSet {
+	count := uint32(0)
+	nextChunk := func() (chunk []byte) {
+		chunk = make([]byte, 4)
+		binary.BigEndian.PutUint32(chunk, count)
+		count++
+		return chunk
+	}
+
+	ts := newFakeTableSet()
+	for _, s := range tableSizes {
+		mt := newMemTable(testMemTableSize)
+		for i := uint32(0); i < s; i++ {
+			c := nextChunk()
+			mt.addChunk(computeAddr(c), c)
+		}
+		ts = ts.Prepend(mt, &Stats{})
+	}
+	return ts.Flatten()
 }
 
 func assertContainAll(t *testing.T, expect, actual tableSet) {
@@ -185,13 +186,6 @@ func makeTempDir(assert *assert.Assertions) string {
 }
 
 func TestTableSetRebase(t *testing.T) {
-	assert := assert.New(t)
-	dir := makeTempDir(assert)
-	defer os.RemoveAll(dir)
-	fc := newFDCache(defaultMaxTables)
-	defer fc.Drop()
-	persister := newFSTablePersister(dir, fc, nil)
-
 	insert := func(ts tableSet, chunks ...[]byte) tableSet {
 		for _, c := range chunks {
 			mt := newMemTable(testMemTableSize)
@@ -200,17 +194,135 @@ func TestTableSetRebase(t *testing.T) {
 		}
 		return ts
 	}
-	fullTS := newTableSet(persister)
-	assert.Empty(fullTS.ToSpecs())
-	fullTS = insert(fullTS, testChunks...)
-	fullTS = fullTS.Flatten()
+	upstream := makeTestTableSet([]uint32{1, 1, 3, 7})
 
-	ts := newTableSet(persister)
-	ts = insert(ts, testChunks[0])
-	assert.Equal(1, ts.Size())
-	ts = ts.Flatten()
-	ts = insert(ts, []byte("novel"))
+	t.Run("NoCompactions", func(t *testing.T) {
+		assert := assert.New(t)
 
-	ts = ts.Rebase(fullTS.ToSpecs())
-	assert.Equal(4, ts.Size())
+		// Inject an upstream table
+		ts := newFakeTableSet()
+		ts = insert(ts, testChunks[0])
+		assert.Equal(1, ts.Size())
+		ts = ts.Flatten()
+		// Add a novel table
+		ts = insert(ts, []byte("novel"))
+
+		ts = ts.Rebase(upstream.ToSpecs())
+		assert.Equal(upstream.Size()+1, ts.Size())
+	})
+
+	t.Run("WithCompactions", func(t *testing.T) {
+		validate := func(rebased, prebased tableSet, crashers chunkSources, t *testing.T) {
+			assert := assert.New(t)
+			specs := rebased.ToSpecs()
+			for _, novel := range prebased.novel {
+				assert.Contains(specs, tableSpec{novel.hash(), novel.count()})
+			}
+			for _, compacted := range prebased.compacted {
+				assert.Contains(specs, tableSpec{compacted.hash(), compacted.count()})
+			}
+			for _, upstream := range prebased.upstream {
+				assert.Contains(specs, tableSpec{upstream.hash(), upstream.count()})
+			}
+			for _, crasher := range crashers {
+				assert.Contains(specs, tableSpec{crasher.hash(), crasher.count()})
+			}
+		}
+		t.Run("KeepSingle", func(t *testing.T) {
+			// Start from upstream, do a compaction and add a novel table
+			local := upstream.Flatten()
+			local = local.Compact(&Stats{})
+			assert.True(t, local.Size() < upstream.Size())
+			local = insert(local, []byte("novel"))
+
+			// Mimic some other committer landing additional novel tables upstream
+			interloper := insert(upstream, []byte("party crasher"))
+			crashers := interloper.novel
+
+			rebased := local.Rebase(interloper.ToSpecs())
+
+			// Since interloper didn't drop any of local's compactees, Rebase should retain the compacted table created above.
+			validate(rebased, local, crashers, t)
+		})
+
+		t.Run("KeepMultiple", func(t *testing.T) {
+			// Start from upstream, do a couple of compactions
+			stats := &Stats{}
+			local := upstream.Flatten()
+			local = local.Compact(stats)
+
+			assert.True(t, local.Size() >= 2)
+			local = local.Compact(stats)
+			local = insert(local, []byte("novel"))
+
+			// Mimic some other committer landing additional novel tables upstream
+			interloper := insert(upstream, []byte("party crasher"))
+			crashers := interloper.novel
+
+			rebased := local.Rebase(interloper.ToSpecs())
+
+			// Since interloper didn't drop any of local's compactees, Rebase should retain the compacted tables created above.
+			validate(rebased, local, crashers, t)
+		})
+
+		t.Run("KeepAcrossMultipleRebases", func(t *testing.T) {
+			// Start from upstream, do a compaction and add a novel table
+			local := upstream.Flatten()
+			local = local.Compact(&Stats{})
+			assert.True(t, local.Size() < upstream.Size())
+			local = insert(local, []byte("novel"))
+
+			// Mimic some other committer landing additional novel tables upstream
+			interloper := insert(upstream, []byte("party crasher"))
+			crashers := interloper.novel
+
+			rebased := local.Rebase(interloper.ToSpecs())
+
+			// Since interloper didn't drop any of local's compactees, Rebase should retain the compacted table created above.
+			validate(rebased, local, crashers, t)
+
+			interloper = insert(interloper, []byte("party crasher 2: electric boogaloo"))
+			crashers = append(crashers, interloper.novel...)
+
+			rebased = local.Rebase(interloper.ToSpecs())
+
+			// Since interloper STILL didn't drop any of local's compactees, Rebase should retain the compacted table created way back before the first rebase.
+			validate(rebased, local, crashers, t)
+		})
+
+		t.Run("Drop", func(t *testing.T) {
+			assert := assert.New(t)
+			// Start from upstream, do a compaction and add a novel table
+			local := upstream.Flatten()
+			local = local.Compact(&Stats{})
+			assert.True(local.Size() < upstream.Size())
+			local = insert(local, []byte("novel"))
+
+			// Mimic some other committer dropping tables upstream (due to e.g. compaction or garbage collection)
+			interloper := insert(upstream, []byte("party crasher")).Flatten()
+			for i, up := range interloper.upstream {
+				if up.hash() == local.compactees[0].hash() {
+					if i == len(interloper.upstream)-1 {
+						interloper.upstream = interloper.upstream[:i]
+					} else {
+						interloper.upstream = append(interloper.upstream[:i], interloper.upstream[i+1:]...)
+					}
+					break
+				}
+			}
+
+			rebased := local.Rebase(interloper.ToSpecs())
+
+			// rebased should retain all novel tables...
+			specs := rebased.ToSpecs()
+			for _, novel := range local.novel {
+				assert.Contains(specs, tableSpec{novel.hash(), novel.count()})
+			}
+			// ...but drop the compacted tables, and take upstream from interloper.
+			assert.Empty(rebased.compacted)
+			for _, upstream := range interloper.upstream {
+				assert.Contains(specs, tableSpec{upstream.hash(), upstream.count()})
+			}
+		})
+	})
 }


### PR DESCRIPTION
Currently, we handle NBS compactions by having clients detect that one
is necessary, perform the compaction locally, and then attempt to
persist the work. The old strategy, removed in this patch, was to
abandon the work if any other client had changed anything upstream
since the compaction began. Since compaction can be slow, this
happened frequently. The new strategy is to tolerate new tables
appearing upstream as long as all the tables the client compacted
still exist. In that case, the client will now rebase against upstream
successfully, droping the tables that got compacted, and then attempt
to land the compaction once again.

Fixes #3462