### PR TITLE
NBS: Store small tables in DynamoDB when persisting to AWS

### DIFF
--- a/go/nbs/aws_table_persister.go
+++ b/go/nbs/aws_table_persister.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/util/sizecache"
 	"github.com/attic-labs/noms/go/util/verbose"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -23,19 +24,54 @@ const (
 	maxS3PartSize = 64 * 1 << 20 // 64MiB
 	maxS3Parts    = 10000
 
+	maxDynamoChunks   = 64
+	maxDynamoItemSize = 400 * (1 << 10) // 400k
+
 	defaultS3PartSize = minS3PartSize // smallest allowed by S3 allows for most throughput
 )
 
-type s3TablePersister struct {
-	s3                                       s3svc
-	bucket                                   string
-	targetPartSize, minPartSize, maxPartSize uint64
-	indexCache                               *indexCache
-	readRl                                   chan struct{}
-	tc                                       tableCache
+type awsTablePersister struct {
+	s3         s3svc
+	bucket     string
+	ddb        ddbsvc
+	table      string
+	limits     awsLimits
+	indexCache *indexCache
+	readRl     chan struct{}
+	tc         tableCache
+	dynamoTC   *sizecache.SizeCache // TODO: merge this and above as part of BUG 3601
 }
 
-func (s3p s3TablePersister) Open(name addr, chunkCount uint32) chunkSource {
+type awsLimits struct {
+	partTarget, partMin, partMax uint64
+	itemMax                      int
+	chunkMax                     uint32
+}
+
+func (al awsLimits) tableFitsInDynamo(name addr, data []byte, chunkCount uint32) bool {
+	calcItemSize := func(n addr, d []byte) int {
+		return len(dbAttr) + len(tablePrefix) + len(n.String()) + len(dataAttr) + len(d)
+	}
+	return chunkCount <= al.chunkMax && calcItemSize(name, data) < al.itemMax
+}
+
+func (al awsLimits) tableMayBeInDynamo(chunkCount uint32) bool {
+	return chunkCount <= al.chunkMax
+}
+
+func (s3p awsTablePersister) Open(name addr, chunkCount uint32) chunkSource {
+	if s3p.limits.tableMayBeInDynamo(chunkCount) {
+		if data, present := dynamoTableCacheMaybeGet(s3p.dynamoTC, name); present {
+			return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
+		}
+		data, err := tryDynamoTableRead(s3p.ddb, s3p.table, name)
+		if data != nil {
+			return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
+		}
+		d.PanicIfTrue(err == nil) // There MUST be either data or an error
+		d.PanicIfNotType(err, tableNotInDynamoErr{})
+	}
+
 	return newS3TableReader(s3p.s3, s3p.bucket, name, chunkCount, s3p.indexCache, s3p.readRl, s3p.tc)
 }
 
@@ -44,22 +80,29 @@ type s3UploadedPart struct {
 	etag string
 }
 
-func (s3p s3TablePersister) Persist(mt *memTable, haver chunkReader, stats *Stats) chunkSource {
+func (s3p awsTablePersister) Persist(mt *memTable, haver chunkReader, stats *Stats) chunkSource {
 	name, data, chunkCount := mt.write(haver, stats)
 	if chunkCount == 0 {
 		return emptyChunkSource{}
 	}
 	t1 := time.Now()
+	if s3p.limits.tableFitsInDynamo(name, data, chunkCount) {
+		dynamoTableWrite(s3p.ddb, s3p.table, name, data)
+		verbose.Log("Persisted table of %d Kb to DynamoDB in %s", len(data)/1024, time.Since(t1))
+
+		dynamoTableCacheMaybeAdd(s3p.dynamoTC, name, data)
+		return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
+	}
+
 	if s3p.tc != nil {
 		go s3p.tc.store(name, bytes.NewReader(data), uint64(len(data)))
 	}
 	s3p.multipartUpload(data, name.String())
-	verbose.Log("Compacted table of %d Kb in %s", len(data)/1024, time.Since(t1))
-
+	verbose.Log("Persisted table of %d Kb in %s", len(data)/1024, time.Since(t1))
 	return s3p.newReaderFromIndexData(data, name)
 }
 
-func (s3p s3TablePersister) newReaderFromIndexData(idxData []byte, name addr) *s3TableReader {
+func (s3p awsTablePersister) newReaderFromIndexData(idxData []byte, name addr) *s3TableReader {
 	s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name, readRl: s3p.readRl}
 	index := parseTableIndex(idxData)
 	if s3p.indexCache != nil {
@@ -71,7 +114,7 @@ func (s3p s3TablePersister) newReaderFromIndexData(idxData []byte, name addr) *s
 	return s3tr
 }
 
-func (s3p s3TablePersister) multipartUpload(data []byte, key string) {
+func (s3p awsTablePersister) multipartUpload(data []byte, key string) {
 	uploadID := s3p.startMultipartUpload(key)
 	multipartUpload, err := s3p.uploadParts(data, key, uploadID)
 	if err != nil {
@@ -81,7 +124,7 @@ func (s3p s3TablePersister) multipartUpload(data []byte, key string) {
 	s3p.completeMultipartUpload(key, uploadID, multipartUpload)
 }
 
-func (s3p s3TablePersister) startMultipartUpload(key string) string {
+func (s3p awsTablePersister) startMultipartUpload(key string) string {
 	result, err := s3p.s3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 		Bucket: aws.String(s3p.bucket),
 		Key:    aws.String(key),
@@ -90,7 +133,7 @@ func (s3p s3TablePersister) startMultipartUpload(key string) string {
 	return *result.UploadId
 }
 
-func (s3p s3TablePersister) abortMultipartUpload(key, uploadID string) {
+func (s3p awsTablePersister) abortMultipartUpload(key, uploadID string) {
 	_, abrtErr := s3p.s3.AbortMultipartUpload(&s3.AbortMultipartUploadInput{
 		Bucket:   aws.String(s3p.bucket),
 		Key:      aws.String(key),
@@ -99,7 +142,7 @@ func (s3p s3TablePersister) abortMultipartUpload(key, uploadID string) {
 	d.PanicIfError(abrtErr)
 }
 
-func (s3p s3TablePersister) completeMultipartUpload(key, uploadID string, mpu *s3.CompletedMultipartUpload) {
+func (s3p awsTablePersister) completeMultipartUpload(key, uploadID string, mpu *s3.CompletedMultipartUpload) {
 	_, err := s3p.s3.CompleteMultipartUpload(&s3.CompleteMultipartUploadInput{
 		Bucket:          aws.String(s3p.bucket),
 		Key:             aws.String(key),
@@ -109,10 +152,10 @@ func (s3p s3TablePersister) completeMultipartUpload(key, uploadID string, mpu *s
 	d.PanicIfError(err)
 }
 
-func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
+func (s3p awsTablePersister) uploadParts(data []byte, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
 	sent, failed, done := make(chan s3UploadedPart), make(chan error), make(chan struct{})
 
-	numParts := getNumParts(uint64(len(data)), s3p.targetPartSize)
+	numParts := getNumParts(uint64(len(data)), s3p.limits.partTarget)
 	d.PanicIfTrue(numParts > maxS3Parts) // TODO: BUG 3433: handle > 10k parts
 	var wg sync.WaitGroup
 	sendPart := func(partNum, start, end uint64) {
@@ -143,7 +186,7 @@ func (s3p s3TablePersister) uploadParts(data []byte, key, uploadID string) (*s3.
 	for i := uint64(0); i < numParts; i++ {
 		wg.Add(1)
 		partNum := i + 1 // Parts are 1-indexed
-		start, end := i*s3p.targetPartSize, (i+1)*s3p.targetPartSize
+		start, end := i*s3p.limits.partTarget, (i+1)*s3p.limits.partTarget
 		go sendPart(partNum, start, end)
 	}
 	go func() {
@@ -202,7 +245,7 @@ func (s partsByPartNum) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-func (s3p s3TablePersister) ConjoinAll(sources chunkSources, stats *Stats) chunkSource {
+func (s3p awsTablePersister) ConjoinAll(sources chunkSources, stats *Stats) chunkSource {
 	plan := planConjoin(sources, stats)
 	if plan.chunkCount == 0 {
 		return emptyChunkSource{}
@@ -218,7 +261,7 @@ func (s3p s3TablePersister) ConjoinAll(sources chunkSources, stats *Stats) chunk
 	return s3p.newReaderFromIndexData(plan.mergedIndex, name)
 }
 
-func (s3p s3TablePersister) loadIntoCache(name addr) {
+func (s3p awsTablePersister) loadIntoCache(name addr) {
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(s3p.bucket),
 		Key:    aws.String(name.String()),
@@ -229,7 +272,7 @@ func (s3p s3TablePersister) loadIntoCache(name addr) {
 	s3p.tc.store(name, result.Body, uint64(*result.ContentLength))
 }
 
-func (s3p s3TablePersister) executeCompactionPlan(plan compactionPlan, key string) {
+func (s3p awsTablePersister) executeCompactionPlan(plan compactionPlan, key string) {
 	uploadID := s3p.startMultipartUpload(key)
 	multipartUpload, err := s3p.assembleTable(plan, key, uploadID)
 	if err != nil {
@@ -239,11 +282,11 @@ func (s3p s3TablePersister) executeCompactionPlan(plan compactionPlan, key strin
 	s3p.completeMultipartUpload(key, uploadID, multipartUpload)
 }
 
-func (s3p s3TablePersister) assembleTable(plan compactionPlan, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
+func (s3p awsTablePersister) assembleTable(plan compactionPlan, key, uploadID string) (*s3.CompletedMultipartUpload, error) {
 	d.PanicIfTrue(len(plan.sources) > maxS3Parts) // TODO: BUG 3433: handle > 10k parts
 
 	// Separate plan.sources by amount of chunkData. Tables with >5MB of chunk data (copies) can be added to the new table using S3's multipart upload copy feature. Smaller tables with <5MB of chunk data (manuals) must be read, assembled into |buff|, and then re-uploaded in parts that are larger than 5MB.
-	copies, manuals, buff := dividePlan(plan, uint64(s3p.minPartSize), uint64(s3p.maxPartSize))
+	copies, manuals, buff := dividePlan(plan, uint64(s3p.limits.partMin), uint64(s3p.limits.partMax))
 
 	// Concurrently read data from small tables into |buff|
 	var readWg sync.WaitGroup
@@ -298,9 +341,9 @@ func (s3p s3TablePersister) assembleTable(plan compactionPlan, key, uploadID str
 	}
 
 	// Then, split buff (data from |manuals| and index) into parts and upload those concurrently.
-	numManualParts := getNumParts(uint64(len(buff)), s3p.targetPartSize) // TODO: What if this is too big?
+	numManualParts := getNumParts(uint64(len(buff)), s3p.limits.partTarget) // TODO: What if this is too big?
 	for i := uint64(0); i < numManualParts; i++ {
-		start, end := i*s3p.targetPartSize, (i+1)*s3p.targetPartSize
+		start, end := i*s3p.limits.partTarget, (i+1)*s3p.limits.partTarget
 		if i+1 == numManualParts { // If this is the last part, make sure it includes any overflow
 			end = uint64(len(buff))
 		}
@@ -418,7 +461,7 @@ func splitOnMaxSize(dataLen, maxPartSize uint64) []int64 {
 	return sizes
 }
 
-func (s3p s3TablePersister) uploadPartCopy(src string, srcStart, srcEnd int64, key, uploadID string, partNum int64) (etag string, err error) {
+func (s3p awsTablePersister) uploadPartCopy(src string, srcStart, srcEnd int64, key, uploadID string, partNum int64) (etag string, err error) {
 	res, err := s3p.s3.UploadPartCopy(&s3.UploadPartCopyInput{
 		// TODO: Use url.PathEscape() once we're on go 1.8
 		CopySource:      aws.String(url.QueryEscape(s3p.bucket + "/" + src)),
@@ -434,7 +477,7 @@ func (s3p s3TablePersister) uploadPartCopy(src string, srcStart, srcEnd int64, k
 	return
 }
 
-func (s3p s3TablePersister) uploadPart(data []byte, key, uploadID string, partNum int64) (etag string, err error) {
+func (s3p awsTablePersister) uploadPart(data []byte, key, uploadID string, partNum int64) (etag string, err error) {
 	res, err := s3p.s3.UploadPart(&s3.UploadPartInput{
 		Bucket:     aws.String(s3p.bucket),
 		Key:        aws.String(key),

--- a/go/nbs/aws_table_persister.go
+++ b/go/nbs/aws_table_persister.go
@@ -85,11 +85,8 @@ func (s3p awsTablePersister) Persist(mt *memTable, haver chunkReader, stats *Sta
 	if chunkCount == 0 {
 		return emptyChunkSource{}
 	}
-	t1 := time.Now()
 	if s3p.limits.tableFitsInDynamo(name, data, chunkCount) {
 		dynamoTableWrite(s3p.ddb, s3p.table, name, data)
-		verbose.Log("Persisted table of %d Kb to DynamoDB in %s", len(data)/1024, time.Since(t1))
-
 		dynamoTableCacheMaybeAdd(s3p.dynamoTC, name, data)
 		return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
 	}
@@ -98,7 +95,6 @@ func (s3p awsTablePersister) Persist(mt *memTable, haver chunkReader, stats *Sta
 		go s3p.tc.store(name, bytes.NewReader(data), uint64(len(data)))
 	}
 	s3p.multipartUpload(data, name.String())
-	verbose.Log("Persisted table of %d Kb in %s", len(data)/1024, time.Since(t1))
 	return s3p.newReaderFromIndexData(data, name)
 }
 

--- a/go/nbs/conjoiner.go
+++ b/go/nbs/conjoiner.go
@@ -86,7 +86,6 @@ func conjoin(upstream manifestContents, mm manifestUpdater, p tablePersister, st
 			}
 		}
 	}
-	panic("Not Reached")
 }
 
 func conjoinTables(p tablePersister, upstream []tableSpec, stats *Stats) (conjoined tableSpec, conjoinees, keepers []tableSpec) {

--- a/go/nbs/dynamo_fake_test.go
+++ b/go/nbs/dynamo_fake_test.go
@@ -1,0 +1,126 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/attic-labs/noms/go/constants"
+	"github.com/attic-labs/testify/assert"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+type fakeDDB struct {
+	data             map[string]interface{}
+	t                *testing.T
+	numPuts, numGets int
+}
+
+type record struct {
+	lock, root  []byte
+	vers, specs string
+}
+
+func makeFakeDDB(t *testing.T) *fakeDDB {
+	return &fakeDDB{
+		data: map[string]interface{}{},
+		t:    t,
+	}
+}
+
+func (m *fakeDDB) readerForTable(name addr) chunkReader {
+	if i, present := m.data[fmtTableName(name)]; present {
+		buff, ok := i.([]byte)
+		assert.True(m.t, ok)
+		return newTableReader(parseTableIndex(buff), tableReaderAtFromBytes(buff), fileBlockSize)
+	}
+	return nil
+}
+
+func (m *fakeDDB) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	key := input.Key[dbAttr].S
+	assert.NotNil(m.t, key, "key should have been a String: %+v", input.Key[dbAttr])
+
+	item := map[string]*dynamodb.AttributeValue{}
+	if e, present := m.data[*key]; present {
+		item[dbAttr] = &dynamodb.AttributeValue{S: key}
+		switch e := e.(type) {
+		case record:
+			item[nbsVersAttr] = &dynamodb.AttributeValue{S: aws.String(StorageVersion)}
+			item[versAttr] = &dynamodb.AttributeValue{S: aws.String(e.vers)}
+			item[rootAttr] = &dynamodb.AttributeValue{B: e.root}
+			item[lockAttr] = &dynamodb.AttributeValue{B: e.lock}
+			if e.specs != "" {
+				item[tableSpecsAttr] = &dynamodb.AttributeValue{S: aws.String(e.specs)}
+			}
+		case []byte:
+			item[dataAttr] = &dynamodb.AttributeValue{B: e}
+		}
+	}
+	m.numGets++
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func (m *fakeDDB) putRecord(k string, l, r []byte, v string, s string) {
+	m.data[k] = record{l, r, v, s}
+}
+
+func (m *fakeDDB) putData(k string, d []byte) {
+	m.data[k] = d
+}
+
+func (m *fakeDDB) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	assert.NotNil(m.t, input.Item[dbAttr], "%s should have been present", dbAttr)
+	assert.NotNil(m.t, input.Item[dbAttr].S, "key should have been a String: %+v", input.Item[dbAttr])
+	key := *input.Item[dbAttr].S
+
+	if input.Item[dataAttr] != nil {
+		assert.NotNil(m.t, input.Item[dataAttr].B, "data should have been a blob: %+v", input.Item[dataAttr])
+		m.putData(key, input.Item[dataAttr].B)
+		return &dynamodb.PutItemOutput{}, nil
+	}
+
+	assert.NotNil(m.t, input.Item[nbsVersAttr], "%s should have been present", nbsVersAttr)
+	assert.NotNil(m.t, input.Item[nbsVersAttr].S, "nbsVers should have been a String: %+v", input.Item[nbsVersAttr])
+	assert.Equal(m.t, StorageVersion, *input.Item[nbsVersAttr].S)
+
+	assert.NotNil(m.t, input.Item[versAttr], "%s should have been present", versAttr)
+	assert.NotNil(m.t, input.Item[versAttr].S, "nbsVers should have been a String: %+v", input.Item[versAttr])
+	assert.Equal(m.t, constants.NomsVersion, *input.Item[versAttr].S)
+
+	assert.NotNil(m.t, input.Item[lockAttr], "%s should have been present", lockAttr)
+	assert.NotNil(m.t, input.Item[lockAttr].B, "lock should have been a blob: %+v", input.Item[lockAttr])
+	lock := input.Item[lockAttr].B
+
+	assert.NotNil(m.t, input.Item[rootAttr], "%s should have been present", rootAttr)
+	assert.NotNil(m.t, input.Item[rootAttr].B, "root should have been a blob: %+v", input.Item[rootAttr])
+	root := input.Item[rootAttr].B
+
+	specs := ""
+	if attr, present := input.Item[tableSpecsAttr]; present {
+		assert.NotNil(m.t, attr.S, "specs should have been a String: %+v", input.Item[tableSpecsAttr])
+		specs = *attr.S
+	}
+
+	mustNotExist := *(input.ConditionExpression) == valueNotExistsOrEqualsExpression
+	current, present := m.data[key]
+
+	if mustNotExist && present {
+		return nil, mockAWSError("ConditionalCheckFailedException")
+	} else if !mustNotExist && !checkCondition(current.(record), input.ExpressionAttributeValues) {
+		return nil, mockAWSError("ConditionalCheckFailedException")
+	}
+
+	m.putRecord(key, lock, root, constants.NomsVersion, specs)
+	m.numPuts++
+
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func checkCondition(current record, expressionAttrVals map[string]*dynamodb.AttributeValue) bool {
+	return current.vers == *expressionAttrVals[":vers"].S && bytes.Equal(current.lock, expressionAttrVals[":prev"].B)
+}

--- a/go/nbs/dynamo_table_reader.go
+++ b/go/nbs/dynamo_table_reader.go
@@ -1,0 +1,144 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/attic-labs/noms/go/d"
+	"github.com/attic-labs/noms/go/util/sizecache"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+const (
+	dataAttr    = "data"
+	tablePrefix = "*" // I want to use NBS table names as keys when they are written to DynamoDB, but a bare table name is a legal Noms Database name as well. To avoid collisions, dynamoTableReader prepends this prefix (which is not a legal character in a Noms Database name).
+)
+
+// dynamoTableReader assumes the existence of a DynamoDB table whose primary partition key is in String format and named `db`.
+type dynamoTableReader struct {
+	tableReader
+	ddb   ddbsvc
+	table string
+	h     addr
+	tc    *sizecache.SizeCache
+}
+
+type tableNotInDynamoErr struct {
+	nbs, dynamo string
+}
+
+func (t tableNotInDynamoErr) Error() string {
+	return fmt.Sprintf("NBS table %s not present in DynamoDB table %s", t.nbs, t.dynamo)
+}
+
+func newDynamoTableReader(ddb ddbsvc, table string, h addr, chunkCount uint32, data []byte, indexCache *indexCache, tc *sizecache.SizeCache) chunkSource {
+	d.PanicIfTrue(table == "")
+	source := &dynamoTableReader{ddb: ddb, table: table, h: h, tc: tc}
+
+	var index tableIndex
+	found := false
+	if indexCache != nil {
+		indexCache.lockEntry(h)
+		defer indexCache.unlockEntry(h)
+		index, found = indexCache.get(h)
+	}
+
+	if !found {
+		index = parseTableIndex(data)
+		if indexCache != nil {
+			indexCache.put(h, index)
+		}
+	}
+
+	source.tableReader = newTableReader(index, source, fileBlockSize)
+	d.PanicIfFalse(chunkCount == source.count())
+	return source
+}
+
+func (dtr *dynamoTableReader) hash() addr {
+	return dtr.h
+}
+
+func (dtr *dynamoTableReader) ReadAtWithStats(p []byte, off int64, stats *Stats) (n int, err error) {
+	if data, present := dynamoTableCacheMaybeGet(dtr.tc, dtr.hash()); present {
+		n = copy(p, data[off:])
+		if n < len(p) {
+			err = io.ErrUnexpectedEOF
+		}
+		return
+	}
+
+	t1 := time.Now()
+	defer func() {
+		stats.DynamoBytesPerRead.Sample(uint64(len(p)))
+		stats.DynamoReadLatency.SampleTimeSince(t1)
+	}()
+	return dtr.readRange(p, off)
+}
+
+func (dtr *dynamoTableReader) readRange(p []byte, off int64) (n int, err error) {
+	data, err := tryDynamoTableRead(dtr.ddb, dtr.table, dtr.h)
+	d.PanicIfError(err)
+
+	dynamoTableCacheMaybeAdd(dtr.tc, dtr.hash(), data)
+
+	n = copy(p, data[off:])
+	if n < len(p) {
+		err = io.ErrUnexpectedEOF
+	}
+	return
+}
+
+func dynamoTableCacheMaybeGet(tc *sizecache.SizeCache, name addr) (data []byte, present bool) {
+	if tc != nil {
+		if i, present := tc.Get(name); present {
+			return i.([]byte), true
+		}
+	}
+	return
+}
+
+func dynamoTableCacheMaybeAdd(tc *sizecache.SizeCache, name addr, data []byte) {
+	if tc != nil {
+		tc.Add(name, uint64(len(data)), data)
+	}
+}
+
+func tryDynamoTableRead(ddb ddbsvc, table string, name addr) (data []byte, err error) {
+	result, rerr := ddb.GetItem(&dynamodb.GetItemInput{
+		ConsistentRead: aws.Bool(true), // This doubles the cost :-(
+		TableName:      aws.String(table),
+		Key: map[string]*dynamodb.AttributeValue{
+			dbAttr: {S: aws.String(fmtTableName(name))},
+		},
+	})
+	if rerr != nil {
+		return nil, rerr
+	} else if len(result.Item) == 0 {
+		return nil, tableNotInDynamoErr{name.String(), table}
+	} else if result.Item[dataAttr] == nil || result.Item[dataAttr].B == nil {
+		return nil, fmt.Errorf("NBS table %s in DynamoDB table %s is malformed", name, table)
+	}
+	return result.Item[dataAttr].B, nil
+}
+
+func fmtTableName(name addr) string {
+	return tablePrefix + name.String()
+}
+
+func dynamoTableWrite(ddb ddbsvc, table string, name addr, data []byte) error {
+	_, err := ddb.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item: map[string]*dynamodb.AttributeValue{
+			dbAttr:   {S: aws.String(fmtTableName(name))},
+			dataAttr: {B: data},
+		},
+	})
+	return err
+}

--- a/go/nbs/dynamo_table_reader_test.go
+++ b/go/nbs/dynamo_table_reader_test.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/attic-labs/noms/go/util/sizecache"
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestDynamoTableReader(t *testing.T) {
+	ddb := makeFakeDDB(t)
+
+	chunks := [][]byte{
+		[]byte("hello2"),
+		[]byte("goodbye2"),
+		[]byte("badbye2"),
+	}
+
+	tableData, h := buildTable(chunks)
+	ddb.putData(fmtTableName(h), tableData)
+
+	t.Run("NoIndexCache", func(t *testing.T) {
+		trc := newDynamoTableReader(ddb, "table", h, uint32(len(chunks)), tableData, nil, nil)
+		assertChunksInReader(chunks, trc, assert.New(t))
+	})
+
+	t.Run("WithIndexCache", func(t *testing.T) {
+		assert := assert.New(t)
+		index := parseTableIndex(tableData)
+		cache := newIndexCache(1024)
+		cache.put(h, index)
+
+		baseline := ddb.numGets
+		trc := newDynamoTableReader(ddb, "table", h, uint32(len(chunks)), tableData, cache, nil)
+
+		// constructing the table reader shouldn't have resulted in any reads
+		assert.Zero(ddb.numGets - baseline)
+		assertChunksInReader(chunks, trc, assert)
+	})
+
+	t.Run("WithTableCache", func(t *testing.T) {
+		assert := assert.New(t)
+		dir := makeTempDir(t)
+		defer os.RemoveAll(dir)
+		stats := &Stats{}
+
+		tc := sizecache.New(uint64(2 * len(tableData)))
+		trc := newDynamoTableReader(ddb, "table", h, uint32(len(chunks)), tableData, nil, tc)
+		tra := trc.(tableReaderAt)
+
+		// First, read when table is not yet cached
+		scratch := make([]byte, len(tableData)/4)
+		baseline := ddb.numGets
+		_, err := tra.ReadAtWithStats(scratch, 0, stats)
+		assert.NoError(err)
+		assert.True(ddb.numGets > baseline)
+
+		// Table should have been cached on read so read again, a different slice this time
+		baseline = ddb.numGets
+		_, err = tra.ReadAtWithStats(scratch, int64(len(scratch)), stats)
+		assert.NoError(err)
+		assert.Zero(ddb.numGets - baseline)
+	})
+}

--- a/go/nbs/s3_table_reader.go
+++ b/go/nbs/s3_table_reader.go
@@ -44,6 +44,7 @@ type s3svc interface {
 }
 
 func newS3TableReader(s3 s3svc, bucket string, h addr, chunkCount uint32, indexCache *indexCache, readRl chan struct{}, tc tableCache) chunkSource {
+	d.PanicIfTrue(bucket == "")
 	source := &s3TableReader{s3: s3, bucket: bucket, h: h, readRl: readRl, tc: tc}
 
 	var index tableIndex

--- a/go/nbs/stats.go
+++ b/go/nbs/stats.go
@@ -17,10 +17,13 @@ type Stats struct {
 	GetLatency   metrics.Histogram
 	ChunksPerGet metrics.Histogram
 
-	FileReadLatency    metrics.Histogram
-	FileBytesPerRead   metrics.Histogram
-	S3ReadLatency      metrics.Histogram
-	S3BytesPerRead     metrics.Histogram
+	FileReadLatency  metrics.Histogram
+	FileBytesPerRead metrics.Histogram
+	S3ReadLatency    metrics.Histogram
+	S3BytesPerRead   metrics.Histogram
+
+	MemReadLatency     metrics.Histogram
+	MemBytesPerRead    metrics.Histogram
 	DynamoReadLatency  metrics.Histogram
 	DynamoBytesPerRead metrics.Histogram
 
@@ -51,6 +54,8 @@ func NewStats() *Stats {
 		FileBytesPerRead:     metrics.NewByteHistogram(),
 		S3ReadLatency:        metrics.NewTimeHistogram(),
 		S3BytesPerRead:       metrics.NewByteHistogram(),
+		MemReadLatency:       metrics.NewTimeHistogram(),
+		MemBytesPerRead:      metrics.NewByteHistogram(),
 		DynamoReadLatency:    metrics.NewTimeHistogram(),
 		DynamoBytesPerRead:   metrics.NewByteHistogram(),
 		HasLatency:           metrics.NewTimeHistogram(),
@@ -76,6 +81,9 @@ func (s *Stats) Add(other Stats) {
 
 	s.S3ReadLatency.Add(other.S3ReadLatency)
 	s.S3BytesPerRead.Add(other.S3BytesPerRead)
+
+	s.MemReadLatency.Add(other.MemReadLatency)
+	s.MemBytesPerRead.Add(other.MemBytesPerRead)
 
 	s.DynamoReadLatency.Add(other.DynamoReadLatency)
 	s.DynamoBytesPerRead.Add(other.DynamoBytesPerRead)
@@ -109,6 +117,9 @@ func (s Stats) Delta(other Stats) Stats {
 		s.S3ReadLatency.Delta(other.S3ReadLatency),
 		s.S3BytesPerRead.Delta(other.S3BytesPerRead),
 
+		s.MemReadLatency.Delta(other.MemReadLatency),
+		s.MemBytesPerRead.Delta(other.MemBytesPerRead),
+
 		s.DynamoReadLatency.Delta(other.DynamoReadLatency),
 		s.DynamoBytesPerRead.Delta(other.DynamoBytesPerRead),
 
@@ -141,6 +152,8 @@ FileReadLatency:      %s
 FileBytesPerRead:     %s
 S3ReadLatency:        %s
 S3BytesPerRead:       %s
+MemReadLatency:    %s
+MemBytesPerRead:   %s
 DynamoReadLatency:    %s
 DynamoBytesPerRead:   %s
 HasLatency:           %s
@@ -167,6 +180,9 @@ WriteManifestLatency: %s
 
 		s.S3ReadLatency,
 		s.S3BytesPerRead,
+
+		s.MemReadLatency,
+		s.MemBytesPerRead,
 
 		s.DynamoReadLatency,
 		s.DynamoBytesPerRead,

--- a/go/nbs/stats.go
+++ b/go/nbs/stats.go
@@ -17,10 +17,12 @@ type Stats struct {
 	GetLatency   metrics.Histogram
 	ChunksPerGet metrics.Histogram
 
-	FileReadLatency  metrics.Histogram
-	FileBytesPerRead metrics.Histogram
-	S3ReadLatency    metrics.Histogram
-	S3BytesPerRead   metrics.Histogram
+	FileReadLatency    metrics.Histogram
+	FileBytesPerRead   metrics.Histogram
+	S3ReadLatency      metrics.Histogram
+	S3BytesPerRead     metrics.Histogram
+	DynamoReadLatency  metrics.Histogram
+	DynamoBytesPerRead metrics.Histogram
 
 	HasLatency      metrics.Histogram
 	AddressesPerHas metrics.Histogram
@@ -49,6 +51,8 @@ func NewStats() *Stats {
 		FileBytesPerRead:     metrics.NewByteHistogram(),
 		S3ReadLatency:        metrics.NewTimeHistogram(),
 		S3BytesPerRead:       metrics.NewByteHistogram(),
+		DynamoReadLatency:    metrics.NewTimeHistogram(),
+		DynamoBytesPerRead:   metrics.NewByteHistogram(),
 		HasLatency:           metrics.NewTimeHistogram(),
 		PutLatency:           metrics.NewTimeHistogram(),
 		PersistLatency:       metrics.NewTimeHistogram(),
@@ -72,6 +76,9 @@ func (s *Stats) Add(other Stats) {
 
 	s.S3ReadLatency.Add(other.S3ReadLatency)
 	s.S3BytesPerRead.Add(other.S3BytesPerRead)
+
+	s.DynamoReadLatency.Add(other.DynamoReadLatency)
+	s.DynamoBytesPerRead.Add(other.DynamoBytesPerRead)
 
 	s.HasLatency.Add(other.HasLatency)
 	s.AddressesPerHas.Add(other.AddressesPerHas)
@@ -102,6 +109,9 @@ func (s Stats) Delta(other Stats) Stats {
 		s.S3ReadLatency.Delta(other.S3ReadLatency),
 		s.S3BytesPerRead.Delta(other.S3BytesPerRead),
 
+		s.DynamoReadLatency.Delta(other.DynamoReadLatency),
+		s.DynamoBytesPerRead.Delta(other.DynamoBytesPerRead),
+
 		s.HasLatency.Delta(other.HasLatency),
 		s.AddressesPerHas.Delta(other.AddressesPerHas),
 
@@ -131,6 +141,8 @@ FileReadLatency:      %s
 FileBytesPerRead:     %s
 S3ReadLatency:        %s
 S3BytesPerRead:       %s
+DynamoReadLatency:    %s
+DynamoBytesPerRead:   %s
 HasLatency:           %s
 AddressesHasGet:      %s
 PutLatency:           %s
@@ -155,6 +167,9 @@ WriteManifestLatency: %s
 
 		s.S3ReadLatency,
 		s.S3BytesPerRead,
+
+		s.DynamoReadLatency,
+		s.DynamoBytesPerRead,
 
 		s.HasLatency,
 		s.AddressesPerHas,

--- a/go/nbs/store.go
+++ b/go/nbs/store.go
@@ -66,14 +66,15 @@ type NomsBlockStore struct {
 
 func NewAWSStore(table, ns, bucket string, s3 s3svc, ddb ddbsvc, memTableSize uint64) *NomsBlockStore {
 	cacheOnce.Do(makeGlobalCaches)
-	p := &s3TablePersister{
+	p := &awsTablePersister{
 		s3,
 		bucket,
-		defaultS3PartSize,
-		minS3PartSize,
-		maxS3PartSize,
+		ddb,
+		table,
+		awsLimits{defaultS3PartSize, minS3PartSize, maxS3PartSize, maxDynamoItemSize, maxDynamoChunks},
 		globalIndexCache,
 		make(chan struct{}, 32),
+		nil,
 		nil,
 	}
 	mm := makeManifestManager(newDynamoManifest(table, ns, ddb))


### PR DESCRIPTION
There seems to be a floor on the amount of time required to persist
small objects to S3. For workloads that generate lots of small tables,
this can really add up. DynamoDB is much faster to read/write, and can
hold items of up to 400k. This patch stores tables with < 64 chunks
that are < 400k in DynamoDB, caching them in memory on persist and
open to reduce load on the back end.

Fixes #3559