### PR TITLE
Dataset caches HeadValue rather than HeadRef

### DIFF
--- a/go/datas/database_common.go
+++ b/go/datas/database_common.go
@@ -59,12 +59,12 @@ func (db *database) GetDataset(datasetID string) Dataset {
 	if !DatasetFullRe.MatchString(datasetID) {
 		d.Panic("Invalid dataset ID: %s", datasetID)
 	}
+	var head types.Value
 	if r, ok := db.Datasets().MaybeGet(types.String(datasetID)); ok {
-		head := r.(types.Ref).TargetValue(db)
-		d.PanicIfFalse(IsCommit(head))
-		return Dataset{db, datasetID, types.NewRef(head)}
+		head = r.(types.Ref).TargetValue(db)
 	}
-	return Dataset{db: db, id: datasetID}
+
+	return newDataset(db, datasetID, head)
 }
 
 func (db *database) Rebase() {


### PR DESCRIPTION
This is kind of minor, but it's silly that db.GetDataset was reading the head value then dropping it on the floor. Instead, cache it inside Dataset rather than the ref. As a side-benefit, this also creates the `HeadRef` lazily, which is nice because it's rarely needed and the type is presently expensive to compute.