### PR TITLE
NBS: Add more tests for table cache usage in s3TablePersister

### DIFF
--- a/go/nbs/fs_table_cache.go
+++ b/go/nbs/fs_table_cache.go
@@ -16,6 +16,12 @@ import (
 	"github.com/attic-labs/noms/go/util/sizecache"
 )
 
+type tableCache interface {
+	checkout(h addr) io.ReaderAt
+	checkin(h addr)
+	store(h addr, data io.Reader, size uint64)
+}
+
 type fsTableCache struct {
 	dir   string
 	cache *sizecache.SizeCache

--- a/go/nbs/s3_fake_test.go
+++ b/go/nbs/s3_fake_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/attic-labs/noms/go/d"
@@ -28,9 +29,9 @@ func (m mockAWSError) Code() string    { return string(m) }
 func (m mockAWSError) Message() string { return string(m) }
 func (m mockAWSError) OrigErr() error  { return nil }
 
-func makeFakeS3(a *assert.Assertions) *fakeS3 {
+func makeFakeS3(t *testing.T) *fakeS3 {
 	return &fakeS3{
-		assert:     a,
+		assert:     assert.New(t),
 		data:       map[string][]byte{},
 		inProgress: map[string]fakeS3Multipart{},
 		parts:      map[string][]byte{},

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -32,7 +32,7 @@ type s3TablePersister struct {
 	targetPartSize, minPartSize, maxPartSize uint64
 	indexCache                               *indexCache
 	readRl                                   chan struct{}
-	tc                                       *fsTableCache
+	tc                                       tableCache
 }
 
 func (s3p s3TablePersister) Open(name addr, chunkCount uint32) chunkSource {
@@ -45,10 +45,7 @@ type s3UploadedPart struct {
 }
 
 func (s3p s3TablePersister) Persist(mt *memTable, haver chunkReader, stats *Stats) chunkSource {
-	return s3p.persistTable(mt.write(haver, stats))
-}
-
-func (s3p s3TablePersister) persistTable(name addr, data []byte, chunkCount uint32) chunkSource {
+	name, data, chunkCount := mt.write(haver, stats)
 	if chunkCount == 0 {
 		return emptyChunkSource{}
 	}

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -30,7 +30,7 @@ type s3TableReader struct {
 	bucket string
 	h      addr
 	readRl chan struct{}
-	tc     *fsTableCache
+	tc     tableCache
 }
 
 type s3svc interface {
@@ -43,7 +43,7 @@ type s3svc interface {
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
-func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *indexCache, readRl chan struct{}, tc *fsTableCache) chunkSource {
+func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *indexCache, readRl chan struct{}, tc tableCache) chunkSource {
 	source := &s3TableReader{s3: s3, bucket: bucket, h: h, readRl: readRl, tc: tc}
 
 	var index tableIndex


### PR DESCRIPTION
These tests verify that tables get cached on Perist(), and that
tableReaders vended by s3TablePersister correctly use the cache.