### PR TITLE
Add two small features to marshaling

### DIFF
--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -352,7 +352,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Float() == 0
 	case reflect.Struct:
 		z := reflect.Zero(v.Type())
-		return z.Interface() == v.Interface()
+		return reflect.DeepEqual(z.Interface(), v.Interface())
 	case reflect.Interface:
 		return v.IsNil()
 	}

--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -96,10 +96,20 @@ func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTa
 			return types.BlobType
 		case "Bool":
 			return types.BoolType
+		case "List":
+			return types.MakeListType(types.ValueType)
+		case "Map":
+			return types.MakeMapType(types.ValueType, types.ValueType)
 		case "Number":
 			return types.NumberType
+		case "Ref":
+			return types.MakeRefType(types.ValueType)
+		case "Set":
+			return types.MakeSetType(types.ValueType)
 		case "String":
 			return types.StringType
+		case "Value":
+			return types.ValueType
 		}
 
 		err := fmt.Errorf("Cannot marshal type %s, it requires type parameters", t)

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -46,6 +46,11 @@ func TestMarshalTypeType(tt *testing.T) {
 	var m map[uint32]string
 	t(types.MakeMapType(types.NumberType, types.StringType), m)
 
+	t(types.MakeListType(types.ValueType), types.List{})
+	t(types.MakeSetType(types.ValueType), types.Set{})
+	t(types.MakeMapType(types.ValueType, types.ValueType), types.Map{})
+	t(types.MakeRefType(types.ValueType), types.Ref{})
+
 	type TestStruct struct {
 		Str string
 		Num float64
@@ -106,8 +111,6 @@ func assertMarshalTypeErrorMessage(t *testing.T, v interface{}, expectedMessage 
 
 func TestMarshalTypeInvalidTypes(t *testing.T) {
 	assertMarshalTypeErrorMessage(t, make(chan int), "Type is not supported, type: chan int")
-	l := types.NewList()
-	assertMarshalTypeErrorMessage(t, l, "Cannot marshal type types.List, it requires type parameters")
 }
 
 func TestMarshalTypeEmbeddedStruct(t *testing.T) {
@@ -176,14 +179,6 @@ func TestMarshalTypeEncodeNonExportedField(t *testing.T) {
 		x int
 	}
 	assertMarshalTypeErrorMessage(t, TestStruct{1}, "Non exported fields are not supported, type: marshal.TestStruct")
-}
-
-func TestMarshalTypeEncodeNomsTypeWithTypeParameters(t *testing.T) {
-
-	assertMarshalTypeErrorMessage(t, types.NewList(), "Cannot marshal type types.List, it requires type parameters")
-	assertMarshalTypeErrorMessage(t, types.NewSet(), "Cannot marshal type types.Set, it requires type parameters")
-	assertMarshalTypeErrorMessage(t, types.NewMap(), "Cannot marshal type types.Map, it requires type parameters")
-	assertMarshalTypeErrorMessage(t, types.NewRef(types.NewSet()), "Cannot marshal type types.Ref, it requires type parameters")
 }
 
 func TestMarshalTypeEncodeTaggingSkip(t *testing.T) {


### PR DESCRIPTION
1. In MarshalType() allow Noms collections without element types, e.g.:

type Foo struct {
  A types.List
}

marshal.MustMarshalType(Foo{}) => struct Foo { A List<Value> }

2. There were cases where we would fail to marshal structs containing
non-comparable Go types (e.g. slices). Fix those using DeepEqual().