### PR TITLE
Simplify Pull()

### DIFF
--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -83,7 +83,7 @@ func runSync(args []string) int {
 	nonFF := false
 	err = d.Try(func() {
 		defer profile.MaybeStartProfile().Stop()
-		datas.PullWithFlush(sourceStore, sinkDB, sourceRef, progressCh)
+		datas.Pull(sourceStore, sinkDB, sourceRef, progressCh)
 
 		var err error
 		sinkDataset, err = sinkDB.FastForward(sinkDataset, sourceRef)

--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -64,18 +64,17 @@ func runSync(args []string) int {
 		var last datas.PullProgress
 
 		for info := range progressCh {
+			last = info
 			if info.KnownCount == 1 {
 				// It's better to print "up to date" than "0% (0/1); 100% (1/1)".
 				continue
 			}
 
-			last = info
 			if status.WillPrint() {
 				pct := 100.0 * float64(info.DoneCount) / float64(info.KnownCount)
 				status.Printf("Syncing - %.2f%% (%s/s)", pct, bytesPerSec(info.ApproxWrittenBytes, start))
 			}
 		}
-
 		lastProgressCh <- last
 	}()
 
@@ -84,7 +83,7 @@ func runSync(args []string) int {
 	nonFF := false
 	err = d.Try(func() {
 		defer profile.MaybeStartProfile().Stop()
-		datas.PullWithFlush(sourceStore, sinkDB, sourceRef, sinkRef, p, progressCh)
+		datas.PullWithFlush(sourceStore, sinkDB, sourceRef, progressCh)
 
 		var err error
 		sinkDataset, err = sinkDB.FastForward(sinkDataset, sourceRef)

--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -23,12 +23,12 @@ type ChunkStore interface {
 	GetMany(hashes hash.HashSet, foundChunks chan *Chunk)
 
 	// Returns true iff the value at the address |h| is contained in the
-	// source
+	// store
 	Has(h hash.Hash) bool
 
 	// Returns a new HashSet containing any members of |hashes| that are
-	// present in the source.
-	HasMany(hashes hash.HashSet) (present hash.HashSet)
+	// absent from the store.
+	HasMany(hashes hash.HashSet) (absent hash.HashSet)
 
 	// Put caches c in the ChunkSource. Upon return, c must be visible to
 	// subsequent Get and Has calls, but must not be persistent until a call

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -124,13 +124,13 @@ func (ms *MemoryStoreView) Has(h hash.Hash) bool {
 }
 
 func (ms *MemoryStoreView) HasMany(hashes hash.HashSet) hash.HashSet {
-	present := hash.HashSet{}
+	absent := hash.HashSet{}
 	for h := range hashes {
-		if ms.Has(h) {
-			present.Insert(h)
+		if !ms.Has(h) {
+			absent.Insert(h)
 		}
 	}
-	return present
+	return absent
 }
 
 func (ms *MemoryStoreView) Version() string {

--- a/go/chunks/remote_requests_test.go
+++ b/go/chunks/remote_requests_test.go
@@ -35,9 +35,9 @@ func TestGetRequestBatch(t *testing.T) {
 	req4chan := make(chan *Chunk, 1)
 
 	batch := ReadBatch{
-		r0: []OutstandingRequest{OutstandingHas(req0chan), OutstandingGet(req1chan)},
-		h1: []OutstandingRequest{OutstandingHas(req2chan)},
-		h2: []OutstandingRequest{OutstandingHas(req3chan), OutstandingGet(req4chan)},
+		r0: []OutstandingRequest{OutstandingAbsent(req0chan), OutstandingGet(req1chan)},
+		h1: []OutstandingRequest{OutstandingAbsent(req2chan)},
+		h2: []OutstandingRequest{OutstandingAbsent(req3chan), OutstandingGet(req4chan)},
 	}
 	go func() {
 		for requestedHash, reqs := range batch {
@@ -63,10 +63,10 @@ func TestGetRequestBatch(t *testing.T) {
 		assert.EqualValues(c2.Hash(), c.Hash())
 	}
 
-	assert.Equal(1, r1True)
-	assert.Equal(0, r1False)
-	assert.Equal(1, r2True)
-	assert.Equal(0, r2False)
+	assert.Equal(0, r1True)
+	assert.Equal(1, r1False)
+	assert.Equal(0, r2True)
+	assert.Equal(1, r2False)
 
 	go batch.Close()
 	var r0True, r0False int
@@ -76,8 +76,8 @@ func TestGetRequestBatch(t *testing.T) {
 	for c := range req1chan {
 		assert.EqualValues(EmptyChunk.Hash(), c.Hash())
 	}
-	assert.Equal(0, r0True)
-	assert.Equal(1, r0False)
+	assert.Equal(1, r0True)
+	assert.Equal(0, r0False)
 }
 
 func TestGetManyRequestBatch(t *testing.T) {
@@ -122,7 +122,7 @@ func TestGetManyRequestBatch(t *testing.T) {
 	assert.True(hashes.Has(h0))
 }
 
-func TestHasManyRequestBatch(t *testing.T) {
+func TestAbsentManyRequestBatch(t *testing.T) {
 	assert := assert.New(t)
 	h0 := hash.Parse("00000000000000000000000000000000")
 	c1 := NewChunk([]byte("abc"))
@@ -136,7 +136,7 @@ func TestHasManyRequestBatch(t *testing.T) {
 	wg.Add(len(hashes))
 	go func() { wg.Wait(); close(found) }()
 
-	req := NewHasManyRequest(hashes, wg, found)
+	req := NewAbsentManyRequest(hashes, wg, found)
 	batch := ReadBatch{}
 	for h := range req.Hashes() {
 		batch[h] = []OutstandingRequest{req.Outstanding()}

--- a/go/constants/version.go
+++ b/go/constants/version.go
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-const NomsVersion = "7.9"
+const NomsVersion = "7.10"
 const NOMS_VERSION_NEXT_ENV_NAME = "NOMS_VERSION_NEXT"
 const NOMS_VERSION_NEXT_ENV_VALUE = "1"
 

--- a/go/datas/completeness_checker.go
+++ b/go/datas/completeness_checker.go
@@ -31,13 +31,7 @@ func (cc *completenessChecker) AddRefs(v types.Value) {
 // PanicIfDangling panics if any refs in unresolved point to chunks not
 // present in cs.
 func (cc *completenessChecker) PanicIfDangling(cs chunks.ChunkStore) {
-	present := cs.HasMany(cc.unresolved)
-	absent := hash.HashSlice{}
-	for h := range cc.unresolved {
-		if !present.Has(h) {
-			absent = append(absent, h)
-		}
-	}
+	absent := cs.HasMany(cc.unresolved)
 	if len(absent) != 0 {
 		d.Panic("Found dangling references to %v", absent)
 	}

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -327,15 +327,8 @@ func (hcs *httpChunkStore) hasRefs(hashes hash.HashSet, batch chunks.ReadBatch) 
 	scanner.Split(bufio.ScanWords)
 	for scanner.Scan() {
 		h := hash.Parse(scanner.Text())
-		d.PanicIfFalse(scanner.Scan())
-		if scanner.Text() == "false" {
-			for _, outstanding := range batch[h] {
-				outstanding.Satisfy(h, &chunks.EmptyChunk)
-			}
-		} else {
-			for _, outstanding := range batch[h] {
-				outstanding.Fail()
-			}
+		for _, outstanding := range batch[h] {
+			outstanding.Satisfy(h, &chunks.EmptyChunk)
 		}
 		delete(batch, h)
 	}

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -178,37 +178,33 @@ func (hcs *httpChunkStore) Has(h hash.Hash) bool {
 
 	ch := make(chan bool)
 	hcs.requestWg.Add(1)
-	hcs.hasQueue <- chunks.NewHasRequest(h, ch)
+	hcs.hasQueue <- chunks.NewAbsentRequest(h, ch)
 	return <-ch
 }
 
-func (hcs *httpChunkStore) HasMany(hashes hash.HashSet) (present hash.HashSet) {
+func (hcs *httpChunkStore) HasMany(hashes hash.HashSet) (absent hash.HashSet) {
+	var remaining hash.HashSet
 	func() {
 		hcs.cacheMu.RLock()
 		defer hcs.cacheMu.RUnlock()
-		present = hcs.unwrittenPuts.HasMany(hashes)
+		remaining = hcs.unwrittenPuts.HasMany(hashes)
 	}()
-	remaining := hash.HashSet{}
-	for h := range hashes {
-		if !present.Has(h) {
-			remaining.Insert(h)
-		}
-	}
 	if len(remaining) == 0 {
-		return present
+		return remaining
 	}
 
 	foundChunks := make(chan hash.Hash)
 	wg := &sync.WaitGroup{}
 	wg.Add(len(remaining))
 	hcs.requestWg.Add(1)
-	hcs.hasQueue <- chunks.NewHasManyRequest(remaining, wg, foundChunks)
+	hcs.hasQueue <- chunks.NewAbsentManyRequest(remaining, wg, foundChunks)
 	go func() { defer close(foundChunks); wg.Wait() }()
 
+	absent = hash.HashSet{}
 	for found := range foundChunks {
-		present.Insert(found)
+		absent.Insert(found)
 	}
-	return present
+	return absent
 }
 
 func (hcs *httpChunkStore) batchHasRequests() {
@@ -332,7 +328,7 @@ func (hcs *httpChunkStore) hasRefs(hashes hash.HashSet, batch chunks.ReadBatch) 
 	for scanner.Scan() {
 		h := hash.Parse(scanner.Text())
 		d.PanicIfFalse(scanner.Scan())
-		if scanner.Text() == "true" {
+		if scanner.Text() == "false" {
 			for _, outstanding := range batch[h] {
 				outstanding.Satisfy(h, &chunks.EmptyChunk)
 			}

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -331,13 +331,13 @@ func (suite *HTTPChunkStoreSuite) TestHasMany() {
 	notPresent := chunks.NewChunk([]byte("ghi")).Hash()
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), notPresent)
-	present := suite.http.HasMany(hashes)
+	absent := suite.http.HasMany(hashes)
 
-	suite.Len(present, len(chnx))
+	suite.Len(absent, 1)
 	for _, c := range chnx {
-		suite.True(present.Has(c.Hash()), "%s not present in %v", c.Hash(), present)
+		suite.False(absent.Has(c.Hash()), "%s present in %v", c.Hash(), absent)
 	}
-	suite.False(present.Has(notPresent))
+	suite.True(absent.Has(notPresent))
 }
 
 func (suite *HTTPChunkStoreSuite) TestHasManyAllCached() {
@@ -351,11 +351,11 @@ func (suite *HTTPChunkStoreSuite) TestHasManyAllCached() {
 	persistChunks(suite.serverCS)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash())
-	present := suite.http.HasMany(hashes)
+	absent := suite.http.HasMany(hashes)
 
-	suite.Len(present, len(chnx))
+	suite.Len(absent, 0)
 	for _, c := range chnx {
-		suite.True(present.Has(c.Hash()), "%s not present in %v", c.Hash(), present)
+		suite.False(absent.Has(c.Hash()), "%s present in %v", c.Hash(), absent)
 	}
 }
 
@@ -372,10 +372,11 @@ func (suite *HTTPChunkStoreSuite) TestHasManySomeCached() {
 	suite.http.Put(cached)
 
 	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), cached.Hash())
-	present := suite.http.HasMany(hashes)
+	absent := suite.http.HasMany(hashes)
 
-	suite.Len(present, len(chnx)+1)
+	suite.Len(absent, 0)
 	for _, c := range chnx {
-		suite.True(present.Has(c.Hash()), "%s not present in %v", c.Hash(), present)
+		suite.False(absent.Has(c.Hash()), "%s present in %v", c.Hash(), absent)
 	}
+	suite.False(absent.Has(cached.Hash()), "%s present in %v", cached.Hash(), absent)
 }

--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -7,9 +7,8 @@ package datas
 import (
 	"math"
 	"math/rand"
-	"sort"
-	"sync"
 
+	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
@@ -29,259 +28,63 @@ const bytesWrittenSampleRate = .10
 // validation, which triggers sinkDB reads, which means that the code can no
 // longer tell which reads were caused by Pull() and which by Flush().
 // TODO: Get rid of this (BUG 2982)
-func PullWithFlush(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) {
-	Pull(srcDB, sinkDB, sourceRef, sinkHeadRef, concurrency, progressCh)
+func PullWithFlush(srcDB, sinkDB Database, sourceRef types.Ref, progressCh chan PullProgress) {
+	Pull(srcDB, sinkDB, sourceRef, progressCh)
 	persistChunks(sinkDB.chunkStore())
 }
 
-// Pull objects that descend from sourceRef from srcDB to sinkDB. sinkHeadRef
-// should point to a Commit (in sinkDB) that's an ancestor of sourceRef. This
-// allows the algorithm to figure out which portions of data are already
-// present in sinkDB and skip copying them.
-func Pull(srcDB, sinkDB Database, sourceRef, sinkHeadRef types.Ref, concurrency int, progressCh chan PullProgress) {
-	srcQ, sinkQ := &types.RefByHeight{sourceRef}, &types.RefByHeight{sinkHeadRef}
+// Pull objects that descend from sourceRef from srcDB to sinkDB.
+func Pull(srcDB, sinkDB Database, sourceRef types.Ref, progressCh chan PullProgress) {
+	// Sanity Check
+	d.PanicIfFalse(srcDB.chunkStore().Has(sourceRef.TargetHash()))
 
-	// If the sourceRef points to an object already in sinkDB, there's nothing to do.
 	if sinkDB.chunkStore().Has(sourceRef.TargetHash()) {
-		return
-	}
-
-	// We generally expect that sourceRef descends from sinkHeadRef, so that walking down from sinkHeadRef yields useful hints. If it's not even in the srcDB, then just clear out sinkQ right now and don't bother.
-	if !srcDB.chunkStore().Has(sinkHeadRef.TargetHash()) {
-		sinkQ.PopBack()
-	}
-
-	// traverseWorker below takes refs off of {src,sink,com}Chan, processes them to figure out what reachable refs should be traversed, and then sends the results to {srcRes,sinkRes,comRes}Chan.
-	// sending to (or closing) the 'done' channel causes traverseWorkers to exit.
-	srcChan := make(chan types.Ref)
-	sinkChan := make(chan types.Ref)
-	comChan := make(chan types.Ref)
-	srcResChan := make(chan traverseSourceResult)
-	sinkResChan := make(chan traverseResult)
-	comResChan := make(chan traverseResult)
-	done := make(chan struct{})
-
-	workerWg := &sync.WaitGroup{}
-	defer func() {
-		close(done)
-		workerWg.Wait()
-
-		close(srcChan)
-		close(sinkChan)
-		close(comChan)
-		close(srcResChan)
-		close(sinkResChan)
-		close(comResChan)
-	}()
-	traverseWorker := func() {
-		workerWg.Add(1)
-		go func() {
-			for {
-				select {
-				case srcRef := <-srcChan:
-					// Hook in here to estimate the bytes written to disk during pull (since
-					// srcChan contains all chunks to be written to the sink). Rather than measuring
-					// the serialized, compressed bytes of each chunk, we take a 10% sample.
-					// There's no immediately observable performance benefit to sampling here, but there's
-					// also no appreciable loss in accuracy, so we'll keep it around.
-					takeSample := rand.Float64() < bytesWrittenSampleRate
-					srcResChan <- traverseSource(srcRef, srcDB, sinkDB, takeSample)
-				case sinkRef := <-sinkChan:
-					sinkResChan <- traverseSink(sinkRef, srcDB)
-				case comRef := <-comChan:
-					comResChan <- traverseCommon(comRef, sinkHeadRef, srcDB)
-				case <-done:
-					workerWg.Done()
-					return
-				}
-			}
-		}()
-	}
-	for i := 0; i < concurrency; i++ {
-		traverseWorker()
+		return // already up to date
 	}
 
 	var doneCount, knownCount, approxBytesWritten uint64
-	updateProgress := func(moreDone, moreKnown, moreBytesRead, moreApproxBytesWritten uint64) {
+	updateProgress := func(moreDone, moreKnown, moreApproxBytesWritten uint64) {
 		if progressCh == nil {
 			return
 		}
 		doneCount, knownCount, approxBytesWritten = doneCount+moreDone, knownCount+moreKnown, approxBytesWritten+moreApproxBytesWritten
-		progressCh <- PullProgress{doneCount, knownCount + uint64(srcQ.Len()), approxBytesWritten}
+		progressCh <- PullProgress{doneCount, knownCount, approxBytesWritten}
 	}
+	var sampleSize, sampleCount uint64
 
-	sampleSize := uint64(0)
-	sampleCount := uint64(0)
-	for !srcQ.Empty() {
-		srcRefs, sinkRefs, comRefs := planWork(srcQ, sinkQ)
-		srcWork, sinkWork, comWork := len(srcRefs), len(sinkRefs), len(comRefs)
-		if srcWork+comWork > 0 {
-			updateProgress(0, uint64(srcWork+comWork), 0, 0)
-		}
+	cc := newCompletenessChecker()
+	absent := hash.NewHashSet(sourceRef.TargetHash())
+	for len(absent) != 0 {
+		updateProgress(0, uint64(len(absent)), 0)
 
-		// These goroutines send work to traverseWorkers, blocking when all are busy. They self-terminate when they've sent all they have.
-		go sendWork(srcChan, srcRefs)
-		go sendWork(sinkChan, sinkRefs)
-		go sendWork(comChan, comRefs)
-		//  Don't use srcRefs, sinkRefs, or comRefs after this point. The goroutines above own them.
+		// Concurrently pull all the chunks the sink is missing out of the source
+		// For each chunk, put it into the sink, then decode it into a value so we can later iterate all the refs in the chunk.
+		absentValues := types.ValueSlice{}
+		foundChunks := make(chan *chunks.Chunk)
+		go func() { defer close(foundChunks); srcDB.chunkStore().GetMany(absent, foundChunks) }()
+		for c := range foundChunks {
+			sinkDB.chunkStore().Put(*c)
+			absentValues = append(absentValues, types.DecodeValue(*c, srcDB))
 
-		for srcWork+sinkWork+comWork > 0 {
-			select {
-			case res := <-srcResChan:
-				for _, reachable := range res.reachables {
-					srcQ.PushBack(reachable)
-				}
-				if res.writeBytes > 0 {
-					sampleSize += uint64(res.writeBytes)
-					sampleCount += 1
-				}
-				srcWork--
-
-				updateProgress(1, 0, uint64(res.readBytes), sampleSize/uint64(math.Max(1, float64(sampleCount))))
-			case res := <-sinkResChan:
-				for _, reachable := range res.reachables {
-					sinkQ.PushBack(reachable)
-				}
-				sinkWork--
-			case res := <-comResChan:
-				isHeadOfSink := res.readHash == sinkHeadRef.TargetHash()
-				for _, reachable := range res.reachables {
-					sinkQ.PushBack(reachable)
-					if !isHeadOfSink {
-						srcQ.PushBack(reachable)
-					}
-				}
-				comWork--
-				updateProgress(1, 0, uint64(res.readBytes), 0)
+			// Randomly sample amount of data written
+			if rand.Float64() < bytesWrittenSampleRate {
+				sampleSize += uint64(len(snappy.Encode(nil, c.Data())))
+				sampleCount++
 			}
+			updateProgress(1, 0, sampleSize/uint64(math.Max(1, float64(sampleCount))))
 		}
-		sort.Sort(sinkQ)
-		sort.Sort(srcQ)
-		sinkQ.Unique()
-		srcQ.Unique()
-	}
-}
-
-type traverseResult struct {
-	readHash   hash.Hash
-	reachables types.RefSlice
-	readBytes  int
-}
-
-type traverseSourceResult struct {
-	traverseResult
-	writeBytes int
-}
-
-// planWork deals with three possible situations:
-// - head of srcQ is higher than head of sinkQ
-// - head of sinkQ is higher than head of srcQ
-// - both heads are at the same height
-//
-// As we build up lists of refs to be processed in parallel, we need to avoid blowing past potential common refs. When processing a given Ref, we enumerate Refs of all Chunks that are directly reachable, which must _by definition_ be shorter than the given Ref. This means that, for example, if the queues are the same height we know that nothing can happen that will put more Refs of that height on either queue. In general, if you look at the height of the Ref at the head of a queue, you know that all Refs of that height in the current graph under consideration are already in the queue. Conversely, for any height less than that of the head of the queue, it's possible that Refs of that height remain to be discovered. Given this, we can figure out which Refs are safe to pull off the 'taller' queue in the cases where the heights of the two queues are not equal.
-// If one queue is 'taller' than the other, it's clear that we can process all refs from the taller queue with height greater than the height of the 'shorter' queue. We should also be able to process refs from the taller queue that are of the same height as the shorter queue, as long as we also check to see if they're common to both queues. It is not safe, however, to pull unique items off the shorter queue at this point. It's possible that, in processing some of the Refs from the taller queue, that these Refs will be discovered to be common after all.
-// TODO: Bug 2203
-func planWork(srcQ, sinkQ *types.RefByHeight) (srcRefs, sinkRefs, comRefs types.RefSlice) {
-	srcHt, sinkHt := srcQ.MaxHeight(), sinkQ.MaxHeight()
-	if srcHt > sinkHt {
-		srcRefs = srcQ.PopRefsOfHeight(srcHt)
-		return
-	}
-	if sinkHt > srcHt {
-		sinkRefs = sinkQ.PopRefsOfHeight(sinkHt)
-		return
-	}
-	d.PanicIfFalse(srcHt == sinkHt)
-	srcRefs, comRefs = findCommon(srcQ, sinkQ, srcHt)
-	sinkRefs = sinkQ.PopRefsOfHeight(sinkHt)
-	return
-}
-
-func findCommon(taller, shorter *types.RefByHeight, height uint64) (tallRefs, comRefs types.RefSlice) {
-	d.PanicIfFalse(taller.MaxHeight() == height)
-	d.PanicIfFalse(shorter.MaxHeight() == height)
-	comIndices := []int{}
-	// Walk through shorter and taller in tandem from the back (where the tallest Refs are). Refs from taller that go into a work queue are popped off directly, but doing so to shorter would mess up shortIdx. So, instead just keep track of the indices of common refs and drop them from shorter at the end.
-	for shortIdx := shorter.Len() - 1; !taller.Empty() && taller.MaxHeight() == height; {
-		tallPeek := taller.PeekEnd()
-		shortPeek := shorter.PeekAt(shortIdx)
-		if types.HeightOrder(tallPeek, shortPeek) {
-			tallRefs = append(tallRefs, taller.PopBack())
-			continue
+		// Descend to the next level of the tree by gathering up the pointers from every chunk we just pulled over to the sink in the loop above
+		nextLevel := hash.HashSet{}
+		for _, v := range absentValues {
+			cc.AddRefs(v)
+			v.WalkRefs(func(r types.Ref) {
+				nextLevel.Insert(r.TargetHash())
+			})
 		}
-		if shortPeek.Equals(tallPeek) {
-			comIndices = append(comIndices, shortIdx)
-			comRefs = append(comRefs, taller.PopBack())
-		}
-		shortIdx--
+
+		// Ask sinkDB which of the next level's hashes it doesn't have.
+		absent = sinkDB.chunkStore().HasMany(nextLevel)
 	}
-	shorter.DropIndices(comIndices)
-	return
-}
 
-func sendWork(ch chan<- types.Ref, refs types.RefSlice) {
-	for _, r := range refs {
-		ch <- r
-	}
-}
-
-type hintCache map[hash.Hash]hash.Hash
-
-func getChunks(v types.Value) (chunks []types.Ref) {
-	v.WalkRefs(func(ref types.Ref) {
-		chunks = append(chunks, ref)
-	})
-	return
-}
-
-func traverseSource(srcRef types.Ref, srcDB, sinkDB Database, estimateBytesWritten bool) traverseSourceResult {
-	h := srcRef.TargetHash()
-	if !sinkDB.chunkStore().Has(h) {
-		c := srcDB.chunkStore().Get(h)
-		v := types.DecodeValue(c, srcDB)
-		if v == nil {
-			d.Panic("Expected decoded chunk to be non-nil.")
-		}
-		sinkDB.chunkStore().Put(c)
-		bytesWritten := 0
-		if estimateBytesWritten {
-			// TODO: Probably better to hide this behind the ChunkStore abstraction since
-			// write size is implementation specific.
-			bytesWritten = len(snappy.Encode(nil, c.Data()))
-		}
-		ts := traverseSourceResult{traverseResult{h, getChunks(v), len(c.Data())}, bytesWritten}
-		return ts
-	}
-	return traverseSourceResult{}
-}
-
-func traverseSink(sinkRef types.Ref, db Database) traverseResult {
-	if sinkRef.Height() > 1 {
-		return traverseResult{sinkRef.TargetHash(), getChunks(sinkRef.TargetValue(db)), 0}
-	}
-	return traverseResult{}
-}
-
-func traverseCommon(comRef, sinkHead types.Ref, db Database) traverseResult {
-	// TODO: Add IsRefOfCommit?
-	if comRef.Height() > 1 && IsRefOfCommitType(types.TypeOf(comRef)) {
-		commit := comRef.TargetValue(db).(types.Struct)
-		// We don't want to traverse the parents of sinkHead, but we still want to traverse its Value on the sinkDB side. We also still want to traverse all children, in both the srcDB and sinkDB, of any common Commit that is not at the Head of sinkDB.
-		exclusionSet := types.NewSet()
-		if comRef.Equals(sinkHead) {
-			exclusionSet = commit.Get(ParentsField).(types.Set)
-		}
-		chunks := types.RefSlice(getChunks(commit))
-		for i := 0; i < len(chunks); {
-			if exclusionSet.Has(chunks[i]) {
-				end := len(chunks) - 1
-				chunks.Swap(i, end)
-				chunks = chunks[:end]
-				continue
-			}
-			i++
-		}
-		return traverseResult{comRef.TargetHash(), chunks, 0}
-	}
-	return traverseResult{}
+	cc.PanicIfDangling(sinkDB.chunkStore())
 }

--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -154,6 +154,27 @@ func (suite *BlockStoreSuite) TestChunkStoreGetMany() {
 	suite.True(found.Equals(hashes))
 }
 
+func (suite *BlockStoreSuite) TestChunkStoreHasMany() {
+	chnx := []chunks.Chunk{
+		chunks.NewChunk([]byte("abc")),
+		chunks.NewChunk([]byte("def")),
+	}
+	for _, c := range chnx {
+		suite.store.Put(c)
+	}
+	suite.store.Commit(chnx[0].Hash(), suite.store.Root()) // Commit writes
+	notPresent := chunks.NewChunk([]byte("ghi")).Hash()
+
+	hashes := hash.NewHashSet(chnx[0].Hash(), chnx[1].Hash(), notPresent)
+	absent := suite.store.HasMany(hashes)
+
+	suite.Len(absent, 1)
+	for _, c := range chnx {
+		suite.False(absent.Has(c.Hash()), "%s present in %v", c.Hash(), absent)
+	}
+	suite.True(absent.Has(notPresent))
+}
+
 func (suite *BlockStoreSuite) TestChunkStoreExtractChunks() {
 	input1, input2 := make([]byte, testMemTableSize/2+1), make([]byte, testMemTableSize/2+1)
 	rand.Read(input1)

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-4:7.9:nh54p8hlk0c6c5q9mf8gb33pt9r9poc0:c1uoqa08f12o0abqgv2lvavmppuc3kg4:7s84n5m4b7i2n1r0vr0ksaemr9qjnhdl:2:ullneu8fijlfnhhmq82dtco4n60gupc2:2
+4:7.10:nh54p8hlk0c6c5q9mf8gb33pt9r9poc0:c1uoqa08f12o0abqgv2lvavmppuc3kg4:7s84n5m4b7i2n1r0vr0ksaemr9qjnhdl:2:ullneu8fijlfnhhmq82dtco4n60gupc2:2


### PR DESCRIPTION
In an NBS world, bulk 'has' checks are waaaay cheaper than they used
to be. In light of this, we can toss out the complex logic we were
using in Pull() -- which basically existed for no reason other than to
avoid doing 'has' checks. Now, the code basically just descends down a
tree of chunks breadth-first, using HasMany() at each level to figure
out which chunks are not yet in the sink all at once, and GetMany() to
pull them from the source in bulk.

Fixes #3182, Towards #3384