### PR TITLE
NBS: Fix usage of manifestCache

### DIFF
--- a/go/nbs/dynamo_manifest_test.go
+++ b/go/nbs/dynamo_manifest_test.go
@@ -22,7 +22,7 @@ const (
 
 func makeDynamoManifestFake(t *testing.T) (mm manifest, ddb *fakeDDB) {
 	ddb = makeFakeDDB(assert.New(t))
-	mm = newDynamoManifest(table, db, ddb, newManifestCache(0))
+	mm = newDynamoManifest(table, db, ddb)
 	return
 }
 

--- a/go/nbs/factory_test.go
+++ b/go/nbs/factory_test.go
@@ -32,7 +32,7 @@ func TestLocalStoreFactory(t *testing.T) {
 	assert.True(store.Commit(c.Hash(), hash.Hash{}))
 
 	dbDir := filepath.Join(dir, dbName)
-	exists, contents := newFileManifest(dbDir, newManifestCache(0)).ParseIfExists(stats, nil)
+	exists, contents := fileManifest{dbDir}.ParseIfExists(stats, nil)
 	assert.True(exists)
 	assert.Len(contents.specs, 1)
 

--- a/go/nbs/file_manifest_test.go
+++ b/go/nbs/file_manifest_test.go
@@ -21,7 +21,7 @@ import (
 func makeFileManifestTempDir(t *testing.T) fileManifest {
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	return fileManifest{dir, newManifestCache(defaultManifestCacheSize)}
+	return fileManifest{dir: dir} //, cache: newManifestCache(defaultManifestCacheSize)}
 }
 
 func TestFileManifestLoadIfExists(t *testing.T) {
@@ -108,7 +108,7 @@ func TestFileManifestUpdateEmpty(t *testing.T) {
 	assert.True(upstream.root.IsEmpty())
 	assert.Empty(upstream.specs)
 
-	fm2 := newFileManifest(fm.dir, newManifestCache(0)) // Open existent, but empty manifest
+	fm2 := fileManifest{fm.dir} // Open existent, but empty manifest
 	exists, upstream := fm2.ParseIfExists(stats, nil)
 	assert.True(exists)
 	assert.Equal(l, upstream.lock)

--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -75,9 +75,7 @@ func (cm cachingManifest) ParseIfExists(stats *Stats, readHook func()) (exists b
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	exists, contents = cm.mm.ParseIfExists(stats, readHook)
-	if exists {
-		cm.cache.Put(cm.Name(), contents)
-	}
+	cm.cache.Put(cm.Name(), contents)
 	return
 }
 

--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -7,10 +7,10 @@ package nbs
 import (
 	"crypto/sha512"
 	"strconv"
+	"sync"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
-	"github.com/attic-labs/noms/go/util/sizecache"
 )
 
 type manifest interface {
@@ -65,25 +65,37 @@ func (mc manifestContents) size() (size uint64) {
 	return
 }
 
-func newManifestCache(maxSize uint64) *manifestCache {
-	return &manifestCache{sizecache.New(maxSize)}
+type cachingManifest struct {
+	mm    manifest
+	mu    *sync.Mutex
+	cache *manifestCache
 }
 
-type manifestCache struct {
-	sc *sizecache.SizeCache
-}
-
-func (mc *manifestCache) Get(db string) (contents manifestContents, present bool) {
-	var cached interface{}
-	if cached, present = mc.sc.Get(db); present {
-		contents = cached.(manifestContents)
+func (cm cachingManifest) ParseIfExists(stats *Stats, readHook func()) (exists bool, contents manifestContents) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	exists, contents = cm.mm.ParseIfExists(stats, readHook)
+	if exists {
+		cm.cache.Put(cm.Name(), contents)
 	}
 	return
 }
 
-func (mc *manifestCache) Put(db string, size uint64, contents manifestContents) {
-	mc.sc.Drop(db)
-	mc.sc.Add(db, size, contents)
+func (cm cachingManifest) Update(lastLock addr, newContents manifestContents, stats *Stats, writeHook func()) manifestContents {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if upstream, hit := cm.cache.Get(cm.Name()); hit {
+		if lastLock != upstream.lock {
+			return upstream
+		}
+	}
+	contents := cm.mm.Update(lastLock, newContents, stats, writeHook)
+	cm.cache.Put(cm.Name(), contents)
+	return contents
+}
+
+func (cm cachingManifest) Name() string {
+	return cm.mm.Name()
 }
 
 type tableSpec struct {

--- a/go/nbs/manifest_cache.go
+++ b/go/nbs/manifest_cache.go
@@ -1,0 +1,85 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"container/list"
+
+	"github.com/attic-labs/noms/go/d"
+)
+
+func newManifestCache(maxSize uint64) *manifestCache {
+	return &manifestCache{
+		maxSize: maxSize,
+		cache:   map[string]manifestCacheEntry{},
+	}
+}
+
+type manifestCacheEntry struct {
+	lruEntry *list.Element
+	contents manifestContents
+}
+
+type manifestCache struct {
+	totalSize uint64
+	maxSize   uint64
+	lru       list.List
+	cache     map[string]manifestCacheEntry
+}
+
+// Get() checks the searches the cache for an entry. If it exists, it moves it's
+// lru entry to the back of the queue and returns (value, true). Otherwise, it
+// returns (nil, false).
+func (mc *manifestCache) Get(db string) (contents manifestContents, present bool) {
+	if entry, ok := mc.entry(db); ok {
+		contents, present = entry.contents, true
+	}
+	return
+}
+
+// entry() checks if the value is in the cache. If not in the cache, it returns an
+// empty manifestCacheEntry and false. It it is in the cache, it moves it to
+// to the back of lru and returns the entry and true.
+func (mc *manifestCache) entry(key string) (manifestCacheEntry, bool) {
+	entry, ok := mc.cache[key]
+	if !ok {
+		return manifestCacheEntry{}, false
+	}
+	mc.lru.MoveToBack(entry.lruEntry)
+	return entry, true
+}
+
+// Put inserts |contents| into the cache with the key |db|, replacing any
+// currently cached value. Put() will add this element to the cache at the
+// back of the queue as long it's size does not exceed maxSize. If the
+// addition of this entry causes the size of the cache to exceed maxSize, the
+// necessary entries at the front of the queue will be deleted in order to
+// keep the total cache size below maxSize.
+func (mc *manifestCache) Put(db string, contents manifestContents) {
+	if entry, ok := mc.entry(db); ok {
+		mc.totalSize -= entry.contents.size()
+		mc.lru.Remove(entry.lruEntry)
+		delete(mc.cache, db)
+	}
+
+	if contents.size() <= mc.maxSize {
+		newEl := mc.lru.PushBack(db)
+		ce := manifestCacheEntry{lruEntry: newEl, contents: contents}
+		mc.cache[db] = ce
+		mc.totalSize += ce.contents.size()
+		for el := mc.lru.Front(); el != nil && mc.totalSize > mc.maxSize; {
+			key1 := el.Value.(string)
+			ce, ok := mc.cache[key1]
+			if !ok {
+				d.Panic("SizeCache is missing expected value")
+			}
+			next := el.Next()
+			delete(mc.cache, key1)
+			mc.totalSize -= ce.contents.size()
+			mc.lru.Remove(el)
+			el = next
+		}
+	}
+}

--- a/go/nbs/manifest_cache.go
+++ b/go/nbs/manifest_cache.go
@@ -73,7 +73,7 @@ func (mc *manifestCache) Put(db string, contents manifestContents) {
 			key1 := el.Value.(string)
 			ce, ok := mc.cache[key1]
 			if !ok {
-				d.Panic("SizeCache is missing expected value")
+				d.Panic("manifestCache is missing expected value")
 			}
 			next := el.Next()
 			delete(mc.cache, key1)

--- a/go/nbs/manifest_cache_test.go
+++ b/go/nbs/manifest_cache_test.go
@@ -1,0 +1,104 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestSizeCache(t *testing.T) {
+	defSize := manifestContents{}.size()
+
+	t.Run("GetAndPut", func(t *testing.T) {
+		assert := assert.New(t)
+
+		c := newManifestCache(2 * defSize)
+		dbA, contentsA := "dbA", manifestContents{lock: computeAddr([]byte("lockA"))}
+		dbB, contentsB := "dbB", manifestContents{lock: computeAddr([]byte("lockB"))}
+
+		c.Put(dbA, contentsA)
+		c.Put(dbB, contentsB)
+
+		cont, present := c.Get(dbA)
+		assert.True(present)
+		assert.Equal(contentsA, cont)
+
+		cont, present = c.Get(dbB)
+		assert.True(present)
+		assert.Equal(contentsB, cont)
+	})
+
+	t.Run("PutDropsLRU", func(t *testing.T) {
+		assert := assert.New(t)
+
+		capacity := uint64(5)
+		c := newManifestCache(capacity * defSize)
+		keys := []string{"db1", "db2", "db3", "db4", "db5", "db6", "db7", "db8", "db9"}
+		for i, v := range keys {
+			c.Put(v, manifestContents{})
+			expected := uint64(i + 1)
+			if expected >= capacity {
+				expected = capacity
+			}
+			assert.Equal(expected*defSize, c.totalSize)
+		}
+
+		lru := len(keys) - int(capacity)
+		for _, db := range keys[:lru] {
+			_, present := c.Get(db)
+			assert.False(present)
+		}
+		for _, db := range keys[lru:] {
+			_, present := c.Get(db)
+			assert.True(present)
+		}
+
+		// Bump |keys[lru]| to the back of the queue, making |keys[lru+1]| the next one to be dropped
+		_, ok := c.Get(keys[lru])
+		assert.True(ok)
+		lru++
+		c.Put("novel", manifestContents{})
+		_, ok = c.Get(keys[lru])
+		assert.False(ok)
+		// |keys[lru]| is gone, so |keys[lru+1]| is next
+		lru++
+
+		// Putting a bigger value will dump multiple existing entries
+		c.Put("big", manifestContents{vers: "big version"})
+		_, ok = c.Get(keys[lru])
+		assert.False(ok)
+		lru++
+		_, ok = c.Get(keys[lru])
+		assert.False(ok)
+		lru++
+
+		// Make sure expected stuff is still in the cache
+		for i := lru; i < len(keys); i++ {
+			_, ok := c.Get(keys[i])
+			assert.True(ok)
+		}
+		for _, key := range []string{"novel", "big"} {
+			_, ok := c.Get(key)
+			assert.True(ok)
+		}
+	})
+
+	t.Run("TooLargeValue", func(t *testing.T) {
+		c := newManifestCache(16)
+		c.Put("db", manifestContents{})
+		_, ok := c.Get("db")
+		assert.False(t, ok)
+	})
+
+	t.Run("ZeroSizeCache", func(t *testing.T) {
+		c := newManifestCache(0)
+		c.Put("db", manifestContents{})
+		_, ok := c.Get("db")
+		assert.False(t, ok)
+	})
+
+}

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -32,18 +32,21 @@ const (
 )
 
 var (
-	cacheOnce           = sync.Once{}
-	globalIndexCache    *indexCache
-	globalManifestCache *manifestCache
-	globalFDCache       *fdCache
-	globalConjoiner     conjoiner
+	cacheOnce        = sync.Once{}
+	globalIndexCache *indexCache
+	globalAddCache   func(manifest) manifest
+	globalFDCache    *fdCache
+	globalConjoiner  conjoiner
 )
 
 func makeGlobalCaches() {
 	globalIndexCache = newIndexCache(defaultIndexCacheSize)
-	globalManifestCache = newManifestCache(defaultManifestCacheSize)
 	globalFDCache = newFDCache(defaultMaxTables)
 	globalConjoiner = newAsyncConjoiner(defaultMaxTables)
+
+	cacheMu := &sync.Mutex{}
+	manifestCache := newManifestCache(defaultManifestCacheSize)
+	globalAddCache = func(mm manifest) manifest { return cachingManifest{mm, cacheMu, manifestCache} }
 }
 
 type NomsBlockStore struct {
@@ -76,7 +79,7 @@ func NewAWSStore(table, ns, bucket string, s3 s3svc, ddb ddbsvc, memTableSize ui
 		make(chan struct{}, 32),
 		nil,
 	}
-	mm := newDynamoManifest(table, ns, ddb, globalManifestCache)
+	mm := globalAddCache(newDynamoManifest(table, ns, ddb))
 	return newNomsBlockStore(mm, p, globalConjoiner, memTableSize)
 }
 
@@ -84,7 +87,7 @@ func NewLocalStore(dir string, memTableSize uint64) *NomsBlockStore {
 	cacheOnce.Do(makeGlobalCaches)
 	d.PanicIfError(checkDir(dir))
 
-	mm := newFileManifest(dir, globalManifestCache)
+	mm := globalAddCache(fileManifest{dir})
 	p := newFSTablePersister(dir, globalFDCache, globalIndexCache)
 	return newNomsBlockStore(mm, p, globalConjoiner, memTableSize)
 }


### PR DESCRIPTION
There were races in both manifest implementations, between cache usage
in ParseIfExists() and Update(). It was possible for Update() calls to
occur between the time that ParseIfExists() read the manifest data and
the time it updated the cache. This led to newer manifest content
getting clobbered in the cache by out-of-date manifest content.

The new approach takes caching out of the hands of the manifest impls,
instead wrapping a shared caching layer around the outside.

Fixes #3551