### PR TITLE
NBS: populate small table cache on Open

### DIFF
--- a/go/nbs/aws_table_persister.go
+++ b/go/nbs/aws_table_persister.go
@@ -66,6 +66,7 @@ func (s3p awsTablePersister) Open(name addr, chunkCount uint32) chunkSource {
 		}
 		data, err := tryDynamoTableRead(s3p.ddb, s3p.table, name)
 		if data != nil {
+			dynamoTableCacheMaybeAdd(s3p.dynamoTC, name, data) // TODO: stop doing this as part of BUG 3607
 			return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
 		}
 		d.PanicIfTrue(err == nil) // There MUST be either data or an error

--- a/go/nbs/factory.go
+++ b/go/nbs/factory.go
@@ -21,7 +21,7 @@ const (
 	defaultAWSReadLimit = 1024
 	awsMaxTables        = 128
 
-	defaultSmallTableCacheSize = 1 << 28 // 256MB
+	defaultSmallTableCacheSize = 1 << 30 // 1GB
 )
 
 // AWSStoreFactory vends NomsBlockStores built on top of DynamoDB and S3.


### PR DESCRIPTION
This will likely bloat the cache with tables no one's going to read
data from, BUT doing this also means that most checks to see if a table
is in Dynamo at all can proceed locally. Stopgap until fix for #3607 lands