### PR TITLE
Use log.PrintXXX rather than fmt.PrintXXX for informational messages

### DIFF
--- a/cmd/noms/noms.go
+++ b/cmd/noms/noms.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"path"
@@ -64,6 +65,9 @@ func main() {
 		util.Help(args[1:])
 		return
 	}
+
+	// Don't prefix log messages with timestamp when running interactively
+	log.SetFlags(0)
 
 	for _, cmd := range commands {
 		if cmd.Name() == args[0] {

--- a/go/config/resolver.go
+++ b/go/config/resolver.go
@@ -37,11 +37,11 @@ func NewResolver() *Resolver {
 
 // Print replacement if one occurred
 func (r *Resolver) verbose(orig string, replacement string) string {
-	if verbose.Verbose() && orig != replacement {
+	if orig != replacement {
 		if orig == "" {
 			orig = `""`
 		}
-		fmt.Printf("\tresolving %s -> %s\n", orig, replacement)
+		verbose.Log("\tresolving %s -> %s\n", orig, replacement)
 	}
 	return replacement
 }

--- a/go/datas/database_server.go
+++ b/go/datas/database_server.go
@@ -6,6 +6,7 @@ package datas
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -56,7 +57,7 @@ func (s *RemoteDatabaseServer) Run() {
 	d.Chk.NoError(err)
 	s.port, err = strconv.Atoi(port)
 	d.Chk.NoError(err)
-	fmt.Printf("Listening on port %d...\n", s.port)
+	log.Printf("Listening on port %d...\n", s.port)
 
 	router := httprouter.New()
 

--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -97,7 +98,7 @@ func createHandler(hndlr Handler, versionCheck bool) Handler {
 		w.Header().Set(NomsVersionHeader, constants.NomsVersion)
 
 		if versionCheck && req.Header.Get(NomsVersionHeader) != constants.NomsVersion {
-			verbose.Log("Returning version mismatch error")
+			log.Printf("returning version mismatch error")
 			http.Error(
 				w,
 				fmt.Sprintf("Error: SDK version %s is incompatible with data of version %s", req.Header.Get(NomsVersionHeader), constants.NomsVersion),
@@ -109,7 +110,7 @@ func createHandler(hndlr Handler, versionCheck bool) Handler {
 		err := d.Try(func() { hndlr(w, req, ps, cs) })
 		if err != nil {
 			err = d.Unwrap(err)
-			verbose.Log("Returning bad request:\n%v\n", err)
+			log.Printf("returning bad request error: %v", err)
 			http.Error(w, fmt.Sprintf("Error: %v", err), http.StatusBadRequest)
 			return
 		}

--- a/go/util/verbose/verbose.go
+++ b/go/util/verbose/verbose.go
@@ -5,7 +5,7 @@
 package verbose
 
 import (
-	"fmt"
+	"log"
 
 	flag "github.com/juju/gnuflag"
 )
@@ -45,9 +45,9 @@ func SetQuiet(q bool) {
 func Log(format string, args ...interface{}) {
 	if Verbose() {
 		if len(args) > 0 {
-			fmt.Printf(format+"\n", args...)
+			log.Printf(format+"\n", args...)
 		} else {
-			fmt.Println(format)
+			log.Println(format)
 		}
 	}
 }


### PR DESCRIPTION
All messages emitted from non-cli code are now output through the standard
logger rather than directly to stdout. This gives code that embeds noms control
over how messages are logged (using log.SetFlags and log.SetOutput).

When the noms cli is used, the logger is initialized so that it only prints the
string logged. In other cases, the log setup is left to the embedding code.

toward: #3590