### PR TITLE
Don't clone cursors in sequence chunker

### DIFF
--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -25,17 +25,19 @@ func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence
 	}
 	chunker := newSequenceChunker(newCursorAtIndex(fst, fst.numLeaves(), false), vr)
 
-	for cur, ch := newCursorAtIndex(snd, 0, false), chunker; cur != nil; cur = cur.parent {
-		// If fst is shallower than snd, its cur will have a parent whereas the
-		// chunker to snd won't. In that case, create a parent for fst.
-		// Note that if the inverse is true - snd is shallower than fst - this just
-		// means higher chunker levels will still have cursors from fst... which
-		// point to the end, so finalisation won't do anything. This is correct.
-		if ch.parent == nil {
-			ch.createParent()
+	for cur, ch := newCursorAtIndex(snd, 0, false), chunker; ch != nil; ch = ch.parent {
+		// Note that if snd is shallower than fst, then higher chunkers will have
+		// their cursors set to nil. This has the effect of "dropping" the final
+		// item in each of those sequences.
+		ch.cur = cur
+		if cur != nil {
+			cur = cur.parent
+			if cur != nil && ch.parent == nil {
+				// If fst is shallower than snd, its cur will have a parent whereas the
+				// chunker to snd won't. In that case, create a parent for fst.
+				ch.createParent()
+			}
 		}
-		ch.cur = cur.clone()
-		ch = ch.parent
 	}
 
 	return chunker.Done()


### PR DESCRIPTION
Towards #2300

This refactor simplifies (and I think clarifies) the behavior of working with cursors in re-chunking a prolly tree. The logic change here is mainly in finalization. I think the way the logic worked (at least) at one point, it was possible that a child & parent cursor would become "decoupled" (i.e. the parent wasn't presently referencing the child. The chunker has been simplified recently, and I think there are no more such necessary cases.

The logic in finalization becomes alot simpler as a result. Basically, what results is that the *only* time we need to explicitly advance a parent cursor is when we have "finished" with the child.

@kalman, please review post-facto. @aboodman, please review for local correctness now.