### PR TITLE
Revert removal of |last| from Commit()

### DIFF
--- a/cmd/noms/noms_root.go
+++ b/cmd/noms/noms_root.go
@@ -86,7 +86,7 @@ Continue?
 		return 0
 	}
 
-	ok = cs.Commit(h)
+	ok = cs.Commit(h, currRoot)
 	if !ok {
 		fmt.Fprintln(os.Stderr, "Optimistic concurrency failure")
 		return 1

--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -48,10 +48,11 @@ type ChunkStore interface {
 	Root() hash.Hash
 
 	// Commit atomically attempts to persist all novel Chunks and update the
-	// persisted root hash to current. If the underlying root has changed this
-	// the ChunkStore was opened (or last Rebased), it will return false and
-	// have tranparently Rebased.
-	Commit(current hash.Hash) bool
+	// persisted root hash from last to current. If last doesn't match the
+	// root in persistent storage, returns false.
+	// TODO: is last now redundant? Maybe this should just try to update from
+	// the cached root to current?
+	Commit(current, last hash.Hash) bool
 
 	// Stats may return some kind of struct that reports statistics about the
 	// ChunkStore instance. The type is implementation-dependent, and impls

--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -48,10 +48,8 @@ type ChunkStore interface {
 	Root() hash.Hash
 
 	// Commit atomically attempts to persist all novel Chunks and update the
-	// persisted root hash from last to current. If last doesn't match the
-	// root in persistent storage, returns false.
-	// TODO: is last now redundant? Maybe this should just try to update from
-	// the cached root to current?
+	// persisted root hash from last to current (or keeps it the same).
+	// If last doesn't match the root in persistent storage, returns false.
 	Commit(current, last hash.Hash) bool
 
 	// Stats may return some kind of struct that reports statistics about the

--- a/go/chunks/memory_store.go
+++ b/go/chunks/memory_store.go
@@ -164,11 +164,14 @@ func (ms *MemoryStoreView) Root() hash.Hash {
 	return ms.rootHash
 }
 
-func (ms *MemoryStoreView) Commit(current hash.Hash) bool {
+func (ms *MemoryStoreView) Commit(current, last hash.Hash) bool {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
+	if last != ms.rootHash {
+		return false
+	}
 
-	success := ms.storage.Update(current, ms.rootHash, ms.pending)
+	success := ms.storage.Update(current, last, ms.pending)
 	if success {
 		ms.pending = nil
 	}

--- a/go/datas/database_test.go
+++ b/go/datas/database_test.go
@@ -337,11 +337,11 @@ type waitDuringUpdateRootChunkStore struct {
 	preUpdateRootHook func()
 }
 
-func (w *waitDuringUpdateRootChunkStore) Commit(current hash.Hash) bool {
+func (w *waitDuringUpdateRootChunkStore) Commit(current, last hash.Hash) bool {
 	if w.preUpdateRootHook != nil {
 		w.preUpdateRootHook()
 	}
-	return w.ChunkStore.Commit(current)
+	return w.ChunkStore.Commit(current, last)
 }
 
 func (suite *DatabaseSuite) TestCommitWithConcurrentChunkStoreUse() {

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -433,13 +433,13 @@ func (hcs *httpChunkStore) getRoot(checkVers bool) (root hash.Hash, vers string)
 	return hash.Parse(string(data)), res.Header.Get(NomsVersionHeader)
 }
 
-func (hcs *httpChunkStore) Commit(current hash.Hash) bool {
+func (hcs *httpChunkStore) Commit(current, last hash.Hash) bool {
 	hcs.rootMu.Lock()
 	defer hcs.rootMu.Unlock()
 	hcs.Flush()
 
 	// POST http://<host>/root?current=<ref>&last=<ref>. Response will be 200 on success, 409 if current is outdated.
-	res := hcs.requestRoot("POST", current, hcs.root)
+	res := hcs.requestRoot("POST", current, last)
 	expectVersion(hcs.version, res)
 	defer closeResponse(res.Body)
 

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -172,8 +172,8 @@ func (suite *HTTPChunkStoreSuite) TestRebase() {
 	suite.Equal(hash.Hash{}, suite.http.Root())
 	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
-	suite.True(suite.serverCS.Commit(c.Hash())) // change happens behind our backs
-	suite.Equal(hash.Hash{}, suite.http.Root()) // shouldn't be visible yet
+	suite.True(suite.serverCS.Commit(c.Hash(), hash.Hash{})) // change happens behind our backs
+	suite.Equal(hash.Hash{}, suite.http.Root())              // shouldn't be visible yet
 
 	suite.http.Rebase()
 	suite.Equal(c.Hash(), suite.serverCS.Root())
@@ -182,7 +182,7 @@ func (suite *HTTPChunkStoreSuite) TestRebase() {
 func (suite *HTTPChunkStoreSuite) TestRoot() {
 	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
-	suite.True(suite.http.Commit(c.Hash()))
+	suite.True(suite.http.Commit(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
@@ -191,18 +191,18 @@ func (suite *HTTPChunkStoreSuite) TestVersionMismatch() {
 	defer store.Close()
 	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
-	suite.Panics(func() { store.Commit(c.Hash()) })
+	suite.Panics(func() { store.Commit(c.Hash(), hash.Hash{}) })
 }
 
 func (suite *HTTPChunkStoreSuite) TestCommit() {
 	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
-	suite.True(suite.http.Commit(c.Hash()))
+	suite.True(suite.http.Commit(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 
 func (suite *HTTPChunkStoreSuite) TestEmptyHashCommit() {
-	suite.True(suite.http.Commit(hash.Hash{}))
+	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
 	suite.Equal(hash.Hash{}, suite.serverCS.Root())
 }
 
@@ -212,7 +212,7 @@ func (suite *HTTPChunkStoreSuite) TestCommitWithParams() {
 	defer store.Close()
 	c := types.EncodeValue(types.NewMap())
 	suite.serverCS.Put(c)
-	suite.True(store.Commit(c.Hash()))
+	suite.True(store.Commit(c.Hash(), hash.Hash{}))
 	suite.Equal(c.Hash(), suite.serverCS.Root())
 }
 

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -252,7 +252,7 @@ func persistChunks(cs chunks.ChunkStore) {
 		Factor: 2,
 		Jitter: true,
 	}
-	for !cs.Commit(cs.Root()) {
+	for !cs.Commit(cs.Root(), cs.Root()) {
 		time.Sleep(b.Duration())
 	}
 }
@@ -408,7 +408,7 @@ func handleRootPost(w http.ResponseWriter, req *http.Request, ps URLParams, cs c
 		}
 	}
 
-	if last != cs.Root() || !cs.Commit(current) {
+	if !cs.Commit(current, last) {
 		w.WriteHeader(http.StatusConflict)
 		w.Header().Add("content-type", "text/plain")
 		fmt.Fprintf(w, "%v", cs.Root().String())

--- a/go/nbs/benchmarks/block_store_benchmarks.go
+++ b/go/nbs/benchmarks/block_store_benchmarks.go
@@ -32,7 +32,7 @@ func writeToEmptyStore(store chunks.ChunkStore, src *dataSource, t assert.Testin
 	}
 	newRoot := chunks.NewChunk([]byte("root"))
 	store.Put(newRoot)
-	assert.True(t, store.Commit(newRoot.Hash()))
+	assert.True(t, store.Commit(newRoot.Hash(), root))
 }
 
 func goReadChunks(src *dataSource) <-chan *chunks.Chunk {

--- a/go/nbs/benchmarks/file_block_store.go
+++ b/go/nbs/benchmarks/file_block_store.go
@@ -64,7 +64,7 @@ func (fb fileBlockStore) Root() hash.Hash {
 	return hash.Hash{}
 }
 
-func (fb fileBlockStore) Commit(current hash.Hash) bool {
+func (fb fileBlockStore) Commit(current, last hash.Hash) bool {
 	fb.bw.Flush()
 	return true
 }

--- a/go/nbs/benchmarks/null_block_store.go
+++ b/go/nbs/benchmarks/null_block_store.go
@@ -55,6 +55,6 @@ func (nb nullBlockStore) Root() hash.Hash {
 	return hash.Hash{}
 }
 
-func (nb nullBlockStore) Commit(current hash.Hash) bool {
+func (nb nullBlockStore) Commit(current, last hash.Hash) bool {
 	return true
 }

--- a/go/nbs/factory_test.go
+++ b/go/nbs/factory_test.go
@@ -29,7 +29,7 @@ func TestLocalStoreFactory(t *testing.T) {
 
 	c := chunks.NewChunk([]byte{0xff})
 	store.Put(c)
-	assert.True(store.Commit(c.Hash()))
+	assert.True(store.Commit(c.Hash(), hash.Hash{}))
 
 	dbDir := filepath.Join(dir, dbName)
 	exists, contents := newFileManifest(dbDir, newManifestCache(0)).ParseIfExists(stats, nil)

--- a/go/nbs/stats_test.go
+++ b/go/nbs/stats_test.go
@@ -54,7 +54,7 @@ func TestStats(t *testing.T) {
 	assert.Equal(uint64(0), stats(store).FileReadLatency.Samples())
 	assert.Equal(uint64(4), stats(store).ChunksPerGet.Sum())
 
-	store.Commit(store.Root())
+	store.Commit(store.Root(), store.Root())
 
 	// Commit will update the manifest
 	assert.EqualValues(1, stats(store).WriteManifestLatency.Samples())
@@ -89,9 +89,9 @@ func TestStats(t *testing.T) {
 	// Force a conjoin
 	store.c = newAsyncConjoiner(2)
 	store.Put(c4)
-	store.Commit(store.Root())
+	store.Commit(store.Root(), store.Root())
 	store.Put(c5)
-	store.Commit(store.Root())
+	store.Commit(store.Root(), store.Root())
 
 	assert.Equal(uint64(1), stats(store).ConjoinLatency.Samples())
 	// TODO: Once random conjoin hack is out, test other conjoin stats

--- a/go/types/incremental_test.go
+++ b/go/types/incremental_test.go
@@ -41,7 +41,7 @@ func TestIncrementalLoadList(t *testing.T) {
 
 	expected := NewList(testVals...)
 	hash := vs.WriteValue(expected).TargetHash()
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 
 	actualVar := vs.ReadValue(hash)
 	actual := actualVar.(List)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -951,7 +951,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	nums1 := generateNumbersAsValues(4000)
 	l1 := NewList(nums1...)
 	hash1 := vs1.WriteValue(l1).TargetHash()
-	vs1.Commit(vs1.Root())
+	vs1.Commit(vs1.Root(), vs1.Root())
 
 	refList1 := vs1.ReadValue(hash1).(List)
 
@@ -960,7 +960,7 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 	nums2 := generateNumbersAsValuesFromToBy(5, 3550, 1)
 	l2 := NewList(nums2...)
 	hash2 := vs2.WriteValue(l2).TargetHash()
-	vs2.Commit(vs1.Root())
+	vs2.Commit(vs1.Root(), vs1.Root())
 	refList2 := vs2.ReadValue(hash2).(List)
 
 	// diff lists without value store

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -377,7 +377,7 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 	cs := ts.NewView()
 	vs := newValueStoreWithCacheAndPending(cs, 0, 0)
 	r := vs.WriteValue(m)
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 
 	cs.Writes = 0
 	cs.Reads = 0
@@ -394,7 +394,7 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 			s = s.Set("Number", Number(float64(s.Get("Number").(Number))+1))
 			m2 = m2.Set(k, s)
 			r := vs.WriteValue(m2)
-			vs.Commit(vs.Root())
+			vs.Commit(vs.Root(), vs.Root())
 			readCount += cs.Reads
 			writeCount += cs.Writes
 			cs.Reads = 0

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -98,7 +98,7 @@ func (suite *diffTestSuite) TestDiff() {
 	rw := func(col Collection) Collection {
 		vs := newTestValueStore()
 		h := vs.WriteValue(col).TargetHash()
-		vs.Commit(vs.Root())
+		vs.Commit(vs.Root(), vs.Root())
 		return vs.ReadValue(h).(Collection)
 	}
 	newSetAsColRw := func(vs []Value) Collection { return rw(newSetAsCol(vs)) }

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -317,7 +317,7 @@ func (lvs *ValueStore) Rebase() {
 // opened, or last Rebased(), it will return false and will have internally
 // rebased. Until Commit() succeeds, no work of the ValueStore will be visible
 // to other readers of the underlying ChunkStore.
-func (lvs *ValueStore) Commit(current hash.Hash) bool {
+func (lvs *ValueStore) Commit(current, last hash.Hash) bool {
 	return func() bool {
 		lvs.bufferMu.Lock()
 		defer lvs.bufferMu.Unlock()
@@ -365,7 +365,7 @@ func (lvs *ValueStore) Commit(current hash.Hash) bool {
 			PanicIfDangling(lvs.unresolvedRefs, lvs.cs)
 		}
 
-		if !lvs.cs.Commit(current) {
+		if !lvs.cs.Commit(current, last) {
 			return false
 		}
 

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -19,7 +19,7 @@ func TestValueReadWriteRead(t *testing.T) {
 	vs := newTestValueStore()
 	assert.Nil(vs.ReadValue(s.Hash())) // nil
 	h := vs.WriteValue(s).TargetHash()
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 	v := vs.ReadValue(h) // non-nil
 	if assert.NotNil(v) {
 		assert.True(s.Equals(v), "%s != %s", EncodedValue(s), EncodedValue(v))
@@ -35,7 +35,7 @@ func TestReadWriteCache(t *testing.T) {
 	var v Value = Bool(true)
 	r := vs.WriteValue(v)
 	assert.NotEqual(hash.Hash{}, r.TargetHash())
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 	assert.Equal(1, ts.Writes)
 
 	v = vs.ReadValue(r.TargetHash())
@@ -56,7 +56,7 @@ func TestValueReadMany(t *testing.T) {
 	for _, v := range vals {
 		h := vs.WriteValue(v).TargetHash()
 		hashes.Insert(h)
-		vs.Commit(vs.Root())
+		vs.Commit(vs.Root(), vs.Root())
 	}
 
 	// Get one Value into vs's Value cache
@@ -95,7 +95,7 @@ func TestValueWriteFlush(t *testing.T) {
 	}
 	assert.NotZero(vs.bufferedChunkSize)
 
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 	assert.Zero(vs.bufferedChunkSize)
 }
 
@@ -160,7 +160,7 @@ func TestFlushOrder(t *testing.T) {
 
 	r := vs.WriteValue(l)
 	ccs.expect(r)
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 }
 
 func TestFlushOverSize(t *testing.T) {
@@ -175,7 +175,7 @@ func TestFlushOverSize(t *testing.T) {
 	ccs.expect(sr, NewRef(l))
 
 	vs.WriteValue(l)
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 }
 
 func TestTolerateTopDown(t *testing.T) {
@@ -201,7 +201,7 @@ func TestTolerateTopDown(t *testing.T) {
 	lr := vs.WriteValue(L)
 	ccs.expect(lr)
 
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 
 	assert.Zero(len(vs.bufferedChunks))
 
@@ -213,7 +213,7 @@ func TestTolerateTopDown(t *testing.T) {
 	// At this point, ValueStore believes ST is a standalone chunk, and that ML -> S
 	// So, it'll look at ML, the one parent it knows about, first and write its child (S). Then, it'll write ML, and then it'll flush the remaining buffered chunks, which is just ST.
 	ccs.expect(sr, mlr, str)
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 }
 
 func TestPanicOnBadVersion(t *testing.T) {
@@ -226,7 +226,7 @@ func TestPanicOnBadVersion(t *testing.T) {
 		cvs := NewValueStore(&badVersionStore{ChunkStore: storage.NewView()})
 		assert.Panics(t, func() {
 			cvs.WriteValue(NewEmptyBlob())
-			cvs.Commit(cvs.Root())
+			cvs.Commit(cvs.Root(), cvs.Root())
 		})
 	})
 }
@@ -240,7 +240,7 @@ func TestPanicIfDangling(t *testing.T) {
 	vs.WriteValue(l)
 
 	assert.Panics(func() {
-		vs.Commit(vs.Root())
+		vs.Commit(vs.Root(), vs.Root())
 	})
 }
 
@@ -252,7 +252,7 @@ func TestSkipEnforceCompleteness(t *testing.T) {
 	l := NewList(r)
 	vs.WriteValue(l)
 
-	vs.Commit(vs.Root())
+	vs.Commit(vs.Root(), vs.Root())
 }
 
 type badVersionStore struct {


### PR DESCRIPTION
Turns out this complicated the threadsafety goal