### PR TITLE
Allow server to re-try commits if it can

### DIFF
--- a/go/constants/version.go
+++ b/go/constants/version.go
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-const NomsVersion = "7.12"
+const NomsVersion = "7.13"
 const NOMS_VERSION_NEXT_ENV_NAME = "NOMS_VERSION_NEXT"
 const NOMS_VERSION_NEXT_ENV_VALUE = "1"
 

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-4:7.12:8s92pdafhd4hkhav6r4748u1rjlosh1k:5b1e9knhol2orv0a8ej6tvelc46jp92l:bsvid54jt8pjto211lcdl14tbfd39jmn:2:998se5i5mf15fld7f318818i6ie0c8rr:2
+4:7.13:8s92pdafhd4hkhav6r4748u1rjlosh1k:5b1e9knhol2orv0a8ej6tvelc46jp92l:bsvid54jt8pjto211lcdl14tbfd39jmn:2:998se5i5mf15fld7f318818i6ie0c8rr:2


### PR DESCRIPTION
Right now, the only kinds of Commits that the server will retry are those to different datasets.
That is, if another client concurrently landed a change to some other dataset, and that is the _only_ thing that causes your Commit attempt to fail, the server will retry.

Fixes #3582