### PR TITLE
move flushing of uncommitted ptree nodes out of EncodeValue

### DIFF
--- a/cmd/noms/noms_show.go
+++ b/cmd/noms/noms_show.go
@@ -57,7 +57,7 @@ func runShow(args []string) int {
 	}
 
 	if showRaw {
-		ch := types.EncodeValue(value, database)
+		ch := types.EncodeValue(value)
 		buf := bytes.NewBuffer(ch.Data())
 		_, err = io.Copy(os.Stdout, buf)
 		d.CheckError(err)

--- a/go/datas/completeness_checker_test.go
+++ b/go/datas/completeness_checker_test.go
@@ -29,7 +29,7 @@ func TestCompletenessChecker(t *testing.T) {
 		t.Run("SomeBad", func(t *testing.T) {
 			t.Parallel()
 			cs := storage.NewView()
-			cs.Put(types.EncodeValue(b, nil))
+			cs.Put(types.EncodeValue(b))
 
 			cc := newCompletenessChecker()
 			cc.AddRefs(badRef)
@@ -42,7 +42,7 @@ func TestCompletenessChecker(t *testing.T) {
 		t.Run("PendingChunk", func(t *testing.T) {
 			t.Parallel()
 			cs := storage.NewView()
-			cs.Put(types.EncodeValue(b, nil))
+			cs.Put(types.EncodeValue(b))
 
 			cc := newCompletenessChecker()
 			cc.AddRefs(r)
@@ -51,7 +51,7 @@ func TestCompletenessChecker(t *testing.T) {
 		t.Run("ExistingChunk", func(t *testing.T) {
 			t.Parallel()
 			cs := storage.NewView()
-			cs.Put(types.EncodeValue(b, nil))
+			cs.Put(types.EncodeValue(b))
 
 			cc := newCompletenessChecker()
 			cc.AddRefs(r)

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -145,7 +145,7 @@ func (suite *HTTPChunkStoreSuite) TearDownTest() {
 }
 
 func (suite *HTTPChunkStoreSuite) TestPutChunk() {
-	c := types.EncodeValue(types.String("abc"), nil)
+	c := types.EncodeValue(types.String("abc"))
 	suite.http.Put(c)
 	suite.http.Flush()
 
@@ -159,10 +159,10 @@ func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
 	}
 	l := types.NewList()
 	for _, val := range vals {
-		suite.http.Put(types.EncodeValue(val, nil))
+		suite.http.Put(types.EncodeValue(val))
 		l = l.Append(types.NewRef(val))
 	}
-	suite.http.Put(types.EncodeValue(l, nil))
+	suite.http.Put(types.EncodeValue(l))
 	suite.http.Flush()
 
 	suite.Equal(3, suite.serverCS.Writes)
@@ -170,7 +170,7 @@ func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
 
 func (suite *HTTPChunkStoreSuite) TestRebase() {
 	suite.Equal(hash.Hash{}, suite.http.Root())
-	c := types.EncodeValue(types.NewMap(), nil)
+	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
 	suite.True(suite.serverCS.Commit(c.Hash(), hash.Hash{})) // change happens behind our backs
 	suite.Equal(hash.Hash{}, suite.http.Root())              // shouldn't be visible yet
@@ -180,7 +180,7 @@ func (suite *HTTPChunkStoreSuite) TestRebase() {
 }
 
 func (suite *HTTPChunkStoreSuite) TestRoot() {
-	c := types.EncodeValue(types.NewMap(), nil)
+	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
 	suite.True(suite.http.Commit(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.serverCS.Root())
@@ -189,13 +189,13 @@ func (suite *HTTPChunkStoreSuite) TestRoot() {
 func (suite *HTTPChunkStoreSuite) TestVersionMismatch() {
 	store := newBadVersionHTTPChunkStoreForTest(suite.serverCS)
 	defer store.Close()
-	c := types.EncodeValue(types.NewMap(), nil)
+	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
 	suite.Panics(func() { store.Commit(c.Hash(), hash.Hash{}) })
 }
 
 func (suite *HTTPChunkStoreSuite) TestCommit() {
-	c := types.EncodeValue(types.NewMap(), nil)
+	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
 	suite.True(suite.http.Commit(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.serverCS.Root())
@@ -210,7 +210,7 @@ func (suite *HTTPChunkStoreSuite) TestCommitWithParams() {
 	u := fmt.Sprintf("http://localhost:9000?access_token=%s&other=19", testAuthToken)
 	store := newAuthenticatingHTTPChunkStoreForTest(suite.Assert(), suite.serverCS, u)
 	defer store.Close()
-	c := types.EncodeValue(types.NewMap(), nil)
+	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
 	suite.True(store.Commit(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.serverCS.Root())

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -37,9 +37,9 @@ func TestHandleWriteValue(t *testing.T) {
 	assert.NoError(err)
 
 	newItem := types.NewEmptyBlob()
-	itemChunk := types.EncodeValue(newItem, nil)
+	itemChunk := types.EncodeValue(newItem)
 	l2 := l.Insert(1, types.NewRef(newItem))
-	listChunk := types.EncodeValue(l2, nil)
+	listChunk := types.EncodeValue(l2)
 
 	body := &bytes.Buffer{}
 	chunks.Serialize(itemChunk, body)
@@ -75,7 +75,7 @@ func TestHandleWriteValueDupChunks(t *testing.T) {
 	storage := &chunks.MemoryStorage{}
 
 	newItem := types.NewEmptyBlob()
-	itemChunk := types.EncodeValue(newItem, nil)
+	itemChunk := types.EncodeValue(newItem)
 
 	body := &bytes.Buffer{}
 	// Write the same chunk to body enough times to be certain that at least one of the concurrent deserialize/decode passes completes before the last one can continue.
@@ -387,7 +387,7 @@ func TestRejectPostRoot(t *testing.T) {
 	cs := storage.NewView()
 
 	newHead := types.NewMap(types.String("dataset1"), types.String("Not a Head"))
-	chunk := types.EncodeValue(newHead, nil)
+	chunk := types.EncodeValue(newHead)
 	cs.Put(chunk)
 	persistChunks(cs)
 

--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -14,9 +14,9 @@ import (
 
 const initialBufferSize = 2048
 
-func EncodeValue(v Value, vw ValueWriter) chunks.Chunk {
+func EncodeValue(v Value) chunks.Chunk {
 	w := newBinaryNomsWriter()
-	enc := newValueEncoder(w, vw, false)
+	enc := newValueEncoder(w, false)
 	enc.writeValue(v)
 
 	c := chunks.NewChunk(w.data())

--- a/go/types/compare_test.go
+++ b/go/types/compare_test.go
@@ -130,7 +130,7 @@ func TestCompareEncodedKeys(t *testing.T) {
 
 func encode(v Value) []byte {
 	w := &binaryNomsWriter{make([]byte, 128, 128), 0}
-	newValueEncoder(w, nil, false).writeValue(v)
+	newValueEncoder(w, false).writeValue(v)
 	return w.data()
 }
 

--- a/go/types/encoding_test.go
+++ b/go/types/encoding_test.go
@@ -102,7 +102,7 @@ func (w *nomsTestWriter) writeHash(h hash.Hash) {
 func assertEncoding(t *testing.T, expect []interface{}, v Value) {
 	vs := newTestValueStore()
 	tw := &nomsTestWriter{}
-	enc := valueEncoder{tw, vs, false}
+	enc := valueEncoder{tw, false}
 	enc.writeValue(v)
 	assert.EqualValues(t, expect, tw.a)
 
@@ -116,7 +116,7 @@ func assertEncoding(t *testing.T, expect []interface{}, v Value) {
 func TestRoundTrips(t *testing.T) {
 	assertRoundTrips := func(v Value) {
 		vs := newTestValueStore()
-		out := DecodeValue(EncodeValue(v, vs), vs)
+		out := DecodeValue(EncodeValue(v), vs)
 		assert.True(t, v.Equals(out))
 	}
 
@@ -173,11 +173,10 @@ func TestRoundTrips(t *testing.T) {
 }
 
 func TestNonFiniteNumbers(tt *testing.T) {
-	vs := newTestValueStore()
 	t := func(f float64, s string) {
 		v := Number(f)
 		err := d.Try(func() {
-			EncodeValue(v, vs)
+			EncodeValue(v)
 		})
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), s)
@@ -345,7 +344,7 @@ func TestWriteStruct(t *testing.T) {
 
 func TestWriteStructTooMuchData(t *testing.T) {
 	s := NewStruct("S", StructData{"x": Number(42), "b": Bool(true)})
-	c := EncodeValue(s, nil)
+	c := EncodeValue(s)
 	data := c.Data()
 	buff := make([]byte, len(data)+1)
 	copy(buff, data)
@@ -584,6 +583,6 @@ func (bg bogusType) typeOf() *Type {
 func TestBogusValueWithUnresolvedCycle(t *testing.T) {
 	g := bogusType(1)
 	assert.Panics(t, func() {
-		EncodeValue(g, nil)
+		EncodeValue(g)
 	})
 }

--- a/go/types/get_hash.go
+++ b/go/types/get_hash.go
@@ -16,7 +16,7 @@ func getHash(v Value) hash.Hash {
 }
 
 func getHashNoOverride(v Value) hash.Hash {
-	return EncodeValue(v, nil).Hash()
+	return EncodeValue(v).Hash()
 }
 
 func EnsureHash(h *hash.Hash, v Value) hash.Hash {

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -342,7 +342,7 @@ func (es emptySequence) isLeaf() bool {
 
 // Invokes |cb| on all "uncommitted" ptree nodes reachable from |v| in
 // "bottom-up" order. It will only follow refs in the case of an in-memory
-// reference to an uncommitted child. Note that |v| maybe not neccesariby be
+// reference to an uncommitted child. Note that |v| maybe not necessarily be
 // a collection, but a collection with uncommitted children maybe be reachable
 // from it (e.g. a Struct).
 func iterateUncommittedChildren(v Value, cb func(sv Value)) {

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -339,3 +339,35 @@ func (es emptySequence) getCompositeChildSequence(start uint64, length uint64, h
 func (es emptySequence) isLeaf() bool {
 	return es.height == 1
 }
+
+// Invokes |cb| on all "uncommitted" ptree nodes reachable from |v| in
+// "bottom-up" order. It will only follow refs in the case of an in-memory
+// reference to an uncommitted child. Note that |v| maybe not neccesariby be
+// a collection, but a collection with uncommitted children maybe be reachable
+// from it (e.g. a Struct).
+func iterateUncommittedChildren(v Value, cb func(sv Value)) {
+	if _, ok := v.(*Type); ok {
+		// Types can be in-memory cyclic, but they cannot reference uncommitted
+		// nodes. Just avoid traversing into them.
+		return
+	}
+
+	if c, ok := v.(Collection); ok {
+		if ms, ok := c.sequence().(metaSequence); ok {
+			// Only traverse uncommitted children of meta sequences
+			for _, mt := range ms.tuples {
+				if mt.child != nil {
+					iterateUncommittedChildren(mt.child, cb)
+					cb(mt.child)
+				}
+			}
+			return
+		}
+	}
+
+	// Traverse subvalues in search of nested collections with uncommitted
+	// ptree nodes.
+	v.WalkValues(func(v Value) {
+		iterateUncommittedChildren(v, cb)
+	})
+}

--- a/go/types/rolling_value_hasher.go
+++ b/go/types/rolling_value_hasher.go
@@ -69,7 +69,7 @@ func newRollingValueHasher() *rollingValueHasher {
 		pattern: pattern,
 		window:  window,
 	}
-	rv.enc = newValueEncoder(rv, nil, true)
+	rv.enc = newValueEncoder(rv, true)
 	return rv
 }
 

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -162,7 +162,7 @@ func TestStructUnionWithCycles(tt *testing.T) {
 	})
 
 	t1, _ := inodeType.Desc.(StructDesc).Field("contents")
-	t2 := DecodeValue(EncodeValue(t1, nil), nil)
+	t2 := DecodeValue(EncodeValue(t1), nil)
 
 	assert.True(tt, t1.Equals(t2))
 	// Note that we cannot ensure pointer equality between t1 and t2 because the

--- a/go/types/validating_decoder_test.go
+++ b/go/types/validating_decoder_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestValidatingBatchingSinkDecode(t *testing.T) {
 	v := Number(42)
-	c := EncodeValue(v, nil)
+	c := EncodeValue(v)
 	storage := &chunks.TestStorage{}
 	vdc := NewValidatingDecoder(storage.NewView())
 
@@ -28,7 +28,7 @@ func assertPanicsOnInvalidChunk(t *testing.T, data []interface{}) {
 	dec := newValueDecoder(r, vs)
 	v := dec.readValue()
 
-	c := EncodeValue(v, nil)
+	c := EncodeValue(v)
 	vdc := NewValidatingDecoder(storage.NewView())
 
 	assert.Panics(t, func() {

--- a/go/types/value_encoder.go
+++ b/go/types/value_encoder.go
@@ -13,12 +13,11 @@ import (
 
 type valueEncoder struct {
 	nomsWriter
-	vw             ValueWriter
 	forRollingHash bool
 }
 
-func newValueEncoder(w nomsWriter, vw ValueWriter, forRollingHash bool) *valueEncoder {
-	return &valueEncoder{w, vw, forRollingHash}
+func newValueEncoder(w nomsWriter, forRollingHash bool) *valueEncoder {
+	return &valueEncoder{w, forRollingHash}
 }
 
 func (w *valueEncoder) writeKind(kind NomsKind) {
@@ -103,10 +102,6 @@ func (w *valueEncoder) maybeWriteMetaSequence(seq sequence) bool {
 	w.writeCount(uint64(count))
 	for i := 0; i < count; i++ {
 		tuple := ms.getItem(i).(metaTuple)
-		if tuple.child != nil && w.vw != nil {
-			// Write unwritten chunked sequences. Chunks are lazily written so that intermediate chunked structures like NewList().Append(x).Append(y) don't cause unnecessary churn.
-			w.vw.WriteValue(tuple.child)
-		}
 		w.writeValue(tuple.ref)
 		v := tuple.key.v
 		if !tuple.key.isOrderedByValue {

--- a/go/types/value_stats.go
+++ b/go/types/value_stats.go
@@ -90,7 +90,7 @@ func printTreeLevel(w io.Writer, level, values, chunks, byteSize uint64) {
 }
 
 func compressedSize(v Value) uint64 {
-	chunk := EncodeValue(v, nil)
+	chunk := EncodeValue(v)
 	compressed := snappy.Encode(nil, chunk.Data())
 	return uint64(len(compressed))
 }


### PR DESCRIPTION
Ok, here's step one. 

Separate the concern of flushing uncommitted (linked in-memory) ptree nodes from encoding.

Towards #3525