### PR TITLE
fix manifest cache race

### DIFF
--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -92,8 +92,9 @@ func (cm cachingManifest) ParseIfExists(stats *Stats, readHook func()) (exists b
 		return true, cached
 	}
 
+	t = time.Now()
 	exists, contents = cm.mm.ParseIfExists(stats, readHook)
-	cm.cache.Put(cm.Name(), contents)
+	cm.cache.Put(cm.Name(), contents, t)
 	return
 }
 
@@ -105,8 +106,9 @@ func (cm cachingManifest) Update(lastLock addr, newContents manifestContents, st
 			return upstream
 		}
 	}
+	t := time.Now()
 	contents := cm.mm.Update(lastLock, newContents, stats, writeHook)
-	cm.cache.Put(cm.Name(), contents)
+	cm.cache.Put(cm.Name(), contents, t)
 	return contents
 }
 

--- a/go/nbs/manifest_cache_test.go
+++ b/go/nbs/manifest_cache_test.go
@@ -6,6 +6,7 @@ package nbs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/attic-labs/testify/assert"
 )
@@ -17,11 +18,12 @@ func TestSizeCache(t *testing.T) {
 		assert := assert.New(t)
 
 		c := newManifestCache(2 * defSize)
+		t1 := time.Now()
 		dbA, contentsA := "dbA", manifestContents{lock: computeAddr([]byte("lockA"))}
 		dbB, contentsB := "dbB", manifestContents{lock: computeAddr([]byte("lockB"))}
 
-		c.Put(dbA, contentsA)
-		c.Put(dbB, contentsB)
+		c.Put(dbA, contentsA, t1)
+		c.Put(dbB, contentsB, t1)
 
 		cont, _, present := c.Get(dbA)
 		assert.True(present)
@@ -39,7 +41,7 @@ func TestSizeCache(t *testing.T) {
 		c := newManifestCache(capacity * defSize)
 		keys := []string{"db1", "db2", "db3", "db4", "db5", "db6", "db7", "db8", "db9"}
 		for i, v := range keys {
-			c.Put(v, manifestContents{})
+			c.Put(v, manifestContents{}, time.Now())
 			expected := uint64(i + 1)
 			if expected >= capacity {
 				expected = capacity
@@ -61,14 +63,14 @@ func TestSizeCache(t *testing.T) {
 		_, _, ok := c.Get(keys[lru])
 		assert.True(ok)
 		lru++
-		c.Put("novel", manifestContents{})
+		c.Put("novel", manifestContents{}, time.Now())
 		_, _, ok = c.Get(keys[lru])
 		assert.False(ok)
 		// |keys[lru]| is gone, so |keys[lru+1]| is next
 		lru++
 
 		// Putting a bigger value will dump multiple existing entries
-		c.Put("big", manifestContents{vers: "big version"})
+		c.Put("big", manifestContents{vers: "big version"}, time.Now())
 		_, _, ok = c.Get(keys[lru])
 		assert.False(ok)
 		lru++
@@ -89,14 +91,14 @@ func TestSizeCache(t *testing.T) {
 
 	t.Run("TooLargeValue", func(t *testing.T) {
 		c := newManifestCache(16)
-		c.Put("db", manifestContents{})
+		c.Put("db", manifestContents{}, time.Now())
 		_, _, ok := c.Get("db")
 		assert.False(t, ok)
 	})
 
 	t.Run("ZeroSizeCache", func(t *testing.T) {
 		c := newManifestCache(0)
-		c.Put("db", manifestContents{})
+		c.Put("db", manifestContents{}, time.Now())
 		_, _, ok := c.Get("db")
 		assert.False(t, ok)
 	})


### PR DESCRIPTION
It occurred to me that the timestamp here needs to be *pessimistic* and use the time prior to initiating the IO call in order to avoid a race. 