### PR TITLE
Marshal: Add a way to define the struct name

### DIFF
--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -75,7 +75,9 @@ import (
 //   Field int `noms:",omitempty"
 //
 // The name of the Noms struct is the name of the Go struct where the first
-// character is changed to upper case.
+// character is changed to upper case. You can also implement the
+// StructNameMarshaler interface to get more control over the actual struct
+// name.
 //
 // Anonymous struct fields are usually marshaled as if their inner exported
 // fields were fields in the outer struct, subject to the usual Go visibility.

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -125,7 +125,7 @@ type Marshaler interface {
 	MarshalNoms() (val types.Value, err error)
 }
 
-// StructNameMarshaler is an interface that can be implemented to to define the
+// StructNameMarshaler is an interface that can be implemented to define the
 // name of a Noms struct.
 type StructNameMarshaler interface {
 	MarshalNomsStructName() string

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
 )
 
@@ -124,6 +123,12 @@ type Marshaler interface {
 	MarshalNoms() (val types.Value, err error)
 }
 
+// StructNameMarshaler is an interface that can be implemented to to define the
+// name of a Noms struct.
+type StructNameMarshaler interface {
+	MarshalNomsStructName() string
+}
+
 // UnsupportedTypeError is returned by encode when attempting to encode a type
 // that isn't supported.
 type UnsupportedTypeError struct {
@@ -171,6 +176,7 @@ type nomsTags struct {
 var nomsValueInterface = reflect.TypeOf((*types.Value)(nil)).Elem()
 var emptyInterface = reflect.TypeOf((*interface{})(nil)).Elem()
 var marshalerInterface = reflect.TypeOf((*Marshaler)(nil)).Elem()
+var structNameMarshalerInterface = reflect.TypeOf((*StructNameMarshaler)(nil)).Elem()
 
 type encoderFunc func(v reflect.Value) types.Value
 
@@ -256,6 +262,14 @@ func typeEncoder(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsT
 	}
 }
 
+func getStructName(t reflect.Type) string {
+	if t.Implements(structNameMarshalerInterface) {
+		v := reflect.Zero(t)
+		return v.Interface().(StructNameMarshaler).MarshalNomsStructName()
+	}
+	return strings.Title(t.Name())
+}
+
 func structEncoder(t reflect.Type, seenStructs map[string]reflect.Type) encoderFunc {
 	if t.Implements(nomsValueInterface) {
 		return nomsValueEncoder
@@ -266,15 +280,17 @@ func structEncoder(t reflect.Type, seenStructs map[string]reflect.Type) encoderF
 		return e
 	}
 
+	structName := getStructName(t)
+
 	seenStructs[t.Name()] = t
-	fields, _, knownShape, originalFieldIndex := typeFields(t, seenStructs, false, false)
+	fields, knownShape, originalFieldIndex := typeFields(t, seenStructs, false, false)
 	if knownShape {
 		fieldNames := make([]string, len(fields))
 		for i, f := range fields {
 			fieldNames[i] = f.name
 		}
 
-		structTemplate := types.MakeStructTemplate(strings.Title(t.Name()), fieldNames)
+		structTemplate := types.MakeStructTemplate(structName, fieldNames)
 		e = func(v reflect.Value) types.Value {
 			values := make(types.ValueSlice, len(fields))
 			for i, f := range fields {
@@ -285,7 +301,6 @@ func structEncoder(t reflect.Type, seenStructs map[string]reflect.Type) encoderF
 	} else if originalFieldIndex == nil {
 		// Slower path: cannot precompute the Noms type since there are Noms collections,
 		// but at least there are a set number of fields.
-		name := strings.Title(t.Name())
 		e = func(v reflect.Value) types.Value {
 			data := make(types.StructData, len(fields))
 			for _, f := range fields {
@@ -295,7 +310,7 @@ func structEncoder(t reflect.Type, seenStructs map[string]reflect.Type) encoderF
 				}
 				data[f.name] = f.encoder(fv)
 			}
-			return types.NewStruct(name, data)
+			return types.NewStruct(structName, data)
 		}
 	} else {
 		// Slowest path - we are extending some other struct. We need to start with the
@@ -304,7 +319,7 @@ func structEncoder(t reflect.Type, seenStructs map[string]reflect.Type) encoderF
 			fv := v.FieldByIndex(originalFieldIndex)
 			ret := fv.Interface().(types.Struct)
 			if ret.IsZeroValue() {
-				ret = types.NewStruct(t.Name(), nil)
+				ret = types.NewStruct(structName, nil)
 			}
 			for _, f := range fields {
 				fv := v.FieldByIndex(f.index)
@@ -427,7 +442,7 @@ func validateField(f reflect.StructField, t reflect.Type) {
 	}
 }
 
-func typeFields(t reflect.Type, seenStructs map[string]reflect.Type, computeType, embedded bool) (fields fieldSlice, structType *types.Type, knownShape bool, originalFieldIndex []int) {
+func typeFields(t reflect.Type, seenStructs map[string]reflect.Type, computeType, embedded bool) (fields fieldSlice, knownShape bool, originalFieldIndex []int) {
 	knownShape = true
 	for i := 0; i < t.NumField(); i++ {
 		index := make([]int, 1)
@@ -444,14 +459,11 @@ func typeFields(t reflect.Type, seenStructs map[string]reflect.Type, computeType
 		}
 
 		if f.Anonymous && f.PkgPath == "" && !tags.hasName {
-			embeddedFields, embeddedStructType, embeddedKnownShape, embeddedOriginalFieldIndex := typeFields(f.Type, seenStructs, computeType, true)
+			embeddedFields, embeddedKnownShape, embeddedOriginalFieldIndex := typeFields(f.Type, seenStructs, computeType, true)
 			if embeddedOriginalFieldIndex != nil {
 				originalFieldIndex = append(index, embeddedOriginalFieldIndex...)
 			}
 			knownShape = knownShape && embeddedKnownShape
-
-			// Should not compute the struct type as we traverse embedded structs.
-			d.PanicIfFalse(embeddedStructType == nil)
 
 			for _, ef := range embeddedFields {
 				ef.index = append(index, ef.index...)
@@ -483,25 +495,10 @@ func typeFields(t reflect.Type, seenStructs map[string]reflect.Type, computeType
 		})
 	}
 
-	if embedded {
-		// fields gets sorted once we return to the caller when computing the
-		// embedded fields.
-		return
+	if !embedded {
+		sort.Sort(fields)
 	}
-
-	sort.Sort(fields)
-
-	if knownShape && computeType {
-		structTypeFields := make([]types.StructField, len(fields))
-		for i, fs := range fields {
-			structTypeFields[i] = types.StructField{
-				Name:     fs.name,
-				Type:     fs.nomsType,
-				Optional: fs.omitEmpty,
-			}
-		}
-		structType = types.MakeStructType(strings.Title(t.Name()), structTypeFields...)
-	}
+	// If embedded then the fields gets sorted once we return to the caller.
 
 	return
 }

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -1010,3 +1010,41 @@ func TestMarshalerErrors(t *testing.T) {
 	m3 := panicsMarshaler{}
 	assert.Panics(func() { Marshal(m3) })
 }
+
+type TestStructWithNameImpl struct {
+	X int
+}
+
+func (ts TestStructWithNameImpl) MarshalNomsStructName() string {
+	return "A"
+}
+func TestMarshalStructName(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := TestStructWithNameImpl{
+		X: 1,
+	}
+	v := MustMarshal(ts)
+	assert.True(types.NewStruct("A", types.StructData{
+		"x": types.Number(1),
+	}).Equals(v), types.EncodedValue(v))
+}
+
+type TestStructWithNameImpl2 struct {
+	X int
+}
+
+func (ts TestStructWithNameImpl2) MarshalNomsStructName() string {
+	return ""
+}
+func TestMarshalStructName2(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := TestStructWithNameImpl2{
+		X: 1,
+	}
+	v := MustMarshal(ts)
+	assert.True(types.NewStruct("", types.StructData{
+		"x": types.Number(1),
+	}).Equals(v), types.EncodedValue(v))
+}

--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -157,6 +157,20 @@ func structEncodeType(t reflect.Type, seenStructs map[string]reflect.Type) *type
 		seenStructs[name] = t
 	}
 
-	_, structType, _, _ := typeFields(t, seenStructs, true, false)
+	fields, knownShape, _ := typeFields(t, seenStructs, true, false)
+
+	var structType *types.Type
+	if knownShape {
+		structTypeFields := make([]types.StructField, len(fields))
+		for i, fs := range fields {
+			structTypeFields[i] = types.StructField{
+				Name:     fs.name,
+				Type:     fs.nomsType,
+				Optional: fs.omitEmpty,
+			}
+		}
+		structType = types.MakeStructType(getStructName(t), structTypeFields...)
+	}
+
 	return structType
 }

--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -17,7 +17,8 @@ import (
 // MarshalType computes a Noms type from a Go type
 //
 // The rules for MarshalType is the same as for Marshal, except for omitempty
-// is ignored since that cannot be determined statically.
+// which leads to an optional field since it depends on the runtime value and
+// can lead to the property not being present.
 //
 // If a Go struct contains a noms tag with original the field is skipped since
 // the Noms type depends on the original Noms value which is not available.

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -542,3 +542,19 @@ func TestTypeMarshalerErrors(t *testing.T) {
 	var m3 panicsMarshaler
 	assert.Panics(func() { MarshalType(m3) })
 }
+
+func TestMarshalTypeStructName(t *testing.T) {
+	assert := assert.New(t)
+
+	var ts TestStructWithNameImpl
+	typ := MustMarshalType(ts)
+	assert.True(types.MakeStructType("A", types.StructField{"x", types.NumberType, false}).Equals(typ), typ.Describe())
+}
+
+func TestMarshalTypeStructName2(t *testing.T) {
+	assert := assert.New(t)
+
+	var ts TestStructWithNameImpl2
+	typ := MustMarshalType(ts)
+	assert.True(types.MakeStructType("", types.StructField{"x", types.NumberType, false}).Equals(typ), typ.Describe())
+}


### PR DESCRIPTION
This is done by implementing StructNameMarshaler interface. For example

```go
type TestStruct struct {
  ...
}
func (ts TestStruct) MarshalNomsStructName() string {
  return "HelloWorld"
}
```

Fixes #2972