### PR TITLE
MarshalType: Make sure we use the user provided name

### DIFF
--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -173,7 +173,7 @@ func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTa
 // nil and we have to wait until we have a value to be able to determine the
 // type.
 func structEncodeType(t reflect.Type, seenStructs map[string]reflect.Type) *types.Type {
-	name := t.Name()
+	name := getStructName(t)
 	if name != "" {
 		if _, ok := seenStructs[name]; ok {
 			return types.MakeCycleType(name)

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/attic-labs/noms/go/nomdl"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/testify/assert"
 )
@@ -589,4 +590,28 @@ func TestMarshalTypeStructName2(t *testing.T) {
 	var ts TestStructWithNameImpl2
 	typ := MustMarshalType(ts)
 	assert.True(types.MakeStructType("", types.StructField{"x", types.NumberType, false}).Equals(typ), typ.Describe())
+}
+
+type OutPhoto struct {
+	Faces             []OutFace `noms:",set"`
+	SomeOtherFacesSet []OutFace `noms:",set"`
+}
+
+type OutFace struct {
+	Blob types.Ref
+}
+
+func (f OutFace) MarshalNomsStructName() string {
+	return "Face"
+}
+
+func TestMarshalTypeOutface(t *testing.T) {
+	typ := MustMarshalType(OutPhoto{})
+	expectedType := nomdl.MustParseType(`struct OutPhoto {
+          faces: Set<struct Face {
+            blob: Ref<Value>,
+          }>,
+          someOtherFacesSet: Set<Cycle<Face>>,
+        }`)
+	assert.True(t, typ.Equals(expectedType))
 }


### PR DESCRIPTION
We need to use getStructName in MarshalType too.

Fixes https://github.com/attic-labs/attic/issues/2289