### PR TITLE
NBS: Sharing one persister at the LocalStoreFactory level is bad

### DIFF
--- a/go/nbs/factory_test.go
+++ b/go/nbs/factory_test.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/hash"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestLocalStoreFactory(t *testing.T) {
+	assert := assert.New(t)
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+
+	f := NewLocalStoreFactory(dir, 0, 8)
+
+	dbName := "db"
+	store := f.CreateStore(dbName)
+
+	c := chunks.NewChunk([]byte{0xff})
+	store.Put(c)
+	assert.True(store.Commit(c.Hash(), hash.Hash{}))
+
+	dbDir := filepath.Join(dir, dbName)
+	exists, _, _, _, specs := fileManifest{dbDir}.ParseIfExists(nil)
+	assert.True(exists)
+	assert.Len(specs, 1)
+
+	_, err := os.Stat(filepath.Join(dbDir, specs[0].name.String()))
+	assert.NoError(err)
+}


### PR DESCRIPTION
When minting NBS stores from a LocalStoreFactory, each gets a
directory with the DB name in the path, to keep the tables nicely
separated.  That means that the tablePersister for each store needs to
know the right directory to use. It can't know that until the DB's
name is provided, which means that we can't share a single persister
object across all stores vended by a LocalStoreFactory. That's fine,
as long as they all share an indexCache and an fdCache.

Fixes #3479