### PR TITLE
NBS: Commit locks out Rebasers for less time

### DIFF
--- a/go/nbs/manifest.go
+++ b/go/nbs/manifest.go
@@ -126,11 +126,11 @@ type manifestManager struct {
 	locks *manifestLocks
 }
 
-func (mm manifestManager) LockOutFetch() {
+func (mm manifestManager) lockOutFetch() {
 	mm.locks.lockForFetch(mm.Name())
 }
 
-func (mm manifestManager) AllowFetch() {
+func (mm manifestManager) allowFetch() {
 	mm.locks.unlockForFetch(mm.Name())
 }
 
@@ -154,8 +154,8 @@ func (mm manifestManager) updateWillFail(lastLock addr) (cached manifestContents
 func (mm manifestManager) Fetch(stats *Stats) (exists bool, contents manifestContents) {
 	entryTime := time.Now()
 
-	mm.LockOutFetch()
-	defer mm.AllowFetch()
+	mm.lockOutFetch()
+	defer mm.allowFetch()
 
 	cached, t, hit := mm.cache.Get(mm.Name())
 
@@ -180,6 +180,10 @@ func (mm manifestManager) Update(lastLock addr, newContents manifestContents, st
 		}
 	}
 	t := time.Now()
+
+	mm.lockOutFetch()
+	defer mm.allowFetch()
+
 	contents := mm.m.Update(lastLock, newContents, stats, writeHook)
 	mm.cache.Put(mm.Name(), contents, t)
 	return contents

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -414,9 +414,6 @@ func (nbs *NomsBlockStore) updateManifest(current, last hash.Hash) error {
 		return errLastRootMismatch
 	}
 
-	nbs.mm.LockOutFetch()
-	defer nbs.mm.AllowFetch()
-
 	handleOptimisticLockFailure := func(upstream manifestContents) error {
 		nbs.upstream = upstream
 		nbs.tables = nbs.tables.Rebase(upstream.specs)


### PR DESCRIPTION
Persisting tables now tacks place outside the manifest fetch lock so rebasers don't spend time blocking on writers persisting.