### PR TITLE
sequenceChunker.advanceTo avoid resuming over items it already consumed

### DIFF
--- a/go/types/map.go
+++ b/go/types/map.go
@@ -308,8 +308,12 @@ func makeMapLeafChunkFn(vr ValueReader) makeChunkFn {
 		d.PanicIfFalse(level == 0)
 		mapData := make([]mapEntry, len(items), len(items))
 
+		var lastKey Value
 		for i, v := range items {
-			mapData[i] = v.(mapEntry)
+			entry := v.(mapEntry)
+			d.PanicIfFalse(lastKey == nil || lastKey.Less(entry.key))
+			lastKey = entry.key
+			mapData[i] = entry
 		}
 
 		m := newMap(newMapLeafSequence(vr, mapData...))

--- a/go/types/ordered_sequences.go
+++ b/go/types/ordered_sequences.go
@@ -95,8 +95,11 @@ func newOrderedMetaSequenceChunkFn(kind NomsKind, vr ValueReader) makeChunkFn {
 		tuples := make([]metaTuple, len(items))
 		numLeaves := uint64(0)
 
+		var lastKey orderedKey
 		for i, v := range items {
 			mt := v.(metaTuple)
+			d.PanicIfFalse(lastKey == emptyKey || lastKey.Less(mt.key))
+			lastKey = mt.key
 			tuples[i] = mt // chunk is written when the root sequence is written
 			numLeaves += mt.numLeaves
 		}

--- a/go/types/sequence_chunker.go
+++ b/go/types/sequence_chunker.go
@@ -107,6 +107,13 @@ func (sc *sequenceChunker) advanceTo(next *sequenceCursor) {
 	for sc.cur.compare(next) < 0 {
 		if sc.Append(sc.cur.current()) && sc.cur.atLastItem() {
 			if sc.cur.parent != nil {
+
+				if sc.cur.parent.compare(next.parent) < 0 {
+					// Case (4): We stopped consuming items on this level before ending
+					// the sequence referenced by |next|
+					reachedNext = false
+				}
+
 				// Note: Logically, what is happening here is that we are consuming the
 				// item at the current level. Logically, we'd call sc.cur.advance(),
 				// but that would force loading of the next sequence, which we don't
@@ -119,7 +126,6 @@ func (sc *sequenceChunker) advanceTo(next *sequenceCursor) {
 				sc.cur.seq = nil
 			}
 
-			reachedNext = false // Case (4)
 			break
 		}
 

--- a/go/types/sequence_chunker.go
+++ b/go/types/sequence_chunker.go
@@ -109,7 +109,7 @@ func (sc *sequenceChunker) advanceTo(next *sequenceCursor) {
 			if sc.cur.parent != nil {
 
 				if sc.cur.parent.compare(next.parent) < 0 {
-					// Case (4): We stopped consuming items on this level before ending
+					// Case (4): We stopped consuming items on this level before entering
 					// the sequence referenced by |next|
 					reachedNext = false
 				}

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -275,8 +275,12 @@ func makeSetLeafChunkFn(vr ValueReader) makeChunkFn {
 		d.PanicIfFalse(level == 0)
 		setData := make([]Value, len(items), len(items))
 
-		for i, v := range items {
-			setData[i] = v.(Value)
+		var lastValue Value
+		for i, item := range items {
+			v := item.(Value)
+			d.PanicIfFalse(lastValue == nil || lastValue.Less(v))
+			lastValue = v
+			setData[i] = v
 		}
 
 		set := newSet(newSetLeafSequence(vr, setData...))


### PR DESCRIPTION
When sequence chunker advances to a new position for streaming edits, it needs to ensure that it doesn't `resume()` over items which have already been consumed at this level.

The specific case that trigger this was making two edits to map, both of which took place within the same leaf sequence. this case can only arise when the final item in the map is an "explicit" boundary. If the first edit doesn't "change" the boundary (i.e. it will still cause the rolling hash to hit a target pattern), and the second edit is trying to append beyond the last existing element, then what happened was the code *thought* that the `next` cursor hadn't been reached and thus "resumed" at that level, but that caused it to re-consume items that were already consumed.