### PR TITLE
maxTable nit-picking

### DIFF
--- a/go/nbs/factory.go
+++ b/go/nbs/factory.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	defaultAWSReadLimit = 1024
+	awsMaxTables        = 128
 )
 
 type AWSStoreFactory struct {
@@ -44,7 +45,7 @@ func NewAWSStoreFactory(sess *session.Session, table, bucket string, indexCacheS
 			make(chan struct{}, defaultAWSReadLimit),
 		},
 		table,
-		newAsyncConjoiner(defaultMaxTables),
+		newAsyncConjoiner(awsMaxTables),
 	}
 }
 
@@ -73,7 +74,7 @@ func checkDir(dir string) error {
 	return nil
 }
 
-func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxTables int) chunks.Factory {
+func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxOpenFiles int) chunks.Factory {
 	err := checkDir(dir)
 	d.PanicIfError(err)
 
@@ -81,8 +82,8 @@ func NewLocalStoreFactory(dir string, indexCacheSize uint64, maxTables int) chun
 	if indexCacheSize > 0 {
 		indexCache = newIndexCache(indexCacheSize)
 	}
-	fc := newFDCache(maxTables)
-	return &LocalStoreFactory{dir, fc, indexCache, newAsyncConjoiner(maxTables)}
+	fc := newFDCache(maxOpenFiles)
+	return &LocalStoreFactory{dir, fc, indexCache, newAsyncConjoiner(defaultMaxTables)}
 }
 
 func (lsf *LocalStoreFactory) CreateStore(ns string) chunks.ChunkStore {

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -26,7 +26,7 @@ const (
 	StorageVersion = "4"
 
 	defaultMemTableSize uint64 = (1 << 20) * 128 // 128MB
-	defaultMaxTables           = 128
+	defaultMaxTables           = 256
 
 	defaultIndexCacheSize = (1 << 20) * 8 // 8MB
 )


### PR DESCRIPTION
Thinking more about it, there's no current need for a consumer to *set* max tables for the file backend (one could imagine it for tuning purposes, but we're not there). However, we now have a more meaningful control over max open file handles, so that's now configured.

Also, while we're picking numbers of out thin air, 128 tends to keep the manifest < 1 read on dynamo, but seems a tad small for file, which has no such limit. setting file 2x as large.