### PR TITLE
NBS: Avoid concurrent (in-process) conjoins to a given store

### DIFF
--- a/go/nbs/conjoiner.go
+++ b/go/nbs/conjoiner.go
@@ -1,0 +1,201 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/jpillora/backoff"
+)
+
+type conjoiner interface {
+	// ConjoinRequired tells the caller whether or not it's time to request a
+	// Conjoin, based upon the contents of |ts| and the conjoiner
+	// implementation's policy. Implementations must be goroutine-safe.
+	ConjoinRequired(ts tableSet) bool
+
+	// Conjoin uses |p| to conjoin some number of tables referenced by |mm|,
+	// allowing it to update |mm| with a new, smaller, set of tables that
+	// references precisely the same set of chunks. Before performing the
+	// conjoin, implementations should verify that a conjoin is actually
+	// currently needed; callers may be working with an out-of-date notion of
+	// upstream state. |novelCount|, the number of new tables the caller is
+	// trying to land, may be used in this determination. Implementations must
+	// be goroutine-safe.
+	Conjoin(mm manifest, p tablePersister, novelCount int, stats *Stats)
+}
+
+func newAsyncConjoiner(maxTables int) *asyncConjoiner {
+	return &asyncConjoiner{
+		waiters:   map[string]chan struct{}{},
+		maxTables: maxTables,
+	}
+}
+
+type asyncConjoiner struct {
+	mu        sync.RWMutex
+	waiters   map[string]chan struct{}
+	maxTables int
+}
+
+func (c *asyncConjoiner) ConjoinRequired(ts tableSet) bool {
+	return ts.Size() > c.maxTables
+}
+
+// Conjoin checks to see if there's already a conjoin underway for the store
+// described by |mm|. If so, it blocks until that conjoin completes. If not,
+// it starts one and blocks until it completes. Conjoin can be called
+// concurrently from many goroutines.
+func (c *asyncConjoiner) Conjoin(mm manifest, p tablePersister, novelCount int, stats *Stats) {
+	needsConjoin := func(upstreamCount int) bool {
+		return upstreamCount+novelCount > c.maxTables
+	}
+	c.await(mm.Name(), func() { conjoin(mm, p, needsConjoin, stats) }, nil)
+	return
+}
+
+// await checks to see if there's already something running for |id| and, if
+// so, waits for it to complete. If not, it runs f() and waits for it to
+// complete. While f() is running, other callers to await that pass in |id|
+// will block until f() completes.
+func (c *asyncConjoiner) await(id string, f func(), testWg *sync.WaitGroup) {
+	wait := func() <-chan struct{} {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if ch, present := c.waiters[id]; present {
+			return ch
+		}
+		c.waiters[id] = make(chan struct{})
+		go c.runAndNotify(id, f)
+		return c.waiters[id]
+	}()
+	if testWg != nil {
+		testWg.Done()
+	}
+	<-wait
+}
+
+// runAndNotify runs f() and, upon completion, signals everyone who called
+// await(id).
+func (c *asyncConjoiner) runAndNotify(id string, f func()) {
+	f()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ch, present := c.waiters[id]
+	d.PanicIfFalse(present)
+	close(ch)
+	delete(c.waiters, id)
+}
+
+func conjoin(mm manifest, p tablePersister, needsConjoin func(int) bool, stats *Stats) {
+	b := &backoff.Backoff{
+		Min:    128 * time.Microsecond,
+		Max:    10 * time.Second,
+		Factor: 2,
+		Jitter: true,
+	}
+
+	exists, _, lock, root, upstream := mm.ParseIfExists(nil)
+	d.PanicIfFalse(exists)
+	// This conjoin may have been requested by someone with an out-of-date notion of what's upstream. Verify that we actually still believe a conjoin is needed and, if not, return early
+	if !needsConjoin(len(upstream)) {
+		return
+	}
+
+	var conjoined tableSpec
+	var conjoinees, keepers []tableSpec
+
+	for {
+		if conjoinees == nil {
+			conjoined, conjoinees, keepers = conjoinTables(p, upstream, stats)
+		}
+
+		specs := append(make([]tableSpec, 0, len(keepers)+1), conjoined)
+		specs = append(specs, keepers...)
+
+		nl := generateLockHash(root, specs)
+		lock, root, upstream = mm.Update(lock, nl, specs, root, nil)
+
+		if nl == lock {
+			return
+		}
+		// Optimistic lock failure. Someone else moved to the root, the set of tables, or both out from under us.
+		// If we can re-use the conjoin we already performed, we want to try again. Currently, we will only do so if ALL conjoinees are still present upstream. If we can't re-use...then someone else almost certainly landed a conjoin upstream. In this case, bail and let clients ask again if they think they still can't proceed.
+		conjoineeSet := map[addr]struct{}{}
+		upstreamNames := map[addr]struct{}{}
+		for _, spec := range upstream {
+			upstreamNames[spec.name] = struct{}{}
+		}
+		for _, c := range conjoinees {
+			if _, present := upstreamNames[c.name]; !present {
+				return // Bail!
+			}
+			conjoineeSet[c.name] = struct{}{}
+		}
+
+		// Filter conjoinees out of upstream to generate new set of keepers
+		keepers = make([]tableSpec, 0, len(upstream)-len(conjoinees))
+		for _, spec := range upstream {
+			if _, present := conjoineeSet[spec.name]; !present {
+				keepers = append(keepers, spec)
+			}
+		}
+		time.Sleep(b.Duration())
+	}
+}
+
+func conjoinTables(p tablePersister, upstream []tableSpec, stats *Stats) (conjoined tableSpec, conjoinees, keepers []tableSpec) {
+	// Open all the upstream tables concurrently
+	sources := make(chunkSources, len(upstream))
+	wg := sync.WaitGroup{}
+	for i, spec := range upstream {
+		wg.Add(1)
+		go func(idx int, spec tableSpec) {
+			sources[idx] = p.Open(spec.name, spec.chunkCount)
+			wg.Done()
+		}(i, spec)
+		i++
+	}
+	wg.Wait()
+
+	t1 := time.Now()
+
+	sortedUpstream := make(chunkSources, len(sources))
+	copy(sortedUpstream, sources)
+	sort.Sort(chunkSourcesByAscendingCount(sortedUpstream))
+
+	partition := 2
+	sum := sortedUpstream[0].count() + sortedUpstream[1].count()
+	for partition < len(sortedUpstream) && sum > sortedUpstream[partition].count() {
+		sum += sortedUpstream[partition].count()
+		partition++
+	}
+
+	toConjoin := sortedUpstream[:partition]
+	conjoinedSrc := p.ConjoinAll(toConjoin, stats)
+	conjoined = tableSpec{conjoinedSrc.hash(), conjoinedSrc.count()}
+	conjoinees = toSpecs(toConjoin)
+	keepers = toSpecs(sortedUpstream[partition:])
+
+	stats.ConjoinLatency.SampleTime(time.Since(t1))
+	stats.TablesPerConjoin.SampleLen(len(toConjoin))
+	stats.ChunksPerConjoin.Sample(uint64(conjoined.chunkCount))
+
+	return conjoined, conjoinees, keepers
+}
+
+func toSpecs(srcs chunkSources) []tableSpec {
+	specs := make([]tableSpec, len(srcs))
+	for i, src := range srcs {
+		d.PanicIfFalse(src.count() > 0)
+		specs[i] = tableSpec{src.hash(), src.count()}
+	}
+	return specs
+}

--- a/go/nbs/conjoiner_test.go
+++ b/go/nbs/conjoiner_test.go
@@ -1,0 +1,240 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/attic-labs/noms/go/constants"
+	"github.com/attic-labs/noms/go/hash"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestAsyncConjoinerAwait(t *testing.T) {
+	runTest := func(t *testing.T, names ...string) {
+		c := newAsyncConjoiner(defaultMaxTables)
+
+		// mu protects |conjoins|
+		mu := sync.Mutex{}
+		conjoins := map[string]int{}
+
+		// |trigger| ensures the goroutines will all await() concurrently
+		trigger := &sync.WaitGroup{}
+		trigger.Add(len(names))
+
+		// |wg| allows the test to wait for all the goroutines started below
+		wg := sync.WaitGroup{}
+		for _, n := range names {
+			wg.Add(1)
+			go func(db string) {
+				defer wg.Done()
+				c.await(db, func() {
+					trigger.Wait()
+					mu.Lock()
+					defer mu.Unlock()
+					cnt := conjoins[db]
+					cnt++
+					conjoins[db] = cnt
+				}, trigger)
+			}(n)
+		}
+		wg.Wait()
+
+		for _, n := range names {
+			assert.EqualValues(t, 1, conjoins[n], "Wrong num conjoins for %s", n)
+		}
+	}
+
+	t.Run("AllDifferent", func(t *testing.T) {
+		runTest(t, "foo", "bar", "baz")
+	})
+
+	t.Run("Concurrent", func(t *testing.T) {
+		runTest(t, "foo", "foo", "bar", "foo", "baz")
+	})
+}
+
+type tableSpecsByAscendingCount []tableSpec
+
+func (ts tableSpecsByAscendingCount) Len() int { return len(ts) }
+func (ts tableSpecsByAscendingCount) Less(i, j int) bool {
+	tsI, tsJ := ts[i], ts[j]
+	if tsI.chunkCount == tsJ.chunkCount {
+		return bytes.Compare(tsI.name[:], tsJ.name[:]) < 0
+	}
+	return tsI.chunkCount < tsJ.chunkCount
+}
+func (ts tableSpecsByAscendingCount) Swap(i, j int) { ts[i], ts[j] = ts[j], ts[i] }
+
+func makeTestSrcs(tableSizes []uint32, p tablePersister) (srcs chunkSources) {
+	count := uint32(0)
+	nextChunk := func() (chunk []byte) {
+		chunk = make([]byte, 4)
+		binary.BigEndian.PutUint32(chunk, count)
+		count++
+		return chunk
+	}
+
+	for _, s := range tableSizes {
+		mt := newMemTable(testMemTableSize)
+		for i := uint32(0); i < s; i++ {
+			c := nextChunk()
+			mt.addChunk(computeAddr(c), c)
+		}
+		srcs = append(srcs, p.Persist(mt, nil, &Stats{}))
+	}
+	return
+}
+
+func TestConjoin(t *testing.T) {
+	// Makes a tableSet with len(tableSizes) upstream tables containing tableSizes[N] unique chunks
+	makeTestTableSpecs := func(tableSizes []uint32, p tablePersister) (specs []tableSpec) {
+		for _, src := range makeTestSrcs(tableSizes, p) {
+			specs = append(specs, tableSpec{src.hash(), src.count()})
+		}
+		return
+	}
+
+	// Returns the chunk counts of the tables in ts.compacted & ts.upstream in ascending order
+	getSortedSizes := func(specs []tableSpec) (sorted []uint32) {
+		all := append([]tableSpec{}, specs...)
+		sort.Sort(tableSpecsByAscendingCount(all))
+		for _, ts := range all {
+			sorted = append(sorted, ts.chunkCount)
+		}
+		return
+	}
+
+	assertContainAll := func(t *testing.T, p tablePersister, expect, actual []tableSpec) {
+		open := func(specs []tableSpec) (srcs chunkReaderGroup) {
+			for _, sp := range specs {
+				srcs = append(srcs, p.Open(sp.name, sp.chunkCount))
+			}
+			return
+		}
+		expectSrcs, actualSrcs := open(expect), open(actual)
+		chunkChan := make(chan extractRecord, expectSrcs.count())
+		expectSrcs.extract(chunkChan)
+		close(chunkChan)
+
+		for rec := range chunkChan {
+			assert.True(t, actualSrcs.has(rec.a))
+		}
+	}
+
+	setup := func(lock addr, root hash.Hash, sizes []uint32) (fm *fakeManifest, p tablePersister, upstream []tableSpec) {
+		p = newFakeTablePersister()
+		upstream = makeTestTableSpecs(sizes, p)
+		fm = &fakeManifest{}
+		fm.set(constants.NomsVersion, lock, root, upstream)
+		return
+	}
+
+	tc := []struct {
+		name        string
+		precompact  []uint32
+		postcompact []uint32
+	}{
+		{"uniform", []uint32{1, 1, 1, 1, 1}, []uint32{5}},
+		{"all but last", []uint32{1, 1, 1, 1, 5}, []uint32{4, 5}},
+		{"all", []uint32{5, 5, 5}, []uint32{15}},
+		{"first four", []uint32{5, 6, 10, 11, 35, 64}, []uint32{32, 35, 64}},
+		{"log, first two", []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{3, 4, 8, 16, 32, 64}},
+		{"log, all", []uint32{2, 3, 4, 8, 16, 32, 64}, []uint32{129}},
+	}
+
+	stats := &Stats{}
+	alwaysConjoin := func(int) bool { return true }
+	startLock, startRoot := computeAddr([]byte("lock")), hash.Of([]byte("root"))
+	t.Run("Success", func(t *testing.T) {
+		// Compact some tables, no one interrupts
+		for _, c := range tc {
+			t.Run(c.name, func(t *testing.T) {
+				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+
+				conjoin(fm, p, alwaysConjoin, stats)
+				exists, _, _, _, newUpstream := fm.ParseIfExists(nil)
+				assert.True(t, exists)
+				assert.Equal(t, c.postcompact, getSortedSizes(newUpstream))
+				assertContainAll(t, p, upstream, newUpstream)
+			})
+		}
+	})
+
+	t.Run("Retry", func(t *testing.T) {
+		// Compact some tables, interloper slips in a new table
+		makeExtra := func(p tablePersister) tableSpec {
+			mt := newMemTable(testMemTableSize)
+			data := []byte{0xde, 0xad}
+			mt.addChunk(computeAddr(data), data)
+			src := p.Persist(mt, nil, &Stats{})
+			return tableSpec{src.hash(), src.count()}
+		}
+		for _, c := range tc {
+			t.Run(c.name, func(t *testing.T) {
+				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+
+				newTable := makeExtra(p)
+				u := updatePreemptManifest{fm, func() {
+					fm.set(constants.NomsVersion, computeAddr([]byte("lock2")), startRoot, append(upstream, newTable))
+				}}
+				conjoin(u, p, alwaysConjoin, stats)
+				exists, _, _, _, newUpstream := fm.ParseIfExists(nil)
+				assert.True(t, exists)
+				assert.Equal(t, append([]uint32{1}, c.postcompact...), getSortedSizes(newUpstream))
+				assertContainAll(t, p, append(upstream, newTable), newUpstream)
+			})
+		}
+	})
+
+	t.Run("TablesDroppedUpstream", func(t *testing.T) {
+		// Interloper drops some compactees
+		for _, c := range tc {
+			t.Run(c.name, func(t *testing.T) {
+				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+
+				u := updatePreemptManifest{fm, func() {
+					fm.set(constants.NomsVersion, computeAddr([]byte("lock2")), startRoot, upstream[1:])
+				}}
+				conjoin(u, p, alwaysConjoin, stats)
+				exists, _, _, _, newUpstream := fm.ParseIfExists(nil)
+				assert.True(t, exists)
+				assert.Equal(t, c.precompact[1:], getSortedSizes(newUpstream))
+			})
+		}
+	})
+
+	neverConjoin := func(int) bool { return false }
+	t.Run("ExitEarly", func(t *testing.T) {
+		// conjoin called with out-of-date manifest; no longer needs a conjoin
+		for _, c := range tc {
+			t.Run(c.name, func(t *testing.T) {
+				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+
+				conjoin(fm, p, neverConjoin, stats)
+				exists, _, _, _, newUpstream := fm.ParseIfExists(nil)
+				assert.True(t, exists)
+				assert.Equal(t, c.precompact, getSortedSizes(newUpstream))
+				assertContainAll(t, p, upstream, newUpstream)
+			})
+		}
+	})
+}
+
+type updatePreemptManifest struct {
+	manifest
+	preUpdate func()
+}
+
+func (u updatePreemptManifest) Update(lastLock, newLock addr, specs []tableSpec, newRoot hash.Hash, writeHook func()) (lock addr, actual hash.Hash, tableSpecs []tableSpec) {
+	if u.preUpdate != nil {
+		u.preUpdate()
+	}
+	return u.manifest.Update(lastLock, newLock, specs, newRoot, writeHook)
+}

--- a/go/nbs/dynamo_manifest.go
+++ b/go/nbs/dynamo_manifest.go
@@ -46,6 +46,10 @@ func newDynamoManifest(table, namespace string, ddb ddbsvc) manifest {
 	return dynamoManifest{table: table, db: namespace, ddbsvc: ddb}
 }
 
+func (dm dynamoManifest) Name() string {
+	return dm.table + dm.db
+}
+
 func (dm dynamoManifest) ParseIfExists(readHook func()) (exists bool, vers string, lock addr, root hash.Hash, tableSpecs []tableSpec) {
 	result, err := dm.ddbsvc.GetItem(&dynamodb.GetItemInput{
 		ConsistentRead: aws.Bool(true), // This doubles the cost :-(

--- a/go/nbs/factory.go
+++ b/go/nbs/factory.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/d"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	defaultAWSReadLimit = 1024
+)
+
+type AWSStoreFactory struct {
+	ddb       ddbsvc
+	persister tablePersister
+	table     string
+	conjoiner conjoiner
+}
+
+func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheSize uint64) chunks.Factory {
+	var indexCache *indexCache
+	if indexCacheSize > 0 {
+		indexCache = newIndexCache(indexCacheSize)
+	}
+	return &AWSStoreFactory{
+		dynamodb.New(sess),
+		&s3TablePersister{
+			s3.New(sess),
+			bucket,
+			defaultS3PartSize,
+			minS3PartSize,
+			maxS3PartSize,
+			indexCache,
+			make(chan struct{}, defaultAWSReadLimit),
+		},
+		table,
+		newAsyncConjoiner(defaultMaxTables),
+	}
+}
+
+func (asf *AWSStoreFactory) CreateStore(ns string) chunks.ChunkStore {
+	return newAWSStore(asf.table, ns, asf.ddb, asf.persister, asf.conjoiner, defaultMemTableSize)
+}
+
+func (asf *AWSStoreFactory) Shutter() {
+}
+
+type LocalStoreFactory struct {
+	dir        string
+	fc         *fdCache
+	indexCache *indexCache
+	conjoiner  conjoiner
+}
+
+func checkDir(dir string) error {
+	stat, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !stat.IsDir() {
+		return fmt.Errorf("Path is not a directory: %s", dir)
+	}
+	return nil
+}
+
+func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxTables int) chunks.Factory {
+	err := checkDir(dir)
+	d.PanicIfError(err)
+
+	var indexCache *indexCache
+	if indexCacheSize > 0 {
+		indexCache = newIndexCache(indexCacheSize)
+	}
+	fc := newFDCache(maxTables)
+	return &LocalStoreFactory{dir, fc, indexCache, newAsyncConjoiner(maxTables)}
+}
+
+func (lsf *LocalStoreFactory) CreateStore(ns string) chunks.ChunkStore {
+	path := path.Join(lsf.dir, ns)
+	err := os.MkdirAll(path, 0777)
+	d.PanicIfError(err)
+	return newLocalStore(path, defaultMemTableSize, lsf.fc, lsf.indexCache, lsf.conjoiner)
+}
+
+func (lsf *LocalStoreFactory) Shutter() {
+	lsf.fc.Drop()
+}

--- a/go/nbs/file_manifest.go
+++ b/go/nbs/file_manifest.go
@@ -32,6 +32,10 @@ type fileManifest struct {
 	dir string
 }
 
+func (fm fileManifest) Name() string {
+	return fm.dir
+}
+
 // ParseIfExists looks for a LOCK and manifest file in fm.dir. If it finds
 // them, it takes the lock, parses the manifest and returns its contents,
 // setting |exists| to true. If not, it sets |exists| to false and returns. In

--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -53,8 +53,8 @@ func (ftp *fsTablePersister) persistTable(name addr, data []byte, chunkCount uin
 	return ftp.Open(name, chunkCount)
 }
 
-func (ftp *fsTablePersister) CompactAll(sources chunkSources, stats *Stats) chunkSource {
-	plan := planCompaction(sources, stats)
+func (ftp *fsTablePersister) ConjoinAll(sources chunkSources, stats *Stats) chunkSource {
+	plan := planConjoin(sources, stats)
 
 	if plan.chunkCount == 0 {
 		return emptyChunkSource{}

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -163,7 +163,7 @@ func TestFSTablePersisterCacheOnPersist(t *testing.T) {
 	assert.Len(present, 1)
 }
 
-func TestFSTablePersisterCompactAll(t *testing.T) {
+func TestFSTablePersisterConjoinAll(t *testing.T) {
 	assert := assert.New(t)
 	assert.True(len(testChunks) > 1, "Whoops, this test isn't meaningful")
 	sources := make(chunkSources, len(testChunks))
@@ -183,7 +183,7 @@ func TestFSTablePersisterCompactAll(t *testing.T) {
 		sources[i] = fts.Open(name, 2)
 	}
 
-	src := fts.CompactAll(sources, &Stats{})
+	src := fts.ConjoinAll(sources, &Stats{})
 
 	if assert.True(src.count() > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))
@@ -197,7 +197,7 @@ func TestFSTablePersisterCompactAll(t *testing.T) {
 	assert.Len(present, len(sources))
 }
 
-func TestFSTablePersisterCompactAllDups(t *testing.T) {
+func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 	assert := assert.New(t)
 	dir := makeTempDir(assert)
 	defer os.RemoveAll(dir)
@@ -214,7 +214,7 @@ func TestFSTablePersisterCompactAllDups(t *testing.T) {
 		}
 		sources[i] = fts.Persist(mt, nil, &Stats{})
 	}
-	src := fts.CompactAll(sources, &Stats{})
+	src := fts.ConjoinAll(sources, &Stats{})
 
 	if assert.True(src.count() > 0) {
 		buff, err := ioutil.ReadFile(filepath.Join(dir, src.hash().String()))

--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -60,6 +60,9 @@ type manifest interface {
 		actual hash.Hash,
 		tableSpecs []tableSpec,
 	)
+
+	// Name returns a stable, unique identifier for the store this manifest describes.
+	Name() string
 }
 
 type tableSpec struct {

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -199,8 +199,8 @@ func (s partsByPartNum) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-func (s3p s3TablePersister) CompactAll(sources chunkSources, stats *Stats) chunkSource {
-	plan := planCompaction(sources, stats)
+func (s3p s3TablePersister) ConjoinAll(sources chunkSources, stats *Stats) chunkSource {
+	plan := planConjoin(sources, stats)
 	if plan.chunkCount == 0 {
 		return emptyChunkSource{}
 	}

--- a/go/nbs/stats_test.go
+++ b/go/nbs/stats_test.go
@@ -76,7 +76,7 @@ func TestStats(t *testing.T) {
 	assert.Equal(uint64(7), store.Stats().ChunksPerRead.Sum())
 
 	// Force a conjoin
-	store.maxTables = 2
+	store.c = newAsyncConjoiner(2)
 	store.Put(c4)
 	store.Commit(store.Root(), store.Root())
 	store.Put(c5)

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -26,7 +26,7 @@ const (
 	StorageVersion = "4"
 
 	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
-	defaultMaxTables           = 1 << 12
+	defaultMaxTables           = 128
 
 	defaultIndexCacheSize = (1 << 20) * 8 // 8MB
 )

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -6,10 +6,6 @@ package nbs
 
 import (
 	"fmt"
-	"math"
-	"math/rand"
-	"os"
-	"path"
 	"sort"
 	"sync"
 	"time"
@@ -18,9 +14,6 @@ import (
 	"github.com/attic-labs/noms/go/constants"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/jpillora/backoff"
 )
 
@@ -33,7 +26,6 @@ const (
 	StorageVersion = "4"
 
 	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
-	defaultAWSReadLimit        = 1024
 	defaultMaxTables           = 1 << 12
 
 	defaultIndexCacheSize = (1 << 20) * 8 // 8MB
@@ -43,15 +35,19 @@ var (
 	cacheOnce        = sync.Once{}
 	globalIndexCache *indexCache
 	globalFDCache    *fdCache
+	globalConjoiner  conjoiner
 )
 
 func makeGlobalCaches() {
 	globalIndexCache = newIndexCache(defaultIndexCacheSize)
 	globalFDCache = newFDCache(defaultMaxTables)
+	globalConjoiner = newAsyncConjoiner(defaultMaxTables)
 }
 
 type NomsBlockStore struct {
 	mm           manifest
+	p            tablePersister
+	c            conjoiner
 	manifestLock addr
 	nomsVersion  string
 
@@ -60,85 +56,10 @@ type NomsBlockStore struct {
 	tables tableSet
 	root   hash.Hash
 
-	mtSize    uint64
-	maxTables int
-	putCount  uint64
+	mtSize   uint64
+	putCount uint64
 
 	stats *Stats
-}
-
-type AWSStoreFactory struct {
-	ddb       ddbsvc
-	persister tablePersister
-	table     string
-}
-
-func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheSize uint64) chunks.Factory {
-	var indexCache *indexCache
-	if indexCacheSize > 0 {
-		indexCache = newIndexCache(indexCacheSize)
-	}
-	return &AWSStoreFactory{
-		dynamodb.New(sess),
-		&s3TablePersister{
-			s3.New(sess),
-			bucket,
-			defaultS3PartSize,
-			minS3PartSize,
-			maxS3PartSize,
-			indexCache,
-			make(chan struct{}, defaultAWSReadLimit),
-		},
-		table,
-	}
-}
-
-func (asf *AWSStoreFactory) CreateStore(ns string) chunks.ChunkStore {
-	return newAWSStore(asf.table, ns, asf.ddb, asf.persister, defaultMemTableSize, defaultMaxTables)
-}
-
-func (asf *AWSStoreFactory) Shutter() {
-}
-
-type LocalStoreFactory struct {
-	dir        string
-	maxTables  int
-	fc         *fdCache
-	indexCache *indexCache
-}
-
-func CheckDir(dir string) error {
-	stat, err := os.Stat(dir)
-	if err != nil {
-		return err
-	}
-	if !stat.IsDir() {
-		return fmt.Errorf("Path is not a directory: %s", dir)
-	}
-	return nil
-}
-
-func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxTables int) chunks.Factory {
-	err := CheckDir(dir)
-	d.PanicIfError(err)
-
-	var indexCache *indexCache
-	if indexCacheSize > 0 {
-		indexCache = newIndexCache(indexCacheSize)
-	}
-	fc := newFDCache(maxTables)
-	return &LocalStoreFactory{dir, maxTables, fc, indexCache}
-}
-
-func (lsf *LocalStoreFactory) CreateStore(ns string) chunks.ChunkStore {
-	path := path.Join(lsf.dir, ns)
-	err := os.MkdirAll(path, 0777)
-	d.PanicIfError(err)
-	return newLocalStore(path, defaultMemTableSize, lsf.fc, lsf.indexCache, lsf.maxTables)
-}
-
-func (lsf *LocalStoreFactory) Shutter() {
-	lsf.fc.Drop()
 }
 
 func NewAWSStore(table, ns, bucket string, s3 s3svc, ddb ddbsvc, memTableSize uint64) *NomsBlockStore {
@@ -152,38 +73,38 @@ func NewAWSStore(table, ns, bucket string, s3 s3svc, ddb ddbsvc, memTableSize ui
 		globalIndexCache,
 		make(chan struct{}, 32),
 	}
-	return newAWSStore(table, ns, ddb, p, memTableSize, defaultMaxTables)
+	return newAWSStore(table, ns, ddb, p, globalConjoiner, memTableSize)
 }
 
-func newAWSStore(table, ns string, ddb ddbsvc, p tablePersister, memTableSize uint64, maxTables int) *NomsBlockStore {
+func newAWSStore(table, ns string, ddb ddbsvc, p tablePersister, c conjoiner, memTableSize uint64) *NomsBlockStore {
 	d.PanicIfTrue(ns == "")
 	mm := newDynamoManifest(table, ns, ddb)
-	ts := newTableSet(p)
-	return newNomsBlockStore(mm, ts, memTableSize, maxTables)
+	return newNomsBlockStore(mm, p, c, memTableSize)
 }
 
 func NewLocalStore(dir string, memTableSize uint64) *NomsBlockStore {
 	cacheOnce.Do(makeGlobalCaches)
-	return newLocalStore(dir, memTableSize, globalFDCache, globalIndexCache, defaultMaxTables)
+	return newLocalStore(dir, memTableSize, globalFDCache, globalIndexCache, globalConjoiner)
 }
 
-func newLocalStore(dir string, memTableSize uint64, fc *fdCache, indexCache *indexCache, maxTables int) *NomsBlockStore {
-	err := CheckDir(dir)
+func newLocalStore(dir string, memTableSize uint64, fc *fdCache, indexCache *indexCache, c conjoiner) *NomsBlockStore {
+	err := checkDir(dir)
 	d.PanicIfError(err)
 	p := newFSTablePersister(dir, fc, indexCache)
-	return newNomsBlockStore(fileManifest{dir}, newTableSet(p), memTableSize, maxTables)
+	return newNomsBlockStore(fileManifest{dir}, p, c, memTableSize)
 }
 
-func newNomsBlockStore(mm manifest, ts tableSet, memTableSize uint64, maxTables int) *NomsBlockStore {
+func newNomsBlockStore(mm manifest, p tablePersister, c conjoiner, memTableSize uint64) *NomsBlockStore {
 	if memTableSize == 0 {
 		memTableSize = defaultMemTableSize
 	}
 	nbs := &NomsBlockStore{
 		mm:          mm,
-		tables:      ts,
+		p:           p,
+		c:           c,
+		tables:      newTableSet(p),
 		nomsVersion: constants.NomsVersion,
 		mtSize:      memTableSize,
-		maxTables:   maxTables,
 		stats:       NewStats(),
 	}
 
@@ -464,8 +385,6 @@ var (
 	errOptimisticLockFailedTables = fmt.Errorf("Tables changed")
 )
 
-var compactThreshRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
@@ -478,26 +397,25 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 		nbs.mt = nil
 	}
 
-	candidate := nbs.tables
+	if nbs.c.ConjoinRequired(nbs.tables) {
+		nbs.c.Conjoin(nbs.mm, nbs.p, nbs.tables.Novel(), nbs.stats)
+		exists, _, lock, actual, upstream := nbs.mm.ParseIfExists(nil)
+		d.PanicIfFalse(exists)
 
-	shouldCompact := func() bool {
-		// As the number of tables grows from 1 to maxTables, the probability of compacting, grows from 0 to 1
-		thresh := float64(math.Max(0, float64(len(candidate.upstream)-1))) / float64(nbs.maxTables-1)
-		return compactThreshRand.Float64() < thresh
+		nbs.manifestLock = lock
+		nbs.root = actual
+		nbs.tables = nbs.tables.Rebase(upstream)
+		return errOptimisticLockFailedTables
 	}
 
-	if shouldCompact() {
-		candidate = candidate.Compact(nbs.stats) // Compact() must only compact upstream tables (BUG 3142)
-	}
-
-	specs := candidate.ToSpecs()
+	specs := nbs.tables.ToSpecs()
 	nl := generateLockHash(current, specs)
 	lock, actual, tableNames := nbs.mm.Update(nbs.manifestLock, nl, specs, current, nil)
 	if nl != lock {
 		// Optimistic lock failure. Someone else moved to the root, the set of tables, or both out from under us.
 		nbs.manifestLock = lock
 		nbs.root = actual
-		nbs.tables = candidate.Rebase(tableNames)
+		nbs.tables = nbs.tables.Rebase(tableNames)
 
 		if last != actual {
 			return errOptimisticLockFailedRoot
@@ -505,7 +423,7 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 		return errOptimisticLockFailedTables
 	}
 
-	nbs.tables = candidate.Flatten()
+	nbs.tables = nbs.tables.Flatten()
 	nbs.nomsVersion, nbs.manifestLock, nbs.root = constants.NomsVersion, lock, current
 	return nil
 }

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -23,9 +23,9 @@ type tablePersister interface {
 	// |haver| may be dropped in the process.
 	Persist(mt *memTable, haver chunkReader, stats *Stats) chunkSource
 
-	// CompactAll conjoins all chunks in |sources| into a single, new
+	// ConjoinAll conjoins all chunks in |sources| into a single, new
 	// chunkSource.
-	CompactAll(sources chunkSources, stats *Stats) chunkSource
+	ConjoinAll(sources chunkSources, stats *Stats) chunkSource
 
 	// Open a table named |name|, containing |chunkCount| chunks. The
 	// tablePersister is responsible for managing the lifetime of the returned
@@ -104,7 +104,7 @@ func (cp compactionPlan) suffixes() []byte {
 	return cp.mergedIndex[suffixesStart : suffixesStart+uint64(cp.chunkCount)*addrSuffixSize]
 }
 
-func planCompaction(sources chunkSources, stats *Stats) (plan compactionPlan) {
+func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan) {
 	var totalUncompressedData uint64
 	for _, src := range sources {
 		totalUncompressedData += src.uncompressedLen()

--- a/go/nbs/table_persister_test.go
+++ b/go/nbs/table_persister_test.go
@@ -32,7 +32,7 @@ func TestPlanCompaction(t *testing.T) {
 		sources = append(sources, src)
 	}
 
-	plan := planCompaction(sources, &Stats{})
+	plan := planConjoin(sources, &Stats{})
 
 	var totalChunks uint32
 	for i, src := range sources {

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -219,9 +219,7 @@ func (tr tableReader) get(h addr, stats *Stats) (data []byte) {
 	n, err := tr.r.ReadAt(buff, int64(offset))
 	stats.BytesPerRead.Sample(length)
 	stats.ChunksPerRead.SampleLen(1)
-	if latency := time.Since(t1); latency >= 0 {
-		stats.ReadLatency.SampleTime(latency)
-	}
+	stats.ReadLatency.SampleTime(roundedSince(t1))
 
 	d.Chk.NoError(err)
 	d.Chk.True(n == int(length))
@@ -229,6 +227,13 @@ func (tr tableReader) get(h addr, stats *Stats) (data []byte) {
 	d.Chk.True(data != nil)
 
 	return
+}
+
+func roundedSince(t1 time.Time) time.Duration {
+	if dur := time.Since(t1); dur > 0 {
+		return dur
+	}
+	return time.Duration(1)
 }
 
 type offsetRec struct {
@@ -259,9 +264,7 @@ func (tr tableReader) readAtOffsets(
 	n, err := tr.r.ReadAt(buff, int64(readStart))
 	stats.BytesPerRead.Sample(readLength)
 	stats.ChunksPerRead.SampleLen(len(offsets))
-	if latency := time.Since(t1); latency >= 0 {
-		stats.ReadLatency.SampleTime(latency)
-	}
+	stats.ReadLatency.SampleTime(roundedSince(t1))
 
 	d.Chk.NoError(err)
 	d.Chk.True(uint64(n) == readLength)

--- a/go/nbs/table_reader.go
+++ b/go/nbs/table_reader.go
@@ -219,7 +219,9 @@ func (tr tableReader) get(h addr, stats *Stats) (data []byte) {
 	n, err := tr.r.ReadAt(buff, int64(offset))
 	stats.BytesPerRead.Sample(length)
 	stats.ChunksPerRead.SampleLen(1)
-	stats.ReadLatency.SampleTime(time.Since(t1))
+	if latency := time.Since(t1); latency >= 0 {
+		stats.ReadLatency.SampleTime(latency)
+	}
 
 	d.Chk.NoError(err)
 	d.Chk.True(n == int(length))
@@ -257,7 +259,9 @@ func (tr tableReader) readAtOffsets(
 	n, err := tr.r.ReadAt(buff, int64(readStart))
 	stats.BytesPerRead.Sample(readLength)
 	stats.ChunksPerRead.SampleLen(len(offsets))
-	stats.ReadLatency.SampleTime(time.Since(t1))
+	if latency := time.Since(t1); latency >= 0 {
+		stats.ReadLatency.SampleTime(latency)
+	}
 
 	d.Chk.NoError(err)
 	d.Chk.True(uint64(n) == readLength)

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -5,9 +5,7 @@
 package nbs
 
 import (
-	"sort"
 	"sync"
-	"time"
 
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/d"
@@ -21,18 +19,9 @@ func newTableSet(persister tablePersister) tableSet {
 
 // tableSet is an immutable set of persistable chunkSources.
 type tableSet struct {
-	// novel chunkSources contain chunks that have not yet been pushed upstream
-	novel chunkSources
-
-	// compactees holds precisely the chunkSources that were conjoined to build the members of compacted. If compacted is empty, compactees is also. The members of compactees are split out of upstream during Compact(), though they still represent actual persisted tables.
-	compacted  chunkSources
-	compactees chunkSources
-
-	// upstream holds the set of already-persisted chunkSources that this tableSet references.
-	upstream chunkSources
-
-	p  tablePersister
-	rl chan struct{}
+	novel, upstream chunkSources
+	p               tablePersister
+	rl              chan struct{}
 }
 
 func (ts tableSet) has(h addr) bool {
@@ -44,7 +33,7 @@ func (ts tableSet) has(h addr) bool {
 		}
 		return false
 	}
-	return f(ts.novel) || f(ts.compacted) || f(ts.upstream)
+	return f(ts.novel) || f(ts.upstream)
 }
 
 func (ts tableSet) hasMany(addrs []hasRecord) (remaining bool) {
@@ -56,7 +45,7 @@ func (ts tableSet) hasMany(addrs []hasRecord) (remaining bool) {
 		}
 		return true
 	}
-	return f(ts.novel) && f(ts.compacted) && f(ts.upstream)
+	return f(ts.novel) && f(ts.upstream)
 }
 
 func (ts tableSet) get(h addr, stats *Stats) []byte {
@@ -71,9 +60,6 @@ func (ts tableSet) get(h addr, stats *Stats) []byte {
 	if data := f(ts.novel); data != nil {
 		return data
 	}
-	if data := f(ts.compacted); data != nil {
-		return data
-	}
 	return f(ts.upstream)
 }
 
@@ -86,7 +72,7 @@ func (ts tableSet) getMany(reqs []getRecord, foundChunks chan *chunks.Chunk, wg 
 		}
 		return true
 	}
-	return f(ts.novel) && f(ts.compacted) && f(ts.upstream)
+	return f(ts.novel) && f(ts.upstream)
 }
 
 func (ts tableSet) calcReads(reqs []getRecord, blockSize uint64) (reads int, split, remaining bool) {
@@ -104,11 +90,6 @@ func (ts tableSet) calcReads(reqs []getRecord, blockSize uint64) (reads int, spl
 	reads, split, remaining = f(ts.novel)
 	if remaining {
 		var rds int
-		rds, split, remaining = f(ts.compacted)
-		reads += rds
-	}
-	if remaining {
-		var rds int
 		rds, split, remaining = f(ts.upstream)
 		reads += rds
 	}
@@ -122,7 +103,7 @@ func (ts tableSet) count() uint32 {
 		}
 		return
 	}
-	return f(ts.novel) + f(ts.compacted) + f(ts.upstream)
+	return f(ts.novel) + f(ts.upstream)
 }
 
 func (ts tableSet) uncompressedLen() uint64 {
@@ -132,121 +113,75 @@ func (ts tableSet) uncompressedLen() uint64 {
 		}
 		return
 	}
-	return f(ts.novel) + f(ts.compacted) + f(ts.upstream)
+	return f(ts.novel) + f(ts.upstream)
 }
 
 // Size returns the number of tables in this tableSet.
 func (ts tableSet) Size() int {
-	return len(ts.novel) + len(ts.compacted) + len(ts.upstream)
+	return len(ts.novel) + len(ts.upstream)
+}
+
+// Novel returns the number of tables containing novel chunks in this
+// tableSet.
+func (ts tableSet) Novel() int {
+	return len(ts.novel)
+}
+
+// Upstream returns the number of known-persisted tables in this tableSet.
+func (ts tableSet) Upstream() int {
+	return len(ts.upstream)
 }
 
 // Prepend adds a memTable to an existing tableSet, compacting |mt| and
 // returning a new tableSet with newly compacted table added.
 func (ts tableSet) Prepend(mt *memTable, stats *Stats) tableSet {
 	newTs := tableSet{
-		novel:      make(chunkSources, len(ts.novel)+1),
-		compacted:  make(chunkSources, len(ts.compacted)),
-		compactees: make(chunkSources, len(ts.compactees)),
-		upstream:   make(chunkSources, len(ts.upstream)),
-		p:          ts.p,
-		rl:         ts.rl,
+		novel:    make(chunkSources, len(ts.novel)+1),
+		upstream: make(chunkSources, len(ts.upstream)),
+		p:        ts.p,
+		rl:       ts.rl,
 	}
 	newTs.novel[0] = newPersistingChunkSource(mt, ts, ts.p, ts.rl, stats)
 	copy(newTs.novel[1:], ts.novel)
-	copy(newTs.compacted, ts.compacted)
-	copy(newTs.compactees, ts.compactees)
 	copy(newTs.upstream, ts.upstream)
 	return newTs
 }
 
-// Compact returns a new tableSet that's smaller than |ts|. It chooses to
-// compact the N smallest (by number of chunks) tables which can be compacted
-// into a new table such that upon replacing the N input tables, the
-// resulting table will still have the fewest chunks in the tableSet.
-func (ts tableSet) Compact(stats *Stats) tableSet {
-	t1 := time.Now()
-
-	ns := tableSet{
-		novel:      make(chunkSources, len(ts.novel)),
-		compacted:  make(chunkSources, len(ts.compacted)+1),
-		compactees: make(chunkSources, len(ts.compactees)),
-		p:          ts.p,
-		rl:         ts.rl,
-	}
-	copy(ns.novel, ts.novel)
-	copy(ns.compacted[1:], ts.compacted) // leave the first slot for the newly compacted table
-	copy(ns.compactees, ts.compactees)
-
-	sortedUpstream := make(chunkSources, len(ts.upstream))
-	copy(sortedUpstream, ts.upstream)
-	sort.Sort(chunkSourcesByAscendingCount(sortedUpstream))
-
-	partition := 2
-	sum := sortedUpstream[0].count() + sortedUpstream[1].count()
-	for partition < len(sortedUpstream) && sum > sortedUpstream[partition].count() {
-		sum += sortedUpstream[partition].count()
-		partition++
-	}
-
-	toCompact := sortedUpstream[:partition]
-
-	ns.compacted[0] = ts.p.CompactAll(toCompact, stats)
-	ns.upstream = append(ns.upstream, sortedUpstream[partition:]...)
-	ns.compactees = append(ns.compactees, toCompact...)
-
-	stats.ConjoinLatency.SampleTime(time.Since(t1))
-	stats.TablesPerConjoin.SampleLen(len(toCompact))
-	stats.ChunksPerConjoin.Sample(uint64(ns.compacted[0].count()))
-
-	return ns
-}
-
 func (ts tableSet) extract(chunks chan<- extractRecord) {
-	// Since new tables are _prepended_ to a tableSet, extracting chunks in insertOrder requires iterating ts.upstream, followed by ts.compacted, followed by ts.novel in back to front order.
+	// Since new tables are _prepended_ to a tableSet, extracting chunks in insertOrder requires iterating ts.upstream back to front, followed by ts.novel.
 	for i := len(ts.upstream) - 1; i >= 0; i-- {
 		ts.upstream[i].extract(chunks)
-	}
-	for i := len(ts.compacted) - 1; i >= 0; i-- {
-		ts.compacted[i].extract(chunks)
 	}
 	for i := len(ts.novel) - 1; i >= 0; i-- {
 		ts.novel[i].extract(chunks)
 	}
 }
 
-// Flatten returns a new tableSet with |upstream| set to the union of ts.novel,
-// |ts.compacted|, and |ts.upstream|. |ts.compactees| is dropped.
+// Flatten returns a new tableSet with |upstream| set to the union of ts.novel
+// and ts.upstream.
 func (ts tableSet) Flatten() (flattened tableSet) {
 	flattened = tableSet{
 		upstream: make(chunkSources, 0, ts.Size()),
 		p:        ts.p,
 		rl:       ts.rl,
 	}
-	f := func(srcs chunkSources) {
-		for _, src := range srcs {
-			if src.count() > 0 {
-				flattened.upstream = append(flattened.upstream, src)
-			}
+	for _, src := range ts.novel {
+		if src.count() > 0 {
+			flattened.upstream = append(flattened.upstream, src)
 		}
 	}
-	f(ts.novel)
-	flattened.upstream = append(flattened.upstream, ts.compacted...)
 	flattened.upstream = append(flattened.upstream, ts.upstream...)
 	return
 }
 
 // Rebase returns a new tableSet holding the novel tables managed by |ts| and
-// those specified by |specs|. If |ts.compacted| is not nil, Rebase runs
-// through |ts.compactees| and checks to see if every element is still
-// mentioned in |specs|. If all of them are still there, Rebase copies
-// compaction state from |ts| to the new tableSet. Specifically,
-// |ts.compacted| and |ts.compactees| are copied to the new tableSet, while
-// the compactees are dropped from the new set of upstream tables.
+// those specified by |specs|.
 func (ts tableSet) Rebase(specs []tableSpec) tableSet {
 	merged := tableSet{
-		novel: make(chunkSources, 0, len(ts.novel)),
-		p:     ts.p,
-		rl:    ts.rl,
+		novel:    make(chunkSources, 0, len(ts.novel)),
+		upstream: make(chunkSources, 0, len(specs)),
+		p:        ts.p,
+		rl:       ts.rl,
 	}
 
 	// Rebase the novel tables, skipping those that are actually empty (usually due to de-duping during table compaction)
@@ -256,36 +191,10 @@ func (ts tableSet) Rebase(specs []tableSpec) tableSet {
 		}
 	}
 
-	// Only keep locally-performed compactions if ALL compactees are still present upstream
-	keepCompactions, compacteeSet := func() (bool, map[addr]struct{}) {
-		specsNames := map[addr]struct{}{}
-		for _, spec := range specs {
-			specsNames[spec.name] = struct{}{}
-		}
-		set := map[addr]struct{}{}
-		for _, compactee := range ts.compactees {
-			if _, present := specsNames[compactee.hash()]; !present {
-				return false, nil
-			}
-			set[compactee.hash()] = struct{}{}
-		}
-		return true, set
-	}()
-	if keepCompactions {
-		merged.compacted = make(chunkSources, len(ts.compacted))
-		merged.compactees = make(chunkSources, len(ts.compactees))
-		copy(merged.compacted, ts.compacted)
-		copy(merged.compactees, ts.compactees)
-	}
-
 	// Create a list of tables to open so we can open them in parallel.
 	tablesToOpen := map[addr]tableSpec{}
 	for _, spec := range specs {
-		if !keepCompactions {
-			tablesToOpen[spec.name] = spec
-			continue
-		}
-		if _, present := compacteeSet[spec.name]; !present { // Filter out compactees
+		if _, present := tablesToOpen[spec.name]; !present { // Filter out dups
 			tablesToOpen[spec.name] = spec
 		}
 	}
@@ -313,10 +222,6 @@ func (ts tableSet) ToSpecs() []tableSpec {
 		if src.count() > 0 {
 			tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
 		}
-	}
-	for _, src := range ts.compacted {
-		d.Chk.True(src.count() > 0)
-		tableSpecs = append(tableSpecs, tableSpec{src.hash(), src.count()})
 	}
 	for _, src := range ts.upstream {
 		d.Chk.True(src.count() > 0)

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -6,10 +6,8 @@ package nbs
 
 import (
 	"io/ioutil"
-	"sort"
+	"os"
 	"testing"
-
-	"encoding/binary"
 
 	"github.com/attic-labs/testify/assert"
 )
@@ -110,75 +108,6 @@ func TestTableSetExtract(t *testing.T) {
 	}
 }
 
-func TestTableSetCompact(t *testing.T) {
-	// Returns the chunk counts of the tables in ts.compacted & ts.upstream in ascending order
-	getSortedSizes := func(ts tableSet) (sorted []uint32) {
-		all := append(chunkSources{}, ts.compacted...)
-		all = append(all, ts.upstream...)
-		sort.Sort(chunkSourcesByAscendingCount(all))
-		sorted = make([]uint32, len(all))
-		for i := 0; i < len(sorted); i++ {
-			sorted[i] = all[i].count()
-		}
-		return
-	}
-
-	tc := []struct {
-		name        string
-		precompact  []uint32
-		postcompact []uint32
-	}{
-		{"uniform", []uint32{1, 1, 1, 1, 1}, []uint32{5}},
-		{"all but last", []uint32{1, 1, 1, 1, 5}, []uint32{4, 5}},
-		{"all", []uint32{5, 5, 10}, []uint32{10, 10}},
-		{"first four", []uint32{5, 6, 10, 11, 35, 64}, []uint32{32, 35, 64}},
-		{"log, first two", []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{3, 4, 8, 16, 32, 64}},
-		{"log, all", []uint32{2, 3, 4, 8, 16, 32, 64}, []uint32{129}},
-	}
-
-	for _, c := range tc {
-		t.Run(c.name, func(t *testing.T) {
-			assert := assert.New(t)
-			ts := makeTestTableSet(c.precompact)
-			ts2 := ts.Compact(&Stats{})
-			assert.Equal(c.postcompact, getSortedSizes(ts2))
-			assertContainAll(t, ts, ts2)
-		})
-	}
-}
-
-// Makes a tableSet with len(tableSizes) upstream tables containing tableSizes[N] unique chunks
-func makeTestTableSet(tableSizes []uint32) tableSet {
-	count := uint32(0)
-	nextChunk := func() (chunk []byte) {
-		chunk = make([]byte, 4)
-		binary.BigEndian.PutUint32(chunk, count)
-		count++
-		return chunk
-	}
-
-	ts := newFakeTableSet()
-	for _, s := range tableSizes {
-		mt := newMemTable(testMemTableSize)
-		for i := uint32(0); i < s; i++ {
-			c := nextChunk()
-			mt.addChunk(computeAddr(c), c)
-		}
-		ts = ts.Prepend(mt, &Stats{})
-	}
-	return ts.Flatten()
-}
-
-func assertContainAll(t *testing.T, expect, actual tableSet) {
-	chunkChan := make(chan extractRecord, expect.count())
-	expect.extract(chunkChan)
-	close(chunkChan)
-
-	for rec := range chunkChan {
-		assert.True(t, actual.has(rec.a))
-	}
-}
-
 func makeTempDir(assert *assert.Assertions) string {
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -186,6 +115,13 @@ func makeTempDir(assert *assert.Assertions) string {
 }
 
 func TestTableSetRebase(t *testing.T) {
+	assert := assert.New(t)
+	dir := makeTempDir(assert)
+	defer os.RemoveAll(dir)
+	fc := newFDCache(defaultMaxTables)
+	defer fc.Drop()
+	persister := newFSTablePersister(dir, fc, nil)
+
 	insert := func(ts tableSet, chunks ...[]byte) tableSet {
 		for _, c := range chunks {
 			mt := newMemTable(testMemTableSize)
@@ -194,138 +130,17 @@ func TestTableSetRebase(t *testing.T) {
 		}
 		return ts
 	}
-	upstream := makeTestTableSet([]uint32{1, 1, 3, 7})
+	fullTS := newTableSet(persister)
+	assert.Empty(fullTS.ToSpecs())
+	fullTS = insert(fullTS, testChunks...)
+	fullTS = fullTS.Flatten()
 
-	t.Run("NoCompactions", func(t *testing.T) {
-		assert := assert.New(t)
+	ts := newTableSet(persister)
+	ts = insert(ts, testChunks[0])
+	assert.Equal(1, ts.Size())
+	ts = ts.Flatten()
+	ts = insert(ts, []byte("novel"))
 
-		// Inject an upstream table
-		ts := newFakeTableSet()
-		ts = insert(ts, testChunks[0])
-		assert.Equal(1, ts.Size())
-		ts = ts.Flatten()
-		// Add a novel table
-		ts = insert(ts, []byte("novel"))
-
-		ts = ts.Rebase(upstream.ToSpecs())
-		assert.Equal(upstream.Size()+1, ts.Size())
-	})
-
-	t.Run("WithCompactions", func(t *testing.T) {
-		validate := func(rebased, prebased tableSet, crashers chunkSources, t *testing.T) {
-			assert := assert.New(t)
-			specs := rebased.ToSpecs()
-			for _, novel := range prebased.novel {
-				assert.Contains(specs, tableSpec{novel.hash(), novel.count()})
-			}
-			for _, compacted := range prebased.compacted {
-				assert.Contains(specs, tableSpec{compacted.hash(), compacted.count()})
-			}
-			for _, upstream := range prebased.upstream {
-				assert.Contains(specs, tableSpec{upstream.hash(), upstream.count()})
-			}
-			for _, compactee := range prebased.compactees {
-				assert.NotContains(specs, tableSpec{compactee.hash(), compactee.count()})
-			}
-			for _, crasher := range crashers {
-				assert.Contains(specs, tableSpec{crasher.hash(), crasher.count()})
-			}
-		}
-		t.Run("KeepSingle", func(t *testing.T) {
-			// Start from upstream, do a compaction and add a novel table
-			local := upstream.Flatten()
-			local = local.Compact(&Stats{})
-			assert.True(t, local.Size() < upstream.Size())
-			local = insert(local, []byte("novel"))
-
-			// Mimic some other committer landing additional novel tables upstream
-			interloper := insert(upstream, []byte("party crasher"))
-			crashers := interloper.novel
-
-			rebased := local.Rebase(interloper.ToSpecs())
-
-			// Since interloper didn't drop any of local's compactees, Rebase should retain the compacted table created above.
-			validate(rebased, local, crashers, t)
-		})
-
-		t.Run("KeepMultiple", func(t *testing.T) {
-			// Start from upstream, do a couple of compactions
-			stats := &Stats{}
-			local := upstream.Flatten()
-			local = local.Compact(stats)
-
-			assert.True(t, local.Size() >= 2)
-			local = local.Compact(stats)
-			local = insert(local, []byte("novel"))
-
-			// Mimic some other committer landing additional novel tables upstream
-			interloper := insert(upstream, []byte("party crasher"))
-			crashers := interloper.novel
-
-			rebased := local.Rebase(interloper.ToSpecs())
-
-			// Since interloper didn't drop any of local's compactees, Rebase should retain the compacted tables created above.
-			validate(rebased, local, crashers, t)
-		})
-
-		t.Run("KeepAcrossMultipleRebases", func(t *testing.T) {
-			// Start from upstream, do a compaction and add a novel table
-			local := upstream.Flatten()
-			local = local.Compact(&Stats{})
-			assert.True(t, local.Size() < upstream.Size())
-			local = insert(local, []byte("novel"))
-
-			// Mimic some other committer landing additional novel tables upstream
-			interloper := insert(upstream, []byte("party crasher"))
-			crashers := interloper.novel
-
-			rebased := local.Rebase(interloper.ToSpecs())
-
-			// Since interloper didn't drop any of local's compactees, Rebase should retain the compacted table created above.
-			validate(rebased, local, crashers, t)
-
-			interloper = insert(interloper, []byte("party crasher 2: electric boogaloo"))
-			crashers = append(crashers, interloper.novel...)
-
-			rebased = local.Rebase(interloper.ToSpecs())
-
-			// Since interloper STILL didn't drop any of local's compactees, Rebase should retain the compacted table created way back before the first rebase.
-			validate(rebased, local, crashers, t)
-		})
-
-		t.Run("Drop", func(t *testing.T) {
-			assert := assert.New(t)
-			// Start from upstream, do a compaction and add a novel table
-			local := upstream.Flatten()
-			local = local.Compact(&Stats{})
-			assert.True(local.Size() < upstream.Size())
-			local = insert(local, []byte("novel"))
-
-			// Mimic some other committer dropping tables upstream (due to e.g. compaction or garbage collection)
-			interloper := insert(upstream, []byte("party crasher")).Flatten()
-			for i, up := range interloper.upstream {
-				if up.hash() == local.compactees[0].hash() {
-					if i == len(interloper.upstream)-1 {
-						interloper.upstream = interloper.upstream[:i]
-					} else {
-						interloper.upstream = append(interloper.upstream[:i], interloper.upstream[i+1:]...)
-					}
-					break
-				}
-			}
-
-			rebased := local.Rebase(interloper.ToSpecs())
-
-			// rebased should retain all novel tables...
-			specs := rebased.ToSpecs()
-			for _, novel := range local.novel {
-				assert.Contains(specs, tableSpec{novel.hash(), novel.count()})
-			}
-			// ...but drop the compacted tables, and take upstream from interloper.
-			assert.Empty(rebased.compacted)
-			for _, upstream := range interloper.upstream {
-				assert.Contains(specs, tableSpec{upstream.hash(), upstream.count()})
-			}
-		})
-	})
+	ts = ts.Rebase(fullTS.ToSpecs())
+	assert.Equal(4, ts.Size())
 }


### PR DESCRIPTION
Previously, every NomsBlockStore instance decided when to conjoin
tables (and which to conjoin) entirely on its own, which led to A LOT
of concurrent conjoining that would mostly be wasted effort, as one
instance would win the race and then all the rest would drop their
work on the floor, rebase, and continue. This patch introduces a
'conjoiner' that is either process-global, or owned by one of the NBS
factory objects you can create. Now, NBS instances vended by a given
factory call this single conjoiner during Commit(), asking it to
perform a conjoin if necessary. If a conjoin is already underway, the
conjoiner blocks the caller until it's finished and then
returns. Whether the conjoin was triggered at the caller's request, or
the caller got to opportunistically piggyback on a conjoin already in
progress, the caller must rebase after Conjoin() returns.

Fixes #3422