### PR TITLE
NBS: Serialize Commit() calls within a process

### DIFF
--- a/go/nbs/conjoiner.go
+++ b/go/nbs/conjoiner.go
@@ -16,99 +16,36 @@ import (
 type conjoiner interface {
 	// ConjoinRequired tells the caller whether or not it's time to request a
 	// Conjoin, based upon the contents of |ts| and the conjoiner
-	// implementation's policy. Implementations must be goroutine-safe.
+	// implementation's policy.
 	ConjoinRequired(ts tableSet) bool
 
 	// Conjoin attempts to use |p| to conjoin some number of tables referenced
-	// by |mm|, allowing it to update |mm| with a new, smaller, set of tables
+	// by |upstream|, allowing it to update |mm| with a new, smaller, set of tables
 	// that references precisely the same set of chunks. Conjoin() may not
 	// actually conjoin any upstream tables, usually because some out-of-
 	// process actor has already landed a conjoin of its own. Callers must
 	// handle this, likely by rebasing against upstream and re-evaluating the
 	// situation.
-	// Before performing the conjoin, implementations should verify that a
-	// conjoin is actually currently needed; callers may be working with an
-	// out-of-date notion of upstream state. |novelCount|, the number of new
-	// tables the caller is trying to land, may be used in this determination.
-	// Implementations must be goroutine-safe.
-	Conjoin(mm manifest, p tablePersister, novelCount int, stats *Stats)
+	Conjoin(upstream manifestContents, mm manifestUpdater, p tablePersister, stats *Stats) manifestContents
 }
 
-func newAsyncConjoiner(maxTables int) *asyncConjoiner {
-	return &asyncConjoiner{
-		waiters:   map[string]chan struct{}{},
-		maxTables: maxTables,
-	}
-}
-
-type asyncConjoiner struct {
-	mu        sync.RWMutex
-	waiters   map[string]chan struct{}
+type inlineConjoiner struct {
 	maxTables int
 }
 
-func (c *asyncConjoiner) ConjoinRequired(ts tableSet) bool {
+func (c inlineConjoiner) ConjoinRequired(ts tableSet) bool {
 	return ts.Size() > c.maxTables
 }
 
-// Conjoin checks to see if there's already a conjoin underway for the store
-// described by |mm|. If so, it blocks until that conjoin completes. If not,
-// it starts one and blocks until it completes. Conjoin can be called
-// concurrently from many goroutines.
-func (c *asyncConjoiner) Conjoin(mm manifest, p tablePersister, novelCount int, stats *Stats) {
-	needsConjoin := func(upstreamCount int) bool {
-		return upstreamCount+novelCount > c.maxTables
-	}
-	c.await(mm.Name(), func() { conjoin(mm, p, needsConjoin, stats) }, nil)
-	return
+func (c inlineConjoiner) Conjoin(upstream manifestContents, mm manifestUpdater, p tablePersister, stats *Stats) manifestContents {
+	return conjoin(upstream, mm, p, stats)
 }
 
-// await checks to see if there's already something running for |id| and, if
-// so, waits for it to complete. If not, it runs f() and waits for it to
-// complete. While f() is running, other callers to await that pass in |id|
-// will block until f() completes.
-func (c *asyncConjoiner) await(id string, f func(), testWg *sync.WaitGroup) {
-	wait := func() <-chan struct{} {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
-		if ch, present := c.waiters[id]; present {
-			return ch
-		}
-		c.waiters[id] = make(chan struct{})
-		go c.runAndNotify(id, f)
-		return c.waiters[id]
-	}()
-	if testWg != nil {
-		testWg.Done()
-	}
-	<-wait
-}
-
-// runAndNotify runs f() and, upon completion, signals everyone who called
-// await(id).
-func (c *asyncConjoiner) runAndNotify(id string, f func()) {
-	f()
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	ch, present := c.waiters[id]
-	d.PanicIfFalse(present)
-	close(ch)
-	delete(c.waiters, id)
-}
-
-func conjoin(mm manifest, p tablePersister, needsConjoin func(int) bool, stats *Stats) {
-	exists, upstream := mm.ParseIfExists(stats, nil)
-	d.PanicIfFalse(exists)
-	// This conjoin may have been requested by someone with an out-of-date notion of what's upstream. Verify that we actually still believe a conjoin is needed and, if not, return early
-	if !needsConjoin(len(upstream.specs)) {
-		return
-	}
-
+func conjoin(upstream manifestContents, mm manifestUpdater, p tablePersister, stats *Stats) manifestContents {
 	var conjoined tableSpec
 	var conjoinees, keepers []tableSpec
 
+Retry:
 	for {
 		if conjoinees == nil {
 			conjoined, conjoinees, keepers = conjoinTables(p, upstream.specs, stats)
@@ -126,7 +63,7 @@ func conjoin(mm manifest, p tablePersister, needsConjoin func(int) bool, stats *
 		upstream = mm.Update(upstream.lock, newContents, stats, nil)
 
 		if newContents.lock == upstream.lock {
-			return
+			break Retry
 		}
 		// Optimistic lock failure. Someone else moved to the root, the set of tables, or both out from under us.
 		// If we can re-use the conjoin we already performed, we want to try again. Currently, we will only do so if ALL conjoinees are still present upstream. If we can't re-use...then someone else almost certainly landed a conjoin upstream. In this case, bail and let clients ask again if they think they still can't proceed.
@@ -137,7 +74,7 @@ func conjoin(mm manifest, p tablePersister, needsConjoin func(int) bool, stats *
 		}
 		for _, c := range conjoinees {
 			if _, present := upstreamNames[c.name]; !present {
-				return // Bail!
+				break Retry // Bail!
 			}
 			conjoineeSet[c.name] = struct{}{}
 		}
@@ -150,6 +87,7 @@ func conjoin(mm manifest, p tablePersister, needsConjoin func(int) bool, stats *
 			}
 		}
 	}
+	return upstream
 }
 
 func conjoinTables(p tablePersister, upstream []tableSpec, stats *Stats) (conjoined tableSpec, conjoinees, keepers []tableSpec) {

--- a/go/nbs/stats_test.go
+++ b/go/nbs/stats_test.go
@@ -87,7 +87,7 @@ func TestStats(t *testing.T) {
 	assert.Equal(uint64(60), stats(store).FileBytesPerRead.Sum())
 
 	// Force a conjoin
-	store.c = newAsyncConjoiner(2)
+	store.c = inlineConjoiner{2}
 	store.Put(c4)
 	store.Commit(store.Root(), store.Root())
 	store.Put(c5)


### PR DESCRIPTION
This patch uses process-wide per-store locking to ensure that only one
NomsBlockStore instance is ever trying to update the upstream NBS
manifest at a time. It also locks out attempts to fetch the manifest
contents during that window.

Conjoining is now much simpler. Since only one instance can ever be in
the critical path of Commit at a time, and conjoining is triggered on
that critical path, we now simply perform the conjoin while excluding
all other in-process NBS instances. Hopefully, locking out instances
who want to fetch the manifest contents during a conjoin won't cripple
performance.

Fixes issue #3583