### PR TITLE
add store-granularity locking to manifest cache

### DIFF
--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"sync"
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -297,7 +296,7 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 	newChunk := chunks.NewChunk([]byte("gnu"))
 
 	t.Run("NoConjoin", func(t *testing.T) {
-		mm := cachingManifest{&fakeManifest{}, &sync.Mutex{}, newManifestCache(0)}
+		mm := cachingManifest{&fakeManifest{}, newManifestCache(0)}
 		p := newFakeTablePersister()
 		c := &fakeConjoiner{}
 
@@ -330,7 +329,7 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 			[]cannedConjoin{makeCanned(upstream[:2], upstream[2:], p)},
 		}
 
-		smallTableStore := newNomsBlockStore(cachingManifest{fm, &sync.Mutex{}, newManifestCache(0)}, p, c, testMemTableSize)
+		smallTableStore := newNomsBlockStore(cachingManifest{fm, newManifestCache(0)}, p, c, testMemTableSize)
 
 		root := smallTableStore.Root()
 		smallTableStore.Put(newChunk)
@@ -353,7 +352,7 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 			},
 		}
 
-		smallTableStore := newNomsBlockStore(cachingManifest{fm, &sync.Mutex{}, newManifestCache(0)}, p, c, testMemTableSize)
+		smallTableStore := newNomsBlockStore(cachingManifest{fm, newManifestCache(0)}, p, c, testMemTableSize)
 
 		root := smallTableStore.Root()
 		smallTableStore.Put(newChunk)

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -104,7 +104,7 @@ func TestChunkStoreManifestAppearsAfterConstruction(t *testing.T) {
 func TestChunkStoreManifestFirstWriteByOtherProcess(t *testing.T) {
 	assert := assert.New(t)
 	fm := &fakeManifest{}
-	mm := cachingManifest{fm, &sync.Mutex{}, newManifestCache(0)}
+	mm := cachingManifest{fm, newManifestCache(0)}
 	p := newFakeTablePersister()
 
 	// Simulate another process writing a manifest behind store's back.
@@ -135,7 +135,7 @@ func TestChunkStoreCommitOptimisticLockFail(t *testing.T) {
 func TestChunkStoreManifestPreemptiveOptimisticLockFail(t *testing.T) {
 	assert := assert.New(t)
 	fm := &fakeManifest{}
-	mm := cachingManifest{fm, &sync.Mutex{}, newManifestCache(defaultManifestCacheSize)}
+	mm := cachingManifest{fm, newManifestCache(defaultManifestCacheSize)}
 	p := newFakeTablePersister()
 	c := newAsyncConjoiner(defaultMaxTables)
 
@@ -165,7 +165,7 @@ func TestChunkStoreManifestPreemptiveOptimisticLockFail(t *testing.T) {
 
 func makeStoreWithFakes(t *testing.T) (fm *fakeManifest, p tablePersister, store *NomsBlockStore) {
 	fm = &fakeManifest{}
-	mm := cachingManifest{fm, &sync.Mutex{}, newManifestCache(0)}
+	mm := cachingManifest{fm, newManifestCache(0)}
 	p = newFakeTablePersister()
 	store = newNomsBlockStore(mm, p, newAsyncConjoiner(defaultMaxTables), 0)
 	return

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -44,9 +44,8 @@ func makeGlobalCaches() {
 	globalFDCache = newFDCache(defaultMaxTables)
 	globalConjoiner = newAsyncConjoiner(defaultMaxTables)
 
-	cacheMu := &sync.Mutex{}
 	manifestCache := newManifestCache(defaultManifestCacheSize)
-	makeCachingManifest = func(mm manifest) cachingManifest { return cachingManifest{mm, cacheMu, manifestCache} }
+	makeCachingManifest = func(mm manifest) cachingManifest { return cachingManifest{mm, manifestCache} }
 }
 
 type NomsBlockStore struct {


### PR DESCRIPTION
Prior to this patch, the manifest cache was effectively serializing all IO to the underlying manifest across a factory (i.e. multiple calls to Rebase() of different stores). This allows IO to different stores to proceed concurrently.