### PR TITLE
Fix httpChunkStore race between Close() and Has/Get

### DIFF
--- a/go/chunks/chunk_store.go
+++ b/go/chunks/chunk_store.go
@@ -57,6 +57,10 @@ type ChunkStore interface {
 	// may return nil
 	Stats() interface{}
 
+	// Close tears down any resources in use by the implementation. After
+	// Close(), the ChunkStore may not be used again. It is NOT SAFE to call
+	// Close() concurrently with any other ChunkStore method; behavior is
+	// undefined and probably crashy.
 	io.Closer
 }
 

--- a/go/chunks/remote_requests.go
+++ b/go/chunks/remote_requests.go
@@ -103,12 +103,10 @@ type OutstandingAbsentMany struct {
 
 func (r OutstandingGet) Satisfy(h hash.Hash, c *Chunk) {
 	r <- c
-	close(r)
 }
 
 func (r OutstandingGet) Fail() {
 	r <- &EmptyChunk
-	close(r)
 }
 
 func (ogm OutstandingGetMany) Satisfy(h hash.Hash, c *Chunk) {
@@ -122,12 +120,10 @@ func (ogm OutstandingGetMany) Fail() {
 
 func (oh OutstandingAbsent) Satisfy(h hash.Hash, c *Chunk) {
 	oh <- false
-	close(oh)
 }
 
 func (oh OutstandingAbsent) Fail() {
 	oh <- true
-	close(oh)
 }
 
 func (ohm OutstandingAbsentMany) Satisfy(h hash.Hash, c *Chunk) {

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -235,15 +235,7 @@ func (hcs *httpChunkStore) batchReadRequests(queue <-chan chunks.ReadRequest, ge
 			case <-hcs.finishedChan:
 				done = true
 			}
-			/*	// Drain queue before returning
-				select {
-				case req := <-queue:
-					hcs.sendReadRequests(req, queue, getter)
-				default:
-					//drained!
-				}*/
 		}
-
 	}()
 }
 

--- a/go/datas/http_chunk_store.go
+++ b/go/datas/http_chunk_store.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	httpChunkSinkConcurrency = 6
-	writeBufferSize          = 1 << 12 // 4K
 	readBufferSize           = 1 << 12 // 4K
 )
 
@@ -48,7 +47,6 @@ type httpChunkStore struct {
 	hasQueue     chan chunks.ReadRequest
 	finishedChan chan struct{}
 	rateLimit    chan struct{}
-	requestWg    *sync.WaitGroup
 	workerWg     *sync.WaitGroup
 
 	cacheMu       *sync.RWMutex
@@ -74,11 +72,10 @@ func newHTTPChunkStoreWithClient(baseURL, auth string, client httpDoer) *httpChu
 		host:          u,
 		httpClient:    client,
 		auth:          auth,
-		getQueue:      make(chan chunks.ReadRequest, readBufferSize),
-		hasQueue:      make(chan chunks.ReadRequest, readBufferSize),
+		getQueue:      make(chan chunks.ReadRequest),
+		hasQueue:      make(chan chunks.ReadRequest),
 		finishedChan:  make(chan struct{}),
 		rateLimit:     make(chan struct{}, httpChunkSinkConcurrency),
-		requestWg:     &sync.WaitGroup{},
 		workerWg:      &sync.WaitGroup{},
 		cacheMu:       &sync.RWMutex{},
 		unwrittenPuts: nbs.NewCache(),
@@ -98,15 +95,8 @@ func (hcs *httpChunkStore) Version() string {
 	return hcs.version
 }
 
-func (hcs *httpChunkStore) Flush() {
-	hcs.sendWriteRequests()
-	hcs.requestWg.Wait()
-	return
-}
-
 func (hcs *httpChunkStore) Close() (e error) {
 	close(hcs.finishedChan)
-	hcs.requestWg.Wait()
 	hcs.workerWg.Wait()
 
 	close(hcs.getQueue)
@@ -134,8 +124,14 @@ func (hcs *httpChunkStore) Get(h hash.Hash) chunks.Chunk {
 	}
 
 	ch := make(chan *chunks.Chunk)
-	hcs.requestWg.Add(1)
-	hcs.getQueue <- chunks.NewGetRequest(h, ch)
+	defer close(ch)
+
+	select {
+	case <-hcs.finishedChan:
+		d.Panic("Tried to Get %s from closed ChunkStore", h)
+	case hcs.getQueue <- chunks.NewGetRequest(h, ch):
+	}
+
 	return *(<-ch)
 }
 
@@ -161,8 +157,11 @@ func (hcs *httpChunkStore) GetMany(hashes hash.HashSet, foundChunks chan *chunks
 	}
 	wg := &sync.WaitGroup{}
 	wg.Add(len(remaining))
-	hcs.requestWg.Add(1)
-	hcs.getQueue <- chunks.NewGetManyRequest(remaining, wg, foundChunks)
+	select {
+	case <-hcs.finishedChan:
+		d.Panic("Tried to GetMany from closed ChunkStore")
+	case hcs.getQueue <- chunks.NewGetManyRequest(remaining, wg, foundChunks):
+	}
 	wg.Wait()
 }
 
@@ -181,8 +180,13 @@ func (hcs *httpChunkStore) Has(h hash.Hash) bool {
 	}
 
 	ch := make(chan bool)
-	hcs.requestWg.Add(1)
-	hcs.hasQueue <- chunks.NewAbsentRequest(h, ch)
+	defer close(ch)
+	select {
+	case <-hcs.finishedChan:
+		d.Panic("Tried to Has %s on closed ChunkStore", h)
+	case hcs.hasQueue <- chunks.NewAbsentRequest(h, ch):
+	}
+
 	return <-ch
 }
 
@@ -200,8 +204,11 @@ func (hcs *httpChunkStore) HasMany(hashes hash.HashSet) (absent hash.HashSet) {
 	foundChunks := make(chan hash.Hash)
 	wg := &sync.WaitGroup{}
 	wg.Add(len(remaining))
-	hcs.requestWg.Add(1)
-	hcs.hasQueue <- chunks.NewAbsentManyRequest(remaining, wg, foundChunks)
+	select {
+	case <-hcs.finishedChan:
+		d.Panic("Tried to HasMany on closed ChunkStore")
+	case hcs.hasQueue <- chunks.NewAbsentManyRequest(remaining, wg, foundChunks):
+	}
 	go func() { defer close(foundChunks); wg.Wait() }()
 
 	absent = hash.HashSet{}
@@ -215,13 +222,12 @@ func (hcs *httpChunkStore) batchHasRequests() {
 	hcs.batchReadRequests(hcs.hasQueue, hcs.hasRefs)
 }
 
-type batchGetter func(hashes hash.HashSet, batch chunks.ReadBatch)
+type batchGetter func(batch chunks.ReadBatch)
 
 func (hcs *httpChunkStore) batchReadRequests(queue <-chan chunks.ReadRequest, getter batchGetter) {
 	hcs.workerWg.Add(1)
 	go func() {
 		defer hcs.workerWg.Done()
-
 		for done := false; !done; {
 			select {
 			case req := <-queue:
@@ -229,32 +235,31 @@ func (hcs *httpChunkStore) batchReadRequests(queue <-chan chunks.ReadRequest, ge
 			case <-hcs.finishedChan:
 				done = true
 			}
-			// Drain queue before returning
-			select {
-			case req := <-queue:
-				hcs.sendReadRequests(req, queue, getter)
-			default:
-				//drained!
-			}
+			/*	// Drain queue before returning
+				select {
+				case req := <-queue:
+					hcs.sendReadRequests(req, queue, getter)
+				default:
+					//drained!
+				}*/
 		}
+
 	}()
 }
 
 func (hcs *httpChunkStore) sendReadRequests(req chunks.ReadRequest, queue <-chan chunks.ReadRequest, getter batchGetter) {
 	batch := chunks.ReadBatch{}
-	hashes := hash.HashSet{}
 
 	count := 0
 	addReq := func(req chunks.ReadRequest) {
 		for h := range req.Hashes() {
 			batch[h] = append(batch[h], req.Outstanding())
-			hashes.Insert(h)
 		}
 		count++
 	}
 
 	addReq(req)
-	for drained := false; !drained && len(hashes) < readBufferSize; {
+	for drained := false; !drained && len(batch) < readBufferSize; {
 		select {
 		case req := <-queue:
 			addReq(req)
@@ -265,17 +270,14 @@ func (hcs *httpChunkStore) sendReadRequests(req chunks.ReadRequest, queue <-chan
 
 	hcs.rateLimit <- struct{}{}
 	go func() {
-		defer func() {
-			hcs.requestWg.Add(-count)
-			batch.Close()
-		}()
+		defer batch.Close()
 
-		getter(hashes, batch)
+		getter(batch)
 		<-hcs.rateLimit
 	}()
 }
 
-func (hcs *httpChunkStore) getRefs(hashes hash.HashSet, batch chunks.ReadBatch) {
+func (hcs *httpChunkStore) getRefs(batch chunks.ReadBatch) {
 	// POST http://<host>/getRefs/. Post body: ref=hash0&ref=hash1& Response will be chunk data if present, 404 if absent.
 	u := *hcs.host
 	u.Path = httprouter.CleanPath(hcs.host.Path + constants.GetRefsPath)
@@ -287,7 +289,7 @@ func (hcs *httpChunkStore) getRefs(hashes hash.HashSet, batch chunks.ReadBatch) 
 	}
 	u.RawQuery = q
 
-	req := newRequest("POST", hcs.auth, u.String(), buildHashesRequest(hashes), http.Header{
+	req := newRequest("POST", hcs.auth, u.String(), buildHashesRequest(batch), http.Header{
 		"Accept-Encoding": {"x-snappy-framed"},
 		"Content-Type":    {"application/x-www-form-urlencoded"},
 	})
@@ -314,12 +316,12 @@ func (hcs *httpChunkStore) getRefs(hashes hash.HashSet, batch chunks.ReadBatch) 
 	}
 }
 
-func (hcs *httpChunkStore) hasRefs(hashes hash.HashSet, batch chunks.ReadBatch) {
+func (hcs *httpChunkStore) hasRefs(batch chunks.ReadBatch) {
 	// POST http://<host>/hasRefs/. Post body: ref=sha1---&ref=sha1---& Response will be text of lines containing "|ref| |bool|".
 	u := *hcs.host
 	u.Path = httprouter.CleanPath(hcs.host.Path + constants.HasRefsPath)
 
-	req := newRequest("POST", hcs.auth, u.String(), buildHashesRequest(hashes), http.Header{
+	req := newRequest("POST", hcs.auth, u.String(), buildHashesRequest(batch), http.Header{
 		"Accept-Encoding": {"x-snappy-framed"},
 		"Content-Type":    {"application/x-www-form-urlencoded"},
 	})
@@ -443,7 +445,7 @@ func (hcs *httpChunkStore) getRoot(checkVers bool) (root hash.Hash, vers string)
 func (hcs *httpChunkStore) Commit(current, last hash.Hash) bool {
 	hcs.rootMu.Lock()
 	defer hcs.rootMu.Unlock()
-	hcs.Flush()
+	hcs.sendWriteRequests()
 
 	// POST http://<host>/root?current=<ref>&last=<ref>. Response will be 200 on success, 409 if current is outdated.
 	res := hcs.requestRoot("POST", current, last)

--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -147,8 +147,9 @@ func (suite *HTTPChunkStoreSuite) TearDownTest() {
 func (suite *HTTPChunkStoreSuite) TestPutChunk() {
 	c := types.EncodeValue(types.String("abc"))
 	suite.http.Put(c)
-	suite.http.Flush()
+	suite.True(suite.http.Has(c.Hash()))
 
+	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
 	suite.Equal(1, suite.serverCS.Writes)
 }
 
@@ -163,7 +164,7 @@ func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
 		l = l.Append(types.NewRef(val))
 	}
 	suite.http.Put(types.EncodeValue(l))
-	suite.http.Flush()
+	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
 
 	suite.Equal(3, suite.serverCS.Writes)
 }

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -322,10 +322,10 @@ func extractHashes(req *http.Request) hash.HashSlice {
 	return hashes
 }
 
-func buildHashesRequest(hashes map[hash.Hash]struct{}) io.Reader {
+func buildHashesRequest(batch chunks.ReadBatch) io.Reader {
 	values := &url.Values{}
-	for r := range hashes {
-		values.Add("ref", r.String())
+	for h := range batch {
+		values.Add("ref", h.String())
 	}
 	return strings.NewReader(values.Encode())
 }

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -134,11 +134,11 @@ func serializeChunks(chnx []chunks.Chunk, assert *assert.Assertions) io.Reader {
 
 func TestBuildHashesRequest(t *testing.T) {
 	assert := assert.New(t)
-	hashes := map[hash.Hash]struct{}{
-		hash.Parse("00000000000000000000000000000002"): {},
-		hash.Parse("00000000000000000000000000000003"): {},
+	batch := chunks.ReadBatch{
+		hash.Parse("00000000000000000000000000000002"): nil,
+		hash.Parse("00000000000000000000000000000003"): nil,
 	}
-	r := buildHashesRequest(hashes)
+	r := buildHashesRequest(batch)
 	b, err := ioutil.ReadAll(r)
 	assert.NoError(err)
 
@@ -147,9 +147,9 @@ func TestBuildHashesRequest(t *testing.T) {
 	assert.NotEmpty(urlValues)
 
 	queryRefs := urlValues["ref"]
-	assert.Len(queryRefs, len(hashes))
+	assert.Len(queryRefs, len(batch))
 	for _, r := range queryRefs {
-		_, present := hashes[hash.Parse(r)]
+		_, present := batch[hash.Parse(r)]
 		assert.True(present, "Query contains %s, which is not in initial refs", r)
 	}
 }

--- a/go/nbs/benchmarks/file_block_store.go
+++ b/go/nbs/benchmarks/file_block_store.go
@@ -47,8 +47,6 @@ func (fb fileBlockStore) Version() string {
 	panic("not impl")
 }
 
-func (fb fileBlockStore) Flush() {}
-
 func (fb fileBlockStore) Close() error {
 	fb.w.Close()
 	return nil

--- a/go/nbs/benchmarks/null_block_store.go
+++ b/go/nbs/benchmarks/null_block_store.go
@@ -39,8 +39,6 @@ func (nb nullBlockStore) Version() string {
 	panic("not impl")
 }
 
-func (nb nullBlockStore) Flush() {}
-
 func (nb nullBlockStore) Close() error {
 	return nil
 }


### PR DESCRIPTION
In httpChunkStore, calls to Get/Has and friends put a request object
with a 'return channel' onto a queue channel, and then block on the
return channel. The queue channel was buffered, which made it
impossible to cause Get, Has et al to terminate reliably when the
store was closed.

This patch removes the buffering on the channel so we can
deterministically bail from Get/Has et al when closing the store. I
don't think we were actually seeing any benefit from the buffer on the
queue channels, because everywhere we write to one of them we
immediately block on another channel, waiting for the result of the
request.

Fixes #3566