### PR TITLE
NBS: Defer AWS reads when opening a table with cached index

### DIFF
--- a/go/nbs/aws_chunk_source.go
+++ b/go/nbs/aws_chunk_source.go
@@ -6,66 +6,62 @@ package nbs
 
 import (
 	"sync"
+	"time"
 
 	"github.com/attic-labs/noms/go/d"
 )
 
-type awsChunkSource struct {
-	tableReader
-	accessor tableAccessor
-	name     addr
-}
-
-func newAWSChunkSource(accessor tableAccessor, name addr, indexCache *indexCache, stats *Stats) chunkSource {
-	source := &awsChunkSource{accessor: accessor, name: name}
-	var index tableIndex
-	found := false
+func newAWSChunkSource(ddb *ddbTableStore, s3 *s3ObjectReader, al awsLimits, name addr, chunkCount uint32, indexCache *indexCache, stats *Stats) chunkSource {
 	if indexCache != nil {
 		indexCache.lockEntry(name)
 		defer indexCache.unlockEntry(name)
-		index, found = indexCache.get(name)
-	}
-
-	if !found {
-		index = source.accessor.getTableIndex(stats)
-		if indexCache != nil {
-			indexCache.put(name, index)
+		if index, found := indexCache.get(name); found {
+			tra := &awsTableReaderAt{al: al, ddb: ddb, s3: s3, name: name, chunkCount: chunkCount}
+			return &awsChunkSource{newTableReader(index, tra, s3BlockSize), name}
 		}
 	}
 
-	source.tableReader = newTableReader(index, source, s3BlockSize)
-	return source
+	t1 := time.Now()
+	indexBytes, tra := func() ([]byte, tableReaderAt) {
+		if al.tableMayBeInDynamo(chunkCount) {
+			data, err := ddb.ReadTable(name, stats)
+			if data != nil {
+				return data, &dynamoTableReaderAt{ddb: ddb, h: name}
+			}
+			d.PanicIfTrue(err == nil) // There MUST be either data or an error
+			d.PanicIfNotType(err, tableNotInDynamoErr{})
+		}
+
+		size := indexSize(chunkCount) + footerSize
+		buff := make([]byte, size)
+
+		n, err := s3.ReadFromEnd(name, buff, stats)
+		d.PanicIfError(err)
+		d.PanicIfFalse(size == uint64(n))
+		return buff, &s3TableReaderAt{s3: s3, h: name}
+	}()
+	stats.IndexBytesPerRead.Sample(uint64(len(indexBytes)))
+	stats.IndexReadLatency.SampleTimeSince(t1)
+
+	index := parseTableIndex(indexBytes)
+	if indexCache != nil {
+		indexCache.put(name, index)
+	}
+	return &awsChunkSource{newTableReader(index, tra, s3BlockSize), name}
+}
+
+type awsChunkSource struct {
+	tableReader
+	name addr
 }
 
 func (acs *awsChunkSource) hash() addr {
 	return acs.name
 }
 
-func (acs *awsChunkSource) ReadAtWithStats(p []byte, off int64, stats *Stats) (n int, err error) {
-	return acs.accessor.getTableReaderAt(stats).ReadAtWithStats(p, off, stats)
-}
-
-type tableAccessor interface {
-	getTableIndex(stats *Stats) tableIndex
-	getTableReaderAt(stats *Stats) tableReaderAt
-}
-
-type trivialTableAccessor struct {
-	tra tableReaderAt
-}
-
-func (tta trivialTableAccessor) getTableIndex(stats *Stats) tableIndex {
-	panic("Not Reached")
-}
-
-func (tta trivialTableAccessor) getTableReaderAt(stats *Stats) tableReaderAt {
-	return tta.tra
-}
-
-type oneShotTableQuery struct {
-	once  sync.Once
-	index tableIndex
-	tra   tableReaderAt
+type awsTableReaderAt struct {
+	once sync.Once
+	tra  tableReaderAt
 
 	al  awsLimits
 	ddb *ddbTableStore
@@ -75,34 +71,24 @@ type oneShotTableQuery struct {
 	chunkCount uint32
 }
 
-func (o *oneShotTableQuery) getTableIndex(stats *Stats) tableIndex {
-	o.once.Do(func() { o.resolve(stats) })
-	return o.index
+func (atra *awsTableReaderAt) hash() addr {
+	return atra.name
 }
 
-func (o *oneShotTableQuery) getTableReaderAt(stats *Stats) tableReaderAt {
-	o.once.Do(func() { o.resolve(stats) })
-	return o.tra
+func (atra *awsTableReaderAt) ReadAtWithStats(p []byte, off int64, stats *Stats) (n int, err error) {
+	atra.once.Do(func() { atra.tra = atra.getTableReaderAt(stats) })
+	return atra.tra.ReadAtWithStats(p, off, stats)
 }
 
-func (o *oneShotTableQuery) resolve(stats *Stats) {
-	if o.al.tableMayBeInDynamo(o.chunkCount) {
-		data, err := o.ddb.ReadTable(o.name, stats)
+func (atra *awsTableReaderAt) getTableReaderAt(stats *Stats) tableReaderAt {
+	if atra.al.tableMayBeInDynamo(atra.chunkCount) {
+		data, err := atra.ddb.ReadTable(atra.name, stats)
 		if data != nil {
-			o.index = parseTableIndex(data)
-			o.tra = &dynamoTableReaderAt{ddb: o.ddb, h: o.name}
-			return
+			return &dynamoTableReaderAt{ddb: atra.ddb, h: atra.name}
 		}
 		d.PanicIfTrue(err == nil) // There MUST be either data or an error
 		d.PanicIfNotType(err, tableNotInDynamoErr{})
 	}
 
-	size := indexSize(o.chunkCount) + footerSize
-	buff := make([]byte, size)
-
-	n, err := o.s3.ReadFromEnd(o.name, buff, stats)
-	d.PanicIfError(err)
-	d.PanicIfFalse(size == uint64(n))
-	o.index = parseTableIndex(buff)
-	o.tra = &s3TableReaderAt{s3: o.s3, h: o.name}
+	return &s3TableReaderAt{s3: atra.s3, h: atra.name}
 }

--- a/go/nbs/aws_chunk_source.go
+++ b/go/nbs/aws_chunk_source.go
@@ -1,0 +1,108 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"sync"
+
+	"github.com/attic-labs/noms/go/d"
+)
+
+type awsChunkSource struct {
+	tableReader
+	accessor tableAccessor
+	name     addr
+}
+
+func newAWSChunkSource(accessor tableAccessor, name addr, indexCache *indexCache, stats *Stats) chunkSource {
+	source := &awsChunkSource{accessor: accessor, name: name}
+	var index tableIndex
+	found := false
+	if indexCache != nil {
+		indexCache.lockEntry(name)
+		defer indexCache.unlockEntry(name)
+		index, found = indexCache.get(name)
+	}
+
+	if !found {
+		index = source.accessor.getTableIndex(stats)
+		if indexCache != nil {
+			indexCache.put(name, index)
+		}
+	}
+
+	source.tableReader = newTableReader(index, source, s3BlockSize)
+	return source
+}
+
+func (acs *awsChunkSource) hash() addr {
+	return acs.name
+}
+
+func (acs *awsChunkSource) ReadAtWithStats(p []byte, off int64, stats *Stats) (n int, err error) {
+	return acs.accessor.getTableReaderAt(stats).ReadAtWithStats(p, off, stats)
+}
+
+type tableAccessor interface {
+	getTableIndex(stats *Stats) tableIndex
+	getTableReaderAt(stats *Stats) tableReaderAt
+}
+
+type trivialTableAccessor struct {
+	tra tableReaderAt
+}
+
+func (tta trivialTableAccessor) getTableIndex(stats *Stats) tableIndex {
+	panic("Not Reached")
+}
+
+func (tta trivialTableAccessor) getTableReaderAt(stats *Stats) tableReaderAt {
+	return tta.tra
+}
+
+type oneShotTableQuery struct {
+	once  sync.Once
+	index tableIndex
+	tra   tableReaderAt
+
+	al  awsLimits
+	ddb *ddbTableStore
+	s3  *s3ObjectReader
+
+	name       addr
+	chunkCount uint32
+}
+
+func (o *oneShotTableQuery) getTableIndex(stats *Stats) tableIndex {
+	o.once.Do(func() { o.resolve(stats) })
+	return o.index
+}
+
+func (o *oneShotTableQuery) getTableReaderAt(stats *Stats) tableReaderAt {
+	o.once.Do(func() { o.resolve(stats) })
+	return o.tra
+}
+
+func (o *oneShotTableQuery) resolve(stats *Stats) {
+	if o.al.tableMayBeInDynamo(o.chunkCount) {
+		data, err := o.ddb.ReadTable(o.name, stats)
+		if data != nil {
+			o.index = parseTableIndex(data)
+			o.tra = &dynamoTableReaderAt{ddb: o.ddb, h: o.name}
+			return
+		}
+		d.PanicIfTrue(err == nil) // There MUST be either data or an error
+		d.PanicIfNotType(err, tableNotInDynamoErr{})
+	}
+
+	size := indexSize(o.chunkCount) + footerSize
+	buff := make([]byte, size)
+
+	n, err := o.s3.ReadFromEnd(o.name, buff, stats)
+	d.PanicIfError(err)
+	d.PanicIfFalse(size == uint64(n))
+	o.index = parseTableIndex(buff)
+	o.tra = &s3TableReaderAt{s3: o.s3, h: o.name}
+}

--- a/go/nbs/aws_chunk_source_test.go
+++ b/go/nbs/aws_chunk_source_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"testing"
+
+	"github.com/attic-labs/testify/assert"
+)
+
+func TestAWSChunkSource(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("hello2"),
+		[]byte("goodbye2"),
+		[]byte("badbye2"),
+	}
+	tableData, h := buildTable(chunks)
+
+	s3 := makeFakeS3(t)
+	ddb := makeFakeDDB(t)
+
+	s3or := &s3ObjectReader{s3, "bucket", nil, nil}
+	dts := &ddbTableStore{ddb, "table", nil, nil}
+
+	makeSrc := func(chunkMax int, ic *indexCache) chunkSource {
+		return newAWSChunkSource(
+			&oneShotTableQuery{
+				al:         awsLimits{itemMax: maxDynamoItemSize, chunkMax: uint32(chunkMax)},
+				ddb:        dts,
+				s3:         s3or,
+				name:       h,
+				chunkCount: uint32(len(chunks)),
+			},
+			h,
+			ic,
+			&Stats{},
+		)
+	}
+
+	t.Run("Dynamo", func(t *testing.T) {
+		ddb.putData(fmtTableName(h), tableData)
+
+		t.Run("NoIndexCache", func(t *testing.T) {
+			src := makeSrc(len(chunks)+1, nil)
+			assertChunksInReader(chunks, src, assert.New(t))
+		})
+
+		t.Run("WithIndexCache", func(t *testing.T) {
+			assert := assert.New(t)
+			index := parseTableIndex(tableData)
+			cache := newIndexCache(1024)
+			cache.put(h, index)
+
+			baseline := ddb.numGets
+			src := makeSrc(len(chunks)+1, cache)
+
+			// constructing the table reader shouldn't have resulted in any reads
+			assert.Zero(ddb.numGets - baseline)
+			assertChunksInReader(chunks, src, assert)
+		})
+	})
+
+	t.Run("S3", func(t *testing.T) {
+		s3.data[h.String()] = tableData
+
+		t.Run("NoIndexCache", func(t *testing.T) {
+			src := makeSrc(len(chunks)-1, nil)
+			assertChunksInReader(chunks, src, assert.New(t))
+		})
+
+		t.Run("WithIndexCache", func(t *testing.T) {
+			assert := assert.New(t)
+			index := parseTableIndex(tableData)
+			cache := newIndexCache(1024)
+			cache.put(h, index)
+
+			baseline := s3.getCount
+			src := makeSrc(len(chunks)-1, cache)
+
+			// constructing the table reader shouldn't have resulted in any reads
+			assert.Zero(s3.getCount - baseline)
+			assertChunksInReader(chunks, src, assert)
+		})
+	})
+}

--- a/go/nbs/aws_chunk_source_test.go
+++ b/go/nbs/aws_chunk_source_test.go
@@ -26,14 +26,11 @@ func TestAWSChunkSource(t *testing.T) {
 
 	makeSrc := func(chunkMax int, ic *indexCache) chunkSource {
 		return newAWSChunkSource(
-			&oneShotTableQuery{
-				al:         awsLimits{itemMax: maxDynamoItemSize, chunkMax: uint32(chunkMax)},
-				ddb:        dts,
-				s3:         s3or,
-				name:       h,
-				chunkCount: uint32(len(chunks)),
-			},
+			dts,
+			s3or,
+			awsLimits{itemMax: maxDynamoItemSize, chunkMax: uint32(chunkMax)},
 			h,
+			uint32(len(chunks)),
 			ic,
 			&Stats{},
 		)

--- a/go/nbs/aws_table_persister.go
+++ b/go/nbs/aws_table_persister.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/attic-labs/noms/go/d"
-	"github.com/attic-labs/noms/go/util/sizecache"
 	"github.com/attic-labs/noms/go/util/verbose"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -33,13 +32,11 @@ const (
 type awsTablePersister struct {
 	s3         s3svc
 	bucket     string
-	ddb        ddbsvc
-	table      string
-	limits     awsLimits
-	indexCache *indexCache
 	readRl     chan struct{}
 	tc         tableCache
-	dynamoTC   *sizecache.SizeCache // TODO: merge this and above as part of BUG 3601
+	ddb        *ddbTableStore
+	limits     awsLimits
+	indexCache *indexCache
 }
 
 type awsLimits struct {
@@ -59,21 +56,18 @@ func (al awsLimits) tableMayBeInDynamo(chunkCount uint32) bool {
 	return chunkCount <= al.chunkMax
 }
 
-func (s3p awsTablePersister) Open(name addr, chunkCount uint32) chunkSource {
-	if s3p.limits.tableMayBeInDynamo(chunkCount) {
-		if data, present := dynamoTableCacheMaybeGet(s3p.dynamoTC, name); present {
-			return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
-		}
-		data, err := tryDynamoTableRead(s3p.ddb, s3p.table, name)
-		if data != nil {
-			dynamoTableCacheMaybeAdd(s3p.dynamoTC, name, data) // TODO: stop doing this as part of BUG 3607
-			return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
-		}
-		d.PanicIfTrue(err == nil) // There MUST be either data or an error
-		d.PanicIfNotType(err, tableNotInDynamoErr{})
-	}
-
-	return newS3TableReader(s3p.s3, s3p.bucket, name, chunkCount, s3p.indexCache, s3p.readRl, s3p.tc)
+func (s3p awsTablePersister) Open(name addr, chunkCount uint32, stats *Stats) chunkSource {
+	return newAWSChunkSource(
+		&oneShotTableQuery{
+			al:         s3p.limits,
+			ddb:        s3p.ddb,
+			s3:         &s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.readRl, tc: s3p.tc},
+			name:       name,
+			chunkCount: chunkCount,
+		},
+		name,
+		s3p.indexCache,
+		stats)
 }
 
 type s3UploadedPart struct {
@@ -87,28 +81,27 @@ func (s3p awsTablePersister) Persist(mt *memTable, haver chunkReader, stats *Sta
 		return emptyChunkSource{}
 	}
 	if s3p.limits.tableFitsInDynamo(name, data, chunkCount) {
-		dynamoTableWrite(s3p.ddb, s3p.table, name, data)
-		dynamoTableCacheMaybeAdd(s3p.dynamoTC, name, data)
-		return newDynamoTableReader(s3p.ddb, s3p.table, name, chunkCount, data, s3p.indexCache, s3p.dynamoTC)
+		s3p.ddb.Write(name, data)
+		tra := &dynamoTableReaderAt{ddb: s3p.ddb, h: name}
+		return s3p.newReaderFromIndexData(data, name, tra)
 	}
 
 	if s3p.tc != nil {
 		go s3p.tc.store(name, bytes.NewReader(data), uint64(len(data)))
 	}
 	s3p.multipartUpload(data, name.String())
-	return s3p.newReaderFromIndexData(data, name)
+	tra := &s3TableReaderAt{&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.readRl, tc: s3p.tc}, name}
+	return s3p.newReaderFromIndexData(data, name, tra)
 }
 
-func (s3p awsTablePersister) newReaderFromIndexData(idxData []byte, name addr) *s3TableReader {
-	s3tr := &s3TableReader{s3: s3p.s3, bucket: s3p.bucket, h: name, readRl: s3p.readRl}
+func (s3p awsTablePersister) newReaderFromIndexData(idxData []byte, name addr, tra tableReaderAt) chunkSource {
 	index := parseTableIndex(idxData)
 	if s3p.indexCache != nil {
 		s3p.indexCache.lockEntry(name)
 		defer s3p.indexCache.unlockEntry(name)
 		s3p.indexCache.put(name, index)
 	}
-	s3tr.tableReader = newTableReader(index, s3tr, s3BlockSize)
-	return s3tr
+	return &awsChunkSource{newTableReader(index, tra, s3BlockSize), trivialTableAccessor{tra}, name}
 }
 
 func (s3p awsTablePersister) multipartUpload(data []byte, key string) {
@@ -255,7 +248,8 @@ func (s3p awsTablePersister) ConjoinAll(sources chunkSources, stats *Stats) chun
 	if s3p.tc != nil {
 		go s3p.loadIntoCache(name) // load conjoined table to the cache
 	}
-	return s3p.newReaderFromIndexData(plan.mergedIndex, name)
+	tra := &s3TableReaderAt{&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.readRl, tc: s3p.tc}, name}
+	return s3p.newReaderFromIndexData(plan.mergedIndex, name, tra)
 }
 
 func (s3p awsTablePersister) loadIntoCache(name addr) {

--- a/go/nbs/block_store_test.go
+++ b/go/nbs/block_store_test.go
@@ -315,7 +315,7 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 	makeCanned := func(conjoinees, keepers []tableSpec, p tablePersister) cannedConjoin {
 		srcs := chunkSources{}
 		for _, sp := range conjoinees {
-			srcs = append(srcs, p.Open(sp.name, sp.chunkCount))
+			srcs = append(srcs, p.Open(sp.name, sp.chunkCount, nil))
 		}
 		conjoined := p.ConjoinAll(srcs, stats)
 		cannedSpecs := []tableSpec{{conjoined.hash(), conjoined.count()}}

--- a/go/nbs/conjoiner.go
+++ b/go/nbs/conjoiner.go
@@ -95,7 +95,7 @@ func conjoinTables(p tablePersister, upstream []tableSpec, stats *Stats) (conjoi
 	for i, spec := range upstream {
 		wg.Add(1)
 		go func(idx int, spec tableSpec) {
-			sources[idx] = p.Open(spec.name, spec.chunkCount)
+			sources[idx] = p.Open(spec.name, spec.chunkCount, stats)
 			wg.Done()
 		}(i, spec)
 		i++

--- a/go/nbs/conjoiner_test.go
+++ b/go/nbs/conjoiner_test.go
@@ -69,7 +69,7 @@ func TestConjoin(t *testing.T) {
 	assertContainAll := func(t *testing.T, p tablePersister, expect, actual []tableSpec) {
 		open := func(specs []tableSpec) (srcs chunkReaderGroup) {
 			for _, sp := range specs {
-				srcs = append(srcs, p.Open(sp.name, sp.chunkCount))
+				srcs = append(srcs, p.Open(sp.name, sp.chunkCount, nil))
 			}
 			return
 		}

--- a/go/nbs/file_table_persister_test.go
+++ b/go/nbs/file_table_persister_test.go
@@ -35,14 +35,14 @@ func TestFSTableCacheOnOpen(t *testing.T) {
 			names = append(names, name)
 		}
 		for _, name := range names {
-			fts.Open(name, 1)
+			fts.Open(name, 1, nil)
 		}
 		removeTables(dir, names...)
 	}()
 
 	// Tables should still be cached, even though they're gone from disk
 	for i, name := range names {
-		src := fts.Open(name, 1)
+		src := fts.Open(name, 1, nil)
 		h := computeAddr([]byte{byte(i)})
 		assert.True(src.has(h))
 	}
@@ -50,7 +50,7 @@ func TestFSTableCacheOnOpen(t *testing.T) {
 	// Kick a table out of the cache
 	name, err := writeTableData(dir, []byte{0xff})
 	assert.NoError(err)
-	fts.Open(name, 1)
+	fts.Open(name, 1, nil)
 
 	present := fc.reportEntries()
 	// Since 0 refcount entries are evicted randomly, the only thing we can validate is that fc remains at its target size
@@ -156,7 +156,7 @@ func TestFSTablePersisterCacheOnPersist(t *testing.T) {
 	}()
 
 	// Table should still be cached, even though it's gone from disk
-	src := fts.Open(name, uint32(len(testChunks)))
+	src := fts.Open(name, uint32(len(testChunks)), nil)
 	assertChunksInReader(testChunks, src, assert)
 
 	// Evict |name| from cache
@@ -185,7 +185,7 @@ func TestFSTablePersisterConjoinAll(t *testing.T) {
 		assert.NoError(err)
 		name, err := writeTableData(dir, c, randChunk)
 		assert.NoError(err)
-		sources[i] = fts.Open(name, 2)
+		sources[i] = fts.Open(name, 2, nil)
 	}
 
 	src := fts.ConjoinAll(sources, &Stats{})

--- a/go/nbs/root_tracker_test.go
+++ b/go/nbs/root_tracker_test.go
@@ -389,7 +389,7 @@ func compactSourcesToBuffer(sources chunkSources) (name addr, data []byte, chunk
 	return name, buff[:tableSize], chunkCount
 }
 
-func (ftp fakeTablePersister) Open(name addr, chunkCount uint32) chunkSource {
+func (ftp fakeTablePersister) Open(name addr, chunkCount uint32, stats *Stats) chunkSource {
 	ftp.mu.RLock()
 	defer ftp.mu.RUnlock()
 	return chunkSourceAdapter{ftp.sources[name], name}

--- a/go/nbs/stats.go
+++ b/go/nbs/stats.go
@@ -14,6 +14,9 @@ type Stats struct {
 	OpenLatency   metrics.Histogram
 	CommitLatency metrics.Histogram
 
+	IndexReadLatency  metrics.Histogram
+	IndexBytesPerRead metrics.Histogram
+
 	GetLatency   metrics.Histogram
 	ChunksPerGet metrics.Histogram
 
@@ -49,6 +52,8 @@ func NewStats() *Stats {
 	return &Stats{
 		OpenLatency:          metrics.NewTimeHistogram(),
 		CommitLatency:        metrics.NewTimeHistogram(),
+		IndexReadLatency:     metrics.NewTimeHistogram(),
+		IndexBytesPerRead:    metrics.NewByteHistogram(),
 		GetLatency:           metrics.NewTimeHistogram(),
 		FileReadLatency:      metrics.NewTimeHistogram(),
 		FileBytesPerRead:     metrics.NewByteHistogram(),
@@ -72,6 +77,9 @@ func NewStats() *Stats {
 func (s *Stats) Add(other Stats) {
 	s.OpenLatency.Add(other.OpenLatency)
 	s.CommitLatency.Add(other.CommitLatency)
+
+	s.IndexReadLatency.Add(other.IndexReadLatency)
+	s.IndexBytesPerRead.Add(other.IndexBytesPerRead)
 
 	s.GetLatency.Add(other.GetLatency)
 	s.ChunksPerGet.Add(other.ChunksPerGet)
@@ -107,6 +115,9 @@ func (s Stats) Delta(other Stats) Stats {
 	return Stats{
 		s.OpenLatency.Delta(other.OpenLatency),
 		s.CommitLatency.Delta(other.CommitLatency),
+
+		s.IndexReadLatency.Delta(other.IndexReadLatency),
+		s.IndexBytesPerRead.Delta(other.IndexBytesPerRead),
 
 		s.GetLatency.Delta(other.GetLatency),
 		s.ChunksPerGet.Delta(other.ChunksPerGet),
@@ -146,14 +157,16 @@ func (s Stats) String() string {
 	return fmt.Sprintf(`---NBS Stats---
 OpenLatecy:           %s
 CommitLatency:        %s
+IndexReadLatency:     %s
+IndexBytesPerRead:    %s
 GetLatency:           %s
 ChunksPerGet:         %s
 FileReadLatency:      %s
 FileBytesPerRead:     %s
 S3ReadLatency:        %s
 S3BytesPerRead:       %s
-MemReadLatency:    %s
-MemBytesPerRead:   %s
+MemReadLatency:       %s
+MemBytesPerRead:      %s
 DynamoReadLatency:    %s
 DynamoBytesPerRead:   %s
 HasLatency:           %s
@@ -171,6 +184,9 @@ WriteManifestLatency: %s
 `,
 		s.OpenLatency,
 		s.CommitLatency,
+
+		s.IndexReadLatency,
+		s.IndexBytesPerRead,
 
 		s.GetLatency,
 		s.ChunksPerGet,

--- a/go/nbs/table_persister.go
+++ b/go/nbs/table_persister.go
@@ -30,7 +30,7 @@ type tablePersister interface {
 	ConjoinAll(sources chunkSources, stats *Stats) chunkSource
 
 	// Open a table named |name|, containing |chunkCount| chunks.
-	Open(name addr, chunkCount uint32) chunkSource
+	Open(name addr, chunkCount uint32, stats *Stats) chunkSource
 }
 
 // indexCache provides sized storage for table indices. While getting and/or

--- a/go/nbs/table_set.go
+++ b/go/nbs/table_set.go
@@ -186,7 +186,7 @@ func (ts tableSet) Flatten() (flattened tableSet) {
 
 // Rebase returns a new tableSet holding the novel tables managed by |ts| and
 // those specified by |specs|.
-func (ts tableSet) Rebase(specs []tableSpec) tableSet {
+func (ts tableSet) Rebase(specs []tableSpec, stats *Stats) tableSet {
 	merged := tableSet{
 		novel:    make(chunkSources, 0, len(ts.novel)),
 		upstream: make(chunkSources, 0, len(specs)),
@@ -216,7 +216,7 @@ func (ts tableSet) Rebase(specs []tableSpec) tableSet {
 	for _, spec := range tablesToOpen {
 		wg.Add(1)
 		go func(idx int, spec tableSpec) {
-			merged.upstream[idx] = ts.p.Open(spec.name, spec.chunkCount)
+			merged.upstream[idx] = ts.p.Open(spec.name, spec.chunkCount, stats)
 			wg.Done()
 		}(i, spec)
 		i++

--- a/go/nbs/table_set_test.go
+++ b/go/nbs/table_set_test.go
@@ -129,6 +129,6 @@ func TestTableSetRebase(t *testing.T) {
 	ts = ts.Flatten()
 	ts = insert(ts, []byte("novel"))
 
-	ts = ts.Rebase(fullTS.ToSpecs())
+	ts = ts.Rebase(fullTS.ToSpecs(), nil)
 	assert.Equal(4, ts.Size())
 }


### PR DESCRIPTION
Prior to this patch, whenever we created a chunkSource for a table
persisted to AWS, awsTablePersister::Open() would hit DynamoDB to
check whether the table data was stored there. That's how it knew
whether to create a dynamoTableReader or an s3TableReader. This
results in consulting Dynamo (or the in-memory small-table cache)
every time we go to open a table. Most of the time, this isn't
necessary, as we separately cache table indices and really only
need that data at Open() time.

This patch defers reading table data if possible.

Fixes #3607