### PR TITLE
NBS: updateManifest() fails fast if Update is DOOOOOOMED

### DIFF
--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -71,6 +71,17 @@ type cachingManifest struct {
 	cache *manifestCache
 }
 
+func (cm cachingManifest) updateWillFail(lastLock addr) (cached manifestContents, doomed bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if upstream, hit := cm.cache.Get(cm.Name()); hit {
+		if lastLock != upstream.lock {
+			doomed, cached = true, upstream
+		}
+	}
+	return
+}
+
 func (cm cachingManifest) ParseIfExists(stats *Stats, readHook func()) (exists bool, contents manifestContents) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()


### PR DESCRIPTION
If NomsBlockStore can assume that its manifest is a cachingManifest,
it can pre-emptively check to see if someone else in-process has
already moved the manifest forward and, if so, fail early.

Fixes #3574