### PR TITLE
Add Stats() to Database

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -54,6 +54,11 @@ type ChunkStore interface {
 	// the cached root to current?
 	Commit(current, last hash.Hash) bool
 
+	// Stats may return some kind of struct that reports statistics about the
+	// ChunkStore instance. The type is implementation-dependent, and impls
+	// may return nil
+	Stats() interface{}
+
 	io.Closer
 }
 

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -179,6 +179,10 @@ func (ms *MemoryStoreView) Commit(current, last hash.Hash) bool {
 	return success
 }
 
+func (ms *MemoryStoreView) Stats() interface{} {
+	return nil
+}
+
 func (ms *MemoryStoreView) Close() error {
 	return nil
 }

--- a/go/datas/database.go
+++ b/go/datas/database.go
@@ -99,6 +99,11 @@ type Database interface {
 	// Regardless, Datasets() is updated to match backing storage upon return.
 	FastForward(ds Dataset, newHeadRef types.Ref) (Dataset, error)
 
+	// Stats may return some kind of struct that reports statistics about the
+	// ChunkStore that backs this Database instance. The type is
+	// implementation-dependent, and impls may return nil
+	Stats() interface{}
+
 	// chunkStore returns the ChunkStore used to read and write
 	// groups of values to the database efficiently. This interface is a low-
 	// level detail of the database that should infrequently be needed by

--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -42,6 +42,10 @@ func (db *database) chunkStore() chunks.ChunkStore {
 	return db.ChunkStore()
 }
 
+func (db *database) Stats() interface{} {
+	return db.ChunkStore().Stats()
+}
+
 func (db *database) Datasets() types.Map {
 	rootHash := db.rt.Root()
 	if rootHash.IsEmpty() {

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -119,6 +119,10 @@ func (hcs *httpChunkStore) Close() (e error) {
 	return
 }
 
+func (hcs *httpChunkStore) Stats() interface{} {
+	return nil
+}
+
 func (hcs *httpChunkStore) Get(h hash.Hash) chunks.Chunk {
 	checkCache := func(h hash.Hash) chunks.Chunk {
 		hcs.cacheMu.RLock()

--- a/go/nbs/benchmarks/file_block_store.go
+++ b/go/nbs/benchmarks/file_block_store.go
@@ -56,6 +56,10 @@ func (fb fileBlockStore) Close() error {
 
 func (fb fileBlockStore) Rebase() {}
 
+func (fb fileBlockStore) Stats() interface{} {
+	return nil
+}
+
 func (fb fileBlockStore) Root() hash.Hash {
 	return hash.Hash{}
 }

--- a/go/nbs/benchmarks/null_block_store.go
+++ b/go/nbs/benchmarks/null_block_store.go
@@ -47,6 +47,10 @@ func (nb nullBlockStore) Close() error {
 
 func (nb nullBlockStore) Rebase() {}
 
+func (nb nullBlockStore) Stats() interface{} {
+	return nil
+}
+
 func (nb nullBlockStore) Root() hash.Hash {
 	return hash.Hash{}
 }

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -434,6 +434,6 @@ func (nbs *NomsBlockStore) Close() (err error) {
 	return
 }
 
-func (nbs *NomsBlockStore) Stats() Stats {
+func (nbs *NomsBlockStore) Stats() interface{} {
 	return *nbs.stats
 }


### PR DESCRIPTION
This just returns interface{}, allowing underlying ChunkStore
implementations to return whatever kind of stats struct they want.

Fixes #3493