### PR TITLE
Add chunks.Factory::CreateStoreFromCache()

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -67,6 +67,10 @@ type ChunkStore interface {
 type Factory interface {
 	CreateStore(ns string) ChunkStore
 
+	// CreateStoreFromCache allows caller to signal to the factory that it's
+	// willing to tolerate an out-of-date ChunkStore.
+	CreateStoreFromCache(ns string) ChunkStore
+
 	// Shutter shuts down the factory. Subsequent calls to CreateStore() will fail.
 	Shutter()
 }

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -193,6 +193,10 @@ func NewMemoryStoreFactory() Factory {
 	return &memoryStoreFactory{map[string]*MemoryStorage{}, &sync.Mutex{}}
 }
 
+func (f *memoryStoreFactory) CreateStoreFromCache(ns string) ChunkStore {
+	return f.CreateStore(ns)
+}
+
 func (f *memoryStoreFactory) CreateStore(ns string) ChunkStore {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/go/nbs/dynamo_manifest.go
+++ b/go/nbs/dynamo_manifest.go
@@ -45,6 +45,8 @@ type dynamoManifest struct {
 }
 
 func newDynamoManifest(table, namespace string, ddb ddbsvc, cache *manifestCache) manifest {
+	d.PanicIfTrue(table == "")
+	d.PanicIfTrue(namespace == "")
 	return dynamoManifest{table, namespace, ddb, cache}
 }
 


### PR DESCRIPTION
Add a method to chunks.Factory that allows the caller to
signal that it's willing to try to make forward progress
using an out-of-date ChunkStore. This allows AWSStoreFactory
and LocalStoreFactory to vend NBS instances without hammering
persistent storage every time.

Towards #3491