### PR TITLE
Collection test

### DIFF
--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -56,13 +56,12 @@ func (b Blob) ReadAt(p []byte, off int64) (n int, err error) {
 		return
 	}
 
-	root := b.sequence()
-	leaves, localStart := loadLeafSequences(root.valueReader(), []sequence{root}, startIdx, endIdx)
+	leaves, localStart := loadLeafNodes([]Collection{b}, startIdx, endIdx)
 	endIdx = localStart + endIdx - startIdx
 	startIdx = localStart
 
-	for _, s := range leaves {
-		bl := s.(blobLeafSequence)
+	for _, b := range leaves {
+		bl := b.sequence().(blobLeafSequence)
 
 		localEnd := endIdx
 		leafLength := uint64(len(bl.data))

--- a/go/types/blob_test.go
+++ b/go/types/blob_test.go
@@ -95,7 +95,7 @@ func newBlobTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff in
 }
 
 func TestBlobSuite4K(t *testing.T) {
-	suite.Run(t, newBlobTestSuite(12, 0, 0, 0))
+	suite.Run(t, newBlobTestSuite(12, 1, 2, 2))
 }
 
 func TestBlobSuite64K(t *testing.T) {

--- a/go/types/collection_test.go
+++ b/go/types/collection_test.go
@@ -38,12 +38,11 @@ func (suite *collectionTestSuite) TestEquals() {
 }
 
 func (suite *collectionTestSuite) TestChunkCountAndType() {
-	chunks := getChunks(suite.col)
-	suite.Equal(suite.expectChunkCount, len(chunks), "chunk count")
+	suite.Equal(suite.expectChunkCount, leafCount(suite.col), "chunk count")
 	refType := MakeRefType(suite.expectType)
-	for _, r := range chunks {
+	suite.col.WalkRefs(func(r Ref) {
 		suite.True(refType.Equals(TypeOf(r)))
-	}
+	})
 }
 
 func (suite *collectionTestSuite) TestRoundTripAndValidate() {
@@ -57,12 +56,12 @@ func (suite *collectionTestSuite) TestRoundTripAndValidate() {
 
 func (suite *collectionTestSuite) TestPrependChunkDiff() {
 	v2 := suite.prependOne()
-	suite.Equal(suite.expectPrependChunkDiff, chunkDiffCount(getChunks(suite.col), getChunks(v2)), "prepend count")
+	suite.Equal(suite.expectPrependChunkDiff, leafDiffCount(suite.col, v2), "prepend count")
 }
 
 func (suite *collectionTestSuite) TestAppendChunkDiff() {
 	v2 := suite.appendOne()
-	suite.Equal(suite.expectAppendChunkDiff, chunkDiffCount(getChunks(suite.col), getChunks(v2)), "append count")
+	suite.Equal(suite.expectAppendChunkDiff, leafDiffCount(suite.col, v2), "append count")
 }
 
 func deriveCollectionHeight(c Collection) uint64 {

--- a/go/types/util_test.go
+++ b/go/types/util_test.go
@@ -75,27 +75,38 @@ func generateNumbersAsRefOfStructs(n int) []Value {
 	return nums
 }
 
-func chunkDiffCount(c1 []Ref, c2 []Ref) int {
+func leafCount(c Collection) int {
+	leaves, _ := loadLeafNodes([]Collection{c}, 0, c.Len())
+	return len(leaves)
+}
+
+func leafDiffCount(c1, c2 Collection) int {
 	count := 0
 	hashes := make(map[hash.Hash]int)
 
-	for _, r := range c1 {
-		hashes[r.TargetHash()]++
+	leaves1, _ := loadLeafNodes([]Collection{c1}, 0, c1.Len())
+	leaves2, _ := loadLeafNodes([]Collection{c2}, 0, c2.Len())
+
+	for _, l := range leaves1 {
+		hashes[l.Hash()]++
 	}
 
-	for _, r := range c2 {
-		if c, ok := hashes[r.TargetHash()]; ok {
+	for _, l := range leaves2 {
+		if c, ok := hashes[l.Hash()]; ok {
 			if c == 1 {
-				delete(hashes, r.TargetHash())
+				delete(hashes, l.Hash())
 			} else {
-				hashes[r.TargetHash()] = c - 1
+				hashes[l.Hash()] = c - 1
 			}
 		} else {
 			count++
 		}
 	}
 
-	count += len(hashes)
+	for _, c := range hashes {
+		count += c
+	}
+
 	return count
 }
 


### PR DESCRIPTION
This fixes a long standing annoyance. The collection tests now sanity check total & diff number of *leave* nodes (as opposed to root-1 level). This makes the tests much easier to reason about because how deep the tree is doesn't create discontinuities when the serialization changes.

TBR @kalman 