### PR TITLE
refactor noms to use kingpin instead of hand-rolled flags parser

### DIFF
--- a/cmd/noms/noms.go
+++ b/cmd/noms/noms.go
@@ -9,27 +9,12 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"path"
 	"time"
 
-	"github.com/attic-labs/noms/cmd/util"
-	"github.com/attic-labs/noms/go/util/exit"
-	flag "github.com/juju/gnuflag"
-)
+	"github.com/attic-labs/noms/go/util/verbose"
 
-var commands = []*util.Command{
-	nomsCommit,
-	nomsConfig,
-	nomsDiff,
-	nomsDs,
-	nomsLog,
-	nomsMerge,
-	nomsRoot,
-	nomsServe,
-	nomsShow,
-	nomsSync,
-	nomsVersion,
-}
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
 
 var actions = []string{
 	"interacting with",
@@ -44,49 +29,70 @@ var actions = []string{
 	"nomming on",
 }
 
-func usageString() string {
-	i := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(len(actions))
-	return fmt.Sprintf(`Noms is a tool for %s Noms data.`, actions[i])
+// CommandHandler - a callback passed to commands
+type CommandHandler func() (exitCode int)
+
+var (
+	verboseFlag *bool
+	quietFlag   *bool
+)
+
+// AddVerboseFlags adds --verbose and --quiet flags to the passed command
+func AddVerboseFlags(cmd *kingpin.CmdClause) (verboseFlag *bool, quietFlag *bool) {
+	verboseFlag = cmd.Flag("verbose", "show more").Short('v').Bool()
+	quietFlag = cmd.Flag("quiet", "show less").Short('q').Bool()
+	return
+}
+
+// ApplyVerbosity - run when commands are invoked to apply the verbosity arguments configured in AddVerboseFlags
+func ApplyVerbosity() {
+	verbose.SetVerbose(*verboseFlag)
+	verbose.SetQuiet(*quietFlag)
+}
+
+// AddDatabaseArg adds a "database" arg to the passed command
+func AddDatabaseArg(cmd *kingpin.CmdClause) (arg *string) {
+	return cmd.Arg("database", "a noms database path").Required().String() // TODO: custom parser for noms db URL?
+}
+
+// Commands, in order of preference
+var commands = []func(*kingpin.Application) (*kingpin.CmdClause, CommandHandler){
+	NomsCommit,
+	NomsConfig,
+	NomsDiff,
+	NomsDs,
+	NomsLog,
+	NomsMerge,
+	NomsRoot,
+	NomsServe,
+	NomsShow,
+	NomsSync,
+	NomsVersion,
 }
 
 func main() {
-	util.InitHelp(path.Base(os.Args[0]), commands, usageString())
+	// allow short (-h) help
+	kingpin.CommandLine.HelpFlag.Short('h')
 
-	flag.Usage = util.Usage
-	flag.Parse(false)
+	// TODO: is there a way to dynamically generate help text other than re-initializing this every time?
+	i := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(len(actions))
+	noms := kingpin.New("noms", fmt.Sprintf(`Noms is a tool for %s Noms data.`, actions[i]))
 
-	args := flag.Args()
-	if len(args) < 1 {
-		util.Usage()
-		return
+	handlers := make(map[string]CommandHandler)
+
+	// install handlers
+	for _, cmdFunction := range commands {
+		command, handler := cmdFunction(noms)
+		handlers[command.FullCommand()] = handler
 	}
 
-	if args[0] == "help" {
-		util.Help(args[1:])
-		return
-	}
+	// parse our input
+	input := kingpin.MustParse(noms.Parse(os.Args[1:]))
 
 	// Don't prefix log messages with timestamp when running interactively
 	log.SetFlags(0)
 
-	for _, cmd := range commands {
-		if cmd.Name() == args[0] {
-			flags := cmd.Flags()
-			flags.Usage = cmd.Usage
-
-			flags.Parse(true, args[1:])
-			args = flags.Args()
-			if cmd.Nargs != 0 && len(args) < cmd.Nargs {
-				cmd.Usage()
-			}
-			exitCode := cmd.Run(args)
-			if exitCode != 0 {
-				exit.Exit(exitCode)
-			}
-			return
-		}
+	if handler := handlers[input]; handler != nil {
+		handler()
 	}
-
-	fmt.Fprintf(os.Stderr, "noms: unknown command %q\n", args[0])
-	util.Usage()
 }

--- a/cmd/noms/noms_commit.go
+++ b/cmd/noms/noms_commit.go
@@ -6,79 +6,71 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/spec"
-	"github.com/attic-labs/noms/go/util/verbose"
-	flag "github.com/juju/gnuflag"
 )
 
-var allowDupe bool
+// NomsCommit - the noms commit command
+func NomsCommit(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	commit := noms.Command("commit", `Commits a specified value as head of the dataset
 
-var nomsCommit = &util.Command{
-	Run:       runCommit,
-	UsageLine: "commit [options] [absolute-path] <dataset>",
-	Short:     "Commits a specified value as head of the dataset",
-	Long:      "If absolute-path is not provided, then it is read from stdin. See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the dataset and absolute-path arguments.",
-	Flags:     setupCommitFlags,
-	Nargs:     1, // if absolute-path not present we read it from stdin
-}
+If absolute-path is not provided, then it is read from stdin. See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the dataset and absolute-path arguments.
+`)
+	allowDupe := commit.Flag("allow-dupe", "creates a new commit, even if it would be identical (modulo metadata and parents) to the existing HEAD.").Default("false").Bool()
+	AddVerboseFlags(commit)
+	database := AddDatabaseArg(commit)
+	absolutePath := commit.Arg("absolute-path", "the path to read data from").String()
 
-func setupCommitFlags() *flag.FlagSet {
-	commitFlagSet := flag.NewFlagSet("commit", flag.ExitOnError)
-	commitFlagSet.BoolVar(&allowDupe, "allow-dupe", false, "creates a new commit, even if it would be identical (modulo metadata and parents) to the existing HEAD.")
-	spec.RegisterCommitMetaFlags(commitFlagSet)
-	verbose.RegisterVerboseFlags(commitFlagSet)
-	return commitFlagSet
-}
-
-func runCommit(args []string) int {
-	cfg := config.NewResolver()
-	db, ds, err := cfg.GetDataset(args[len(args)-1])
-	d.CheckError(err)
-	defer db.Close()
-
-	var path string
-	if len(args) == 2 {
-		path = args[0]
-	} else {
-		readPath, _, err := bufio.NewReader(os.Stdin).ReadLine()
+	return commit, func() int {
+		ApplyVerbosity()
+		cfg := config.NewResolver()
+		db, ds, err := cfg.GetDataset(*database)
 		d.CheckError(err)
-		path = string(readPath)
-	}
-	absPath, err := spec.NewAbsolutePath(path)
-	d.CheckError(err)
+		defer db.Close()
 
-	value := absPath.Resolve(db)
-	if value == nil {
-		d.CheckErrorNoUsage(errors.New(fmt.Sprintf("Error resolving value: %s", path)))
-	}
-
-	oldCommitRef, oldCommitExists := ds.MaybeHeadRef()
-	if oldCommitExists {
-		head := ds.HeadValue()
-		if head.Hash() == value.Hash() && !allowDupe {
-			fmt.Fprintf(os.Stdout, "Commit aborted - allow-dupe is set to off and this commit would create a duplicate\n")
-			return 0
+		var path string
+		if absolutePath != nil {
+			path = *absolutePath
+		} else {
+			readPath, _, err := bufio.NewReader(os.Stdin).ReadLine()
+			d.CheckError(err)
+			path = string(readPath)
 		}
+		absPath, err := spec.NewAbsolutePath(path)
+		d.CheckError(err)
+
+		value := absPath.Resolve(db)
+		if value == nil {
+			d.CheckErrorNoUsage(fmt.Errorf("Error resolving value: %s", path))
+		}
+
+		oldCommitRef, oldCommitExists := ds.MaybeHeadRef()
+		if oldCommitExists {
+			head := ds.HeadValue()
+			if head.Hash() == value.Hash() && !*allowDupe {
+				fmt.Fprintf(os.Stdout, "Commit aborted - allow-dupe is set to off and this commit would create a duplicate\n")
+				return 0
+			}
+		}
+
+		meta, err := spec.CreateCommitMetaStruct(db, "", "", nil, nil)
+		d.CheckErrorNoUsage(err)
+
+		ds, err = db.Commit(ds, value, datas.CommitOptions{Meta: meta})
+		d.CheckErrorNoUsage(err)
+
+		if oldCommitExists {
+			fmt.Fprintf(os.Stdout, "New head #%v (was #%v)\n", ds.HeadRef().TargetHash().String(), oldCommitRef.TargetHash().String())
+		} else {
+			fmt.Fprintf(os.Stdout, "New head #%v\n", ds.HeadRef().TargetHash().String())
+		}
+		return 0
 	}
-
-	meta, err := spec.CreateCommitMetaStruct(db, "", "", nil, nil)
-	d.CheckErrorNoUsage(err)
-
-	ds, err = db.Commit(ds, value, datas.CommitOptions{Meta: meta})
-	d.CheckErrorNoUsage(err)
-
-	if oldCommitExists {
-		fmt.Fprintf(os.Stdout, "New head #%v (was #%v)\n", ds.HeadRef().TargetHash().String(), oldCommitRef.TargetHash().String())
-	} else {
-		fmt.Fprintf(os.Stdout, "New head #%v\n", ds.HeadRef().TargetHash().String())
-	}
-	return 0
 }

--- a/cmd/noms/noms_commit.go
+++ b/cmd/noms/noms_commit.go
@@ -17,8 +17,7 @@ import (
 	"github.com/attic-labs/noms/go/spec"
 )
 
-// NomsCommit - the noms commit command
-func NomsCommit(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsCommit(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	commit := noms.Command("commit", `Commits a specified value as head of the dataset
 
 If absolute-path is not provided, then it is read from stdin. See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the dataset and absolute-path arguments.

--- a/cmd/noms/noms_config.go
+++ b/cmd/noms/noms_config.go
@@ -14,8 +14,7 @@ import (
 	"github.com/attic-labs/noms/go/d"
 )
 
-// NomsConfig - the noms config command
-func NomsConfig(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsConfig(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	configCmd := noms.Command("config", "Prints the active configuration if a .nomsconfig file is present")
 
 	return configCmd, func() int {

--- a/cmd/noms/noms_config.go
+++ b/cmd/noms/noms_config.go
@@ -8,32 +8,24 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
-	flag "github.com/juju/gnuflag"
 )
 
-var nomsConfig = &util.Command{
-	Run:       runConfig,
-	UsageLine: "config ",
-	Short:     "Display noms config info",
-	Long:      "Prints the active configuration if a .nomsconfig file is present",
-	Flags:     setupConfigFlags,
-	Nargs:     0,
-}
+// NomsConfig - the noms config command
+func NomsConfig(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	configCmd := noms.Command("config", "Prints the active configuration if a .nomsconfig file is present")
 
-func setupConfigFlags() *flag.FlagSet {
-	return flag.NewFlagSet("config", flag.ExitOnError)
-}
-
-func runConfig(args []string) int {
-	c, err := config.FindNomsConfig()
-	if err == config.NoConfig {
-		fmt.Fprintf(os.Stdout, "no config active\n")
-	} else {
-		d.CheckError(err)
-		fmt.Fprintf(os.Stdout, "%s\n", c.String())
+	return configCmd, func() int {
+		c, err := config.FindNomsConfig()
+		if err == config.NoConfig {
+			fmt.Fprintf(os.Stdout, "no config active\n")
+		} else {
+			d.CheckError(err)
+			fmt.Fprintf(os.Stdout, "%s\n", c.String())
+		}
+		return 0
 	}
-	return 0
 }

--- a/cmd/noms/noms_diff.go
+++ b/cmd/noms/noms_diff.go
@@ -7,59 +7,54 @@ package main
 import (
 	"fmt"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/diff"
 	"github.com/attic-labs/noms/go/util/outputpager"
-	"github.com/attic-labs/noms/go/util/verbose"
-	flag "github.com/juju/gnuflag"
 )
 
-var summarize bool
+// NomsDiff - the noms diff command
+func NomsDiff(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	diffCmd := noms.Command("diff", `Shows the difference between two objects
 
-var nomsDiff = &util.Command{
-	Run:       runDiff,
-	UsageLine: "diff [--summarize] <object1> <object2>",
-	Short:     "Shows the difference between two objects",
-	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object arguments.",
-	Flags:     setupDiffFlags,
-	Nargs:     2,
-}
+See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object arguments.
+`)
+	summarize := diffCmd.Flag("summarize", "Writes a summary of the changes instead").Short('s').Bool()
+	AddVerboseFlags(diffCmd)
+	// TODO: deal with paged output
+	// outputpager.RegisterOutputpagerFlags(diffFlagSet)
 
-func setupDiffFlags() *flag.FlagSet {
-	diffFlagSet := flag.NewFlagSet("diff", flag.ExitOnError)
-	diffFlagSet.BoolVar(&summarize, "summarize", false, "Writes a summary of the changes instead")
-	outputpager.RegisterOutputpagerFlags(diffFlagSet)
-	verbose.RegisterVerboseFlags(diffFlagSet)
+	object1 := diffCmd.Arg("object1", "").Required().String()
+	object2 := diffCmd.Arg("object2", "").Required().String()
 
-	return diffFlagSet
-}
+	return diffCmd, func() int {
+		ApplyVerbosity()
+		cfg := config.NewResolver()
+		db1, value1, err := cfg.GetPath(*object1)
+		d.CheckErrorNoUsage(err)
+		if value1 == nil {
+			d.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", *object1))
+		}
+		defer db1.Close()
 
-func runDiff(args []string) int {
-	cfg := config.NewResolver()
-	db1, value1, err := cfg.GetPath(args[0])
-	d.CheckErrorNoUsage(err)
-	if value1 == nil {
-		d.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", args[0]))
-	}
-	defer db1.Close()
+		db2, value2, err := cfg.GetPath(*object2)
+		d.CheckErrorNoUsage(err)
+		if value2 == nil {
+			d.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", *object2))
+		}
+		defer db2.Close()
 
-	db2, value2, err := cfg.GetPath(args[1])
-	d.CheckErrorNoUsage(err)
-	if value2 == nil {
-		d.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", args[1]))
-	}
-	defer db2.Close()
+		if *summarize {
+			diff.Summary(value1, value2)
+			return 0
+		}
 
-	if summarize {
-		diff.Summary(value1, value2)
+		pgr := outputpager.Start()
+		defer pgr.Stop()
+
+		diff.PrintDiff(pgr.Writer, value1, value2, false)
 		return 0
 	}
-
-	pgr := outputpager.Start()
-	defer pgr.Stop()
-
-	diff.PrintDiff(pgr.Writer, value1, value2, false)
-	return 0
 }

--- a/cmd/noms/noms_diff.go
+++ b/cmd/noms/noms_diff.go
@@ -15,8 +15,7 @@ import (
 	"github.com/attic-labs/noms/go/util/outputpager"
 )
 
-// NomsDiff - the noms diff command
-func NomsDiff(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsDiff(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	diffCmd := noms.Command("diff", `Shows the difference between two objects
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object arguments.

--- a/cmd/noms/noms_ds.go
+++ b/cmd/noms/noms_ds.go
@@ -14,8 +14,7 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-// NomsDs - the noms ds (dataset) command
-func NomsDs(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsDs(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	ds := noms.Command("ds", `Noms dataset management
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

--- a/cmd/noms/noms_ds.go
+++ b/cmd/noms/noms_ds.go
@@ -7,60 +7,53 @@ package main
 import (
 	"fmt"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
-	"github.com/attic-labs/noms/go/util/verbose"
-	flag "github.com/juju/gnuflag"
 )
 
-var toDelete string
+// NomsDs - the noms ds (dataset) command
+func NomsDs(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	ds := noms.Command("ds", `Noms dataset management
 
-var nomsDs = &util.Command{
-	Run:       runDs,
-	UsageLine: "ds [<database> | -d <dataset>]",
-	Short:     "Noms dataset management",
-	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database and dataset arguments.",
-	Flags:     setupDsFlags,
-	Nargs:     0,
-}
+See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.
+`)
 
-func setupDsFlags() *flag.FlagSet {
-	dsFlagSet := flag.NewFlagSet("ds", flag.ExitOnError)
-	dsFlagSet.StringVar(&toDelete, "d", "", "dataset to delete")
-	verbose.RegisterVerboseFlags(dsFlagSet)
-	return dsFlagSet
-}
+	toDelete := ds.Flag("delete", "dataset to delete").Short('d').String()
+	AddVerboseFlags(ds)
+	// TODO: break out delete and use
+	// database := AddDatabaseArg(ds)
+	// instead
+	database := ds.Arg("database", "a noms database path").String()
 
-func runDs(args []string) int {
-	cfg := config.NewResolver()
-	if toDelete != "" {
-		db, set, err := cfg.GetDataset(toDelete)
-		d.CheckError(err)
-		defer db.Close()
+	return ds, func() int {
+		ApplyVerbosity()
+		cfg := config.NewResolver()
+		if toDelete != nil {
+			db, set, err := cfg.GetDataset(*toDelete)
+			d.CheckError(err)
+			defer db.Close()
 
-		oldCommitRef, errBool := set.MaybeHeadRef()
-		if !errBool {
-			d.CheckError(fmt.Errorf("Dataset %v not found", set.ID()))
+			oldCommitRef, errBool := set.MaybeHeadRef()
+			if !errBool {
+				d.CheckError(fmt.Errorf("Dataset %v not found", set.ID()))
+			}
+
+			_, err = set.Database().Delete(set)
+			d.CheckError(err)
+
+			fmt.Printf("Deleted %v (was #%v)\n", toDelete, oldCommitRef.TargetHash().String())
+		} else {
+			store, err := cfg.GetDatabase(*database)
+			d.CheckError(err)
+			defer store.Close()
+
+			store.Datasets().IterAll(func(k, v types.Value) {
+				fmt.Println(k)
+			})
 		}
-
-		_, err = set.Database().Delete(set)
-		d.CheckError(err)
-
-		fmt.Printf("Deleted %v (was #%v)\n", toDelete, oldCommitRef.TargetHash().String())
-	} else {
-		dbSpec := ""
-		if len(args) >= 1 {
-			dbSpec = args[0]
-		}
-		store, err := cfg.GetDatabase(dbSpec)
-		d.CheckError(err)
-		defer store.Close()
-
-		store.Datasets().IterAll(func(k, v types.Value) {
-			fmt.Println(k)
-		})
+		return 0
 	}
-	return 0
 }

--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -12,7 +12,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
@@ -22,115 +23,112 @@ import (
 	"github.com/attic-labs/noms/go/util/datetime"
 	"github.com/attic-labs/noms/go/util/functions"
 	"github.com/attic-labs/noms/go/util/outputpager"
-	"github.com/attic-labs/noms/go/util/verbose"
 	"github.com/attic-labs/noms/go/util/writers"
-	flag "github.com/juju/gnuflag"
 	"github.com/mgutz/ansi"
-)
-
-var (
-	useColor   = false
-	color      int
-	maxLines   int
-	maxCommits int
-	oneline    bool
-	showGraph  bool
-	showValue  bool
 )
 
 const parallelism = 16
 
-var nomsLog = &util.Command{
-	Run:       runLog,
-	UsageLine: "log [options] <path-spec>",
-	Short:     "Displays the history of a path",
-	Long:      "Displays the history of a path. See Spelling Values at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the <path-spec> parameter.",
-	Flags:     setupLogFlags,
-	Nargs:     1,
-}
+var (
+	useColor  = false
+	maxLines  int
+	oneline   bool
+	showGraph bool
+	showValue bool
+)
 
-func setupLogFlags() *flag.FlagSet {
-	logFlagSet := flag.NewFlagSet("log", flag.ExitOnError)
-	logFlagSet.IntVar(&color, "color", -1, "value of 1 forces color on, 0 forces color off")
-	logFlagSet.IntVar(&maxLines, "max-lines", 9, "max number of lines to show per commit (-1 for all lines)")
-	logFlagSet.IntVar(&maxCommits, "n", 0, "max number of commits to display (0 for all commits)")
-	logFlagSet.BoolVar(&oneline, "oneline", false, "show a summary of each commit on a single line")
-	logFlagSet.BoolVar(&showGraph, "graph", false, "show ascii-based commit hierarchy on left side of output")
-	logFlagSet.BoolVar(&showValue, "show-value", false, "show commit value rather than diff information")
-	outputpager.RegisterOutputpagerFlags(logFlagSet)
-	verbose.RegisterVerboseFlags(logFlagSet)
-	return logFlagSet
-}
+// NomsLog - the noms log command
+func NomsLog(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	log := noms.Command("log", `Displays the history of a path
 
-func runLog(args []string) int {
-	useColor = shouldUseColor()
-	cfg := config.NewResolver()
+See Spelling Values at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the <path-spec> parameter.
+`)
+	color := log.Flag("color", "value of 1 forces color on, 0 forces color off").Default("-1").Int()
+	maxLinesVal := log.Flag("max-lines", "max number of lines to show per commit (-1 for all lines)").Default("9").Int()
+	maxCommitsVal := log.Flag("max-commits", "max number of commits to display (0 for all commits)").Short('n').Default("0").Int()
+	onelineVal := log.Flag("oneline", "show a summary of each commit on a single line").Bool()
+	showGraphVal := log.Flag("ascii", "show ascii-based commit hierarchy on left side of output").Bool()
+	showValueVal := log.Flag("show-value", "show commit value rather than diff information").Bool()
+	AddVerboseFlags(log)
 
-	resolved := cfg.ResolvePathSpec(args[0])
-	sp, err := spec.ForPath(resolved)
-	d.CheckErrorNoUsage(err)
-	defer sp.Close()
+	pathSpec := log.Arg("path-spec", "").Required().String()
 
-	pinned, ok := sp.Pin()
-	if !ok {
-		fmt.Fprintf(os.Stderr, "Cannot resolve spec: %s\n", args[0])
-		return 1
-	}
-	defer pinned.Close()
-	database := pinned.GetDatabase()
+	return log, func() int {
+		maxCommits := *maxCommitsVal
+		maxLines = *maxLinesVal
+		oneline = *onelineVal
+		showGraph = *showGraphVal
+		showValue = *showValueVal
+		ApplyVerbosity()
+		useColor = shouldUseColor(*color)
+		cfg := config.NewResolver()
 
-	absPath := pinned.Path
-	path := absPath.Path
-	if len(path) == 0 {
-		path = types.MustParsePath(".value")
-	}
+		resolved := cfg.ResolvePathSpec(*pathSpec)
+		sp, err := spec.ForPath(resolved)
+		d.CheckErrorNoUsage(err)
+		defer sp.Close()
 
-	origCommit, ok := database.ReadValue(absPath.Hash).(types.Struct)
-	if !ok || !datas.IsCommit(origCommit) {
-		d.CheckError(fmt.Errorf("%s does not reference a Commit object", args[0]))
-	}
-
-	iter := NewCommitIterator(database, origCommit)
-	displayed := 0
-	if maxCommits <= 0 {
-		maxCommits = math.MaxInt32
-	}
-
-	bytesChan := make(chan chan []byte, parallelism)
-
-	var done = false
-
-	go func() {
-		for ln, ok := iter.Next(); !done && ok && displayed < maxCommits; ln, ok = iter.Next() {
-			ch := make(chan []byte)
-			bytesChan <- ch
-
-			go func(ch chan []byte, node LogNode) {
-				buff := &bytes.Buffer{}
-				printCommit(node, path, buff, database)
-				ch <- buff.Bytes()
-			}(ch, ln)
-
-			displayed++
+		pinned, ok := sp.Pin()
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Cannot resolve spec: %s\n", *pathSpec)
+			return 1
 		}
-		close(bytesChan)
-	}()
+		defer pinned.Close()
+		database := pinned.GetDatabase()
 
-	pgr := outputpager.Start()
-	defer pgr.Stop()
+		absPath := pinned.Path
+		path := absPath.Path
+		if len(path) == 0 {
+			path = types.MustParsePath(".value")
+		}
 
-	for ch := range bytesChan {
-		commitBuff := <-ch
-		_, err := io.Copy(pgr.Writer, bytes.NewReader(commitBuff))
-		if err != nil {
-			done = true
-			for range bytesChan {
-				// drain the output
+		origCommit, ok := database.ReadValue(absPath.Hash).(types.Struct)
+		if !ok || !datas.IsCommit(origCommit) {
+			d.CheckError(fmt.Errorf("%s does not reference a Commit object", *pathSpec))
+		}
+
+		iter := NewCommitIterator(database, origCommit)
+		displayed := 0
+		if maxCommits <= 0 {
+			maxCommits = math.MaxInt32
+		}
+
+		bytesChan := make(chan chan []byte, parallelism)
+
+		var done = false
+
+		go func() {
+			for ln, ok := iter.Next(); !done && ok && displayed < maxCommits; ln, ok = iter.Next() {
+				ch := make(chan []byte)
+				bytesChan <- ch
+
+				go func(ch chan []byte, node LogNode) {
+					buff := &bytes.Buffer{}
+					printCommit(node, path, buff, database)
+					ch <- buff.Bytes()
+				}(ch, ln)
+
+				displayed++
+			}
+			close(bytesChan)
+		}()
+
+		pgr := outputpager.Start()
+		defer pgr.Stop()
+
+		for ch := range bytesChan {
+			commitBuff := <-ch
+			_, err := io.Copy(pgr.Writer, bytes.NewReader(commitBuff))
+			if err != nil {
+				done = true
+				for range bytesChan {
+					// drain the output
+				}
 			}
 		}
-	}
 
-	return 0
+		return 0
+	}
 }
 
 // Prints the information for one commit in the log, including ascii graph on left side of commits if
@@ -354,7 +352,7 @@ func writeDiffLines(node LogNode, path types.Path, db datas.Database, maxLines, 
 	return int(pw.NumLines), err
 }
 
-func shouldUseColor() bool {
+func shouldUseColor(color int) bool {
 	if color != 1 && color != 0 {
 		return outputpager.IsStdoutTty()
 	}

--- a/cmd/noms/noms_log.go
+++ b/cmd/noms/noms_log.go
@@ -37,8 +37,7 @@ var (
 	showValue bool
 )
 
-// NomsLog - the noms log command
-func NomsLog(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsLog(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	log := noms.Command("log", `Displays the history of a path
 
 See Spelling Values at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the <path-spec> parameter.

--- a/cmd/noms/noms_merge.go
+++ b/cmd/noms/noms_merge.go
@@ -21,8 +21,7 @@ import (
 	"github.com/attic-labs/noms/go/util/verbose"
 )
 
-// NomsMerge - the noms merge command
-func NomsMerge(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsMerge(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	merge := noms.Command("merge", `Merges and commits the head values of two named datasets
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

--- a/cmd/noms/noms_root.go
+++ b/cmd/noms/noms_root.go
@@ -8,92 +8,85 @@ import (
 	"fmt"
 	"os"
 
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"strings"
 
-	"github.com/attic-labs/noms/cmd/util"
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/types"
-	flag "github.com/juju/gnuflag"
 )
 
-var nomsRoot = &util.Command{
-	Run:       runRoot,
-	UsageLine: "root <db-spec>",
-	Short:     "Get or set the current root hash of the entire database",
-	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.",
-	Flags:     setupRootFlags,
-	Nargs:     1,
-}
+// NomsRoot - the noms root command
+func NomsRoot(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	root := noms.Command("root", `Get or set the current root hash of the entire database
 
-var updateRoot = ""
-
-func setupRootFlags() *flag.FlagSet {
-	flagSet := flag.NewFlagSet("root", flag.ExitOnError)
-	flagSet.StringVar(&updateRoot, "update", "", "Replaces the entire database with the one with the given hash")
-	return flagSet
-}
-
-func runRoot(args []string) int {
-	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "Not enough arguments")
-		return 0
-	}
-
-	cfg := config.NewResolver()
-	cs, err := cfg.GetChunkStore(args[0])
-	d.CheckErrorNoUsage(err)
-
-	currRoot := cs.Root()
-
-	if updateRoot == "" {
-		fmt.Println(currRoot)
-		return 0
-	}
-
-	if updateRoot[0] == '#' {
-		updateRoot = updateRoot[1:]
-	}
-	h, ok := hash.MaybeParse(updateRoot)
-	if !ok {
-		fmt.Fprintf(os.Stderr, "Invalid hash: %s\n", h.String())
-		return 1
-	}
-
-	// If BUG 3407 is correct, we might be able to just take cs and make a Database directly from that.
-	db, err := cfg.GetDatabase(args[0])
-	d.CheckErrorNoUsage(err)
-	defer db.Close()
-	if !validate(db.ReadValue(h)) {
-		return 1
-	}
-
-	fmt.Println(`WARNING
-
-This operation replaces the entire database with the instance having the given
-hash. The old database becomes eligible for GC.
-
-ANYTHING NOT SAVED WILL BE LOST
-
-Continue?
+See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.
 `)
-	var input string
-	n, err := fmt.Scanln(&input)
-	d.CheckErrorNoUsage(err)
-	if n != 1 || strings.ToLower(input) != "y" {
+
+	update := root.Flag("update", "Replaces the entire database with the one with the given hash").String()
+	AddVerboseFlags(root)
+	database := AddDatabaseArg(root)
+
+	return root, func() int {
+		ApplyVerbosity()
+		cfg := config.NewResolver()
+		cs, err := cfg.GetChunkStore(*database)
+		d.CheckErrorNoUsage(err)
+
+		currRoot := cs.Root()
+
+		if update == nil {
+			fmt.Println(currRoot)
+			return 0
+		}
+
+		updateRoot := *update
+
+		if updateRoot[0] == '#' {
+			updateRoot = updateRoot[1:]
+		}
+		h, ok := hash.MaybeParse(updateRoot)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Invalid hash: %s\n", h.String())
+			return 1
+		}
+
+		// If BUG 3407 is correct, we might be able to just take cs and make a Database directly from that.
+		db, err := cfg.GetDatabase(*database)
+		d.CheckErrorNoUsage(err)
+		defer db.Close()
+		if !validate(db.ReadValue(h)) {
+			return 1
+		}
+
+		fmt.Println(`WARNING
+	
+	This operation replaces the entire database with the instance having the given
+	hash. The old database becomes eligible for GC.
+	
+	ANYTHING NOT SAVED WILL BE LOST
+	
+	Continue?
+	`)
+		var input string
+		n, err := fmt.Scanln(&input)
+		d.CheckErrorNoUsage(err)
+		if n != 1 || strings.ToLower(input) != "y" {
+			return 0
+		}
+
+		ok = cs.Commit(h, currRoot)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Optimistic concurrency failure")
+			return 1
+		}
+
+		fmt.Printf("Success. Previous root was: %s\n", currRoot)
 		return 0
 	}
-
-	ok = cs.Commit(h, currRoot)
-	if !ok {
-		fmt.Fprintln(os.Stderr, "Optimistic concurrency failure")
-		return 1
-	}
-
-	fmt.Printf("Success. Previous root was: %s\n", currRoot)
-	return 0
 }
 
 func validate(r types.Value) bool {

--- a/cmd/noms/noms_root.go
+++ b/cmd/noms/noms_root.go
@@ -19,8 +19,7 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-// NomsRoot - the noms root command
-func NomsRoot(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsRoot(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	root := noms.Command("root", `Get or set the current root hash of the entire database
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

--- a/cmd/noms/noms_serve.go
+++ b/cmd/noms/noms_serve.go
@@ -17,8 +17,7 @@ import (
 	"github.com/attic-labs/noms/go/util/profile"
 )
 
-// NomsServe - the noms serve command
-func NomsServe(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsServe(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	serve := noms.Command("serve", `Serves a Noms database over HTTP
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

--- a/cmd/noms/noms_serve.go
+++ b/cmd/noms/noms_serve.go
@@ -9,58 +9,42 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/util/profile"
-	"github.com/attic-labs/noms/go/util/verbose"
-	flag "github.com/juju/gnuflag"
 )
 
-var (
-	port int
-)
+// NomsServe - the noms serve command
+func NomsServe(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	serve := noms.Command("serve", `Serves a Noms database over HTTP
 
-var nomsServe = &util.Command{
-	Run:       runServe,
-	UsageLine: "serve [options] <database>",
-	Short:     "Serves a Noms database over HTTP",
-	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.",
-	Flags:     setupServeFlags,
-	Nargs:     0,
-}
+See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.
+`)
+	port := serve.Flag("port", "port to listen on for HTTP requests").Default("8000").Int()
+	database := AddDatabaseArg(serve)
 
-func setupServeFlags() *flag.FlagSet {
-	serveFlagSet := flag.NewFlagSet("serve", flag.ExitOnError)
-	serveFlagSet.IntVar(&port, "port", 8000, "port to listen on for HTTP requests")
-	verbose.RegisterVerboseFlags(serveFlagSet)
-	profile.RegisterProfileFlags(serveFlagSet)
-	return serveFlagSet
-}
+	return serve, func() int {
+		cfg := config.NewResolver()
+		cs, err := cfg.GetChunkStore(*database)
+		d.CheckError(err)
+		server := datas.NewRemoteDatabaseServer(cs, *port)
 
-func runServe(args []string) int {
-	cfg := config.NewResolver()
-	db := ""
-	if len(args) > 0 {
-		db = args[0]
+		// Shutdown server gracefully so that profile may be written
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		signal.Notify(c, syscall.SIGTERM)
+		go func() {
+			<-c
+			server.Stop()
+		}()
+
+		d.Try(func() {
+			defer profile.MaybeStartProfile().Stop()
+			server.Run()
+		})
+		return 0
 	}
-	cs, err := cfg.GetChunkStore(db)
-	d.CheckError(err)
-	server := datas.NewRemoteDatabaseServer(cs, port)
-
-	// Shutdown server gracefully so that profile may be written
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, syscall.SIGTERM)
-	go func() {
-		<-c
-		server.Stop()
-	}()
-
-	d.Try(func() {
-		defer profile.MaybeStartProfile().Stop()
-		server.Run()
-	})
-	return 0
 }

--- a/cmd/noms/noms_show.go
+++ b/cmd/noms/noms_show.go
@@ -10,69 +10,65 @@ import (
 	"io"
 	"os"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/outputpager"
-	"github.com/attic-labs/noms/go/util/verbose"
-	flag "github.com/juju/gnuflag"
 )
 
-var nomsShow = &util.Command{
-	Run:       runShow,
-	UsageLine: "show [flags] <object>",
-	Short:     "Shows a serialization of a Noms object",
-	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object argument.",
-	Flags:     setupShowFlags,
-	Nargs:     1,
-}
+// NomsShow - the noms show command
+func NomsShow(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	show := noms.Command("show", `Shows a serialization of a Noms object
 
-var showRaw = false
-var showStats = false
+See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object argument.
+`)
 
-func setupShowFlags() *flag.FlagSet {
-	showFlagSet := flag.NewFlagSet("show", flag.ExitOnError)
-	outputpager.RegisterOutputpagerFlags(showFlagSet)
-	verbose.RegisterVerboseFlags(showFlagSet)
-	showFlagSet.BoolVar(&showRaw, "raw", false, "If true, dumps the raw binary version of the data")
-	showFlagSet.BoolVar(&showStats, "stats", false, "If true, reports statistics related to the value")
-	return showFlagSet
-}
+	raw := show.Flag("raw", "If true, dumps the raw binary version of the data").Bool()
+	stats := show.Flag("stats", "If true, reports statistics related to the value").Bool()
+	AddVerboseFlags(show)
+	object := show.Arg("object", "a noms object").Required().String()
 
-func runShow(args []string) int {
-	cfg := config.NewResolver()
-	database, value, err := cfg.GetPath(args[0])
-	d.CheckErrorNoUsage(err)
-	defer database.Close()
+	// TODO: outputpager stuff?
 
-	if value == nil {
-		fmt.Fprintf(os.Stderr, "Object not found: %s\n", args[0])
+	return show, func() int {
+		showRaw := *raw
+		showStats := *stats
+		ApplyVerbosity()
+		cfg := config.NewResolver()
+		database, value, err := cfg.GetPath(*object)
+		d.CheckErrorNoUsage(err)
+		defer database.Close()
+
+		if value == nil {
+			fmt.Fprintf(os.Stderr, "Object not found: %s\n", *object)
+			return 0
+		}
+
+		if showRaw && showStats {
+			fmt.Fprintln(os.Stderr, "--raw and --stats are mutually exclusive")
+			return 0
+		}
+
+		if showRaw {
+			ch := types.EncodeValue(value)
+			buf := bytes.NewBuffer(ch.Data())
+			_, err = io.Copy(os.Stdout, buf)
+			d.CheckError(err)
+			return 0
+		}
+
+		if showStats {
+			types.WriteValueStats(os.Stdout, value, database)
+			return 0
+		}
+
+		pgr := outputpager.Start()
+		defer pgr.Stop()
+
+		types.WriteEncodedValue(pgr.Writer, value)
+		fmt.Fprintln(pgr.Writer)
 		return 0
 	}
-
-	if showRaw && showStats {
-		fmt.Fprintln(os.Stderr, "--raw and --stats are mutually exclusive")
-		return 0
-	}
-
-	if showRaw {
-		ch := types.EncodeValue(value)
-		buf := bytes.NewBuffer(ch.Data())
-		_, err = io.Copy(os.Stdout, buf)
-		d.CheckError(err)
-		return 0
-	}
-
-	if showStats {
-		types.WriteValueStats(os.Stdout, value, database)
-		return 0
-	}
-
-	pgr := outputpager.Start()
-	defer pgr.Stop()
-
-	types.WriteEncodedValue(pgr.Writer, value)
-	fmt.Fprintln(pgr.Writer)
-	return 0
 }

--- a/cmd/noms/noms_show.go
+++ b/cmd/noms/noms_show.go
@@ -18,8 +18,7 @@ import (
 	"github.com/attic-labs/noms/go/util/outputpager"
 )
 
-// NomsShow - the noms show command
-func NomsShow(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsShow(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	show := noms.Command("show", `Shows a serialization of a Noms object
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object argument.

--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -9,109 +9,104 @@ import (
 	"log"
 	"time"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/profile"
 	"github.com/attic-labs/noms/go/util/status"
-	"github.com/attic-labs/noms/go/util/verbose"
 	humanize "github.com/dustin/go-humanize"
-	flag "github.com/juju/gnuflag"
 )
 
-var (
-	p int
-)
+// NomsSync - the noms sync command
+func NomsSync(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	sync := noms.Command("sync", `Moves datasets between or within databases
 
-var nomsSync = &util.Command{
-	Run:       runSync,
-	UsageLine: "sync [options] <source-object> <dest-dataset>",
-	Short:     "Moves datasets between or within databases",
-	Long:      "See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object and dataset arguments.",
-	Flags:     setupSyncFlags,
-	Nargs:     2,
-}
+See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object and dataset arguments.
+`)
 
-func setupSyncFlags() *flag.FlagSet {
-	syncFlagSet := flag.NewFlagSet("sync", flag.ExitOnError)
-	syncFlagSet.IntVar(&p, "p", 512, "parallelism")
-	verbose.RegisterVerboseFlags(syncFlagSet)
-	profile.RegisterProfileFlags(syncFlagSet)
-	return syncFlagSet
-}
+	// TODO: original command had this flag but don't see it being used anywhere?
+	// parallelism := sync.Flag("parallelism", "").Short('p').Default("512").Int()
+	AddVerboseFlags(sync)
+	// TODO: profile flags?
+	sourceObject := sync.Arg("source-object", "a noms source object").Required().String()
+	database := sync.Arg("dest-dataset", "a noms dataset").Required().String()
 
-func runSync(args []string) int {
-	cfg := config.NewResolver()
-	sourceStore, sourceObj, err := cfg.GetPath(args[0])
-	d.CheckError(err)
-	defer sourceStore.Close()
+	return sync, func() int {
+		// p := *parallelism
+		ApplyVerbosity()
+		cfg := config.NewResolver()
+		sourceStore, sourceObj, err := cfg.GetPath(*sourceObject)
+		d.CheckError(err)
+		defer sourceStore.Close()
 
-	if sourceObj == nil {
-		d.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", args[0]))
-	}
-
-	sinkDB, sinkDataset, err := cfg.GetDataset(args[1])
-	d.CheckError(err)
-	defer sinkDB.Close()
-
-	start := time.Now()
-	progressCh := make(chan datas.PullProgress)
-	lastProgressCh := make(chan datas.PullProgress)
-
-	go func() {
-		var last datas.PullProgress
-
-		for info := range progressCh {
-			last = info
-			if info.KnownCount == 1 {
-				// It's better to print "up to date" than "0% (0/1); 100% (1/1)".
-				continue
-			}
-
-			if status.WillPrint() {
-				pct := 100.0 * float64(info.DoneCount) / float64(info.KnownCount)
-				status.Printf("Syncing - %.2f%% (%s/s)", pct, bytesPerSec(info.ApproxWrittenBytes, start))
-			}
+		if sourceObj == nil {
+			d.CheckErrorNoUsage(fmt.Errorf("Object not found: %s", *sourceObject))
 		}
-		lastProgressCh <- last
-	}()
 
-	sourceRef := types.NewRef(sourceObj)
-	sinkRef, sinkExists := sinkDataset.MaybeHeadRef()
-	nonFF := false
-	err = d.Try(func() {
-		defer profile.MaybeStartProfile().Stop()
-		datas.Pull(sourceStore, sinkDB, sourceRef, progressCh)
+		sinkDB, sinkDataset, err := cfg.GetDataset(*database)
+		d.CheckError(err)
+		defer sinkDB.Close()
 
-		var err error
-		sinkDataset, err = sinkDB.FastForward(sinkDataset, sourceRef)
-		if err == datas.ErrMergeNeeded {
-			sinkDataset, err = sinkDB.SetHead(sinkDataset, sourceRef)
-			nonFF = true
+		start := time.Now()
+		progressCh := make(chan datas.PullProgress)
+		lastProgressCh := make(chan datas.PullProgress)
+
+		go func() {
+			var last datas.PullProgress
+
+			for info := range progressCh {
+				last = info
+				if info.KnownCount == 1 {
+					// It's better to print "up to date" than "0% (0/1); 100% (1/1)".
+					continue
+				}
+
+				if status.WillPrint() {
+					pct := 100.0 * float64(info.DoneCount) / float64(info.KnownCount)
+					status.Printf("Syncing - %.2f%% (%s/s)", pct, bytesPerSec(info.ApproxWrittenBytes, start))
+				}
+			}
+			lastProgressCh <- last
+		}()
+
+		sourceRef := types.NewRef(sourceObj)
+		sinkRef, sinkExists := sinkDataset.MaybeHeadRef()
+		nonFF := false
+		err = d.Try(func() {
+			defer profile.MaybeStartProfile().Stop()
+			datas.Pull(sourceStore, sinkDB, sourceRef, progressCh)
+
+			var err error
+			sinkDataset, err = sinkDB.FastForward(sinkDataset, sourceRef)
+			if err == datas.ErrMergeNeeded {
+				sinkDataset, err = sinkDB.SetHead(sinkDataset, sourceRef)
+				nonFF = true
+			}
+			d.PanicIfError(err)
+		})
+
+		if err != nil {
+			log.Fatal(err)
 		}
-		d.PanicIfError(err)
-	})
 
-	if err != nil {
-		log.Fatal(err)
+		close(progressCh)
+		if last := <-lastProgressCh; last.DoneCount > 0 {
+			status.Printf("Done - Synced %s in %s (%s/s)",
+				humanize.Bytes(last.ApproxWrittenBytes), since(start), bytesPerSec(last.ApproxWrittenBytes, start))
+			status.Done()
+		} else if !sinkExists {
+			fmt.Printf("All chunks already exist at destination! Created new dataset %s.\n", *database)
+		} else if nonFF && !sourceRef.Equals(sinkRef) {
+			fmt.Printf("Abandoning %s; new head is %s\n", sinkRef.TargetHash(), sourceRef.TargetHash())
+		} else {
+			fmt.Printf("Dataset %s is already up to date.\n", *database)
+		}
+
+		return 0
 	}
-
-	close(progressCh)
-	if last := <-lastProgressCh; last.DoneCount > 0 {
-		status.Printf("Done - Synced %s in %s (%s/s)",
-			humanize.Bytes(last.ApproxWrittenBytes), since(start), bytesPerSec(last.ApproxWrittenBytes, start))
-		status.Done()
-	} else if !sinkExists {
-		fmt.Printf("All chunks already exist at destination! Created new dataset %s.\n", args[1])
-	} else if nonFF && !sourceRef.Equals(sinkRef) {
-		fmt.Printf("Abandoning %s; new head is %s\n", sinkRef.TargetHash(), sourceRef.TargetHash())
-	} else {
-		fmt.Printf("Dataset %s is already up to date.\n", args[1])
-	}
-
-	return 0
 }
 
 func bytesPerSec(bytes uint64, start time.Time) string {

--- a/cmd/noms/noms_sync.go
+++ b/cmd/noms/noms_sync.go
@@ -20,8 +20,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
-// NomsSync - the noms sync command
-func NomsSync(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsSync(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	sync := noms.Command("sync", `Moves datasets between or within databases
 
 See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object and dataset arguments.

--- a/cmd/noms/noms_version.go
+++ b/cmd/noms/noms_version.go
@@ -8,26 +8,18 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/attic-labs/noms/cmd/util"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/attic-labs/noms/go/constants"
-	flag "github.com/juju/gnuflag"
 )
 
-var nomsVersion = &util.Command{
-	Run:       runVersion,
-	UsageLine: "version ",
-	Short:     "Display noms version",
-	Long:      "version prints the Noms data version and build identifier",
-	Flags:     setupVersionFlags,
-	Nargs:     0,
-}
+// NomsVersion - the noms version command
+func NomsVersion(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+	version := noms.Command("version", "Print the noms version")
 
-func setupVersionFlags() *flag.FlagSet {
-	return flag.NewFlagSet("version", flag.ExitOnError)
-}
-
-func runVersion(args []string) int {
-	fmt.Fprintf(os.Stdout, "format version: %v\n", constants.NomsVersion)
-	fmt.Fprintf(os.Stdout, "built from %v\n", constants.NomsGitSHA)
-	return 0
+	return version, func() int {
+		fmt.Fprintf(os.Stdout, "format version: %v\n", constants.NomsVersion)
+		fmt.Fprintf(os.Stdout, "built from %v\n", constants.NomsGitSHA)
+		return 0
+	}
 }

--- a/cmd/noms/noms_version.go
+++ b/cmd/noms/noms_version.go
@@ -13,8 +13,7 @@ import (
 	"github.com/attic-labs/noms/go/constants"
 )
 
-// NomsVersion - the noms version command
-func NomsVersion(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
+func nomsVersion(noms *kingpin.Application) (*kingpin.CmdClause, CommandHandler) {
 	version := noms.Command("version", "Print the noms version")
 
 	return version, func() int {


### PR DESCRIPTION
Initial work on #2157:

Summary
---

This PR switches the CLI to use [kingpin](https://github.com/alecthomas/kingpin), which has a number of advantages, namely:

- arbitrary depth contextual commands and help. This will remove weird hacks like `noms ds --delete <ds>`, which should be `noms ds delete <ds>`, and allow for creating "suites" of CLI tools, like `noms blob [command]`.
- don't hide basic usage docs under `thing help` commands, show it at the root and provide details when `thing --help`'d
- no need to check `args.length` anymore, can just mark args required
- everything is named, so stuff is a bit easier to parse
- non-defined args are `nil` when not provided by the user now that they are pointers. Could simplify things like using `-1` as a proxy for `nil`
- [easier CLI doc customization](https://github.com/alecthomas/kingpin#custom-help)
- [free shell completion and manpage generation](https://github.com/alecthomas/kingpin#bashzsh-shell-completion)

in general, it's also nice to have a lib handle deciding how to represent things like optional params and short flags, so it'll be consistent.

I opened this PR for initial eyes, but I'll at minimum break out the dataset command on this PR, and possibly start adding commands from #2157 (e.g. `blob`) on here depending on the temperature of the room.

TODO
---

- [ ] `@<file>` stuff for file paths?
- [ ] Restore or intentionally remove profiling
- [ ] Fix any broken tests
- [ ] Simplify verbosity and remove old flags libs

examples
---

**output from `noms`**:
```
usage: noms [<flags>] <command> [<args> ...]

Noms is a tool for showing off Noms data.

Flags:
  --help  Show context-sensitive help (also try --help-long and --help-man).

Commands:
  help [<command>...]
    Show help.

  commit [<flags>] <database> [<absolute-path>]
    Commits a specified value as head of the dataset

    If absolute-path is not provided, then it is read from stdin. See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the dataset and absolute-path arguments.

  config
    Prints the active configuration if a .nomsconfig file is present

  diff [<flags>] <object1> <object2>
    Shows the difference between two objects

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object arguments.

  ds [<flags>] [<database>]
    Noms dataset management

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

  log [<flags>] <path-spec>
    Displays the history of a path

    See Spelling Values at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the <path-spec> parameter.

  merge [<flags>] <database> <left-dataset-name> <right-dataset-name> <output-dataset-name>
    Merges and commits the head values of two named datasets

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

    You must provide a working database and the names of two Datasets you want to merge. The values at the heads of these Datasets will be merged, put into a new Commit object, and set as the Head of the third provided Dataset name.

  root [<flags>] <database>
    Get or set the current root hash of the entire database

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

  serve [<flags>] <database>
    Serves a Noms database over HTTP

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

  show [<flags>] <object>
    Shows a serialization of a Noms object

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object argument.

  sync [<flags>] <source-object> <dest-dataset>
    Moves datasets between or within databases

    See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the object and dataset arguments.

  version
    Print the noms version
```

**output of `noms merge --help`**
```
usage: noms merge [<flags>] <database> <left-dataset-name> <right-dataset-name> <output-dataset-name>

Merges and commits the head values of two named datasets

See Spelling Objects at https://github.com/attic-labs/noms/blob/master/doc/spelling.md for details on the database argument.

You must provide a working database and the names of two Datasets you want to merge. The values at the heads of these Datasets will be merged, put into a new Commit object, and set as the Head of the third provided Dataset name.

Flags:
      --help      Show context-sensitive help (also try --help-long and --help-man).
      --policy=n  conflict resolution policy for merging. Defaults to 'n', which means no resolution strategy will be applied. Supported values are 'l' (left), 'r' (right) and 'p' (prompt). 'prompt' will bring up a simple command-line prompt allowing you to resolve conflicts
                  by choosing between 'l' or 'r' on a case-by-case basis.
  -v, --verbose   show more
  -q, --quiet     show less

Args:
  <database>             a noms database path
  <left-dataset-name>    a dataset
  <right-dataset-name>   a dataset
  <output-dataset-name>  a dataset
```