### PR TITLE
NBS: Prevent concurrent loading of the same table index

### DIFF
--- a/go/nbs/file_table_persister.go
+++ b/go/nbs/file_table_persister.go
@@ -46,6 +46,8 @@ func (ftp *fsTablePersister) persistTable(name addr, data []byte, chunkCount uin
 		io.Copy(temp, bytes.NewReader(data))
 		index := parseTableIndex(data)
 		if ftp.indexCache != nil {
+			ftp.indexCache.lockEntry(name)
+			defer ftp.indexCache.unlockEntry(name)
 			ftp.indexCache.put(name, index)
 		}
 		return temp.Name()

--- a/go/nbs/mmap_table_reader.go
+++ b/go/nbs/mmap_table_reader.go
@@ -44,6 +44,8 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32, indexCache *index
 	var index tableIndex
 	found := false
 	if indexCache != nil {
+		indexCache.lockEntry(h)
+		defer indexCache.unlockEntry(h)
 		index, found = indexCache.get(h)
 	}
 

--- a/go/nbs/s3_table_persister.go
+++ b/go/nbs/s3_table_persister.go
@@ -63,6 +63,8 @@ func (s3p s3TablePersister) newReaderFromIndexData(idxData []byte, name addr) *s
 	s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name, readRl: s3p.readRl}
 	index := parseTableIndex(idxData)
 	if s3p.indexCache != nil {
+		s3p.indexCache.lockEntry(name)
+		defer s3p.indexCache.unlockEntry(name)
 		s3p.indexCache.put(name, index)
 	}
 	s3tr.tableReader = newTableReader(index, s3tr, s3BlockSize)

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -49,6 +49,8 @@ func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexC
 	var index tableIndex
 	found := false
 	if indexCache != nil {
+		indexCache.lockEntry(h)
+		defer indexCache.unlockEntry(h)
 		index, found = indexCache.get(h)
 	}
 


### PR DESCRIPTION
By adding per-entry locking to indexCache, this patch allows both NBS
storage backends to ensure that only one goroutine is loading a given
table index at a time. Previoudly, if multiple readers tried to open
the same table at the same time, it was possible for both to get a
cache-miss and then read in the table index at the same time, which
wastes memory.  Now, one will win the race, load the index, and then
the other will see a cache hit.

Fixes #3581