### PR TITLE
add .Now() to datetime package

### DIFF
--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -32,6 +32,11 @@ var dateTimeTemplate = types.MakeStructTemplate("DateTime", []string{"secSinceEp
 // which makes it useful for testing or checking for uninitialized values
 var Epoch = DateTime{time.Unix(0, 0)}
 
+// Now is an alias for a DateTime initialized with time.Now()
+func Now() DateTime {
+	return DateTime{time.Now()}
+}
+
 // MarshalNoms makes DateTime implement marshal.Marshaler and it makes
 // DateTime marshal into a Noms struct with type DateTimeType.
 func (dt DateTime) MarshalNoms() (types.Value, error) {


### PR DESCRIPTION
Mainly putting this up for consideration, could easily put this abstraction in the consuming code.

Also not sure if there's a way to test this. Is there a way to mock a package that isn't injected in go?