### PR TITLE
Refactor Blob reading

### DIFF
--- a/go/datas/remote_database_handlers.go
+++ b/go/datas/remote_database_handlers.go
@@ -305,7 +305,7 @@ func handleGetBlob(w http.ResponseWriter, req *http.Request, ps URLParams, cs ch
 	w.Header().Add("Content-Length", fmt.Sprintf("%d", b.Len()))
 	w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", 60*60*24*365))
 
-	b.Reader().Copy(w)
+	b.Copy(w)
 }
 
 func extractHashes(req *http.Request) hash.HashSlice {

--- a/go/perf/codec-perf-rig/main.go
+++ b/go/perf/codec-perf-rig/main.go
@@ -104,7 +104,7 @@ func main() {
 	t1 = time.Now()
 	blob = ds.HeadValue().(types.Blob)
 	buff := &bytes.Buffer{}
-	blob.Reader().Copy(buff)
+	blob.Copy(buff)
 	outBytes := buff.Bytes()
 	readDuration := time.Since(t1)
 	d.PanicIfFalse(bytes.Compare(blobBytes, outBytes) == 0)

--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -5,7 +5,6 @@
 package types
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"sync"
@@ -30,10 +29,99 @@ func NewEmptyBlob() Blob {
 	return Blob{newBlobLeafSequence(nil, []byte{}), &hash.Hash{}}
 }
 
-// BUG 155 - Should provide Write... Maybe even have Blob implement ReadWriteSeeker
+// ReaderAt interface. Eagerly loads requested byte-range from the blob p-tree.
+func (b Blob) ReadAt(p []byte, off int64) (n int, err error) {
+	// TODO: Support negative off?
+	d.PanicIfTrue(off < 0)
+
+	startIdx := uint64(off)
+	if startIdx >= b.Len() {
+		return 0, io.EOF
+	}
+
+	endIdx := startIdx + uint64(len(p))
+	if endIdx > b.Len() {
+		endIdx = b.Len()
+	}
+
+	if endIdx == b.Len() {
+		err = io.EOF
+	}
+
+	if startIdx == endIdx {
+		return
+	}
+
+	leaves, localStart := LoadLeafSequences(b, startIdx, endIdx)
+	endIdx = localStart + endIdx - startIdx
+	startIdx = localStart
+
+	for _, s := range leaves {
+		bl := s.(blobLeafSequence)
+
+		le := endIdx
+		ll := uint64(len(bl.data))
+		if le > ll {
+			le = ll
+		}
+		src := bl.data[startIdx:le]
+
+		copy(p[n:], src)
+		n += len(src)
+		endIdx -= le
+		startIdx = 0
+	}
+
+	return
+}
+
 func (b Blob) Reader() *BlobReader {
-	cursor := newCursorAtIndex(b.seq, 0, true)
-	return &BlobReader{b.seq, cursor, nil, 0}
+	return &BlobReader{b, 0}
+}
+
+func (b Blob) Copy(w io.Writer) (n int64) {
+	return b.CopyReadAhead(w, 1<<23 /* 8MB */, 6)
+}
+
+func (b Blob) CopyReadAhead(w io.Writer, chunkSize uint64, concurrency int) (n int64) {
+	bChan := make(chan chan []byte, concurrency)
+
+	go func() {
+		idx := uint64(0)
+		for idx < b.Len() {
+			bc := make(chan []byte)
+			bChan <- bc
+
+			start := idx
+			len := b.Len() - start
+			if len > chunkSize {
+				len = chunkSize
+			}
+			idx += len
+
+			go func() {
+				buff := make([]byte, len)
+				b.ReadAt(buff, int64(start))
+				bc <- buff
+			}()
+		}
+		close(bChan)
+	}()
+
+	// Ensure read-ahead goroutines can exit
+	defer func() {
+		for _ = range bChan {
+		}
+	}()
+
+	for b := range bChan {
+		ln, err := w.Write(<-b)
+		n += int64(ln)
+		if err != nil {
+			return
+		}
+	}
+	return
 }
 
 func (b Blob) Splice(idx uint64, deleteCount uint64, data []byte) Blob {
@@ -124,62 +212,13 @@ func (b Blob) Kind() NomsKind {
 }
 
 type BlobReader struct {
-	seq           sequence
-	cursor        *sequenceCursor
-	currentReader io.ReadSeeker
-	pos           uint64
+	b   Blob
+	pos int64
 }
 
 func (cbr *BlobReader) Read(p []byte) (n int, err error) {
-	if cbr.currentReader == nil {
-		cbr.updateReader()
-	}
-
-	n, err = cbr.currentReader.Read(p)
-	for i := 0; i < n; i++ {
-		cbr.pos++
-		cbr.cursor.advance()
-	}
-	if err == io.EOF && cbr.cursor.idx < cbr.cursor.seq.seqLen() {
-		cbr.currentReader = nil
-		err = nil
-	}
-
-	return
-}
-
-func (cbr BlobReader) Copy(w io.Writer) (n int64) {
-	if cbr.cursor.parent == nil {
-		data := cbr.cursor.seq.(blobLeafSequence).data
-		n, err := io.Copy(w, bytes.NewReader(data))
-		d.Chk.NoError(err)
-		d.Chk.True(n == int64(len(data)))
-		return n
-	}
-
-	curChan := make(chan chan *sequenceCursor, 30)
-	stopChan := make(chan struct{})
-
-	go func() {
-		readAheadLeafCursors(cbr.cursor, curChan, stopChan)
-		close(curChan)
-	}()
-
-	// Copy the bytes of each leaf
-	for ch := range curChan {
-		leafCur := <-ch
-		parentCur := leafCur.parent
-		d.Chk.NotNil(parentCur.childSeqs)
-		// This is hacky, but iterating over the each of these preloaded cursors actual dramatically
-		// degrades perf. Just reach in and grab the leaf sequences
-		for _, leaf := range parentCur.childSeqs {
-			data := leaf.(blobLeafSequence).data
-			n, err := io.Copy(w, bytes.NewReader(data))
-			d.Chk.NoError(err)
-			d.Chk.True(n == int64(len(data)))
-		}
-	}
-
+	n, err = cbr.b.ReadAt(p, cbr.pos)
+	cbr.pos += int64(n)
 	return
 }
 
@@ -192,7 +231,7 @@ func (cbr *BlobReader) Seek(offset int64, whence int) (int64, error) {
 	case 1:
 		abs += offset
 	case 2:
-		abs = int64(cbr.seq.numLeaves()) + offset
+		abs = int64(cbr.b.Len()) + offset
 	default:
 		return 0, errors.New("Blob.Reader.Seek: invalid whence")
 	}
@@ -201,15 +240,8 @@ func (cbr *BlobReader) Seek(offset int64, whence int) (int64, error) {
 		return 0, errors.New("Blob.Reader.Seek: negative position")
 	}
 
-	cbr.pos = uint64(abs)
-	cbr.cursor = newCursorAtIndex(cbr.seq, cbr.pos, true)
-	cbr.currentReader = nil
+	cbr.pos = int64(abs)
 	return abs, nil
-}
-
-func (cbr *BlobReader) updateReader() {
-	cbr.currentReader = bytes.NewReader(cbr.cursor.seq.(blobLeafSequence).data)
-	cbr.currentReader.Seek(int64(cbr.cursor.idx), 0)
 }
 
 func makeBlobLeafChunkFn(vr ValueReader) makeChunkFn {

--- a/go/types/blob_test.go
+++ b/go/types/blob_test.go
@@ -74,7 +74,7 @@ func newBlobTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff in
 			validate: func(v2 Collection) bool {
 				b2 := v2.(Blob)
 				outBuff := &bytes.Buffer{}
-				b2.Reader().Copy(outBuff)
+				b2.Copy(outBuff)
 				return bytes.Compare(outBuff.Bytes(), buff) == 0
 			},
 			prependOne: func() Collection {
@@ -320,6 +320,6 @@ func TestStreamingParallelBlob(t *testing.T) {
 	vs := newTestValueStore()
 	blob := NewStreamingBlob(vs, readers...)
 	outBuff := &bytes.Buffer{}
-	blob.Reader().Copy(outBuff)
+	blob.Copy(outBuff)
 	assert.True(bytes.Compare(buff, outBuff.Bytes()) == 0)
 }

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -4,7 +4,10 @@
 
 package types
 
-import "github.com/attic-labs/noms/go/d"
+import (
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/hash"
+)
 
 func newListMetaSequence(level uint64, tuples []metaTuple, vr ValueReader) metaSequence {
 	return newMetaSequence(ListKind, level, tuples, vr)
@@ -76,4 +79,75 @@ func orderedKeyFromSum(msd []metaTuple) orderedKey {
 		sum += mt.numLeaves
 	}
 	return orderedKeyFromUint64(sum)
+}
+
+func LoadLeafSequences(c Collection, startIdx, endIdx uint64) (leaves []sequence, firstIdx uint64) {
+	return loadLeafSequences(c.sequence().valueReader(), []sequence{c.sequence()}, startIdx, endIdx)
+}
+
+func loadLeafSequences(vr ValueReader, seqs []sequence, startIdx, endIdx uint64) ([]sequence, uint64) {
+	if seqs[0].isLeaf() {
+		for _, s := range seqs {
+			d.PanicIfFalse(s.isLeaf())
+		}
+
+		return seqs, startIdx
+	}
+
+	level := seqs[0].treeLevel()
+	childTuples := []metaTuple{}
+
+	cum := uint64(0)
+	for _, s := range seqs {
+		d.PanicIfFalse(s.treeLevel() == level)
+		ms := s.(metaSequence)
+
+		for _, mt := range ms.tuples {
+			if cum == 0 && mt.numLeaves <= startIdx {
+				startIdx -= mt.numLeaves
+				endIdx -= mt.numLeaves
+				continue
+			}
+
+			childTuples = append(childTuples, mt)
+			cum += mt.numLeaves
+			if cum >= endIdx {
+				break
+			}
+		}
+	}
+
+	hs := hash.HashSet{}
+	for _, mt := range childTuples {
+		if mt.child != nil {
+			continue
+		}
+		hs.Insert(mt.ref.TargetHash())
+	}
+
+	// Fetch committed child sequences in a single batch
+	fetched := make(map[hash.Hash]sequence, len(hs))
+	if len(hs) > 0 {
+		valueChan := make(chan Value, len(hs))
+		go func() {
+			d.PanicIfTrue(vr == nil)
+			vr.ReadManyValues(hs, valueChan)
+			close(valueChan)
+		}()
+		for value := range valueChan {
+			fetched[value.Hash()] = value.(Collection).sequence()
+		}
+	}
+
+	childSeqs := make([]sequence, len(childTuples))
+	for i, mt := range childTuples {
+		if mt.child != nil {
+			childSeqs[i] = mt.child.sequence()
+			continue
+		}
+
+		childSeqs[i] = fetched[mt.ref.TargetHash()]
+	}
+
+	return loadLeafSequences(vr, childSeqs, startIdx, endIdx)
 }

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -81,10 +81,8 @@ func orderedKeyFromSum(msd []metaTuple) orderedKey {
 	return orderedKeyFromUint64(sum)
 }
 
-func LoadLeafSequences(c Collection, startIdx, endIdx uint64) (leaves []sequence, firstIdx uint64) {
-	return loadLeafSequences(c.sequence().valueReader(), []sequence{c.sequence()}, startIdx, endIdx)
-}
-
+// loads the set of leaf sequences which contain the items [startIdx -> endIdx).
+// Returns the set of sequences and the offset within the first sequence which corresponds to |startIdx|.
 func loadLeafSequences(vr ValueReader, seqs []sequence, startIdx, endIdx uint64) ([]sequence, uint64) {
 	if seqs[0].isLeaf() {
 		for _, s := range seqs {
@@ -104,6 +102,7 @@ func loadLeafSequences(vr ValueReader, seqs []sequence, startIdx, endIdx uint64)
 
 		for _, mt := range ms.tuples {
 			if cum == 0 && mt.numLeaves <= startIdx {
+				// skip tuples whose items are < startIdx
 				startIdx -= mt.numLeaves
 				endIdx -= mt.numLeaves
 				continue

--- a/samples/go/blob-get/blob_get.go
+++ b/samples/go/blob-get/blob_get.go
@@ -55,7 +55,7 @@ func main() {
 
 	filePath := flag.Arg(1)
 	if filePath == "" {
-		blob.Reader().Copy(os.Stdout)
+		blob.Copy(os.Stdout)
 		return
 	}
 
@@ -71,7 +71,7 @@ func main() {
 	preader, pwriter := io.Pipe()
 
 	go func() {
-		blob.Reader().Copy(pwriter)
+		blob.Copy(pwriter)
 		pwriter.Close()
 	}()
 

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -90,7 +90,7 @@ func main() {
 		defer db.Close()
 		preader, pwriter := io.Pipe()
 		go func() {
-			blob.Reader().Copy(pwriter)
+			blob.Copy(pwriter)
 			pwriter.Close()
 		}()
 		r = preader

--- a/samples/go/nomsfs/nomsfs.go
+++ b/samples/go/nomsfs/nomsfs.go
@@ -449,13 +449,7 @@ func (nfile nomsFile) Read(dest []byte, off int64) (fuse.ReadResult, fuse.Status
 	ref := file.(types.Struct).Get("data").(types.Ref)
 	blob := ref.TargetValue(nfile.fs.db).(types.Blob)
 
-	br := blob.Reader()
-
-	_, err := br.Seek(off, 0)
-	if err != nil {
-		return nil, fuse.EIO
-	}
-	n, err := br.Read(dest)
+	n, err := blob.ReadAt(dest, off)
 	if err != nil {
 		return fuse.ReadResultData(dest[:n]), fuse.EIO
 	}
@@ -862,9 +856,8 @@ func (fs *nomsFS) GetXAttr(path string, attribute string, context *fuse.Context)
 	}
 
 	blob := v.(types.Blob)
-
 	data := make([]byte, blob.Len())
-	blob.Reader().Read(data)
+	blob.ReadAt(data, 0)
 
 	return data, fuse.OK
 }


### PR DESCRIPTION
Towards #3562 (Next patch will be BlobReadWriter)

This patch refactors Blob reading generally:

-Add `LoadLeafSequences`, which eagerly loads exactly the set of leaf sequences which contain a given idx range
-`Blob` now supports the golang `ReaderAt` interface. The implementation uses `LoadLeafSequences` to eagerly load exactly the needed byte range
-`BlobReader` is now basically just an `int` (pos) which turns around and uses `Blob.ReadAt`
-`BlobReader.Copy` is moved to `Blob` and uses a read ahead strategy of N concurrent forward reads, but each uses `ReadAt` (rather than the less precise `readAheadLeafCursors`).

This wasn't the goal here, but a happy side-effect is that blob reading perf has generally increased:

-Reading large blob via http: +40% (now about 250MB/s on my mac)
-Reading large blob via nbs: +40% (now about 650MB/s on my mac)
-`getBlob` http endpoint can now service many "image" sized blobs (e.g. 1-20MB) is ~3 physical reads, rather than 8-10.

Also, this `LoadLeafSequences` lays the groundwork for the graphql endpoint to use precise eager reading, since it always knows the exact item range it needs when it's reading ranges of ptrees.