### PR TITLE
NBS: increase size of small-table memory cache

### DIFF
--- a/go/nbs/factory.go
+++ b/go/nbs/factory.go
@@ -21,7 +21,7 @@ const (
 	defaultAWSReadLimit = 1024
 	awsMaxTables        = 128
 
-	defaultSmallTableCacheSize = 1 << 26 // 64MB
+	defaultSmallTableCacheSize = 1 << 28 // 256MB
 )
 
 // AWSStoreFactory vends NomsBlockStores built on top of DynamoDB and S3.


### PR DESCRIPTION
Looking at metrics on staging today, there are frequent spikes of
tens of thousands of throttled DynamoDB reads. One explanation is
that we're constantly evicting 'hot' tables from the in-memory
cache because the working set is larger than the space we've
allotted for the cache.