### PR TITLE
List Editor

### DIFF
--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -158,12 +158,12 @@ func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
 		types.String("abc"),
 		types.String("def"),
 	}
-	l := types.NewList()
+	le := types.NewList().Edit()
 	for _, val := range vals {
 		suite.http.Put(types.EncodeValue(val))
-		l = l.Append(types.NewRef(val))
+		le.Append(types.NewRef(val))
 	}
-	suite.http.Put(types.EncodeValue(l))
+	suite.http.Put(types.EncodeValue(le.List(nil)))
 	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
 
 	suite.Equal(3, suite.serverCS.Writes)

--- a/go/datas/pull_test.go
+++ b/go/datas/pull_test.go
@@ -232,9 +232,9 @@ func (suite *PullSuite) TestPullDivergentHistory() {
 	srcL := buildListOfHeight(3, suite.source)
 	sourceRef := suite.commitToSource(srcL, types.NewSet())
 
-	sinkL = sinkL.Append(types.String("oy!"))
+	sinkL = sinkL.Edit().Append(types.String("oy!")).List(nil)
 	sinkRef = suite.commitToSink(sinkL, types.NewSet(sinkRef))
-	srcL = srcL.Set(1, buildListOfHeight(5, suite.source))
+	srcL = srcL.Edit().Set(1, buildListOfHeight(5, suite.source)).List(nil)
 	sourceRef = suite.commitToSource(srcL, types.NewSet(sourceRef))
 	preReads := suite.sinkCS.Reads
 
@@ -275,9 +275,9 @@ func (suite *PullSuite) TestPullUpdates() {
 	sourceRef := suite.commitToSource(srcL, types.NewSet())
 	L3 := srcL.Get(1).(types.Ref).TargetValue(suite.source).(types.List)
 	L2 := L3.Get(1).(types.Ref).TargetValue(suite.source).(types.List)
-	L2 = L2.Append(suite.source.WriteValue(types.String("oy!")))
-	L3 = L3.Set(1, suite.source.WriteValue(L2))
-	srcL = srcL.Set(1, suite.source.WriteValue(L3))
+	L2 = L2.Edit().Append(suite.source.WriteValue(types.String("oy!"))).List(nil)
+	L3 = L3.Edit().Set(1, suite.source.WriteValue(L2)).List(nil)
+	srcL = srcL.Edit().Set(1, suite.source.WriteValue(L3)).List(nil)
 	sourceRef = suite.commitToSource(srcL, types.NewSet(sourceRef))
 
 	pt := startProgressTracker()

--- a/go/datas/remote_database_handlers_test.go
+++ b/go/datas/remote_database_handlers_test.go
@@ -38,7 +38,7 @@ func TestHandleWriteValue(t *testing.T) {
 
 	newItem := types.NewEmptyBlob()
 	itemChunk := types.EncodeValue(newItem)
-	l2 := l.Insert(1, types.NewRef(newItem))
+	l2 := l.Edit().Insert(1, types.NewRef(newItem)).List(nil)
 	listChunk := types.EncodeValue(l2)
 
 	body := &bytes.Buffer{}

--- a/go/diff/apply_patch.go
+++ b/go/diff/apply_patch.go
@@ -124,14 +124,14 @@ func (stack *patchStack) updateNode(top *stackElem, parent types.Value) types.Va
 			switch top.changeType {
 			case types.DiffChangeAdded:
 				if realIdx > el.Len() {
-					nv = el.Append(top.newValue)
+					nv = el.Edit().Append(top.newValue).List(nil)
 				} else {
-					nv = el.Insert(realIdx, top.newValue)
+					nv = el.Edit().Insert(realIdx, top.newValue).List(nil)
 				}
 			case types.DiffChangeRemoved:
-				nv = el.RemoveAt(realIdx)
+				nv = el.Edit().RemoveAt(realIdx).List(nil)
 			case types.DiffChangeModified:
-				nv = el.Set(realIdx, top.newValue)
+				nv = el.Edit().Set(realIdx, top.newValue).List(nil)
 			}
 			return nv
 		case types.Map:

--- a/go/merge/three_way_list.go
+++ b/go/merge/three_way_list.go
@@ -111,7 +111,7 @@ func merge(s1, s2 types.Splice) types.Splice {
 }
 
 func apply(source, target types.List, offset uint64, s types.Splice) types.List {
-	toAdd := make(types.ValueSlice, s.SpAdded)
+	toAdd := make([]types.Valuable, s.SpAdded)
 	iter := source.IteratorAt(s.SpFrom)
 	for i := 0; uint64(i) < s.SpAdded; i++ {
 		v := iter.Next()
@@ -120,7 +120,7 @@ func apply(source, target types.List, offset uint64, s types.Splice) types.List 
 		}
 		toAdd[i] = v
 	}
-	return target.Splice(s.SpAt+offset, s.SpRemoved, toAdd...)
+	return target.Edit().Splice(s.SpAt+offset, s.SpRemoved, toAdd...).List(nil)
 }
 
 func describeSplice(s types.Splice) string {

--- a/go/perf/codec-perf-rig/main.go
+++ b/go/perf/codec-perf-rig/main.go
@@ -34,7 +34,7 @@ func main() {
 	flag.Parse(true)
 
 	buildCount := *count
-	insertCount := buildCount / 50
+	insertCount := buildCount
 	defer profile.MaybeStartProfile().Stop()
 
 	collectionTypes := []string{"List", "Set", "Map"}
@@ -172,12 +172,12 @@ func buildList(count uint64, createFn createValueFn) types.Collection {
 }
 
 func buildListIncrementally(count uint64, createFn createValueFn) types.Collection {
-	l := types.NewList()
+	l := types.NewList().Edit()
 	for i := uint64(0); i < count; i++ {
-		l = l.Insert(i, createFn(i))
+		l.Insert(i, createFn(i))
 	}
 
-	return l
+	return l.List(nil)
 }
 
 func readList(c types.Collection) {

--- a/go/types/list_editor.go
+++ b/go/types/list_editor.go
@@ -1,0 +1,293 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/attic-labs/noms/go/d"
+)
+
+type ListEditor struct {
+	l     List
+	edits *listEdit
+}
+
+func NewListEditor(l List) *ListEditor {
+	return &ListEditor{l, nil}
+}
+
+func (le *ListEditor) Kind() NomsKind {
+	return ListKind
+}
+
+func (le *ListEditor) Value(vrw ValueReadWriter) Value {
+	return le.List(vrw)
+}
+
+func (le *ListEditor) List(vrw ValueReadWriter) List {
+	if le.edits == nil {
+		return le.l // no edits
+	}
+
+	seq := le.l.sequence()
+	vr := seq.valueReader()
+
+	if vrw != nil {
+		vr = vrw
+	}
+
+	cursChan := make(chan chan *sequenceCursor)
+	spliceChan := make(chan chan listEdit)
+
+	go func() {
+		for edit := le.edits; edit != nil; edit = edit.next {
+			edit := edit
+
+			// TODO: Use ReadMany
+			cc := make(chan *sequenceCursor, 1)
+			cursChan <- cc
+
+			go func() {
+				cc <- newCursorAtIndex(seq, edit.idx, false)
+			}()
+
+			sc := make(chan listEdit, 1)
+			spliceChan <- sc
+
+			wg := sync.WaitGroup{}
+			subEditors := false
+			for i, v := range edit.inserted {
+				if _, ok := v.(Value); ok {
+					continue
+				}
+
+				subEditors = true
+				idx := i
+				wg.Add(1)
+				go func() {
+					edit.inserted[idx] = v.Value(vrw)
+					wg.Done()
+				}()
+			}
+			if !subEditors {
+				sc <- *edit
+				continue
+			}
+
+			go func() {
+				wg.Wait()
+				sc <- *edit
+			}()
+		}
+
+		close(cursChan)
+		close(spliceChan)
+	}()
+
+	var ch *sequenceChunker
+	for cc := range cursChan {
+		cur := <-cc
+		sp := <-<-spliceChan
+
+		if ch == nil {
+			ch = newSequenceChunker(cur, 0, vr, vrw, makeListLeafChunkFn(vr), newIndexedMetaSequenceChunkFn(ListKind, vr), hashValueBytes)
+		} else {
+			ch.advanceTo(cur)
+		}
+
+		dc := sp.removed
+		for dc > 0 {
+			ch.Skip()
+			dc--
+		}
+
+		for _, v := range sp.inserted {
+			if emp, ok := v.(Emptyable); ok && emp.Empty() {
+				continue
+			}
+
+			ch.Append(v)
+		}
+	}
+
+	return newList(ch.Done())
+}
+
+func collapse(newEdit, edit *listEdit) bool {
+	if newEdit.idx+newEdit.removed < edit.idx ||
+		edit.idx+uint64(len(edit.inserted)) < newEdit.idx {
+		return false
+	}
+
+	collapsed := &listEdit{}
+
+	if newEdit.idx <= edit.idx {
+		collapsed.idx = newEdit.idx
+
+		overlap := newEdit.removed - (edit.idx - newEdit.idx) // number of leading N values removed from edit.inserted
+		if overlap < uint64(len(edit.inserted)) {
+			// newEdit doesn't remove all of edit.inserted
+			collapsed.inserted = append(newEdit.inserted, edit.inserted[overlap:]...)
+			collapsed.removed = newEdit.removed + edit.removed - overlap
+		} else {
+			// newEdit removes all of edit.inserted
+			collapsed.inserted = newEdit.inserted
+			collapsed.removed = newEdit.removed + edit.removed - uint64(len(edit.inserted))
+		}
+	} else {
+		// edit.idx < newEdit.idx
+
+		collapsed.idx = edit.idx
+
+		editInsertedLen := uint64(len(edit.inserted))
+		beginEditRemovePoint := newEdit.idx - edit.idx
+
+		if beginEditRemovePoint == editInsertedLen {
+			// newEdit took place at the position immediately after the last element of edit.inserted
+			collapsed.inserted = append(edit.inserted, newEdit.inserted...)
+			collapsed.removed = edit.removed + newEdit.removed
+		} else {
+			// newEdit takes place within edit.inserted
+			collapsed.inserted = append(collapsed.inserted, edit.inserted[:beginEditRemovePoint]...)
+			collapsed.inserted = append(collapsed.inserted, newEdit.inserted...)
+
+			endEditRemovePoint := beginEditRemovePoint + newEdit.removed
+			if endEditRemovePoint < editInsertedLen {
+				// elements of edit.inserted remain beyond newEdit.removed
+				collapsed.removed = edit.removed
+				collapsed.inserted = append(collapsed.inserted, edit.inserted[endEditRemovePoint:]...)
+			} else {
+				collapsed.removed = edit.removed + endEditRemovePoint - editInsertedLen
+			}
+		}
+	}
+
+	*newEdit = *collapsed
+	return true
+}
+
+func (le *ListEditor) Len() uint64 {
+	delta := int64(0)
+	for edit := le.edits; edit != nil; edit = edit.next {
+		delta += -int64(edit.removed) + int64(len(edit.inserted))
+	}
+
+	return uint64(int64(le.l.Len()) + delta)
+}
+
+func (le *ListEditor) dump() {
+	fmt.Println("ListEditor", le.Len())
+	for edit := le.edits; edit != nil; edit = edit.next {
+		fmt.Println("Edit", edit.idx, edit.removed, edit.inserted)
+	}
+}
+
+func (le *ListEditor) Splice(idx uint64, deleteCount uint64, vs ...Valuable) *ListEditor {
+	for _, sv := range vs {
+		d.PanicIfTrue(sv == nil)
+	}
+
+	ne := &listEdit{idx, deleteCount, vs, nil}
+
+	var last *listEdit
+	edit := le.edits
+
+	for edit != nil {
+		if collapse(ne, edit) {
+			if last == nil {
+				le.edits = edit.next
+			} else {
+				last.next = edit.next
+			}
+
+			edit = edit.next
+			continue
+		}
+
+		if edit.idx > ne.idx {
+			break
+		}
+
+		ne.idx = adjustIdx(ne.idx, edit)
+		last = edit
+		edit = edit.next
+	}
+
+	if ne.removed == 0 && len(ne.inserted) == 0 {
+		return le // effectively removed 1 or more existing slices
+	}
+
+	if ne.idx > le.l.Len() {
+		d.Panic("Index Out Of Bounds")
+	}
+	if ne.idx == le.l.Len() && ne.removed > 0 {
+		d.Panic("Index Out Of Bounds")
+	}
+
+	if last == nil {
+		// Insert |ne| in first position
+		ne.next = le.edits
+		le.edits = ne
+	} else {
+		ne.next = last.next
+		last.next = ne
+	}
+
+	return le
+}
+
+func (le *ListEditor) Set(idx uint64, v Valuable) *ListEditor {
+	return le.Splice(idx, 1, v)
+}
+
+func (le *ListEditor) Append(vs ...Valuable) *ListEditor {
+	return le.Splice(le.Len(), 0, vs...)
+}
+
+func (le *ListEditor) Insert(idx uint64, vs ...Valuable) *ListEditor {
+	return le.Splice(idx, 0, vs...)
+}
+
+func (le *ListEditor) Remove(start uint64, end uint64) *ListEditor {
+	d.PanicIfFalse(start <= end)
+	return le.Splice(start, end-start)
+}
+
+func (le *ListEditor) RemoveAt(idx uint64) *ListEditor {
+	return le.Splice(idx, 1)
+}
+
+func adjustIdx(idx uint64, e *listEdit) uint64 {
+	return idx + e.removed - uint64(len(e.inserted))
+}
+
+func (le *ListEditor) Get(idx uint64) Valuable {
+	edit := le.edits
+	for edit != nil {
+		if edit.idx > idx {
+			// idx is before next splice
+			return le.l.Get(idx)
+		}
+
+		if edit.idx <= idx && idx < (edit.idx+uint64(len(edit.inserted))) {
+			// idx is within the insert values of edit
+			return edit.inserted[idx-edit.idx]
+		}
+
+		idx = adjustIdx(idx, edit)
+		edit = edit.next
+	}
+
+	return le.l.Get(idx)
+}
+
+type listEdit struct {
+	idx      uint64
+	removed  uint64
+	inserted []Valuable
+	next     *listEdit
+}

--- a/go/types/list_editor_test.go
+++ b/go/types/list_editor_test.go
@@ -1,0 +1,215 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func listOfInts(vals ...int) List {
+	vs := ValueSlice{}
+	for _, v := range vals {
+		vs = append(vs, Number(v))
+	}
+	return NewList(vs...)
+}
+
+func testEditor(vals ...int) *ListEditor {
+	return NewListEditor(listOfInts(vals...))
+}
+
+func edit(le *ListEditor, idx, remove int, insert ...int) {
+	vals := []Valuable{}
+	for _, v := range insert {
+		vals = append(vals, Number(v))
+	}
+	le.Splice(uint64(idx), uint64(remove), vals...)
+}
+
+func assertState(t *testing.T, le *ListEditor, expectItems []int, expectEditCount int) {
+	assert.Equal(t, uint64(len(expectItems)), le.Len())
+
+	for i, v := range expectItems {
+		assert.Equal(t, Number(v), le.Get(uint64(i)))
+	}
+
+	actualEditCount := 0
+	for edit := le.edits; edit != nil; edit = edit.next {
+		actualEditCount++
+	}
+
+	assert.Equal(t, expectEditCount, actualEditCount)
+
+	assert.True(t, listOfInts(expectItems...).Equals(le.List(nil)))
+}
+
+func TestListEditorBasic(t *testing.T) {
+	t.Run("remove  a few", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 2, 2)
+		assertState(t, le, []int{0, 1, 4, 5}, 1)
+	})
+
+	t.Run("insert  a few", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 2, 0, 9, 8, 7)
+		assertState(t, le, []int{0, 1, 9, 8, 7, 2, 3, 4, 5}, 1)
+	})
+
+	t.Run("remove 2, insert 3", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 2, 2, 9, 8, 7)
+		assertState(t, le, []int{0, 1, 9, 8, 7, 4, 5}, 1)
+	})
+
+	t.Run("insert 2 twice", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 2, 0, 9, 10)
+		assertState(t, le, []int{0, 1, 9, 10, 2, 3, 4, 5}, 1)
+		edit(le, 7, 0, 8, 9)
+		assertState(t, le, []int{0, 1, 9, 10, 2, 3, 4, 8, 9, 5}, 2)
+	})
+
+	t.Run("remove 2 twice", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		edit(le, 5, 2)
+		assertState(t, le, []int{0, 1, 2, 3, 4, 7}, 1)
+		edit(le, 1, 2)
+		assertState(t, le, []int{0, 3, 4, 7}, 2)
+	})
+}
+
+func TestCollapseSplices(t *testing.T) {
+	t.Run("left adjacent", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		edit(le, 4, 3)
+		assertState(t, le, []int{0, 1, 2, 3, 7}, 1)
+		edit(le, 1, 3)
+		assertState(t, le, []int{0, 7}, 1)
+	})
+
+	t.Run("left adjacent 2", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		edit(le, 4, 3, 0, 0)
+		assertState(t, le, []int{0, 1, 2, 3, 0, 0, 7}, 1)
+		edit(le, 1, 3, 5, 5)
+		assertState(t, le, []int{0, 5, 5, 0, 0, 7}, 1)
+	})
+
+	t.Run("left consume", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		edit(le, 2, 4)
+		assertState(t, le, []int{0, 1, 6, 7}, 1)
+		edit(le, 1, 2)
+		assertState(t, le, []int{0, 7}, 1)
+	})
+
+	t.Run("left overlap ", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 3, 2, 7, 8, 9)
+		assertState(t, le, []int{0, 1, 2, 7, 8, 9, 5}, 1)
+		edit(le, 0, 4)
+		assertState(t, le, []int{8, 9, 5}, 1)
+	})
+
+	t.Run("undo 1", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 2, 3)
+		assertState(t, le, []int{0, 1, 5}, 1)
+		edit(le, 2, 0, 2, 3, 4)
+		assertState(t, le, []int{0, 1, 2, 3, 4, 5}, 1)
+	})
+
+	t.Run("undo 2", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 2, 0, 9, 8, 7)
+		assertState(t, le, []int{0, 1, 9, 8, 7, 2, 3, 4, 5}, 1)
+		edit(le, 2, 3)
+		assertState(t, le, []int{0, 1, 2, 3, 4, 5}, 0)
+	})
+
+	t.Run("splice middile of splice", func(t *testing.T) {
+		le := testEditor(0, 1)
+		edit(le, 1, 0, 9, 8, 7, 6)
+		assertState(t, le, []int{0, 9, 8, 7, 6, 1}, 1)
+		edit(le, 2, 2)
+		assertState(t, le, []int{0, 9, 6, 1}, 1)
+	})
+}
+
+func TestFuzzFails(t *testing.T) {
+	t.Run("Case 1", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+		edit(le, 23, 0, 0, 3, 2)
+		assertState(t, le, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 0, 3, 2, 23, 24}, 1)
+		edit(le, 5, 15, 1, 2, 9, 8)
+		assertState(t, le, []int{0, 1, 2, 3, 4, 1, 2, 9, 8, 20, 21, 22, 0, 3, 2, 23, 24}, 2)
+		edit(le, 4, 7, 7)
+		assertState(t, le, []int{0, 1, 2, 3, 7, 22, 0, 3, 2, 23, 24}, 2)
+	})
+
+	t.Run("Case 2", func(t *testing.T) {
+		le := testEditor(0, 1, 2, 3, 4, 5)
+		edit(le, 5, 0, 1, 7, 5, 3, 13, 17)
+		assertState(t, le, []int{0, 1, 2, 3, 4, 1, 7, 5, 3, 13, 17, 5}, 1)
+		edit(le, 2, 2, 16, 5, 12, 5, 15, 0, 15, 15, 7)
+		assertState(t, le, []int{0, 1, 16, 5, 12, 5, 15, 0, 15, 15, 7, 4, 1, 7, 5, 3, 13, 17, 5}, 2)
+		edit(le, 8, 5, 4, 13)
+		assertState(t, le, []int{0, 1, 16, 5, 12, 5, 15, 0, 4, 13, 7, 5, 3, 13, 17, 5}, 1)
+		edit(le, 6, 2, 8, 2, 6, 3, 14, 6)
+		assertState(t, le, []int{0, 1, 16, 5, 12, 5, 8, 2, 6, 3, 14, 6, 4, 13, 7, 5, 3, 13, 17, 5}, 1)
+
+	})
+}
+
+func AsValuables(vs []Value) []Valuable {
+	res := make([]Valuable, len(vs))
+	for i, v := range vs {
+		res[i] = v
+	}
+	return res
+}
+
+func TestSpliceFuzzer(t *testing.T) {
+	startCount := 1000
+	rounds := 1000
+	splices := 100
+	maxInsertCount := uint64(50)
+	maxInt := uint64(100)
+
+	r := rand.New(rand.NewSource(0))
+
+	nextRandInt := func(from, to uint64) uint64 {
+		return from + uint64(float64(to-from)*r.Float64())
+	}
+
+	nextRandomSplice := func(len int) (idx, remove uint64, insert []Value) {
+		idx = nextRandInt(0, uint64(len))
+		remove = nextRandInt(0, uint64(len)-idx)
+		insCount := nextRandInt(0, maxInsertCount)
+		for i := uint64(0); i < insCount; i++ {
+			insert = append(insert, Number(nextRandInt(0, maxInt)))
+		}
+
+		return
+	}
+
+	for i := 0; i < rounds; i++ {
+		tl := newTestList(startCount)
+		le := tl.toList().Edit()
+
+		for j := 0; j < splices; j++ {
+			idx, removed, insert := nextRandomSplice(len(tl))
+			tl = tl.Splice(int(idx), int(removed), insert...)
+			le.Splice(idx, removed, AsValuables(insert)...)
+		}
+		expect := tl.toList()
+		actual := le.List(nil)
+		assert.True(t, expect.Equals(actual))
+	}
+}

--- a/go/types/map_editor.go
+++ b/go/types/map_editor.go
@@ -17,14 +17,13 @@ import (
 // Note: The implementation biases performance towards a usage which applies
 // edits in key-order.
 type MapEditor struct {
-	m                 Map
-	edits             mapEditSlice // edits may contain duplicate key values, in which case, the last edit of a given key is used
-	normalized        bool
-	removeEmptyValues bool // TODO-Make configurable
+	m          Map
+	edits      mapEditSlice // edits may contain duplicate key values, in which case, the last edit of a given key is used
+	normalized bool
 }
 
 func NewMapEditor(m Map) *MapEditor {
-	return &MapEditor{m, mapEditSlice{}, true, true}
+	return &MapEditor{m, mapEditSlice{}, true}
 }
 
 func (me *MapEditor) Kind() NomsKind {

--- a/go/types/ref_test.go
+++ b/go/types/ref_test.go
@@ -15,7 +15,7 @@ func TestRefInList(t *testing.T) {
 
 	l := NewList()
 	r := NewRef(l)
-	l = l.Append(r)
+	l = l.Edit().Append(r).List(nil)
 	r2 := l.Get(0)
 	assert.True(r.Equals(r2))
 }

--- a/go/util/jsontonoms/json_to_noms_test.go
+++ b/go/util/jsontonoms/json_to_noms_test.go
@@ -29,13 +29,13 @@ func (suite *LibTestSuite) TestPrimitiveTypes() {
 func (suite *LibTestSuite) TestCompositeTypes() {
 	// [false true]
 	suite.EqualValues(
-		types.NewList().Append(types.Bool(false)).Append(types.Bool(true)),
+		types.NewList().Edit().Append(types.Bool(false)).Append(types.Bool(true)).List(nil),
 		NomsValueFromDecodedJSON([]interface{}{false, true}, false))
 
 	// [[false true]]
 	suite.EqualValues(
-		types.NewList().Append(
-			types.NewList().Append(types.Bool(false)).Append(types.Bool(true))),
+		types.NewList().Edit().Append(
+			types.NewList().Edit().Append(types.Bool(false)).Append(types.Bool(true)).List(nil)).List(nil),
 		NomsValueFromDecodedJSON([]interface{}{[]interface{}{false, true}}, false))
 
 	// {"string": "string",
@@ -46,7 +46,7 @@ func (suite *LibTestSuite) TestCompositeTypes() {
 		types.String("string"),
 		types.String("string"),
 		types.String("list"),
-		types.NewList().Append(types.Bool(false)).Append(types.Bool(true)),
+		types.NewList().Edit().Append(types.Bool(false)).Append(types.Bool(true)).List(nil),
 		types.String("map"),
 		types.NewMap(
 			types.String("nested"),
@@ -67,7 +67,7 @@ func (suite *LibTestSuite) TestCompositeTypeWithStruct() {
 	// }
 	tstruct := types.NewStruct("", types.StructData{
 		"string": types.String("string"),
-		"list":   types.NewList().Append(types.Bool(false)).Append(types.Bool(true)),
+		"list":   types.NewList().Edit().Append(types.Bool(false)).Append(types.Bool(true)).List(nil),
 		"struct": types.NewStruct("", types.StructData{
 			"nested": types.String("string"),
 		}),
@@ -90,7 +90,7 @@ func (suite *LibTestSuite) TestCompositeTypeWithNamedStruct() {
 	// }
 	tstruct := types.NewStruct("TStruct1", types.StructData{
 		"string": types.String("string"),
-		"list":   types.NewList().Append(types.Bool(false)).Append(types.Bool(true)),
+		"list":   types.NewList().Edit().Append(types.Bool(false)).Append(types.Bool(true)).List(nil),
 		"struct": types.NewStruct("Id", types.StructData{
 			"owner": types.String("string"),
 			"value": types.String("string"),


### PR DESCRIPTION
This should look somewhat familiar =-).

Towards #3562. This removes the mutative API from List and adds a ListEditor which is logically consistent with the existing Set/MapEditor. BlobEditor is next and should look similar to ListEditor.