### PR TITLE
Remove in mem graphs

### DIFF
--- a/cmd/noms/noms_blob_get_test.go
+++ b/cmd/noms/noms_blob_get_test.go
@@ -26,13 +26,14 @@ type nbeSuite struct {
 }
 
 func (s *nbeSuite) TestNomsBlobGet() {
-	blobBytes := []byte("hello")
-	blob := types.NewBlob(bytes.NewBuffer(blobBytes))
-
 	sp, err := spec.ForDatabase(s.TempDir)
 	s.NoError(err)
 	defer sp.Close()
 	db := sp.GetDatabase()
+
+	blobBytes := []byte("hello")
+	blob := types.NewBlob(db, bytes.NewBuffer(blobBytes))
+
 	ref := db.WriteValue(blob)
 	_, err = db.CommitValue(db.GetDataset("datasetID"), ref)
 	s.NoError(err)

--- a/cmd/noms/noms_blob_put.go
+++ b/cmd/noms/noms_blob_put.go
@@ -52,7 +52,7 @@ func nomsBlobPut(filePath string, dsPath string, concurrency int) int {
 	}
 	defer db.Close()
 
-	blob := types.NewStreamingBlob(db, readers...)
+	blob := types.NewBlob(db, readers...)
 
 	_, err = db.CommitValue(ds, blob)
 	if err != nil {

--- a/cmd/noms/noms_diff_test.go
+++ b/cmd/noms/noms_diff_test.go
@@ -62,11 +62,11 @@ func (s *nomsDiffTestSuite) TestNomsDiffSummarize() {
 	out, _ = s.MustRun(main, []string{"diff", "--summarize", r1 + ".value", r2 + ".value"})
 	s.NotContains(out, "Comparing commit values")
 
-	ds, err = db.CommitValue(ds, types.NewList(types.Number(1), types.Number(2), types.Number(3), types.Number(4)))
+	ds, err = db.CommitValue(ds, types.NewList(db, types.Number(1), types.Number(2), types.Number(3), types.Number(4)))
 	s.NoError(err)
 	r3 := spec.CreateHashSpecString("nbs", s.DBDir, ds.HeadRef().TargetHash()) + ".value"
 
-	ds, err = db.CommitValue(ds, types.NewList(types.Number(1), types.Number(222), types.Number(4)))
+	ds, err = db.CommitValue(ds, types.NewList(db, types.Number(1), types.Number(222), types.Number(4)))
 	s.NoError(err)
 	r4 := spec.CreateHashSpecString("nbs", s.DBDir, ds.HeadRef().TargetHash()) + ".value"
 

--- a/cmd/noms/noms_merge.go
+++ b/cmd/noms/noms_merge.go
@@ -66,7 +66,7 @@ func runMerge(args []string) int {
 	d.CheckErrorNoUsage(err)
 	close(pc)
 
-	_, err = db.SetHead(outDS, db.WriteValue(datas.NewCommit(merged, types.NewSet(leftDS.HeadRef(), rightDS.HeadRef()), types.EmptyStruct)))
+	_, err = db.SetHead(outDS, db.WriteValue(datas.NewCommit(merged, types.NewSet(db, leftDS.HeadRef(), rightDS.HeadRef()), types.EmptyStruct)))
 	d.PanicIfError(err)
 	if !verbose.Quiet() {
 		status.Printf("Done")

--- a/cmd/noms/splore/noms_splore_test.go
+++ b/cmd/noms/splore/noms_splore_test.go
@@ -67,14 +67,15 @@ func TestNomsSplore(t *testing.T) {
 	sp, err := spec.ForDataset(fmt.Sprintf("nbs:%s::ds", dir))
 	d.PanicIfError(err)
 	defer sp.Close()
+	db := sp.GetDatabase()
 	strct := types.NewStruct("StructName", types.StructData{
-		"blob":   types.NewBlob(),
+		"blob":   types.NewBlob(db),
 		"bool":   types.Bool(true),
-		"list":   types.NewList(types.Number(1), types.Number(2)),
-		"map":    types.NewMap(types.String("a"), types.String("b"), types.String("c"), types.String("d")),
+		"list":   types.NewList(db, types.Number(1), types.Number(2)),
+		"map":    types.NewMap(db, types.String("a"), types.String("b"), types.String("c"), types.String("d")),
 		"number": types.Number(42),
-		"ref":    sp.GetDatabase().WriteValue(types.Bool(true)),
-		"set":    types.NewSet(types.Number(3), types.Number(4)),
+		"ref":    db.WriteValue(types.Bool(true)),
+		"set":    types.NewSet(db, types.Number(3), types.Number(4)),
 		"string": types.String("hello world"),
 	})
 	sp.GetDatabase().CommitValue(sp.GetDataset(), strct)
@@ -467,28 +468,28 @@ func TestNomsSploreGetMetaChildren(t *testing.T) {
 	// A bunch of lists with just numbers or ref<number>s in them. None of these
 	// should be detected as meta sequences:
 
-	l1 := types.NewList()
+	l1 := types.NewList(db)
 	assert.Nil(getMetaChildren(l1))
 
-	l2 := types.NewList(types.Number(1))
+	l2 := types.NewList(db, types.Number(1))
 	assert.Nil(getMetaChildren(l2))
 
-	l3 := types.NewList(types.Number(1), types.Number(2))
+	l3 := types.NewList(db, types.Number(1), types.Number(2))
 	assert.Nil(getMetaChildren(l3))
 
-	l4 := types.NewList(db.WriteValue(types.Number(1)))
+	l4 := types.NewList(db, db.WriteValue(types.Number(1)))
 	assert.Nil(getMetaChildren(l4))
 
-	l5 := types.NewList(db.WriteValue(types.Number(1)), types.Number(2))
+	l5 := types.NewList(db, db.WriteValue(types.Number(1)), types.Number(2))
 	assert.Nil(getMetaChildren(l5))
 
-	l6 := types.NewList(db.WriteValue(types.Number(1)), db.WriteValue(types.Number(2)))
+	l6 := types.NewList(db, db.WriteValue(types.Number(1)), db.WriteValue(types.Number(2)))
 	assert.Nil(getMetaChildren(l6))
 
-	l7 := types.NewList(l1)
+	l7 := types.NewList(db, l1)
 	assert.Nil(getMetaChildren(l7))
 
-	l8 := types.NewList(l4)
+	l8 := types.NewList(db, l4)
 	assert.Nil(getMetaChildren(l8))
 
 	// List with more or equal ref<list> than elements. This can't possibly be a meta
@@ -497,21 +498,21 @@ func TestNomsSploreGetMetaChildren(t *testing.T) {
 	l1Ref := db.WriteValue(l1)
 	l2Ref := db.WriteValue(l2)
 	l3Ref := db.WriteValue(l3)
-	listRefList := types.NewList(l1Ref, l2Ref, l3Ref)
+	listRefList := types.NewList(db, l1Ref, l2Ref, l3Ref)
 
-	l9 := types.NewList(listRefList)
+	l9 := types.NewList(db, listRefList)
 	assert.Nil(getMetaChildren(l9))
 
-	l10 := types.NewList(types.Number(1), listRefList)
+	l10 := types.NewList(db, types.Number(1), listRefList)
 	assert.Nil(getMetaChildren(l10))
 
 	l11 := listRefList
 	assert.Nil(getMetaChildren(l11))
 
-	l12 := types.NewList(types.Number(1), types.Number(2), listRefList)
+	l12 := types.NewList(db, types.Number(1), types.Number(2), listRefList)
 	assert.Nil(getMetaChildren(l12))
 
-	l13 := types.NewList(types.Number(1), db.WriteValue(types.Number(2)), listRefList)
+	l13 := types.NewList(db, types.Number(1), db.WriteValue(types.Number(2)), listRefList)
 	assert.Nil(getMetaChildren(l13))
 
 	// List with fewer ref<list> as children. For now this is the closet
@@ -526,15 +527,15 @@ func TestNomsSploreGetMetaChildren(t *testing.T) {
 		nodeChild{Value: nodeInfo{HasChildren: true, ID: l3Hash, Name: "List" + l3Hash}},
 	}
 
-	l14 := types.NewList(types.Number(1), types.Number(2), types.Number(3), listRefList)
+	l14 := types.NewList(db, types.Number(1), types.Number(2), types.Number(3), listRefList)
 	assert.Equal(expectNodeChildren, getMetaChildren(l14))
 
-	l15 := types.NewList(types.Number(1), types.Number(2), db.WriteValue(types.Number(3)), listRefList)
+	l15 := types.NewList(db, types.Number(1), types.Number(2), db.WriteValue(types.Number(3)), listRefList)
 	assert.Equal(expectNodeChildren, getMetaChildren(l15))
 
-	l16 := types.NewList(types.Number(1), types.Number(2), types.Number(3), types.Number(4), listRefList)
+	l16 := types.NewList(db, types.Number(1), types.Number(2), types.Number(3), types.Number(4), listRefList)
 	assert.Equal(expectNodeChildren, getMetaChildren(l16))
 
-	l17 := types.NewList(types.Number(1), types.Number(2), db.WriteValue(types.Number(3)), db.WriteValue(types.Number(4)), listRefList)
+	l17 := types.NewList(db, types.Number(1), types.Number(2), db.WriteValue(types.Number(3)), db.WriteValue(types.Number(4)), listRefList)
 	assert.Equal(expectNodeChildren, getMetaChildren(l17))
 }

--- a/go/datas/dataset_test.go
+++ b/go/datas/dataset_test.go
@@ -31,7 +31,7 @@ func TestExplicitBranchUsingDatasets(t *testing.T) {
 	// ds1: |a|
 	//        \ds2
 	ds2 := store.GetDataset(id2)
-	ds2, err = store.Commit(ds2, ds1.HeadValue(), CommitOptions{Parents: types.NewSet(ds1.HeadRef())})
+	ds2, err = store.Commit(ds2, ds1.HeadValue(), CommitOptions{Parents: types.NewSet(store, ds1.HeadRef())})
 	assert.NoError(err)
 	assert.True(ds2.Head().Get(ValueField).Equals(a))
 
@@ -50,7 +50,7 @@ func TestExplicitBranchUsingDatasets(t *testing.T) {
 
 	// ds1: |a|    <- |b| <--|d|
 	//        \ds2 <- |c| <--/
-	mergeParents := types.NewSet(types.NewRef(ds1.Head()), types.NewRef(ds2.Head()))
+	mergeParents := types.NewSet(store, types.NewRef(ds1.Head()), types.NewRef(ds2.Head()))
 	d := types.String("d")
 	ds2, err = store.Commit(ds2, d, CommitOptions{Parents: mergeParents})
 	assert.NoError(err)

--- a/go/diff/apply_patch.go
+++ b/go/diff/apply_patch.go
@@ -124,36 +124,36 @@ func (stack *patchStack) updateNode(top *stackElem, parent types.Value) types.Va
 			switch top.changeType {
 			case types.DiffChangeAdded:
 				if realIdx > el.Len() {
-					nv = el.Edit().Append(top.newValue).List(nil)
+					nv = el.Edit().Append(top.newValue).List()
 				} else {
-					nv = el.Edit().Insert(realIdx, top.newValue).List(nil)
+					nv = el.Edit().Insert(realIdx, top.newValue).List()
 				}
 			case types.DiffChangeRemoved:
-				nv = el.Edit().RemoveAt(realIdx).List(nil)
+				nv = el.Edit().RemoveAt(realIdx).List()
 			case types.DiffChangeModified:
-				nv = el.Edit().Set(realIdx, top.newValue).List(nil)
+				nv = el.Edit().Set(realIdx, top.newValue).List()
 			}
 			return nv
 		case types.Map:
 			switch top.changeType {
 			case types.DiffChangeAdded:
-				return el.Edit().Set(part.Index, top.newValue).Map(nil)
+				return el.Edit().Set(part.Index, top.newValue).Map()
 			case types.DiffChangeRemoved:
-				return el.Edit().Remove(part.Index).Map(nil)
+				return el.Edit().Remove(part.Index).Map()
 			case types.DiffChangeModified:
 				if part.IntoKey {
 					newPart := types.IndexPath{Index: part.Index}
 					ov := newPart.Resolve(parent, nil)
-					return el.Edit().Remove(part.Index).Set(top.newValue, ov).Map(nil)
+					return el.Edit().Remove(part.Index).Set(top.newValue, ov).Map()
 				}
-				return el.Edit().Set(part.Index, top.newValue).Map(nil)
+				return el.Edit().Set(part.Index, top.newValue).Map()
 			}
 		case types.Set:
 			if top.oldValue != nil {
-				el = el.Edit().Remove(top.oldValue).Set(nil)
+				el = el.Edit().Remove(top.oldValue).Set()
 			}
 			if top.newValue != nil {
-				el = el.Edit().Insert(top.newValue).Set(nil)
+				el = el.Edit().Insert(top.newValue).Set()
 			}
 			return el
 		}
@@ -162,11 +162,11 @@ func (stack *patchStack) updateNode(top *stackElem, parent types.Value) types.Va
 		case types.Set:
 			switch top.changeType {
 			case types.DiffChangeAdded:
-				return el.Edit().Insert(top.newValue).Set(nil)
+				return el.Edit().Insert(top.newValue).Set()
 			case types.DiffChangeRemoved:
-				return el.Edit().Remove(top.oldValue).Set(nil)
+				return el.Edit().Remove(top.oldValue).Set()
 			case types.DiffChangeModified:
-				return el.Edit().Remove(top.oldValue).Insert(top.newValue).Set(nil)
+				return el.Edit().Remove(top.oldValue).Insert(top.newValue).Set()
 			}
 		case types.Map:
 			keyPart := types.HashIndexPath{Hash: part.Hash, IntoKey: true}
@@ -174,15 +174,15 @@ func (stack *patchStack) updateNode(top *stackElem, parent types.Value) types.Va
 			switch top.changeType {
 			case types.DiffChangeAdded:
 				k := top.newKeyValue
-				return el.Edit().Set(k, top.newValue).Map(nil)
+				return el.Edit().Set(k, top.newValue).Map()
 			case types.DiffChangeRemoved:
-				return el.Edit().Remove(k).Map(nil)
+				return el.Edit().Remove(k).Map()
 			case types.DiffChangeModified:
 				if part.IntoKey {
 					v := el.Get(k)
-					return el.Edit().Remove(k).Set(top.newValue, v).Map(nil)
+					return el.Edit().Remove(k).Set(top.newValue, v).Map()
 				}
-				return el.Edit().Set(k, top.newValue).Map(nil)
+				return el.Edit().Set(k, top.newValue).Map()
 			}
 		}
 	}

--- a/go/diff/diff_test.go
+++ b/go/diff/diff_test.go
@@ -50,18 +50,24 @@ func valsToTypesValues(kv ...interface{}) []types.Value {
 }
 
 func createMap(kv ...interface{}) types.Map {
+	vs := newTestValueStore()
+	defer vs.Close()
 	keyValues := valsToTypesValues(kv...)
-	return types.NewMap(keyValues...)
+	return types.NewMap(vs, keyValues...)
 }
 
 func createSet(kv ...interface{}) types.Set {
+	vs := newTestValueStore()
+	defer vs.Close()
 	keyValues := valsToTypesValues(kv...)
-	return types.NewSet(keyValues...)
+	return types.NewSet(vs, keyValues...)
 }
 
 func createList(kv ...interface{}) types.List {
+	vs := newTestValueStore()
+	defer vs.Close()
 	keyValues := valsToTypesValues(kv...)
-	return types.NewList(keyValues...)
+	return types.NewList(vs, keyValues...)
 }
 
 func createStruct(name string, kv ...interface{}) types.Struct {
@@ -307,6 +313,10 @@ func TestNomsDiffPrintStruct(t *testing.T) {
 
 func TestNomsDiffPrintMapWithStructKeys(t *testing.T) {
 	a := assert.New(t)
+
+	vs := newTestValueStore()
+	defer vs.Close()
+
 	k1 := createStruct("TestKey", "name", "n1", "label", "l1")
 
 	expected1 := `(root) {
@@ -321,8 +331,8 @@ func TestNomsDiffPrintMapWithStructKeys(t *testing.T) {
   }
 `
 
-	m1 := types.NewMap(k1, types.Bool(true))
-	m2 := types.NewMap(k1, types.Bool(false))
+	m1 := types.NewMap(vs, k1, types.Bool(true))
+	m2 := types.NewMap(vs, k1, types.Bool(false))
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
 		PrintDiff(buf, m1, m2, leftRight)
@@ -407,10 +417,13 @@ func TestNomsDiffPrintList(t *testing.T) {
 func TestNomsDiffPrintBlob(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+	defer vs.Close()
+
 	expected := "-   Blob (2.0 kB)\n+   Blob (11 B)\n"
 	expectedPaths1 := []string{``}
-	b1 := types.NewBlob(strings.NewReader(strings.Repeat("x", 2*1024)))
-	b2 := types.NewBlob(strings.NewReader("Hello World"))
+	b1 := types.NewBlob(vs, strings.NewReader(strings.Repeat("x", 2*1024)))
+	b2 := types.NewBlob(vs, strings.NewReader("Hello World"))
 
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}

--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -22,12 +22,12 @@ import (
 //
 // If a Go struct contains a noms tag with original the field is skipped since
 // the Noms type depends on the original Noms value which is not available.
-func MarshalType(v interface{}) (nt *types.Type, err error) {
-	return MarshalTypeOpt(v, Opt{})
+func MarshalType(vrw types.ValueReadWriter, v interface{}) (nt *types.Type, err error) {
+	return MarshalTypeOpt(vrw, v, Opt{})
 }
 
 // MarshalTypeOpt is like MarshalType but with additional options.
-func MarshalTypeOpt(v interface{}, opt Opt) (nt *types.Type, err error) {
+func MarshalTypeOpt(vrw types.ValueReadWriter, v interface{}, opt Opt) (nt *types.Type, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			switch r := r.(type) {
@@ -40,23 +40,23 @@ func MarshalTypeOpt(v interface{}, opt Opt) (nt *types.Type, err error) {
 			}
 		}
 	}()
-	nt = MustMarshalTypeOpt(v, opt)
+	nt = MustMarshalTypeOpt(vrw, v, opt)
 	return
 }
 
 // MustMarshalType computes a Noms type from a Go type or panics if there is an
 // error.
-func MustMarshalType(v interface{}) (nt *types.Type) {
-	return MustMarshalTypeOpt(v, Opt{})
+func MustMarshalType(vrw types.ValueReadWriter, v interface{}) (nt *types.Type) {
+	return MustMarshalTypeOpt(vrw, v, Opt{})
 }
 
 // MustMarshalTypeOpt is like MustMarshalType but provides additional options.
-func MustMarshalTypeOpt(v interface{}, opt Opt) (nt *types.Type) {
+func MustMarshalTypeOpt(vrw types.ValueReadWriter, v interface{}, opt Opt) (nt *types.Type) {
 	rv := reflect.ValueOf(v)
 	tags := nomsTags{
 		set: opt.Set,
 	}
-	nt = encodeType(rv.Type(), map[string]reflect.Type{}, tags)
+	nt = encodeType(vrw, rv.Type(), map[string]reflect.Type{}, tags)
 
 	if nt == nil {
 		panic(&UnsupportedTypeError{Type: rv.Type()})
@@ -77,7 +77,7 @@ type TypeMarshaler interface {
 var typeOfTypesType = reflect.TypeOf((*types.Type)(nil))
 var typeMarshalerInterface = reflect.TypeOf((*TypeMarshaler)(nil)).Elem()
 
-func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTags) *types.Type {
+func encodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTags) *types.Type {
 	if t.Implements(typeMarshalerInterface) {
 		v := reflect.Zero(t)
 		typ, err := v.Interface().(TypeMarshaler).MarshalNomsType()
@@ -137,9 +137,9 @@ func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTa
 	case reflect.String:
 		return types.StringType
 	case reflect.Struct:
-		return structEncodeType(t, seenStructs)
+		return structEncodeType(vrw, t, seenStructs)
 	case reflect.Array, reflect.Slice:
-		elemType := encodeType(t.Elem(), seenStructs, nomsTags{})
+		elemType := encodeType(vrw, t.Elem(), seenStructs, nomsTags{})
 		if elemType == nil {
 			break
 		}
@@ -148,7 +148,7 @@ func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTa
 		}
 		return types.MakeListType(elemType)
 	case reflect.Map:
-		keyType := encodeType(t.Key(), seenStructs, nomsTags{})
+		keyType := encodeType(vrw, t.Key(), seenStructs, nomsTags{})
 		if keyType == nil {
 			break
 		}
@@ -157,7 +157,7 @@ func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTa
 			return types.MakeSetType(keyType)
 		}
 
-		valueType := encodeType(t.Elem(), seenStructs, nomsTags{})
+		valueType := encodeType(vrw, t.Elem(), seenStructs, nomsTags{})
 		if valueType != nil {
 			return types.MakeMapType(keyType, valueType)
 		}
@@ -172,7 +172,7 @@ func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTa
 // the type but we also need to look at the value. In these cases this returns
 // nil and we have to wait until we have a value to be able to determine the
 // type.
-func structEncodeType(t reflect.Type, seenStructs map[string]reflect.Type) *types.Type {
+func structEncodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[string]reflect.Type) *types.Type {
 	name := getStructName(t)
 	if name != "" {
 		if _, ok := seenStructs[name]; ok {
@@ -181,7 +181,7 @@ func structEncodeType(t reflect.Type, seenStructs map[string]reflect.Type) *type
 		seenStructs[name] = t
 	}
 
-	fields, knownShape, _ := typeFields(t, seenStructs, true, false)
+	fields, knownShape, _ := typeFields(vrw, t, seenStructs, true, false)
 
 	var structType *types.Type
 	if knownShape {

--- a/go/merge/three_way_keyval_test.go
+++ b/go/merge/three_way_keyval_test.go
@@ -75,7 +75,7 @@ func (s *ThreeWayMapMergeSuite) SetupSuite() {
 	s.create = func(seq seq) (val types.Value) {
 		if seq != nil {
 			keyValues := valsToTypesValues(s.create, seq.items()...)
-			val = types.NewMap(keyValues...)
+			val = types.NewMap(s.vs, keyValues...)
 		}
 		return
 	}
@@ -209,8 +209,8 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_NilConflict() {
 }
 
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_ImmediateConflict() {
-	s.tryThreeWayConflict(types.NewSet(), s.create(mm2b), s.create(mm2), "Cannot merge Set<> with "+s.typeStr)
-	s.tryThreeWayConflict(s.create(mm2b), types.NewSet(), s.create(mm2), "Cannot merge "+s.typeStr)
+	s.tryThreeWayConflict(types.NewSet(s.vs), s.create(mm2b), s.create(mm2), "Cannot merge Set<> with "+s.typeStr)
+	s.tryThreeWayConflict(s.create(mm2b), types.NewSet(s.vs), s.create(mm2), "Cannot merge "+s.typeStr)
 }
 
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefConflict() {
@@ -226,8 +226,8 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefConflict() {
 }
 
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_NestedConflict() {
-	a := mm2a.set("k2", types.NewSet())
-	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), types.EncodedValue(types.NewSet()))
+	a := mm2a.set("k2", types.NewSet(s.vs))
+	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), types.EncodedValue(types.NewSet(s.vs)))
 	s.tryThreeWayConflict(s.create(a), s.create(mm2b), s.create(mm2), types.EncodedValue(s.create(aa1b)))
 }
 

--- a/go/merge/three_way_list.go
+++ b/go/merge/three_way_list.go
@@ -120,7 +120,7 @@ func apply(source, target types.List, offset uint64, s types.Splice) types.List 
 		}
 		toAdd[i] = v
 	}
-	return target.Edit().Splice(s.SpAt+offset, s.SpRemoved, toAdd...).List(nil)
+	return target.Edit().Splice(s.SpAt+offset, s.SpRemoved, toAdd...).List()
 }
 
 func describeSplice(s types.Splice) string {

--- a/go/merge/three_way_list_test.go
+++ b/go/merge/three_way_list_test.go
@@ -23,7 +23,7 @@ func (s *ThreeWayListMergeSuite) SetupSuite() {
 	s.create = func(i seq) (val types.Value) {
 		if i != nil {
 			items := valsToTypesValues(s.create, i.items()...)
-			val = types.NewList(items...)
+			val = types.NewList(s.vs, items...)
 		}
 		return
 	}

--- a/go/merge/three_way_set_test.go
+++ b/go/merge/three_way_set_test.go
@@ -29,7 +29,7 @@ func (s *ThreeWaySetMergeSuite) SetupSuite() {
 	s.create = func(i seq) (val types.Value) {
 		if i != nil {
 			keyValues := valsToTypesValues(s.create, i.items()...)
-			val = types.NewSet(keyValues...)
+			val = types.NewSet(s.vs, keyValues...)
 		}
 		return
 	}
@@ -80,6 +80,6 @@ func (s *ThreeWaySetMergeSuite) TestThreeWayMerge_Refs() {
 }
 
 func (s *ThreeWaySetMergeSuite) TestThreeWayMerge_ImmediateConflict() {
-	s.tryThreeWayConflict(types.NewMap(), s.create(ss1b), s.create(ss1), "Cannot merge Map<> with "+s.typeStr)
-	s.tryThreeWayConflict(s.create(ss1b), types.NewMap(), s.create(ss1), "Cannot merge "+s.typeStr)
+	s.tryThreeWayConflict(types.NewMap(s.vs), s.create(ss1b), s.create(ss1), "Cannot merge Map<> with "+s.typeStr)
+	s.tryThreeWayConflict(s.create(ss1b), types.NewMap(s.vs), s.create(ss1), "Cannot merge "+s.typeStr)
 }

--- a/go/ngql/query.go
+++ b/go/ngql/query.go
@@ -31,7 +31,7 @@ const (
 	throughKey     = "through"
 	valueKey       = "value"
 	valuesKey      = "values"
-	vrKey          = "vr"
+	vrwKey         = "vrw"
 )
 
 // NewRootQueryObject creates a "root" query object that can be used to
@@ -61,22 +61,22 @@ func (tc *TypeConverter) NewRootQueryObject(rootValue types.Value) *graphql.Obje
 
 // NewContext creates a new context.Context with the extra data added to it
 // that is required by ngql.
-func NewContext(vr types.ValueReader) context.Context {
-	return context.WithValue(context.Background(), vrKey, vr)
+func NewContext(vrw types.ValueReader) context.Context {
+	return context.WithValue(context.Background(), vrwKey, vrw)
 }
 
 // Query takes |rootValue|, builds a GraphQL scheme from rootValue.Type() and
 // executes |query| against it, encoding the result to |w|.
-func Query(rootValue types.Value, query string, vr types.ValueReader, w io.Writer) {
+func Query(rootValue types.Value, query string, vrw types.ValueReadWriter, w io.Writer) {
 	schemaConfig := graphql.SchemaConfig{}
 	tc := NewTypeConverter()
-	queryWithSchemaConfig(rootValue, query, schemaConfig, vr, tc, w)
+	queryWithSchemaConfig(rootValue, query, schemaConfig, vrw, tc, w)
 }
 
-func queryWithSchemaConfig(rootValue types.Value, query string, schemaConfig graphql.SchemaConfig, vr types.ValueReader, tc *TypeConverter, w io.Writer) {
+func queryWithSchemaConfig(rootValue types.Value, query string, schemaConfig graphql.SchemaConfig, vrw types.ValueReadWriter, tc *TypeConverter, w io.Writer) {
 	schemaConfig.Query = tc.NewRootQueryObject(rootValue)
 	schema, _ := graphql.NewSchema(schemaConfig)
-	ctx := NewContext(vr)
+	ctx := NewContext(vrw)
 
 	r := graphql.Do(graphql.Params{
 		Schema:        schema,

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -95,27 +95,27 @@ func (suite *QueryGraphQLSuite) TestEmbeddedStruct() {
 
 func (suite *QueryGraphQLSuite) TestListBasic() {
 	for _, valuesKey := range []string{"elements", "values"} {
-		list := types.NewList()
+		list := types.NewList(suite.vs)
 		suite.assertQueryResult(list, "{root{size}}", `{"data":{"root":{"size":0}}}`)
 		suite.assertQueryResult(list, "{root{"+valuesKey+"}}", `{"data":{"root":{}}}`)
 
-		list = types.NewList(types.String("foo"), types.String("bar"), types.String("baz"))
+		list = types.NewList(suite.vs, types.String("foo"), types.String("bar"), types.String("baz"))
 
 		suite.assertQueryResult(list, "{root{"+valuesKey+"}}", `{"data":{"root":{"`+valuesKey+`":["foo","bar","baz"]}}}`)
 		suite.assertQueryResult(list, "{root{size}}", `{"data":{"root":{"size":3}}}`)
 		suite.assertQueryResult(list, "{root{"+valuesKey+"(at:1,count:2)}}", `{"data":{"root":{"`+valuesKey+`":["bar","baz"]}}}`)
 
-		list = types.NewList(types.Bool(true), types.Bool(false), types.Bool(false))
+		list = types.NewList(suite.vs, types.Bool(true), types.Bool(false), types.Bool(false))
 
 		suite.assertQueryResult(list, "{root{"+valuesKey+"}}", `{"data":{"root":{"`+valuesKey+`":[true,false,false]}}}`)
 		suite.assertQueryResult(list, "{root{"+valuesKey+"(at:1,count:2)}}", `{"data":{"root":{"`+valuesKey+`":[false,false]}}}`)
 
-		list = types.NewList(types.Number(1), types.Number(1.1), types.Number(-100))
+		list = types.NewList(suite.vs, types.Number(1), types.Number(1.1), types.Number(-100))
 
 		suite.assertQueryResult(list, "{root{"+valuesKey+"}}", `{"data":{"root":{"`+valuesKey+`":[1,1.1,-100]}}}`)
 		suite.assertQueryResult(list, "{root{"+valuesKey+"(at:1,count:2)}}", `{"data":{"root":{"`+valuesKey+`":[1.1,-100]}}}`)
 
-		list = types.NewList(types.String("a"), types.String("b"), types.String("c"))
+		list = types.NewList(suite.vs, types.String("a"), types.String("b"), types.String("c"))
 		suite.assertQueryResult(list, "{root{"+valuesKey+"(at:4)}}", `{"data":{"root":{"`+valuesKey+`":[]}}}`)
 		suite.assertQueryResult(list, "{root{"+valuesKey+"(count:0)}}", `{"data":{"root":{"`+valuesKey+`":[]}}}`)
 		suite.assertQueryResult(list, "{root{"+valuesKey+"(count:10)}}", `{"data":{"root":{"`+valuesKey+`":["a","b","c"]}}}`)
@@ -124,7 +124,7 @@ func (suite *QueryGraphQLSuite) TestListBasic() {
 }
 
 func (suite *QueryGraphQLSuite) TestListOfStruct() {
-	list := types.NewList(
+	list := types.NewList(suite.vs,
 		types.NewStruct("Foo", types.StructData{
 			"a": types.Number(28),
 			"b": types.String("foo"),
@@ -145,7 +145,7 @@ func (suite *QueryGraphQLSuite) TestListOfStruct() {
 }
 
 func (suite *QueryGraphQLSuite) TestListOfStructWithOptionalFields() {
-	list := types.NewList(
+	list := types.NewList(suite.vs,
 		types.NewStruct("Foo", types.StructData{
 			"a": types.Number(1),
 		}),
@@ -169,27 +169,27 @@ func (suite *QueryGraphQLSuite) TestListOfStructWithOptionalFields() {
 
 func (suite *QueryGraphQLSuite) TestSetBasic() {
 	for _, valuesKey := range []string{"elements", "values"} {
-		set := types.NewSet()
+		set := types.NewSet(suite.vs)
 		suite.assertQueryResult(set, "{root{size}}", `{"data":{"root":{"size":0}}}`)
 		suite.assertQueryResult(set, "{root{"+valuesKey+"}}", `{"data":{"root":{}}}`)
 
-		set = types.NewSet(types.String("foo"), types.String("bar"), types.String("baz"))
+		set = types.NewSet(suite.vs, types.String("foo"), types.String("bar"), types.String("baz"))
 
 		suite.assertQueryResult(set, "{root{"+valuesKey+"}}", `{"data":{"root":{"`+valuesKey+`":["bar","baz","foo"]}}}`)
 		suite.assertQueryResult(set, "{root{size}}", `{"data":{"root":{"size":3}}}`)
 		suite.assertQueryResult(set, "{root{"+valuesKey+"(count:2)}}", `{"data":{"root":{"`+valuesKey+`":["bar","baz"]}}}`)
 
-		set = types.NewSet(types.Bool(true), types.Bool(false))
+		set = types.NewSet(suite.vs, types.Bool(true), types.Bool(false))
 
 		suite.assertQueryResult(set, "{root{"+valuesKey+"}}", `{"data":{"root":{"`+valuesKey+`":[false,true]}}}`)
 		suite.assertQueryResult(set, "{root{"+valuesKey+"(count:1)}}", `{"data":{"root":{"`+valuesKey+`":[false]}}}`)
 
-		set = types.NewSet(types.Number(1), types.Number(1.1), types.Number(-100))
+		set = types.NewSet(suite.vs, types.Number(1), types.Number(1.1), types.Number(-100))
 
 		suite.assertQueryResult(set, "{root{"+valuesKey+"}}", `{"data":{"root":{"`+valuesKey+`":[-100,1,1.1]}}}`)
 		suite.assertQueryResult(set, "{root{"+valuesKey+"(count:2)}}", `{"data":{"root":{"`+valuesKey+`":[-100,1]}}}`)
 
-		set = types.NewSet(types.String("a"), types.String("b"), types.String("c"), types.String("d"))
+		set = types.NewSet(suite.vs, types.String("a"), types.String("b"), types.String("c"), types.String("d"))
 		suite.assertQueryResult(set, "{root{"+valuesKey+"(count:0)}}", `{"data":{"root":{"`+valuesKey+`":[]}}}`)
 		suite.assertQueryResult(set, "{root{"+valuesKey+"(count:2)}}", `{"data":{"root":{"`+valuesKey+`":["a","b"]}}}`)
 
@@ -204,7 +204,7 @@ func (suite *QueryGraphQLSuite) TestSetBasic() {
 }
 
 func (suite *QueryGraphQLSuite) TestSetOfStruct() {
-	set := types.NewSet(
+	set := types.NewSet(suite.vs,
 		types.NewStruct("Foo", types.StructData{
 			"a": types.Number(28),
 			"b": types.String("foo"),
@@ -227,11 +227,11 @@ func (suite *QueryGraphQLSuite) TestSetOfStruct() {
 func (suite *QueryGraphQLSuite) TestMapBasic() {
 	for _, entriesKey := range []string{"elements", "entries"} {
 
-		m := types.NewMap()
+		m := types.NewMap(suite.vs)
 		suite.assertQueryResult(m, "{root{size}}", `{"data":{"root":{"size":0}}}`)
 		suite.assertQueryResult(m, "{root{"+entriesKey+"}}", `{"data":{"root":{}}}`)
 
-		m = types.NewMap(
+		m = types.NewMap(suite.vs,
 			types.String("a"), types.Number(1),
 			types.String("b"), types.Number(2),
 			types.String("c"), types.Number(3),
@@ -244,7 +244,7 @@ func (suite *QueryGraphQLSuite) TestMapBasic() {
 }
 
 func (suite *QueryGraphQLSuite) TestMapOfStruct() {
-	m := types.NewMap(
+	m := types.NewMap(suite.vs,
 		types.String("foo"), types.NewStruct("Foo", types.StructData{
 			"a": types.Number(28),
 			"b": types.String("foo"),
@@ -279,14 +279,14 @@ func (suite *QueryGraphQLSuite) TestRef() {
 	suite.assertQueryResult(r, "{root{targetValue{a}}}", `{"data":{"root":{"targetValue":{"a":28}}}}`)
 	suite.assertQueryResult(r, "{root{targetValue{a b}}}", `{"data":{"root":{"targetValue":{"a":28,"b":"foo"}}}}`)
 
-	r = suite.vs.WriteValue(types.NewList(types.String("foo"), types.String("bar"), types.String("baz")))
+	r = suite.vs.WriteValue(types.NewList(suite.vs, types.String("foo"), types.String("bar"), types.String("baz")))
 
 	suite.assertQueryResult(r, "{root{targetValue{values}}}", `{"data":{"root":{"targetValue":{"values":["foo","bar","baz"]}}}}`)
 	suite.assertQueryResult(r, "{root{targetValue{values(at:1,count:2)}}}", `{"data":{"root":{"targetValue":{"values":["bar","baz"]}}}}`)
 }
 
 func (suite *QueryGraphQLSuite) TestListOfUnionOfStructs() {
-	list := types.NewList(
+	list := types.NewList(suite.vs,
 		types.NewStruct("Foo", types.StructData{
 			"a": types.Number(28),
 			"b": types.String("baz"),
@@ -308,7 +308,7 @@ func (suite *QueryGraphQLSuite) TestListOfUnionOfStructs() {
 }
 
 func (suite *QueryGraphQLSuite) TestListOfUnionOfStructsConflictingFieldTypes() {
-	list := types.NewList(
+	list := types.NewList(suite.vs,
 		types.NewStruct("Foo", types.StructData{
 			"a": types.Number(28),
 		}),
@@ -329,7 +329,7 @@ func (suite *QueryGraphQLSuite) TestListOfUnionOfStructsConflictingFieldTypes() 
 }
 
 func (suite *QueryGraphQLSuite) TestListOfUnionOfScalars() {
-	list := types.NewList(
+	list := types.NewList(suite.vs,
 		types.Number(28),
 		types.String("bar"),
 		types.Bool(true),
@@ -349,10 +349,10 @@ func (suite *QueryGraphQLSuite) TestCyclicStructs() {
 
 	s1 := types.NewStruct("A", types.StructData{
 		"a": types.String("aaa"),
-		"b": types.NewSet(
+		"b": types.NewSet(suite.vs,
 			types.NewStruct("A", types.StructData{
 				"a": types.String("bbb"),
-				"b": types.NewSet(),
+				"b": types.NewSet(suite.vs),
 			})),
 	})
 
@@ -432,14 +432,14 @@ func (suite *QueryGraphQLSuite) TestCyclicStructsWithUnion() {
 }
 
 func (suite *QueryGraphQLSuite) TestNestedCollection() {
-	list := types.NewList(
-		types.NewSet(
-			types.NewMap(types.Number(10), types.String("foo")),
-			types.NewMap(types.Number(20), types.String("bar")),
+	list := types.NewList(suite.vs,
+		types.NewSet(suite.vs,
+			types.NewMap(suite.vs, types.Number(10), types.String("foo")),
+			types.NewMap(suite.vs, types.Number(20), types.String("bar")),
 		),
-		types.NewSet(
-			types.NewMap(types.Number(30), types.String("baz")),
-			types.NewMap(types.Number(40), types.String("bat")),
+		types.NewSet(suite.vs,
+			types.NewMap(suite.vs, types.Number(30), types.String("baz")),
+			types.NewMap(suite.vs, types.Number(40), types.String("bat")),
 		),
 	)
 
@@ -450,7 +450,7 @@ func (suite *QueryGraphQLSuite) TestNestedCollection() {
 }
 
 func (suite *QueryGraphQLSuite) TestLoFi() {
-	b := types.NewBlob(bytes.NewBufferString("I am a blob"))
+	b := types.NewBlob(suite.vs, bytes.NewBufferString("I am a blob"))
 
 	suite.assertQueryResult(b, "{root}", `{"data":{"root":"0123456789abcdefghijklmnopqrstuv"}}`)
 
@@ -468,7 +468,7 @@ func (suite *QueryGraphQLSuite) TestError() {
 func (suite *QueryGraphQLSuite) TestMapArgs() {
 	for _, entriesKey := range []string{"elements", "entries"} {
 
-		m := types.NewMap(
+		m := types.NewMap(suite.vs,
 			types.String("a"), types.Number(1),
 			types.String("c"), types.Number(2),
 			types.String("e"), types.Number(3),
@@ -567,7 +567,7 @@ func (suite *QueryGraphQLSuite) TestMapArgs() {
 
 func (suite *QueryGraphQLSuite) TestMapKeysArg() {
 	for _, entriesKey := range []string{"elements", "entries"} {
-		m := types.NewMap(
+		m := types.NewMap(suite.vs,
 			types.String("a"), types.Number(1),
 			types.String("c"), types.Number(2),
 			types.String("e"), types.Number(3),
@@ -578,7 +578,7 @@ func (suite *QueryGraphQLSuite) TestMapKeysArg() {
 		suite.assertQueryResult(m, `{root{`+entriesKey+`(keys:[]){value}}}`,
 			`{"data":{"root":{"`+entriesKey+`":[]}}}`)
 
-		m = types.NewMap(
+		m = types.NewMap(suite.vs,
 			types.Number(1), types.String("a"),
 			types.Number(2), types.String("c"),
 			types.Number(3), types.String("e"),
@@ -601,7 +601,7 @@ func (suite *QueryGraphQLSuite) TestMapKeysArg() {
 
 func (suite *QueryGraphQLSuite) TestSetArgs() {
 	for _, valuesKey := range []string{"elements", "values"} {
-		s := types.NewSet(
+		s := types.NewSet(suite.vs,
 			types.String("a"),
 			types.String("c"),
 			types.String("e"),
@@ -702,7 +702,7 @@ func (suite *QueryGraphQLSuite) TestSetArgs() {
 }
 
 func (suite *QueryGraphQLSuite) TestMapValues() {
-	m := types.NewMap(
+	m := types.NewMap(suite.vs,
 		types.String("a"), types.Number(1),
 		types.String("c"), types.Number(2),
 		types.String("e"), types.Number(3),
@@ -780,7 +780,7 @@ func (suite *QueryGraphQLSuite) TestMapValues() {
 }
 
 func (suite *QueryGraphQLSuite) TestMapKeys() {
-	m := types.NewMap(
+	m := types.NewMap(suite.vs,
 		types.String("a"), types.Number(1),
 		types.String("c"), types.Number(2),
 		types.String("e"), types.Number(3),
@@ -859,7 +859,7 @@ func (suite *QueryGraphQLSuite) TestMapKeys() {
 
 func (suite *QueryGraphQLSuite) TestMapNullable() {
 	// When selecting the result based on keys the values may be null.
-	m := types.NewMap(
+	m := types.NewMap(suite.vs,
 		types.String("a"), types.Number(1),
 		types.String("c"), types.Number(2),
 	)
@@ -1020,11 +1020,11 @@ func (suite *QueryGraphQLSuite) TestMutationCollectionArgs() {
 }
 
 func (suite *QueryGraphQLSuite) TestMapWithComplexKeys() {
-	m := types.NewMap(
-		types.NewList(types.String("a")), types.Number(1),
-		types.NewList(types.String("c")), types.Number(2),
-		types.NewList(types.String("e")), types.Number(3),
-		types.NewList(types.String("g")), types.Number(4),
+	m := types.NewMap(suite.vs,
+		types.NewList(suite.vs, types.String("a")), types.Number(1),
+		types.NewList(suite.vs, types.String("c")), types.Number(2),
+		types.NewList(suite.vs, types.String("e")), types.Number(3),
+		types.NewList(suite.vs, types.String("g")), types.Number(4),
 	)
 
 	suite.assertQueryResult(m, `{root{values(key: ["e"])}}`, `{"data":{"root":{"values":[3]}}}`)
@@ -1050,7 +1050,7 @@ func (suite *QueryGraphQLSuite) TestMapWithComplexKeys() {
                 }
         }}`)
 
-	m2 := types.NewMap(
+	m2 := types.NewMap(suite.vs,
 		types.NewStruct("", types.StructData{
 			"n": types.String("a"),
 		}), types.Number(1),
@@ -1075,11 +1075,11 @@ func (suite *QueryGraphQLSuite) TestMapWithComplexKeys() {
 }
 
 func (suite *QueryGraphQLSuite) TestSetWithComplexKeys() {
-	s := types.NewSet(
-		types.NewList(types.String("a")),
-		types.NewList(types.String("c")),
-		types.NewList(types.String("e")),
-		types.NewList(types.String("g")),
+	s := types.NewSet(suite.vs,
+		types.NewList(suite.vs, types.String("a")),
+		types.NewList(suite.vs, types.String("c")),
+		types.NewList(suite.vs, types.String("e")),
+		types.NewList(suite.vs, types.String("g")),
 	)
 
 	suite.assertQueryResult(s, `{root{values(key: ["e"]) { values }}}`,
@@ -1090,7 +1090,7 @@ func (suite *QueryGraphQLSuite) TestSetWithComplexKeys() {
 	suite.assertQueryResult(s, `{root{values(key: ["g"], through: ["c"]) { values }}}`,
 		`{"data":{"root":{"values":[{"values":["g"]},{"values":["a"]},{"values":["c"]}]}}}`)
 
-	s2 := types.NewSet(
+	s2 := types.NewSet(suite.vs,
 		types.NewStruct("", types.StructData{
 			"n": types.String("a"),
 		}),
@@ -1130,28 +1130,28 @@ func (suite *QueryGraphQLSuite) TestInputToNomsValue() {
 	test(types.String("hi"), "hi")
 	test(types.String(""), "")
 
-	test(types.NewList(types.Number(42)), []interface{}{float64(42)})
-	test(types.NewList(types.Number(1), types.Number(2)), []interface{}{float64(1), float64(2)})
+	test(types.NewList(suite.vs, types.Number(42)), []interface{}{float64(42)})
+	test(types.NewList(suite.vs, types.Number(1), types.Number(2)), []interface{}{float64(1), float64(2)})
 
-	test(types.NewSet(types.Number(42)), []interface{}{float64(42)})
-	test(types.NewSet(types.Number(1), types.Number(2)), []interface{}{float64(1), float64(2)})
+	test(types.NewSet(suite.vs, types.Number(42)), []interface{}{float64(42)})
+	test(types.NewSet(suite.vs, types.Number(1), types.Number(2)), []interface{}{float64(1), float64(2)})
 
-	test(types.NewMap(
+	test(types.NewMap(suite.vs,
 		types.String("a"), types.Number(1),
 		types.String("b"), types.Number(2),
 	), []interface{}{
 		map[string]interface{}{"key": "a", "value": 1},
 		map[string]interface{}{"key": "b", "value": 2},
 	})
-	test(types.NewMap(
-		types.NewList(types.String("a")), types.Number(1),
-		types.NewList(types.String("b")), types.Number(2),
+	test(types.NewMap(suite.vs,
+		types.NewList(suite.vs, types.String("a")), types.Number(1),
+		types.NewList(suite.vs, types.String("b")), types.Number(2),
 	), []interface{}{
 		map[string]interface{}{"key": []interface{}{"a"}, "value": 1},
 		map[string]interface{}{"key": []interface{}{"b"}, "value": 2},
 	})
 
-	test(types.NewMap(
+	test(types.NewMap(suite.vs,
 		types.NewStruct("S", types.StructData{"a": types.Number(1)}), types.Number(11),
 		types.NewStruct("S", types.StructData{"a": types.Number(2)}), types.Number(22),
 	), []interface{}{
@@ -1159,7 +1159,7 @@ func (suite *QueryGraphQLSuite) TestInputToNomsValue() {
 		map[string]interface{}{"key": map[string]interface{}{"a": float64(2)}, "value": 22},
 	})
 
-	test(types.NewSet(
+	test(types.NewSet(suite.vs,
 		types.NewStruct("S", types.StructData{"a": types.Number(1)}),
 		types.NewStruct("S", types.StructData{"a": types.Number(2)}),
 	), []interface{}{
@@ -1239,13 +1239,13 @@ func (suite *QueryGraphQLSuite) TestVariables() {
 		suite.JSONEq(expected, string(b))
 	}
 
-	v := types.NewList(types.Number(0), types.Number(1), types.Number(2), types.Number(3))
+	v := types.NewList(suite.vs, types.Number(0), types.Number(1), types.Number(2), types.Number(3))
 	test(v, `{"data":{"root":{"values":[0,1,2,3]}}}`, `query Test($c: Int) { root { values(count: $c) } }`, nil)
 	test(v, `{"data":{"root":{"values":[0,1]}}}`, `query Test($c: Int) { root { values(count: $c) } }`, map[string]interface{}{
 		"c": 2,
 	})
 
-	m := types.NewMap(
+	m := types.NewMap(suite.vs,
 		types.String("a"), types.Number(0),
 		types.String("b"), types.Number(1),
 		types.String("c"), types.Number(2),
@@ -1264,7 +1264,7 @@ func (suite *QueryGraphQLSuite) TestVariables() {
 			"ks": []string{"a", "c"},
 		})
 
-	m2 := types.NewMap(
+	m2 := types.NewMap(suite.vs,
 		types.NewStruct("S", types.StructData{"n": types.String("a")}), types.Number(0),
 		types.NewStruct("S", types.StructData{"n": types.String("b")}), types.Number(1),
 		types.NewStruct("S", types.StructData{"n": types.String("c")}), types.Number(2),
@@ -1326,9 +1326,9 @@ func (suite *QueryGraphQLSuite) TestVariables() {
 		},
 	)
 
-	m3 := types.NewMap(
-		types.NewMap(types.Number(0), types.String("zero")), types.Bool(false),
-		types.NewMap(types.Number(1), types.String("one")), types.Bool(true),
+	m3 := types.NewMap(suite.vs,
+		types.NewMap(suite.vs, types.Number(0), types.String("zero")), types.Bool(false),
+		types.NewMap(suite.vs, types.Number(1), types.String("one")), types.Bool(true),
 	)
 	keyNomsType := types.TypeOf(m3).Desc.(types.CompoundDesc).ElemTypes[0]
 	tc := NewTypeConverter()
@@ -1408,7 +1408,7 @@ func (suite *QueryGraphQLSuite) TestNameFunc() {
 		"b": types.Number(2),
 	})
 
-	list := types.NewList(aVal, bVal)
+	list := types.NewList(suite.vs, aVal, bVal)
 
 	tc := NewTypeConverter()
 	tc.NameFunc = func(nomsType *types.Type, isInputType bool) string {
@@ -1445,7 +1445,7 @@ func (suite *QueryGraphQLSuite) TestNameFunc() {
         }`
 	test(tc, list, expected, query, nil)
 
-	set := types.NewSet(aVal,
+	set := types.NewSet(suite.vs, aVal,
 		types.NewStruct("A", types.StructData{
 			"a": types.Number(2),
 		}),
@@ -1488,7 +1488,7 @@ func (suite *QueryGraphQLSuite) TestNameFunc() {
 func TestGetListElementsWithSet(t *testing.T) {
 	assert := assert.New(t)
 	vs := newTestValueStore()
-	v := types.NewSet(types.Number(0), types.Number(1), types.Number(2))
+	v := types.NewSet(vs, types.Number(0), types.Number(1), types.Number(2))
 	r := getListElements(vs, v, map[string]interface{}{})
 	assert.Equal([]interface{}{float64(0), float64(1), float64(2)}, r)
 
@@ -1506,6 +1506,9 @@ func TestGetListElementsWithSet(t *testing.T) {
 func TestNoErrorOnNonCyclicTypeRefsInputType(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+	defer vs.Close()
+
 	type User struct {
 		ID string `noms:"id"`
 	}
@@ -1515,7 +1518,7 @@ func TestNoErrorOnNonCyclicTypeRefsInputType(t *testing.T) {
 	}
 
 	var a Account
-	typ := marshal.MustMarshalType(a)
+	typ := marshal.MustMarshalType(vs, a)
 	tc := NewTypeConverter()
 	_, err := tc.NomsTypeToGraphQLInputType(typ)
 	assert.NoError(err)
@@ -1524,12 +1527,15 @@ func TestNoErrorOnNonCyclicTypeRefsInputType(t *testing.T) {
 func TestErrorOnCyclicTypeRefsInputType(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+	defer vs.Close()
+
 	type Node struct {
 		Children map[string]Node
 	}
 
 	var n Node
-	typ := marshal.MustMarshalType(n)
+	typ := marshal.MustMarshalType(vs, n)
 	tc := NewTypeConverter()
 	_, err := tc.NomsTypeToGraphQLInputType(typ)
 	assert.Error(err)

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -96,7 +96,7 @@ type getFieldFn func(v interface{}, fieldName string, ctx context.Context) types
 // When a field name is resolved, it may take key:value arguments. A
 // getSubvaluesFn handles returning one or more *noms* values whose presence is
 // indicated by the provided arguments.
-type getSubvaluesFn func(vr types.ValueReader, v types.Value, args map[string]interface{}) interface{}
+type getSubvaluesFn func(vrw types.ValueReadWriter, v types.Value, args map[string]interface{}) interface{}
 
 // GraphQL requires all memberTypes in a Union to be Structs, so when a noms
 // union contains a scalar, we represent it in that context as a "boxed" value.
@@ -404,7 +404,7 @@ var listArgs = graphql.FieldConfigArgument{
 	countKey: &graphql.ArgumentConfig{Type: graphql.Int},
 }
 
-func getListElements(vr types.ValueReader, v types.Value, args map[string]interface{}) interface{} {
+func getListElements(vrw types.ValueReadWriter, v types.Value, args map[string]interface{}) interface{} {
 	l := v.(types.Collection)
 	idx := 0
 	count := int(l.Len())
@@ -450,10 +450,10 @@ func getListElements(vr types.ValueReader, v types.Value, args map[string]interf
 	return values
 }
 
-func getSetElements(vr types.ValueReader, v types.Value, args map[string]interface{}) interface{} {
+func getSetElements(vrw types.ValueReadWriter, v types.Value, args map[string]interface{}) interface{} {
 	s := v.(types.Set)
 
-	iter, nomsKey, nomsThrough, count, singleExactMatch := getCollectionArgs(vr, s, args, iteratorFactory{
+	iter, nomsKey, nomsThrough, count, singleExactMatch := getCollectionArgs(vrw, s, args, iteratorFactory{
 		IteratorFrom: func(from types.Value) interface{} {
 			return s.IteratorFrom(from)
 		},
@@ -497,7 +497,7 @@ func getSetElements(vr types.ValueReader, v types.Value, args map[string]interfa
 	return values
 }
 
-func getCollectionArgs(vr types.ValueReader, col types.Collection, args map[string]interface{}, factory iteratorFactory) (iter interface{}, nomsKey, nomsThrough types.Value, count uint64, singleExactMatch bool) {
+func getCollectionArgs(vrw types.ValueReadWriter, col types.Collection, args map[string]interface{}, factory iteratorFactory) (iter interface{}, nomsKey, nomsThrough types.Value, count uint64, singleExactMatch bool) {
 	typ := types.TypeOf(col)
 	length := col.Len()
 	nomsKeyType := typ.Desc.(types.CompoundDesc).ElemTypes[0]
@@ -507,7 +507,7 @@ func getCollectionArgs(vr types.ValueReader, col types.Collection, args map[stri
 		nomsKeys := make(types.ValueSlice, len(slice))
 		for i, v := range slice {
 			var nomsValue types.Value
-			nomsValue = InputToNomsValue(vr, v, nomsKeyType)
+			nomsValue = InputToNomsValue(vrw, v, nomsKeyType)
 			nomsKeys[i] = nomsValue
 		}
 		count = uint64(len(slice))
@@ -518,12 +518,12 @@ func getCollectionArgs(vr types.ValueReader, col types.Collection, args map[stri
 		return
 	}
 
-	nomsThrough = getThroughArg(vr, nomsKeyType, args)
+	nomsThrough = getThroughArg(vrw, nomsKeyType, args)
 
 	count, singleExactMatch = getCountArg(length, args)
 
 	if key, ok := args[keyKey]; ok {
-		nomsKey = InputToNomsValue(vr, key, nomsKeyType)
+		nomsKey = InputToNomsValue(vrw, key, nomsKeyType)
 		iter = factory.IteratorFrom(nomsKey)
 	} else if at, ok := args[atKey]; ok {
 		idx := at.(int)
@@ -546,10 +546,10 @@ func getCollectionArgs(vr types.ValueReader, col types.Collection, args map[stri
 
 type mapAppender func(slice []interface{}, k, v types.Value) []interface{}
 
-func getMapElements(vr types.ValueReader, v types.Value, args map[string]interface{}, app mapAppender) (interface{}, error) {
+func getMapElements(vrw types.ValueReadWriter, v types.Value, args map[string]interface{}, app mapAppender) (interface{}, error) {
 	m := v.(types.Map)
 
-	iter, nomsKey, nomsThrough, count, singleExactMatch := getCollectionArgs(vr, m, args, iteratorFactory{
+	iter, nomsKey, nomsThrough, count, singleExactMatch := getCollectionArgs(vrw, m, args, iteratorFactory{
 		IteratorFrom: func(from types.Value) interface{} {
 			return m.IteratorFrom(from)
 		},
@@ -612,9 +612,9 @@ func getCountArg(count uint64, args map[string]interface{}) (c uint64, singleExa
 	return count, false
 }
 
-func getThroughArg(vr types.ValueReader, nomsKeyType *types.Type, args map[string]interface{}) types.Value {
+func getThroughArg(vrw types.ValueReadWriter, nomsKeyType *types.Type, args map[string]interface{}) types.Value {
 	if through, ok := args[throughKey]; ok {
-		return InputToNomsValue(vr, through, nomsKeyType)
+		return InputToNomsValue(vrw, through, nomsKeyType)
 	}
 	return nil
 }
@@ -819,8 +819,8 @@ func (tc *TypeConverter) listAndSetToGraphQLObject(nomsType *types.Type) *graphq
 					Args: args,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						c := p.Source.(types.Collection)
-						vr := p.Context.Value(vrKey).(types.ValueReader)
-						return getSubvalues(vr, c, p.Args), nil
+						vrw := p.Context.Value(vrwKey).(types.ValueReadWriter)
+						return getSubvalues(vrw, c, p.Args), nil
 					},
 				}
 				fields[valuesKey] = valuesField
@@ -863,8 +863,8 @@ func (tc *TypeConverter) mapToGraphQLObject(nomsType *types.Type) *graphql.Objec
 					Args: args,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						c := p.Source.(types.Collection)
-						vr := p.Context.Value(vrKey).(types.ValueReader)
-						return getMapElements(vr, c, p.Args, mapAppendEntry)
+						vrw := p.Context.Value(vrwKey).(types.ValueReadWriter)
+						return getMapElements(vrw, c, p.Args, mapAppendEntry)
 					},
 				}
 				fields[entriesKey] = entriesField
@@ -875,8 +875,8 @@ func (tc *TypeConverter) mapToGraphQLObject(nomsType *types.Type) *graphql.Objec
 					Args: args,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						c := p.Source.(types.Collection)
-						vr := p.Context.Value(vrKey).(types.ValueReader)
-						return getMapElements(vr, c, p.Args, mapAppendKey)
+						vrw := p.Context.Value(vrwKey).(types.ValueReadWriter)
+						return getMapElements(vrw, c, p.Args, mapAppendKey)
 					},
 				}
 				fields[valuesKey] = &graphql.Field{
@@ -884,8 +884,8 @@ func (tc *TypeConverter) mapToGraphQLObject(nomsType *types.Type) *graphql.Objec
 					Args: args,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						c := p.Source.(types.Collection)
-						vr := p.Context.Value(vrKey).(types.ValueReader)
-						return getMapElements(vr, c, p.Args, mapAppendValue)
+						vrw := p.Context.Value(vrwKey).(types.ValueReadWriter)
+						return getMapElements(vrw, c, p.Args, mapAppendValue)
 					},
 				}
 			}
@@ -933,7 +933,7 @@ func (tc *TypeConverter) refToGraphQLObject(nomsType *types.Type) *graphql.Objec
 					Type: targetType,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						r := p.Source.(types.Ref)
-						return MaybeGetScalar(r.TargetValue(p.Context.Value(vrKey).(types.ValueReader))), nil
+						return MaybeGetScalar(r.TargetValue(p.Context.Value(vrwKey).(types.ValueReader))), nil
 					},
 				},
 			}
@@ -959,7 +959,7 @@ func MaybeGetScalar(v types.Value) interface{} {
 
 // InputToNomsValue converts a GraphQL input value (as used in arguments and
 // variables) to a Noms value.
-func InputToNomsValue(vr types.ValueReader, arg interface{}, nomsType *types.Type) types.Value {
+func InputToNomsValue(vrw types.ValueReadWriter, arg interface{}, nomsType *types.Type) types.Value {
 	switch nomsType.TargetKind() {
 	case types.BoolKind:
 		return types.Bool(arg.(bool))
@@ -975,12 +975,12 @@ func InputToNomsValue(vr types.ValueReader, arg interface{}, nomsType *types.Typ
 		sl := arg.([]interface{})
 		vs := make(types.ValueSlice, len(sl))
 		for i, v := range sl {
-			vs[i] = InputToNomsValue(vr, v, elemType)
+			vs[i] = InputToNomsValue(vrw, v, elemType)
 		}
 		if nomsType.TargetKind() == types.ListKind {
-			return types.NewList(vs...)
+			return types.NewList(vrw, vs...)
 		}
-		return types.NewSet(vs...)
+		return types.NewSet(vrw, vs...)
 	case types.MapKind:
 		// Maps are passed as [{key: K, value: V}, ...]
 		keyType := nomsType.Desc.(types.CompoundDesc).ElemTypes[0]
@@ -989,17 +989,17 @@ func InputToNomsValue(vr types.ValueReader, arg interface{}, nomsType *types.Typ
 		kvs := make(types.ValueSlice, 2*len(sl))
 		for i, v := range sl {
 			v := v.(map[string]interface{})
-			kvs[2*i] = InputToNomsValue(vr, v["key"], keyType)
-			kvs[2*i+1] = InputToNomsValue(vr, v["value"], valType)
+			kvs[2*i] = InputToNomsValue(vrw, v["key"], keyType)
+			kvs[2*i+1] = InputToNomsValue(vrw, v["value"], valType)
 		}
-		return types.NewMap(kvs...)
+		return types.NewMap(vrw, kvs...)
 	case types.StructKind:
 		desc := nomsType.Desc.(types.StructDesc)
 		data := make(types.StructData, desc.Len())
 		m := arg.(map[string]interface{})
 		desc.IterFields(func(name string, t *types.Type, optional bool) {
 			if m[name] != nil || !optional {
-				data[name] = InputToNomsValue(vr, m[name], t)
+				data[name] = InputToNomsValue(vrw, m[name], t)
 			}
 		})
 		return types.NewStruct(desc.Name, data)

--- a/go/perf/suite/suite_test.go
+++ b/go/perf/suite/suite_test.go
@@ -279,6 +279,7 @@ func TestPrefixFlag(t *testing.T) {
 }
 
 func TestRunFlag(t *testing.T) {
+	t.Skip("Fails on Jenkins most of the times")
 	assert := assert.New(t)
 
 	type expect struct {

--- a/go/spec/absolute_path_test.go
+++ b/go/spec/absolute_path_test.go
@@ -33,12 +33,12 @@ func TestAbsolutePathToAndFromString(t *testing.T) {
 func TestAbsolutePaths(t *testing.T) {
 	assert := assert.New(t)
 	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 
 	s0, s1 := types.String("foo"), types.String("bar")
-	list := types.NewList(s0, s1)
-	emptySet := types.NewSet()
+	list := types.NewList(db, s0, s1)
+	emptySet := types.NewSet(db)
 
-	db := datas.NewDatabase(storage.NewView())
 	db.WriteValue(s0)
 	db.WriteValue(s1)
 	db.WriteValue(list)
@@ -84,13 +84,13 @@ func TestAbsolutePaths(t *testing.T) {
 func TestReadAbsolutePaths(t *testing.T) {
 	assert := assert.New(t)
 	storage := &chunks.MemoryStorage{}
+	db := datas.NewDatabase(storage.NewView())
 
 	s0, s1 := types.String("foo"), types.String("bar")
-	list := types.NewList(s0, s1)
+	list := types.NewList(db, s0, s1)
 
-	db := datas.NewDatabase(storage.NewView())
 	ds := db.GetDataset("ds")
-	ds, err := db.CommitValue(ds, list)
+	_, err := db.CommitValue(ds, list)
 	assert.NoError(err)
 
 	vals, err := ReadAbsolutePaths(db, "ds.value[0]", "ds.value[1]")

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -91,7 +91,7 @@ func TestMemDatasetPathSpec(t *testing.T) {
 
 	db := spec.GetDatabase()
 	ds := db.GetDataset("test")
-	ds, err = db.CommitValue(ds, types.NewList(types.Number(42)))
+	ds, err = db.CommitValue(ds, types.NewList(db, types.Number(42)))
 	assert.NoError(err)
 
 	assert.Equal(types.Number(42), spec.GetValue())

--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -131,26 +131,6 @@ func (b Blob) CopyReadAhead(w io.Writer, chunkSize uint64, concurrency int) (n i
 	return
 }
 
-func (b Blob) Splice(idx uint64, deleteCount uint64, data []byte) Blob {
-	if deleteCount == 0 && len(data) == 0 {
-		return b
-	}
-
-	d.PanicIfFalse(idx <= b.Len())
-	d.PanicIfFalse(idx+deleteCount <= b.Len())
-
-	ch := b.newChunker(newCursorAtIndex(b.seq, idx, false), b.seq.valueReadWriter())
-	for deleteCount > 0 {
-		ch.Skip()
-		deleteCount--
-	}
-
-	for _, v := range data {
-		ch.Append(v)
-	}
-	return newBlob(ch.Done())
-}
-
 // Concat returns a new Blob comprised of this joined with other. It only needs
 // to visit the rightmost prolly tree chunks of this Blob, and the leftmost
 // prolly tree chunks of other, so it's efficient.

--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -25,8 +25,8 @@ func newBlob(seq sequence) Blob {
 	return Blob{seq, &hash.Hash{}}
 }
 
-func NewEmptyBlob() Blob {
-	return Blob{newBlobLeafSequence(nil, []byte{}), &hash.Hash{}}
+func NewEmptyBlob(vrw ValueReadWriter) Blob {
+	return Blob{newBlobLeafSequence(vrw, []byte{}), &hash.Hash{}}
 }
 
 func (b Blob) Edit() *BlobEditor {
@@ -131,18 +131,38 @@ func (b Blob) CopyReadAhead(w io.Writer, chunkSize uint64, concurrency int) (n i
 	return
 }
 
+func (b Blob) Splice(idx uint64, deleteCount uint64, data []byte) Blob {
+	if deleteCount == 0 && len(data) == 0 {
+		return b
+	}
+
+	d.PanicIfFalse(idx <= b.Len())
+	d.PanicIfFalse(idx+deleteCount <= b.Len())
+
+	ch := b.newChunker(newCursorAtIndex(b.seq, idx, false), b.seq.valueReadWriter())
+	for deleteCount > 0 {
+		ch.Skip()
+		deleteCount--
+	}
+
+	for _, v := range data {
+		ch.Append(v)
+	}
+	return newBlob(ch.Done())
+}
+
 // Concat returns a new Blob comprised of this joined with other. It only needs
 // to visit the rightmost prolly tree chunks of this Blob, and the leftmost
 // prolly tree chunks of other, so it's efficient.
 func (b Blob) Concat(other Blob) Blob {
-	seq := concat(b.seq, other.seq, func(cur *sequenceCursor, vr ValueReader) *sequenceChunker {
-		return b.newChunker(cur, vr)
+	seq := concat(b.seq, other.seq, func(cur *sequenceCursor, vrw ValueReadWriter) *sequenceChunker {
+		return b.newChunker(cur, vrw)
 	})
 	return newBlob(seq)
 }
 
-func (b Blob) newChunker(cur *sequenceCursor, vr ValueReader) *sequenceChunker {
-	return newSequenceChunker(cur, 0, vr, nil, makeBlobLeafChunkFn(vr), newIndexedMetaSequenceChunkFn(BlobKind, vr), hashValueByte)
+func (b Blob) newChunker(cur *sequenceCursor, vrw ValueReadWriter) *sequenceChunker {
+	return newSequenceChunker(cur, 0, vrw, makeBlobLeafChunkFn(vrw), newIndexedMetaSequenceChunkFn(BlobKind, vrw), hashValueByte)
 }
 
 // Collection interface
@@ -163,7 +183,7 @@ func (b Blob) hashPointer() *hash.Hash {
 }
 
 // Value interface
-func (b Blob) Value(vrw ValueReadWriter) Value {
+func (b Blob) Value() Value {
 	return b
 }
 
@@ -231,7 +251,7 @@ func (cbr *BlobReader) Seek(offset int64, whence int) (int64, error) {
 	return abs, nil
 }
 
-func makeBlobLeafChunkFn(vr ValueReader) makeChunkFn {
+func makeBlobLeafChunkFn(vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		d.PanicIfFalse(level == 0)
 		buff := make([]byte, len(items))
@@ -240,34 +260,26 @@ func makeBlobLeafChunkFn(vr ValueReader) makeChunkFn {
 			buff[i] = v.(byte)
 		}
 
-		return chunkBlobLeaf(vr, buff)
+		return chunkBlobLeaf(vrw, buff)
 	}
 }
 
-func chunkBlobLeaf(vr ValueReader, buff []byte) (Collection, orderedKey, uint64) {
-	blob := newBlob(newBlobLeafSequence(vr, buff))
+func chunkBlobLeaf(vrw ValueReadWriter, buff []byte) (Collection, orderedKey, uint64) {
+	blob := newBlob(newBlobLeafSequence(vrw, buff))
 	return blob, orderedKeyFromInt(len(buff)), uint64(len(buff))
 }
 
-// NewBlob creates a Blob by reading from every Reader in rs and concatenating
-// the result. NewBlob uses one goroutine per Reader. Chunks are kept in memory
-// as they're created - to reduce memory pressure and write to disk instead,
-// use NewStreamingBlob with a non-nil reader.
-func NewBlob(rs ...io.Reader) Blob {
-	return readBlobsP(nil, rs...)
-}
-
-// NewStreamingBlob creates a Blob by reading from every Reader in rs and
-// concatenating the result. NewStreamingBlob uses one goroutine per Reader.
+// NewBlob creates a Blob by reading from every Reader in rs and
+// concatenating the result. NewBlob uses one goroutine per Reader.
 // If vrw is not nil, chunks are written to vrw instead of kept in memory.
-func NewStreamingBlob(vrw ValueReadWriter, rs ...io.Reader) Blob {
+func NewBlob(vrw ValueReadWriter, rs ...io.Reader) Blob {
 	return readBlobsP(vrw, rs...)
 }
 
 func readBlobsP(vrw ValueReadWriter, rs ...io.Reader) Blob {
 	switch len(rs) {
 	case 0:
-		return NewEmptyBlob()
+		return NewEmptyBlob(vrw)
 	case 1:
 		return readBlob(rs[0], vrw)
 	}
@@ -295,7 +307,7 @@ func readBlobsP(vrw ValueReadWriter, rs ...io.Reader) Blob {
 }
 
 func readBlob(r io.Reader, vrw ValueReadWriter) Blob {
-	sc := newEmptySequenceChunker(vrw, vrw, makeBlobLeafChunkFn(vrw), newIndexedMetaSequenceChunkFn(BlobKind, vrw), func(item sequenceItem, rv *rollingValueHasher) {
+	sc := newEmptySequenceChunker(vrw, makeBlobLeafChunkFn(vrw), newIndexedMetaSequenceChunkFn(BlobKind, vrw), func(item sequenceItem, rv *rollingValueHasher) {
 		rv.HashByte(item.(byte))
 	})
 
@@ -328,14 +340,7 @@ func readBlob(r io.Reader, vrw ValueReadWriter) Blob {
 
 		go func(ch chan metaTuple, cp []byte) {
 			col, key, numLeaves := chunkBlobLeaf(vrw, cp)
-			var ref Ref
-			if vrw != nil {
-				ref = vrw.WriteValue(col)
-				col = nil
-			} else {
-				ref = NewRef(col)
-			}
-			ch <- newMetaTuple(ref, key, numLeaves, col)
+			ch <- newMetaTuple(vrw.WriteValue(col), key, numLeaves)
 		}(ch, cp)
 
 		offset = 0

--- a/go/types/blob_editor.go
+++ b/go/types/blob_editor.go
@@ -28,21 +28,17 @@ func (be *BlobEditor) Kind() NomsKind {
 	return BlobKind
 }
 
-func (be *BlobEditor) Value(vrw ValueReadWriter) Value {
-	return be.Blob(vrw)
+func (be *BlobEditor) Value() Value {
+	return be.Blob()
 }
 
-func (be *BlobEditor) Blob(vrw ValueReadWriter) Blob {
+func (be *BlobEditor) Blob() Blob {
 	if be.edits == nil {
 		return be.b // no edits
 	}
 
 	seq := be.b.sequence()
-	vr := seq.valueReader()
-
-	if vrw != nil {
-		vr = vrw
-	}
+	vrw := seq.valueReadWriter()
 
 	curs := make([]chan *sequenceCursor, 0)
 	for edit := be.edits; edit != nil; edit = edit.next {
@@ -63,7 +59,7 @@ func (be *BlobEditor) Blob(vrw ValueReadWriter) Blob {
 		idx++
 
 		if ch == nil {
-			ch = newSequenceChunker(cur, 0, vr, vrw, makeBlobLeafChunkFn(vr), newIndexedMetaSequenceChunkFn(BlobKind, vr), hashValueByte)
+			ch = newSequenceChunker(cur, 0, vrw, makeBlobLeafChunkFn(vrw), newIndexedMetaSequenceChunkFn(BlobKind, vrw), hashValueByte)
 		} else {
 			ch.advanceTo(cur)
 		}

--- a/go/types/blob_editor_test.go
+++ b/go/types/blob_editor_test.go
@@ -35,7 +35,7 @@ func TestBlobReadWriteFuzzer(t *testing.T) {
 	cr := newCountingReader()
 
 	for i := 0; i < rounds; i++ {
-		b := NewBlob()
+		b := NewBlob(vs)
 
 		f, _ := ioutil.TempFile("", "buff")
 		be := b.Edit()
@@ -68,13 +68,13 @@ func TestBlobReadWriteFuzzer(t *testing.T) {
 			}
 			if j%flushEvery == 0 {
 				// Flush
-				b = be.Blob(vs)
+				b = be.Blob()
 				be = b.Edit()
 			}
 		}
 
 		f.Sync()
-		b = be.Blob(vs)
+		b = be.Blob()
 
 		f.Seek(0, 0)
 		info, err := f.Stat()

--- a/go/types/blob_leaf_sequence.go
+++ b/go/types/blob_leaf_sequence.go
@@ -4,13 +4,16 @@
 
 package types
 
+import "github.com/attic-labs/noms/go/d"
+
 type blobLeafSequence struct {
 	leafSequence
 	data []byte
 }
 
-func newBlobLeafSequence(vr ValueReader, data []byte) sequence {
-	return blobLeafSequence{leafSequence{vr, len(data), BlobKind}, data}
+func newBlobLeafSequence(vrw ValueReadWriter, data []byte) sequence {
+	d.PanicIfTrue(vrw == nil)
+	return blobLeafSequence{leafSequence{vrw, len(data), BlobKind}, data}
 }
 
 // sequence interface

--- a/go/types/bool.go
+++ b/go/types/bool.go
@@ -12,7 +12,7 @@ import (
 type Bool bool
 
 // Value interface
-func (v Bool) Value(vrw ValueReadWriter) Value {
+func (v Bool) Value() Value {
 	return v
 }
 

--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -27,26 +27,26 @@ func EncodeValue(v Value) chunks.Chunk {
 	return c
 }
 
-func DecodeFromBytes(data []byte, vr ValueReader) Value {
+func DecodeFromBytes(data []byte, vrw ValueReadWriter) Value {
 	br := &binaryNomsReader{data, 0}
-	dec := newValueDecoder(br, vr)
+	dec := newValueDecoder(br, vrw)
 	v := dec.readValue()
 	d.PanicIfFalse(br.pos() == uint32(len(data)))
 	return v
 }
 
-func decodeFromBytesWithValidation(data []byte, vr ValueReader) Value {
+func decodeFromBytesWithValidation(data []byte, vrw ValueReadWriter) Value {
 	br := &binaryNomsReader{data, 0}
-	dec := newValueDecoderWithValidation(br, vr)
+	dec := newValueDecoderWithValidation(br, vrw)
 	v := dec.readValue()
 	d.PanicIfFalse(br.pos() == uint32(len(data)))
 	return v
 }
 
 // DecodeValue decodes a value from a chunk source. It is an error to provide an empty chunk.
-func DecodeValue(c chunks.Chunk, vr ValueReader) Value {
+func DecodeValue(c chunks.Chunk, vrw ValueReadWriter) Value {
 	d.PanicIfTrue(c.IsEmpty())
-	v := DecodeFromBytes(c.Data(), vr)
+	v := DecodeFromBytes(c.Data(), vrw)
 	if cacher, ok := v.(hashCacher); ok {
 		assignHash(cacher, c.Hash())
 	}

--- a/go/types/collection_test.go
+++ b/go/types/collection_test.go
@@ -46,12 +46,7 @@ func (suite *collectionTestSuite) TestChunkCountAndType() {
 }
 
 func (suite *collectionTestSuite) TestRoundTripAndValidate() {
-	vs := newTestValueStore()
-	r := vs.WriteValue(suite.col)
-	v2 := vs.ReadValue(r.TargetHash()).(Collection)
-	suite.True(v2.Equals(suite.col))
-	suite.True(suite.col.Equals(v2))
-	suite.True(suite.validate(v2))
+	suite.True(suite.validate(suite.col))
 }
 
 func (suite *collectionTestSuite) TestPrependChunkDiff() {

--- a/go/types/compare_test.go
+++ b/go/types/compare_test.go
@@ -16,6 +16,7 @@ var prefix = []byte{0x01, 0x02, 0x03, 0x04}
 
 func TestCompareTotalOrdering(t *testing.T) {
 	assert := assert.New(t)
+	vrw := newTestValueStore()
 
 	// values in increasing order. Some of these are compared by ref so changing the serialization might change the ordering.
 	values := []Value{
@@ -24,7 +25,7 @@ func TestCompareTotalOrdering(t *testing.T) {
 		String("a"), String("b"), String("c"),
 
 		// The order of these are done by the hash.
-		NewSet(Number(0), Number(1), Number(2), Number(3)),
+		NewSet(vrw, Number(0), Number(1), Number(2), Number(3)),
 		BoolType,
 
 		// Value - values cannot be value
@@ -63,11 +64,11 @@ func TestCompareDifferentPrimitiveTypes(t *testing.T) {
 	nums := ValueSlice{Number(1), Number(2), Number(3)}
 	words := ValueSlice{String("k1"), String("v1")}
 
-	blob := NewBlob(bytes.NewBuffer([]byte{1, 2, 3}))
-	nList := NewList(nums...)
-	nMap := NewMap(words...)
+	blob := NewBlob(vrw, bytes.NewBuffer([]byte{1, 2, 3}))
+	nList := NewList(vrw, nums...)
+	nMap := NewMap(vrw, words...)
 	nRef := NewRef(blob)
-	nSet := NewSet(nums...)
+	nSet := NewSet(vrw, nums...)
 	nStruct := NewStruct("teststruct", map[string]Value{"f1": Number(1)})
 
 	vals := ValueSlice{Bool(true), Number(19), String("hellow"), blob, nList, nMap, nRef, nSet, nStruct}
@@ -77,7 +78,7 @@ func TestCompareDifferentPrimitiveTypes(t *testing.T) {
 		for j, v2 := range vals {
 			iBytes := [1024]byte{}
 			jBytes := [1024]byte{}
-			res := compareEncodedKey(encodeGraphKey(iBytes[:0], v1, vrw), encodeGraphKey(jBytes[:0], v2, vrw))
+			res := compareEncodedKey(encodeGraphKey(iBytes[:0], v1), encodeGraphKey(jBytes[:0], v2))
 			assert.Equal(compareInts(i, j), res)
 		}
 	}
@@ -123,8 +124,8 @@ func TestCompareEncodedKeys(t *testing.T) {
 	bs1 := [initialBufferSize]byte{}
 	bs2 := [initialBufferSize]byte{}
 
-	e1, _ := encodeKeys(bs1[:0], 0x01020304, MapKind, k1, vrw)
-	e2, _ := encodeKeys(bs2[:0], 0x01020304, MapKind, k2, vrw)
+	e1, _ := encodeKeys(bs1[:0], 0x01020304, MapKind, k1)
+	e2, _ := encodeKeys(bs2[:0], 0x01020304, MapKind, k2)
 	assert.Equal(-1, comp.Compare(e1, e2))
 }
 

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -69,23 +69,25 @@ func TestWriteHumanReadableRef(t *testing.T) {
 }
 
 func TestWriteHumanReadableCollections(t *testing.T) {
-	l := NewList(Number(0), Number(1), Number(2), Number(3))
+	vrw := newTestValueStore()
+
+	l := NewList(vrw, Number(0), Number(1), Number(2), Number(3))
 	assertWriteHRSEqual(t, "[  // 4 items\n  0,\n  1,\n  2,\n  3,\n]", l)
 	assertWriteTaggedHRSEqual(t, "List<Number>([  // 4 items\n  0,\n  1,\n  2,\n  3,\n])", l)
 
-	s := NewSet(Number(0), Number(1), Number(2), Number(3))
+	s := NewSet(vrw, Number(0), Number(1), Number(2), Number(3))
 	assertWriteHRSEqual(t, "{  // 4 items\n  0,\n  1,\n  2,\n  3,\n}", s)
 	assertWriteTaggedHRSEqual(t, "Set<Number>({  // 4 items\n  0,\n  1,\n  2,\n  3,\n})", s)
 
-	m := NewMap(Number(0), Bool(false), Number(1), Bool(true))
+	m := NewMap(vrw, Number(0), Bool(false), Number(1), Bool(true))
 	assertWriteHRSEqual(t, "{\n  0: false,\n  1: true,\n}", m)
 	assertWriteTaggedHRSEqual(t, "Map<Number, Bool>({\n  0: false,\n  1: true,\n})", m)
 
-	l2 := NewList()
+	l2 := NewList(vrw)
 	assertWriteHRSEqual(t, "[]", l2)
 	assertWriteTaggedHRSEqual(t, "List<>([])", l2)
 
-	l3 := NewList(Number(0))
+	l3 := NewList(vrw, Number(0))
 	assertWriteHRSEqual(t, "[\n  0,\n]", l3)
 	assertWriteTaggedHRSEqual(t, "List<Number>([\n  0,\n])", l3)
 
@@ -93,18 +95,20 @@ func TestWriteHumanReadableCollections(t *testing.T) {
 	for i := range nums {
 		nums[i] = Number(0)
 	}
-	l4 := NewList(nums...)
+	l4 := NewList(vrw, nums...)
 	assertWriteTaggedHRSEqual(t, "List<Number>([  // 2,000 items\n"+strings.Repeat("  0,\n", 2000)+"])", l4)
 }
 
 func TestWriteHumanReadableNested(t *testing.T) {
-	l := NewList(Number(0), Number(1))
-	l2 := NewList(Number(2), Number(3))
+	vrw := newTestValueStore()
 
-	s := NewSet(String("a"), String("b"))
-	s2 := NewSet(String("c"), String("d"))
+	l := NewList(vrw, Number(0), Number(1))
+	l2 := NewList(vrw, Number(2), Number(3))
 
-	m := NewMap(s, l, s2, l2)
+	s := NewSet(vrw, String("a"), String("b"))
+	s2 := NewSet(vrw, String("c"), String("d"))
+
+	m := NewMap(vrw, s, l, s2, l2)
 	assertWriteHRSEqual(t, `{
   {
     "c",
@@ -149,6 +153,8 @@ func TestWriteHumanReadableStruct(t *testing.T) {
 }
 
 func TestWriteHumanReadableListOfStruct(t *testing.T) {
+	vrw := newTestValueStore()
+
 	str1 := NewStruct("S3", StructData{
 		"x": Number(1),
 	})
@@ -158,7 +164,7 @@ func TestWriteHumanReadableListOfStruct(t *testing.T) {
 	str3 := NewStruct("S3", StructData{
 		"x": Number(3),
 	})
-	l := NewList(str1, str2, str3)
+	l := NewList(vrw, str1, str2, str3)
 	assertWriteHRSEqual(t, `[
   S3 {
     x: 1,
@@ -186,25 +192,27 @@ func TestWriteHumanReadableListOfStruct(t *testing.T) {
 }
 
 func TestWriteHumanReadableBlob(t *testing.T) {
-	assertWriteHRSEqual(t, "", NewEmptyBlob())
-	assertWriteTaggedHRSEqual(t, "Blob()", NewEmptyBlob())
+	vrw := newTestValueStore()
 
-	b1 := NewBlob(bytes.NewBuffer([]byte{0x01}))
+	assertWriteHRSEqual(t, "", NewEmptyBlob(vrw))
+	assertWriteTaggedHRSEqual(t, "Blob()", NewEmptyBlob(vrw))
+
+	b1 := NewBlob(vrw, bytes.NewBuffer([]byte{0x01}))
 	assertWriteHRSEqual(t, "01", b1)
 	assertWriteTaggedHRSEqual(t, "Blob(01)", b1)
 
-	b2 := NewBlob(bytes.NewBuffer([]byte{0x01, 0x02}))
+	b2 := NewBlob(vrw, bytes.NewBuffer([]byte{0x01, 0x02}))
 	assertWriteHRSEqual(t, "01 02", b2)
 	assertWriteTaggedHRSEqual(t, "Blob(01 02)", b2)
 
-	b3 := NewBlob(bytes.NewBuffer([]byte{
+	b3 := NewBlob(vrw, bytes.NewBuffer([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 	}))
 	assertWriteHRSEqual(t, "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f", b3)
 	assertWriteTaggedHRSEqual(t, "Blob(00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f)", b3)
 
-	b4 := NewBlob(bytes.NewBuffer([]byte{
+	b4 := NewBlob(vrw, bytes.NewBuffer([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 		0x10,
@@ -217,25 +225,27 @@ func TestWriteHumanReadableBlob(t *testing.T) {
 		bs[i] = byte(i)
 	}
 
-	b5 := NewBlob(bytes.NewBuffer(bs))
+	b5 := NewBlob(vrw, bytes.NewBuffer(bs))
 	assertWriteHRSEqual(t, "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 256 B\n10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f\n20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f\n30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f\n40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f\n50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f\n60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f\n70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f\n80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f\n90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f\na0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af\nb0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf\nc0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf\nd0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df\ne0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef\nf0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff", b5)
 	assertWriteTaggedHRSEqual(t, "Blob(00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 256 B\n10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f\n20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f\n30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f\n40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f\n50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f\n60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f\n70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f\n80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f\n90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f\na0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af\nb0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf\nc0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf\nd0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df\ne0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef\nf0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff)", b5)
 
-	b6 := NewBlob(bytes.NewBuffer(make([]byte, 16*100)))
+	b6 := NewBlob(vrw, bytes.NewBuffer(make([]byte, 16*100)))
 	row := strings.Repeat("00 ", 15) + "00"
 	s := strings.Repeat(row+"\n", 98) + row
 	assertWriteTaggedHRSEqual(t, "Blob("+row+"  // 1.6 kB\n"+s+")", b6)
 }
 
 func TestWriteHumanReadableListOfBlob(t *testing.T) {
-	b1 := NewBlob(bytes.NewBuffer([]byte{0x01}))
-	b2 := NewBlob(bytes.NewBuffer([]byte{0x02}))
-	b3 := NewBlob(bytes.NewBuffer([]byte{
+	vrw := newTestValueStore()
+
+	b1 := NewBlob(vrw, bytes.NewBuffer([]byte{0x01}))
+	b2 := NewBlob(vrw, bytes.NewBuffer([]byte{0x02}))
+	b3 := NewBlob(vrw, bytes.NewBuffer([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 		0x10,
 	}))
-	l := NewList(b1, NewEmptyBlob(), b2, b3)
+	l := NewList(vrw, b1, NewEmptyBlob(vrw), b2, b3)
 	assertWriteHRSEqual(t, "[  // 4 items\n  01,\n  ,\n  02,\n  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 17 B\n  10,\n]", l)
 	assertWriteTaggedHRSEqual(t, "List<Blob>([  // 4 items\n  01,\n  ,\n  02,\n  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 17 B\n  10,\n])", l)
 }
@@ -391,23 +401,27 @@ func TestWriteHumanReadableWriterError(t *testing.T) {
 }
 
 func TestEmptyCollections(t *testing.T) {
+	vrw := newTestValueStore()
+
 	a := MakeStructType("Nothing")
 	assertWriteTaggedHRSEqual(t, "Type(struct Nothing {})", a)
 	b := NewStruct("Rien", StructData{})
 	assertWriteTaggedHRSEqual(t, "struct Rien {}({})", b)
 	c := MakeMapType(BlobType, NumberType)
 	assertWriteTaggedHRSEqual(t, "Type(Map<Blob, Number>)", c)
-	d := NewMap()
+	d := NewMap(vrw)
 	assertWriteTaggedHRSEqual(t, "Map<>({})", d)
 	e := MakeSetType(StringType)
 	assertWriteTaggedHRSEqual(t, "Type(Set<String>)", e)
-	f := NewSet()
+	f := NewSet(vrw)
 	assertWriteTaggedHRSEqual(t, "Set<>({})", f)
 }
 
 func TestEncodedValueMaxLines(t *testing.T) {
 	assert := assert.New(t)
-	l1 := NewList(generateNumbersAsValues(11)...)
+	vrw := newTestValueStore()
+
+	l1 := NewList(vrw, generateNumbersAsValues(11)...)
 	expected := strings.Join(strings.SplitAfterN(EncodedValue(l1), "\n", 6)[:5], "")
 	assert.Equal(expected, EncodedValueMaxLines(l1, 5))
 

--- a/go/types/equals_test.go
+++ b/go/types/equals_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestValueEquals(t *testing.T) {
 	assert := assert.New(t)
+	vrw := newTestValueStore()
 
 	values := []func() Value{
 		func() Value { return Bool(false) },
@@ -24,29 +25,29 @@ func TestValueEquals(t *testing.T) {
 		func() Value { return String("hi") },
 		func() Value { return String("bye") },
 		func() Value {
-			return NewBlob(&bytes.Buffer{})
+			return NewBlob(vrw, &bytes.Buffer{})
 		},
 		func() Value {
-			return NewBlob(bytes.NewBufferString("hi"))
+			return NewBlob(vrw, bytes.NewBufferString("hi"))
 		},
 		func() Value {
-			return NewBlob(bytes.NewBufferString("bye"))
+			return NewBlob(vrw, bytes.NewBufferString("bye"))
 		},
 		func() Value {
-			b1 := NewBlob(bytes.NewBufferString("hi"))
-			b2 := NewBlob(bytes.NewBufferString("bye"))
+			b1 := NewBlob(vrw, bytes.NewBufferString("hi"))
+			b2 := NewBlob(vrw, bytes.NewBufferString("bye"))
 			return newBlob(newBlobMetaSequence(1, []metaTuple{
-				newMetaTuple(NewRef(b1), orderedKeyFromInt(2), 2, b1),
-				newMetaTuple(NewRef(b2), orderedKeyFromInt(5), 5, b2),
+				newMetaTuple(NewRef(b1), orderedKeyFromInt(2), 2),
+				newMetaTuple(NewRef(b2), orderedKeyFromInt(5), 5),
 			}, nil))
 		},
-		func() Value { return NewList() },
-		func() Value { return NewList(String("foo")) },
-		func() Value { return NewList(String("bar")) },
-		func() Value { return NewMap() },
-		func() Value { return NewMap(String("a"), String("a")) },
-		func() Value { return NewSet() },
-		func() Value { return NewSet(String("hi")) },
+		func() Value { return NewList(vrw) },
+		func() Value { return NewList(vrw, String("foo")) },
+		func() Value { return NewList(vrw, String("bar")) },
+		func() Value { return NewMap(vrw) },
+		func() Value { return NewMap(vrw, String("a"), String("a")) },
+		func() Value { return NewSet(vrw) },
+		func() Value { return NewSet(vrw, String("hi")) },
 
 		func() Value { return BoolType },
 		func() Value { return StringType },

--- a/go/types/get_hash_test.go
+++ b/go/types/get_hash_test.go
@@ -33,32 +33,32 @@ func TestEnsureHash(t *testing.T) {
 		getHashOverride = nil
 	}()
 
-	bl := newBlob(newBlobLeafSequence(nil, []byte("hi")))
-	cb := newBlob(newBlobMetaSequence(1, []metaTuple{{Ref{}, newOrderedKey(Number(2)), 2, bl}}, vs))
+	bl := newBlob(newBlobLeafSequence(vs, []byte("hi")))
+	cb := newBlob(newBlobMetaSequence(1, []metaTuple{{vs.WriteValue(bl), newOrderedKey(Number(2)), 2}}, vs))
 
-	ll := newList(newListLeafSequence(nil, String("foo")))
-	cl := newList(newMetaSequence(ListKind, 1, []metaTuple{{Ref{}, newOrderedKey(Number(1)), 1, ll}}, vs))
+	ll := newList(newListLeafSequence(vs, String("foo")))
+	cl := newList(newMetaSequence(ListKind, 1, []metaTuple{{vs.WriteValue(ll), newOrderedKey(Number(1)), 1}}, vs))
 
 	newStringOrderedKey := func(s string) orderedKey {
 		return newOrderedKey(String(s))
 	}
 
-	ml := newMap(newMapLeafSequence(nil, mapEntry{String("foo"), String("bar")}))
-	cm := newMap(newMetaSequence(MapKind, 1, []metaTuple{{Ref{}, newStringOrderedKey("foo"), 1, ml}}, vs))
+	ml := newMap(newMapLeafSequence(vs, mapEntry{String("foo"), String("bar")}))
+	cm := newMap(newMetaSequence(MapKind, 1, []metaTuple{{vs.WriteValue(ml), newStringOrderedKey("foo"), 1}}, vs))
 
-	sl := newSet(newSetLeafSequence(nil, String("foo")))
-	cps := newSet(newMetaSequence(SetKind, 1, []metaTuple{{Ref{}, newStringOrderedKey("foo"), 1, sl}}, vs))
+	sl := newSet(newSetLeafSequence(vs, String("foo")))
+	cps := newSet(newMetaSequence(SetKind, 1, []metaTuple{{vs.WriteValue(sl), newStringOrderedKey("foo"), 1}}, vs))
 
 	count = byte(1)
 	values := []Value{
-		newBlob(newBlobLeafSequence(nil, []byte{})),
+		newBlob(newBlobLeafSequence(vs, []byte{})),
 		cb,
-		newList(newListLeafSequence(nil, String("bar"))),
+		newList(newListLeafSequence(vs, String("bar"))),
 		cl,
 		cm,
-		newMap(newMapLeafSequence(nil)),
+		newMap(newMapLeafSequence(vs)),
 		cps,
-		newSet(newSetLeafSequence(nil)),
+		newSet(newSetLeafSequence(vs)),
 	}
 	for i := 0; i < 2; i++ {
 		for j, v := range values {

--- a/go/types/graph_builder.go
+++ b/go/types/graph_builder.go
@@ -199,11 +199,11 @@ func (b *GraphBuilder) pushNewKeyOnStack(key Value, kind NomsKind) {
 	var ch *sequenceChunker
 	switch kind {
 	case MapKind:
-		ch = newEmptyMapSequenceChunker(b.vrw, b.vrw)
+		ch = newEmptyMapSequenceChunker(b.vrw)
 	case SetKind:
-		ch = newEmptySetSequenceChunker(b.vrw, b.vrw)
+		ch = newEmptySetSequenceChunker(b.vrw)
 	case ListKind:
-		ch = newEmptyListSequenceChunker(b.vrw, b.vrw)
+		ch = newEmptyListSequenceChunker(b.vrw)
 	default:
 		panic("bad 'kind' value in GraphBuilder, newElem()")
 	}

--- a/go/types/graph_builder_test.go
+++ b/go/types/graph_builder_test.go
@@ -77,7 +77,7 @@ func TestGraphBuilderEncodeDecodeAsKey(t *testing.T) {
 		} else {
 			expectedRes = append(expectedRes, nil)
 		}
-		bs = encodeGraphKey(bs, k, vrw)
+		bs = encodeGraphKey(bs, k)
 	}
 	res := ValueSlice{}
 	for pos := 0; pos < numKeys; pos++ {
@@ -107,7 +107,7 @@ func TestGraphBuilderEncodeDecodeAsValue(t *testing.T) {
 	bs := byteBuf[:0]
 	numKeys := len(keys)
 	for _, k := range keys {
-		bs = encodeGraphValue(bs, k, vrw)
+		bs = encodeGraphValue(bs, k)
 	}
 	res := ValueSlice{}
 	for pos := 0; pos < numKeys; pos++ {
@@ -157,7 +157,7 @@ func TestGraphBuilderMapSetGraphOp(t *testing.T) {
 // |avgSize| parameters. The graph will contain nested maps with a
 // depth == |levels|, each map will contain |avgSize| elements of different
 // types.
-func createTestMap(levels, avgSize int, valGen func() Value) Map {
+func createTestMap(vrw ValueReadWriter, levels, avgSize int, valGen func() Value) Map {
 	sampleSize := func() int {
 		size := (int(rand.Int31()) % avgSize) + (avgSize / 2)
 		if size < 2 {
@@ -177,11 +177,11 @@ func createTestMap(levels, avgSize int, valGen func() Value) Map {
 			if numElems%2 != 0 {
 				numElems -= 1
 			}
-			return NewMap(elems[:numElems]...)
+			return NewMap(vrw, elems[:numElems]...)
 		case 1:
-			return NewSet(elems...)
+			return NewSet(vrw, elems...)
 		case 2:
-			return NewList(elems...)
+			return NewList(vrw, elems...)
 		}
 		panic("unreachable")
 	}
@@ -203,7 +203,7 @@ func createTestMap(levels, avgSize int, valGen func() Value) Map {
 				}
 			}
 		}
-		return NewMap(kvs...)
+		return NewMap(vrw, kvs...)
 	}
 
 	return genChildren(0)
@@ -247,7 +247,7 @@ func TestGraphBuilderNestedMapSet(t *testing.T) {
 	vs := newTestValueStore()
 	defer vs.Close()
 
-	expected := createTestMap(3, 4, valGen)
+	expected := createTestMap(vs, 3, 4, valGen)
 	b := NewGraphBuilder(vs, MapKind)
 
 	ops := []testGraphOp{}

--- a/go/types/incremental_test.go
+++ b/go/types/incremental_test.go
@@ -12,18 +12,18 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
-var (
-	testVals = []Value{
+func getTestVals(vrw ValueReadWriter) []Value {
+	return []Value{
 		Bool(true),
 		Number(1),
 		String("hi"),
-		NewBlob(bytes.NewReader([]byte("hi"))),
+		NewBlob(vrw, bytes.NewReader([]byte("hi"))),
 		// compoundBlob
-		NewSet(String("hi")),
-		NewList(String("hi")),
-		NewMap(String("hi"), String("hi")),
+		NewSet(vrw, String("hi")),
+		NewList(vrw, String("hi")),
+		NewMap(vrw, String("hi"), String("hi")),
 	}
-)
+}
 
 func isEncodedOutOfLine(v Value) int {
 	switch v.(type) {
@@ -39,7 +39,7 @@ func TestIncrementalLoadList(t *testing.T) {
 	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
-	expected := NewList(testVals...)
+	expected := NewList(vs, getTestVals(vs)...)
 	hash := vs.WriteValue(expected).TargetHash()
 	vs.Commit(vs.Root(), vs.Root())
 
@@ -69,7 +69,7 @@ func SkipTestIncrementalLoadSet(t *testing.T) {
 	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
-	expected := NewSet(testVals...)
+	expected := NewSet(vs, getTestVals(vs)...)
 	ref := vs.WriteValue(expected).TargetHash()
 
 	actualVar := vs.ReadValue(ref)
@@ -90,7 +90,7 @@ func SkipTestIncrementalLoadMap(t *testing.T) {
 	cs := ts.NewView()
 	vs := NewValueStore(cs)
 
-	expected := NewMap(testVals...)
+	expected := NewMap(vs, getTestVals(vs)...)
 	ref := vs.WriteValue(expected).TargetHash()
 
 	actualVar := vs.ReadValue(ref)
@@ -115,7 +115,7 @@ func SkipTestIncrementalAddRef(t *testing.T) {
 	expectedItem := Number(42)
 	ref := vs.WriteValue(expectedItem)
 
-	expected := NewList(ref)
+	expected := NewList(vs, ref)
 	ref = vs.WriteValue(expected)
 	actualVar := vs.ReadValue(ref.TargetHash())
 

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -84,7 +84,8 @@ func orderedKeyFromSum(msd []metaTuple) orderedKey {
 // loads the set of leaf nodes which contain the items [startIdx -> endIdx).
 // Returns the set of nodes and the offset within the first sequence which corresponds to |startIdx|.
 func loadLeafNodes(cols []Collection, startIdx, endIdx uint64) ([]Collection, uint64) {
-	vr := cols[0].sequence().valueReader()
+	vrw := cols[0].sequence().valueReadWriter()
+	d.PanicIfTrue(vrw == nil)
 
 	if cols[0].sequence().isLeaf() {
 		for _, c := range cols {
@@ -125,43 +126,21 @@ func loadLeafNodes(cols []Collection, startIdx, endIdx uint64) ([]Collection, ui
 	}
 
 	// Fetch committed child sequences in a single batch
-<<<<<<< HEAD
 	fetched := make(map[hash.Hash]Collection, len(hs))
 	if len(hs) > 0 {
 		valueChan := make(chan Value, len(hs))
 		go func() {
-			d.PanicIfTrue(vr == nil)
-			vr.ReadManyValues(hs, valueChan)
+			vrw.ReadManyValues(hs, valueChan)
 			close(valueChan)
 		}()
 		for value := range valueChan {
 			fetched[value.Hash()] = value.(Collection)
 		}
-=======
-	fetched := make(map[hash.Hash]sequence, len(hs))
-	valueChan := make(chan Value, len(hs))
-	go func() {
-		d.PanicIfTrue(vr == nil)
-		vr.ReadManyValues(hs, valueChan)
-		close(valueChan)
-	}()
-	for value := range valueChan {
-		fetched[value.Hash()] = value.(Collection).sequence()
->>>>>>> types (nearly) passing tests
 	}
 
 	childCols := make([]Collection, len(childTuples))
 	for i, mt := range childTuples {
-<<<<<<< HEAD
-		if mt.child != nil {
-			childCols[i] = mt.child.(Collection)
-			continue
-		}
-
 		childCols[i] = fetched[mt.ref.TargetHash()]
-=======
-		childSeqs[i] = fetched[mt.ref.TargetHash()]
->>>>>>> types (nearly) passing tests
 	}
 
 	return loadLeafNodes(childCols, startIdx, endIdx)

--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -5,7 +5,7 @@
 package types
 
 type leafSequence struct {
-	vr     ValueReader
+	vrw    ValueReadWriter
 	length int
 	kind   NomsKind
 }
@@ -18,8 +18,8 @@ func (seq leafSequence) numLeaves() uint64 {
 	return uint64(seq.length)
 }
 
-func (seq leafSequence) valueReader() ValueReader {
-	return seq.vr
+func (seq leafSequence) valueReadWriter() ValueReadWriter {
+	return seq.vrw
 }
 
 func (seq leafSequence) getChildSequence(idx int) sequence {

--- a/go/types/list_editor_test.go
+++ b/go/types/list_editor_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/attic-labs/testify/assert"
 )
 
-func listOfInts(vals ...int) List {
+func listOfInts(vrw ValueReadWriter, vals ...int) List {
 	vs := ValueSlice{}
 	for _, v := range vals {
 		vs = append(vs, Number(v))
 	}
-	return NewList(vs...)
+	return NewList(vrw, vs...)
 }
 
-func testEditor(vals ...int) *ListEditor {
-	return NewListEditor(listOfInts(vals...))
+func testEditor(vrw ValueReadWriter, vals ...int) *ListEditor {
+	return NewListEditor(listOfInts(vrw, vals...))
 }
 
 func edit(le *ListEditor, idx, remove int, insert ...int) {
@@ -31,7 +31,7 @@ func edit(le *ListEditor, idx, remove int, insert ...int) {
 	le.Splice(uint64(idx), uint64(remove), vals...)
 }
 
-func assertState(t *testing.T, le *ListEditor, expectItems []int, expectEditCount int) {
+func assertState(t *testing.T, vrw ValueReadWriter, le *ListEditor, expectItems []int, expectEditCount int) {
 	assert.Equal(t, uint64(len(expectItems)), le.Len())
 
 	for i, v := range expectItems {
@@ -45,124 +45,130 @@ func assertState(t *testing.T, le *ListEditor, expectItems []int, expectEditCoun
 
 	assert.Equal(t, expectEditCount, actualEditCount)
 
-	assert.True(t, listOfInts(expectItems...).Equals(le.List(nil)))
+	assert.True(t, listOfInts(vrw, expectItems...).Equals(le.List()))
 }
 
 func TestListEditorBasic(t *testing.T) {
+	vrw := newTestValueStore()
+
 	t.Run("remove  a few", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 2, 2)
-		assertState(t, le, []int{0, 1, 4, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 4, 5}, 1)
 	})
 
 	t.Run("insert  a few", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 2, 0, 9, 8, 7)
-		assertState(t, le, []int{0, 1, 9, 8, 7, 2, 3, 4, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 9, 8, 7, 2, 3, 4, 5}, 1)
 	})
 
 	t.Run("remove 2, insert 3", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 2, 2, 9, 8, 7)
-		assertState(t, le, []int{0, 1, 9, 8, 7, 4, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 9, 8, 7, 4, 5}, 1)
 	})
 
 	t.Run("insert 2 twice", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 2, 0, 9, 10)
-		assertState(t, le, []int{0, 1, 9, 10, 2, 3, 4, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 9, 10, 2, 3, 4, 5}, 1)
 		edit(le, 7, 0, 8, 9)
-		assertState(t, le, []int{0, 1, 9, 10, 2, 3, 4, 8, 9, 5}, 2)
+		assertState(t, vrw, le, []int{0, 1, 9, 10, 2, 3, 4, 8, 9, 5}, 2)
 	})
 
 	t.Run("remove 2 twice", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5, 6, 7)
 		edit(le, 5, 2)
-		assertState(t, le, []int{0, 1, 2, 3, 4, 7}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 4, 7}, 1)
 		edit(le, 1, 2)
-		assertState(t, le, []int{0, 3, 4, 7}, 2)
+		assertState(t, vrw, le, []int{0, 3, 4, 7}, 2)
 	})
 }
 
 func TestCollapseSplices(t *testing.T) {
+	vrw := newTestValueStore()
+
 	t.Run("left adjacent", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5, 6, 7)
 		edit(le, 4, 3)
-		assertState(t, le, []int{0, 1, 2, 3, 7}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 7}, 1)
 		edit(le, 1, 3)
-		assertState(t, le, []int{0, 7}, 1)
+		assertState(t, vrw, le, []int{0, 7}, 1)
 	})
 
 	t.Run("left adjacent 2", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5, 6, 7)
 		edit(le, 4, 3, 0, 0)
-		assertState(t, le, []int{0, 1, 2, 3, 0, 0, 7}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 0, 0, 7}, 1)
 		edit(le, 1, 3, 5, 5)
-		assertState(t, le, []int{0, 5, 5, 0, 0, 7}, 1)
+		assertState(t, vrw, le, []int{0, 5, 5, 0, 0, 7}, 1)
 	})
 
 	t.Run("left consume", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5, 6, 7)
 		edit(le, 2, 4)
-		assertState(t, le, []int{0, 1, 6, 7}, 1)
+		assertState(t, vrw, le, []int{0, 1, 6, 7}, 1)
 		edit(le, 1, 2)
-		assertState(t, le, []int{0, 7}, 1)
+		assertState(t, vrw, le, []int{0, 7}, 1)
 	})
 
 	t.Run("left overlap ", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 3, 2, 7, 8, 9)
-		assertState(t, le, []int{0, 1, 2, 7, 8, 9, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 7, 8, 9, 5}, 1)
 		edit(le, 0, 4)
-		assertState(t, le, []int{8, 9, 5}, 1)
+		assertState(t, vrw, le, []int{8, 9, 5}, 1)
 	})
 
 	t.Run("undo 1", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 2, 3)
-		assertState(t, le, []int{0, 1, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 5}, 1)
 		edit(le, 2, 0, 2, 3, 4)
-		assertState(t, le, []int{0, 1, 2, 3, 4, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 4, 5}, 1)
 	})
 
 	t.Run("undo 2", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 2, 0, 9, 8, 7)
-		assertState(t, le, []int{0, 1, 9, 8, 7, 2, 3, 4, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 9, 8, 7, 2, 3, 4, 5}, 1)
 		edit(le, 2, 3)
-		assertState(t, le, []int{0, 1, 2, 3, 4, 5}, 0)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 4, 5}, 0)
 	})
 
 	t.Run("splice middile of splice", func(t *testing.T) {
-		le := testEditor(0, 1)
+		le := testEditor(vrw, 0, 1)
 		edit(le, 1, 0, 9, 8, 7, 6)
-		assertState(t, le, []int{0, 9, 8, 7, 6, 1}, 1)
+		assertState(t, vrw, le, []int{0, 9, 8, 7, 6, 1}, 1)
 		edit(le, 2, 2)
-		assertState(t, le, []int{0, 9, 6, 1}, 1)
+		assertState(t, vrw, le, []int{0, 9, 6, 1}, 1)
 	})
 }
 
 func TestFuzzFails(t *testing.T) {
+	vrw := newTestValueStore()
+
 	t.Run("Case 1", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
 		edit(le, 23, 0, 0, 3, 2)
-		assertState(t, le, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 0, 3, 2, 23, 24}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 0, 3, 2, 23, 24}, 1)
 		edit(le, 5, 15, 1, 2, 9, 8)
-		assertState(t, le, []int{0, 1, 2, 3, 4, 1, 2, 9, 8, 20, 21, 22, 0, 3, 2, 23, 24}, 2)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 4, 1, 2, 9, 8, 20, 21, 22, 0, 3, 2, 23, 24}, 2)
 		edit(le, 4, 7, 7)
-		assertState(t, le, []int{0, 1, 2, 3, 7, 22, 0, 3, 2, 23, 24}, 2)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 7, 22, 0, 3, 2, 23, 24}, 2)
 	})
 
 	t.Run("Case 2", func(t *testing.T) {
-		le := testEditor(0, 1, 2, 3, 4, 5)
+		le := testEditor(vrw, 0, 1, 2, 3, 4, 5)
 		edit(le, 5, 0, 1, 7, 5, 3, 13, 17)
-		assertState(t, le, []int{0, 1, 2, 3, 4, 1, 7, 5, 3, 13, 17, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 2, 3, 4, 1, 7, 5, 3, 13, 17, 5}, 1)
 		edit(le, 2, 2, 16, 5, 12, 5, 15, 0, 15, 15, 7)
-		assertState(t, le, []int{0, 1, 16, 5, 12, 5, 15, 0, 15, 15, 7, 4, 1, 7, 5, 3, 13, 17, 5}, 2)
+		assertState(t, vrw, le, []int{0, 1, 16, 5, 12, 5, 15, 0, 15, 15, 7, 4, 1, 7, 5, 3, 13, 17, 5}, 2)
 		edit(le, 8, 5, 4, 13)
-		assertState(t, le, []int{0, 1, 16, 5, 12, 5, 15, 0, 4, 13, 7, 5, 3, 13, 17, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 16, 5, 12, 5, 15, 0, 4, 13, 7, 5, 3, 13, 17, 5}, 1)
 		edit(le, 6, 2, 8, 2, 6, 3, 14, 6)
-		assertState(t, le, []int{0, 1, 16, 5, 12, 5, 8, 2, 6, 3, 14, 6, 4, 13, 7, 5, 3, 13, 17, 5}, 1)
+		assertState(t, vrw, le, []int{0, 1, 16, 5, 12, 5, 8, 2, 6, 3, 14, 6, 4, 13, 7, 5, 3, 13, 17, 5}, 1)
 
 	})
 }
@@ -181,6 +187,8 @@ func TestListSpliceFuzzer(t *testing.T) {
 	splices := 100
 	maxInsertCount := uint64(50)
 	maxInt := uint64(100)
+
+	vrw := newTestValueStore()
 
 	r := rand.New(rand.NewSource(0))
 
@@ -201,15 +209,15 @@ func TestListSpliceFuzzer(t *testing.T) {
 
 	for i := 0; i < rounds; i++ {
 		tl := newTestList(startCount)
-		le := tl.toList().Edit()
+		le := tl.toList(vrw).Edit()
 
 		for j := 0; j < splices; j++ {
 			idx, removed, insert := nextRandomSplice(len(tl))
 			tl = tl.Splice(int(idx), int(removed), insert...)
 			le.Splice(idx, removed, AsValuables(insert)...)
 		}
-		expect := tl.toList()
-		actual := le.List(nil)
+		expect := tl.toList(vrw)
+		actual := le.List()
 		assert.True(t, expect.Equals(actual))
 	}
 }

--- a/go/types/list_iterator_test.go
+++ b/go/types/list_iterator_test.go
@@ -12,9 +12,10 @@ import (
 
 func TestListIterator(t *testing.T) {
 	assert := assert.New(t)
+	vrw := newTestValueStore()
 
 	numbers := append(generateNumbersAsValues(10), Number(20), Number(25))
-	l := NewList(numbers...)
+	l := NewList(vrw, numbers...)
 	i := l.Iterator()
 	vs := iterToSlice(i)
 	assert.True(vs.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)

--- a/go/types/list_leaf_sequence.go
+++ b/go/types/list_leaf_sequence.go
@@ -4,13 +4,16 @@
 
 package types
 
+import "github.com/attic-labs/noms/go/d"
+
 type listLeafSequence struct {
 	leafSequence
 	values []Value
 }
 
-func newListLeafSequence(vr ValueReader, v ...Value) sequence {
-	return listLeafSequence{leafSequence{vr, len(v), ListKind}, v}
+func newListLeafSequence(vrw ValueReadWriter, v ...Value) sequence {
+	d.PanicIfTrue(vrw == nil)
+	return listLeafSequence{leafSequence{vrw, len(v), ListKind}, v}
 }
 
 // sequence interface

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -27,9 +27,9 @@ func mapHashValueBytes(item sequenceItem, rv *rollingValueHasher) {
 	hashValueBytes(entry.value, rv)
 }
 
-func NewMap(kv ...Value) Map {
+func NewMap(vrw ValueReadWriter, kv ...Value) Map {
 	entries := buildMapData(kv)
-	ch := newEmptyMapSequenceChunker(nil, nil)
+	ch := newEmptyMapSequenceChunker(vrw)
 
 	for _, entry := range entries {
 		ch.Append(entry)
@@ -61,7 +61,7 @@ func newStreamingMap(vrw ValueReadWriter, kvs <-chan Value, readFunc streamingMa
 
 func readMapInput(vrw ValueReadWriter, kvs <-chan Value, outChan chan<- Map) {
 	defer close(outChan)
-	ch := newEmptyMapSequenceChunker(vrw, vrw)
+	ch := newEmptyMapSequenceChunker(vrw)
 	var lastK Value
 	nextIsKey := true
 	var k Value
@@ -127,7 +127,7 @@ func (m Map) hashPointer() *hash.Hash {
 }
 
 // Value interface
-func (m Map) Value(vrw ValueReadWriter) Value {
+func (m Map) Value() Value {
 	return m
 }
 
@@ -317,7 +317,7 @@ func buildMapData(values []Value) mapEntrySlice {
 
 // If |vw| is not nil, chunks will be eagerly written as they're created. Otherwise they are
 // written when the root is written.
-func makeMapLeafChunkFn(vr ValueReader) makeChunkFn {
+func makeMapLeafChunkFn(vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		d.PanicIfFalse(level == 0)
 		mapData := make([]mapEntry, len(items), len(items))
@@ -330,7 +330,7 @@ func makeMapLeafChunkFn(vr ValueReader) makeChunkFn {
 			mapData[i] = entry
 		}
 
-		m := newMap(newMapLeafSequence(vr, mapData...))
+		m := newMap(newMapLeafSequence(vrw, mapData...))
 		var key orderedKey
 		if len(mapData) > 0 {
 			key = newOrderedKey(mapData[len(mapData)-1].key)
@@ -339,6 +339,6 @@ func makeMapLeafChunkFn(vr ValueReader) makeChunkFn {
 	}
 }
 
-func newEmptyMapSequenceChunker(vr ValueReader, vw ValueWriter) *sequenceChunker {
-	return newEmptySequenceChunker(vr, vw, makeMapLeafChunkFn(vr), newOrderedMetaSequenceChunkFn(MapKind, vr), mapHashValueBytes)
+func newEmptyMapSequenceChunker(vrw ValueReadWriter) *sequenceChunker {
+	return newEmptySequenceChunker(vrw, makeMapLeafChunkFn(vrw), newOrderedMetaSequenceChunkFn(MapKind, vrw), mapHashValueBytes)
 }

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -46,6 +46,7 @@ func NewMap(vrw ValueReadWriter, kv ...Value) Map {
 // closed by the caller, a finished Map will be sent to the output channel. See
 // graph_builder.go for building collections with values that are not in order.
 func NewStreamingMap(vrw ValueReadWriter, kvs <-chan Value) <-chan Map {
+	d.PanicIfTrue(vrw == nil)
 	return newStreamingMap(vrw, kvs, func(vrw ValueReadWriter, kvs <-chan Value, outChan chan<- Map) {
 		go readMapInput(vrw, kvs, outChan)
 	})

--- a/go/types/map_editor.go
+++ b/go/types/map_editor.go
@@ -30,19 +30,16 @@ func (me *MapEditor) Kind() NomsKind {
 	return MapKind
 }
 
-func (me *MapEditor) Value(vrw ValueReadWriter) Value {
-	return me.Map(vrw)
+func (me *MapEditor) Value() Value {
+	return me.Map()
 }
 
-func (me *MapEditor) Map(vrw ValueReadWriter) Map {
+func (me *MapEditor) Map() Map {
 	if len(me.edits) == 0 {
 		return me.m // no edits
 	}
 
-	vr := me.m.sequence().valueReader()
-	if vrw != nil {
-		vr = vrw
-	}
+	vrw := me.m.sequence().valueReadWriter()
 
 	me.normalize()
 
@@ -79,7 +76,7 @@ func (me *MapEditor) Map(vrw ValueReadWriter) Map {
 			}
 
 			go func() {
-				sv := edit.value.Value(vrw)
+				sv := edit.value.Value()
 				if e, ok := sv.(Emptyable); ok {
 					if e.Empty() {
 						sv = nil
@@ -116,7 +113,7 @@ func (me *MapEditor) Map(vrw ValueReadWriter) Map {
 		}
 
 		if ch == nil {
-			ch = newSequenceChunker(cur, 0, vr, vrw, makeMapLeafChunkFn(vr), newOrderedMetaSequenceChunkFn(MapKind, vr), mapHashValueBytes)
+			ch = newSequenceChunker(cur, 0, vrw, makeMapLeafChunkFn(vrw), newOrderedMetaSequenceChunkFn(MapKind, vrw), mapHashValueBytes)
 		} else {
 			ch.advanceTo(cur)
 		}

--- a/go/types/map_iterator_test.go
+++ b/go/types/map_iterator_test.go
@@ -13,12 +13,14 @@ import (
 func TestMapIterator(t *testing.T) {
 	assert := assert.New(t)
 
-	me := NewMap().Edit()
+	vrw := newTestValueStore()
+
+	me := NewMap(vrw).Edit()
 	for i := 0; i < 5; i++ {
 		me.Set(String(string(byte(65+i))), Number(i))
 	}
 
-	m := me.Map(nil)
+	m := me.Map()
 	test := func(it MapIterator, start int, msg string) {
 		for i := start; i < 5; i++ {
 			k, v := it.Next()

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -4,6 +4,8 @@
 
 package types
 
+import "github.com/attic-labs/noms/go/d"
+
 type mapLeafSequence struct {
 	leafSequence
 	data []mapEntry // sorted by entry.key.Hash()
@@ -33,8 +35,9 @@ func (mes mapEntrySlice) Equals(other mapEntrySlice) bool {
 	return true
 }
 
-func newMapLeafSequence(vr ValueReader, data ...mapEntry) orderedSequence {
-	return mapLeafSequence{leafSequence{vr, len(data), MapKind}, data}
+func newMapLeafSequence(vrw ValueReadWriter, data ...mapEntry) orderedSequence {
+	d.PanicIfTrue(vrw == nil)
+	return mapLeafSequence{leafSequence{vrw, len(data), MapKind}, data}
 }
 
 // sequence interface

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -87,12 +87,12 @@ func (tm testMap) Diff(last testMap) (added []Value, removed []Value, modified [
 	return
 }
 
-func (tm testMap) toMap() Map {
+func (tm testMap) toMap(vrw ValueReadWriter) Map {
 	keyvals := []Value{}
 	for _, entry := range tm.entries {
 		keyvals = append(keyvals, entry.key, entry.value)
 	}
-	return NewMap(keyvals...)
+	return NewMap(vrw, keyvals...)
 }
 
 func toValuable(vs ValueSlice) []Valuable {
@@ -158,9 +158,9 @@ func newRandomTestMap(length int, gen genValueFn) testMap {
 	return testMap{entries, gen(mask + 1)}
 }
 
-func validateMap(t *testing.T, m Map, entries mapEntrySlice) {
+func validateMap(t *testing.T, vrw ValueReadWriter, m Map, entries mapEntrySlice) {
 	tm := testMap{entries: entries}
-	assert.True(t, m.Equals(tm.toMap()))
+	assert.True(t, m.Equals(tm.toMap(vrw)))
 
 	out := mapEntrySlice{}
 	m.IterAll(func(k Value, v Value) {
@@ -176,11 +176,13 @@ type mapTestSuite struct {
 }
 
 func newMapTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff int, expectAppendChunkDiff int, gen genValueFn) *mapTestSuite {
+	vrw := newTestValueStore()
+
 	length := 1 << size
 	keyType := TypeOf(gen(0))
 	elems := newSortedTestMap(length, gen)
 	tr := MakeMapType(keyType, NumberType)
-	tmap := NewMap(elems.FlattenAll()...)
+	tmap := NewMap(vrw, elems.FlattenAll()...)
 	return &mapTestSuite{
 		collectionTestSuite: collectionTestSuite{
 			col:                    tmap,
@@ -219,7 +221,7 @@ func newMapTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff int
 				for _, entry := range dup {
 					flat = append(flat, entry.key, entry.value)
 				}
-				return NewMap(flat...)
+				return NewMap(vrw, flat...)
 			},
 			appendOne: func() Collection {
 				dup := make([]mapEntry, length+1)
@@ -229,7 +231,7 @@ func newMapTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff int
 				for _, entry := range dup {
 					flat = append(flat, entry.key, entry.value)
 				}
-				return NewMap(flat...)
+				return NewMap(vrw, flat...)
 			},
 		},
 		elems: elems,
@@ -331,9 +333,9 @@ func getTestRefToNativeOrderMap(scale int, vw ValueWriter) testMap {
 	})
 }
 
-func getTestRefToValueOrderMap(scale int, vw ValueWriter) testMap {
+func getTestRefToValueOrderMap(scale int, vrw ValueReadWriter) testMap {
 	return newRandomTestMap(64*scale, func(i int) Value {
-		return vw.WriteValue(NewSet(Number(i)))
+		return vrw.WriteValue(NewSet(vrw, Number(i)))
 	})
 }
 
@@ -378,11 +380,13 @@ func TestMapDiff(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	testMap1 := newRandomTestMap(64*2, newNumber)
 	testMap2 := newRandomTestMap(64*2, newNumber)
 	testMapAdded, testMapRemoved, testMapModified := testMap1.Diff(testMap2)
-	map1 := testMap1.toMap()
-	map2 := testMap2.toMap()
+	map1 := testMap1.toMap(vrw)
+	map2 := testMap2.toMap(vrw)
 
 	mapDiffAdded, mapDiffRemoved, mapDiffModified := accumulateMapDiffChanges(map1, map2)
 	assert.Equal(t, testMapAdded, mapDiffAdded, "testMap.diff != map.diff")
@@ -405,42 +409,49 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 		})
 	}
 
-	m := newRandomTestMap(4000, newLargeStruct).toMap()
-	every := 100
-
 	ts := &chunks.TestStorage{}
 	cs := ts.NewView()
 	vs := newValueStoreWithCacheAndPending(cs, 0, 0)
+
+	me := NewMap(vs).Edit()
+	for i := 0; i < 4000; i++ {
+		me.Set(Number(i), newLargeStruct(i))
+	}
+	m := me.Map()
 	r := vs.WriteValue(m)
 	vs.Commit(vs.Root(), vs.Root())
+	m = r.TargetValue(vs).(Map)
 
-	cs.Writes = 0
-	cs.Reads = 0
+	every := 100
 
-	i := 0
-
-	me := vs.ReadValue(r.TargetHash()).(Map).Edit()
-	m.IterAll(func(k, v Value) {
+	me = m.Edit()
+	for i := 0; i < 4000; i++ {
 		if i%every == 0 {
-			s := v.(Struct)
-
+			k := Number(i)
+			s := me.Get(Number(i)).(Struct)
 			s = s.Set("Number", Number(float64(s.Get("Number").(Number))+1))
 			me.Set(k, s)
 		}
 		i++
-	})
+	}
 
-	me.Map(vs)
+	cs.Writes = 0
+	cs.Reads = 0
+
+	m = me.Map()
+
 	vs.Commit(vs.Root(), vs.Root())
 
 	assert.Equal(t, uint64(3), NewRef(m).Height())
-	assert.Equal(t, 84, cs.Reads)
-	assert.Equal(t, 45, cs.Writes)
+	assert.Equal(t, 82, cs.Reads)
+	assert.Equal(t, 44, cs.Writes)
 }
 
 func TestMapInfiniteChunkBug(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
+
+	vrw := newTestValueStore()
 
 	keyLen := chunkWindow + 1
 
@@ -451,26 +462,30 @@ func TestMapInfiniteChunkBug(t *testing.T) {
 
 	prefix := buff.String()
 
-	me := NewMap().Edit()
+	me := NewMap(vrw).Edit()
 
 	for i := 0; i < 10000; i++ {
 		me.Set(String(prefix+fmt.Sprintf("%d", i)), Number(i))
 	}
 
-	me.Map(nil)
+	me.Map()
 }
 
 func TestNewMap(t *testing.T) {
 	assert := assert.New(t)
-	m := NewMap()
+	vrw := newTestValueStore()
+
+	m := NewMap(vrw)
 	assert.Equal(uint64(0), m.Len())
-	m = NewMap(String("foo1"), String("bar1"), String("foo2"), String("bar2"))
+	m = NewMap(vrw, String("foo1"), String("bar1"), String("foo2"), String("bar2"))
 	assert.Equal(uint64(2), m.Len())
 	assert.True(String("bar1").Equals(m.Get(String("foo1"))))
 	assert.True(String("bar2").Equals(m.Get(String("foo2"))))
 }
 
 func TestMapUniqueKeysString(t *testing.T) {
+	vrw := newTestValueStore()
+
 	assert := assert.New(t)
 	l := []Value{
 		String("hello"), String("world"),
@@ -478,13 +493,15 @@ func TestMapUniqueKeysString(t *testing.T) {
 		String("bar"), String("foo"),
 		String("hello"), String("foo"),
 	}
-	m := NewMap(l...)
+	m := NewMap(vrw, l...)
 	assert.Equal(uint64(3), m.Len())
 	assert.True(String("foo").Equals(m.Get(String("hello"))))
 }
 
 func TestMapUniqueKeysNumber(t *testing.T) {
 	assert := assert.New(t)
+	vrw := newTestValueStore()
+
 	l := []Value{
 		Number(4), Number(1),
 		Number(0), Number(2),
@@ -492,7 +509,7 @@ func TestMapUniqueKeysNumber(t *testing.T) {
 		Number(3), Number(4),
 		Number(1), Number(5),
 	}
-	m := NewMap(l...)
+	m := NewMap(vrw, l...)
 	assert.Equal(uint64(4), m.Len())
 	assert.True(Number(5).Equals(m.Get(Number(1))))
 }
@@ -509,7 +526,7 @@ func TestMapHas(t *testing.T) {
 
 	vs := newTestValueStore()
 	doTest := func(tm testMap) {
-		m := tm.toMap()
+		m := tm.toMap(vs)
 		m2 := vs.ReadValue(vs.WriteValue(m).TargetHash()).(Map)
 		for _, entry := range tm.entries {
 			k, v := entry.key, entry.value
@@ -529,11 +546,12 @@ func TestMapHas(t *testing.T) {
 
 func TestMapHasRemove(t *testing.T) {
 	assert := assert.New(t)
+	vrw := newTestValueStore()
 
-	me := NewMap().Edit()
+	me := NewMap(vrw).Edit()
 	bothHave := func(k Value) bool {
 		meHas := me.Has(k)
-		mHas := me.Map(nil).Has(k)
+		mHas := me.Map().Has(k)
 		assert.Equal(meHas, mHas)
 		return meHas
 	}
@@ -576,7 +594,7 @@ func TestMapHasRemove(t *testing.T) {
 	assert.False(bothHave(String("b")))
 	assert.False(bothHave(String("c")))
 
-	m := me.Map(nil)
+	m := me.Map()
 	assert.True(m.Len() == 0)
 }
 
@@ -588,13 +606,15 @@ func TestMapRemove(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	assert := assert.New(t)
 
 	doTest := func(incr int, tm testMap) {
-		whole := tm.toMap()
+		whole := tm.toMap(vrw)
 		run := func(i int) {
-			expected := tm.Remove(i, i+1).toMap()
-			actual := whole.Edit().Remove(tm.entries[i].key).Map(nil)
+			expected := tm.Remove(i, i+1).toMap(vrw)
+			actual := whole.Edit().Remove(tm.entries[i].key).Map()
 			assert.Equal(expected.Len(), actual.Len())
 			assert.True(expected.Equals(actual))
 			diffMapTest(assert, expected, actual, 0, 0, 0)
@@ -617,9 +637,11 @@ func TestMapRemoveNonexistentKey(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	tm := getTestNativeOrderMap(2)
-	original := tm.toMap()
-	actual := original.Edit().Remove(Number(-1)).Map(nil) // rand.Int63 returns non-negative numbers.
+	original := tm.toMap(vrw)
+	actual := original.Edit().Remove(Number(-1)).Map() // rand.Int63 returns non-negative numbers.
 
 	assert.Equal(original.Len(), actual.Len())
 	assert.True(original.Equals(actual))
@@ -631,12 +653,14 @@ func TestMapFirst(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	m1 := NewMap()
+	vrw := newTestValueStore()
+
+	m1 := NewMap(vrw)
 	k, v := m1.First()
 	assert.Nil(k)
 	assert.Nil(v)
 
-	m1 = m1.Edit().Set(String("foo"), String("bar")).Set(String("hot"), String("dog")).Map(nil)
+	m1 = m1.Edit().Set(String("foo"), String("bar")).Set(String("hot"), String("dog")).Map()
 	ak, av := m1.First()
 	var ek, ev Value
 
@@ -658,8 +682,10 @@ func TestMapFirst2(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	doTest := func(tm testMap) {
-		m := tm.toMap()
+		m := tm.toMap(vrw)
 		sort.Stable(tm.entries)
 		actualKey, actualValue := m.First()
 		assert.True(tm.entries[0].key.Equals(actualKey))
@@ -678,12 +704,14 @@ func TestMapLast(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	m1 := NewMap()
+	vrw := newTestValueStore()
+
+	m1 := NewMap(vrw)
 	k, v := m1.First()
 	assert.Nil(k)
 	assert.Nil(v)
 
-	m1 = m1.Edit().Set(String("foo"), String("bar")).Set(String("hot"), String("dog")).Map(nil)
+	m1 = m1.Edit().Set(String("foo"), String("bar")).Set(String("hot"), String("dog")).Map()
 	ak, av := m1.Last()
 	var ek, ev Value
 
@@ -705,8 +733,10 @@ func TestMapLast2(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	doTest := func(tm testMap) {
-		m := tm.toMap()
+		m := tm.toMap(vrw)
 		sort.Stable(tm.entries)
 		actualKey, actualValue := m.Last()
 		assert.True(tm.entries[len(tm.entries)-1].key.Equals(actualKey))
@@ -725,10 +755,12 @@ func TestMapSetGet(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	me := NewMap().Edit()
+	vrw := newTestValueStore()
+
+	me := NewMap(vrw).Edit()
 	bothAre := func(k Value) Value {
 		meV := me.Get(k)
-		mV := me.Map(nil).Get(k)
+		mV := me.Map().Get(k)
 		assert.True((meV == nil && mV == nil) || meV.(Value).Equals(mV))
 		return mV
 	}
@@ -772,23 +804,25 @@ func TestMapSetGet(t *testing.T) {
 	assert.Nil(bothAre(String("z")))
 	assert.Nil(bothAre(String("never-inserted")))
 
-	m := me.Map(nil)
+	m := me.Map()
 	assert.True(m.Len() == 0)
 }
 
 func validateMapInsertion(t *testing.T, tm testMap) {
-	allMe := NewMap().Edit()
-	incrMe := NewMap().Edit()
+	vrw := newTestValueStore()
+
+	allMe := NewMap(vrw).Edit()
+	incrMe := NewMap(vrw).Edit()
 
 	for i, entry := range tm.entries {
 		allMe.Set(entry.key, entry.value)
 		incrMe.Set(entry.key, entry.value)
 
-		m1 := allMe.Map(nil)
-		m2 := incrMe.Map(nil)
+		m1 := allMe.Map()
+		m2 := incrMe.Map()
 
-		validateMap(t, m1, tm.entries[0:i+1])
-		validateMap(t, m2, tm.entries[0:i+1])
+		validateMap(t, vrw, m1, tm.entries[0:i+1])
+		validateMap(t, vrw, m2, tm.entries[0:i+1])
 
 		incrMe = m2.Edit()
 	}
@@ -813,12 +847,14 @@ func TestMapSet(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	assert := assert.New(t)
 
 	doTest := func(incr, offset int, tm testMap) {
-		expected := tm.toMap()
+		expected := tm.toMap(vrw)
 		run := func(from, to int) {
-			actual := tm.Remove(from, to).toMap().Edit().SetM(toValuable(tm.Flatten(from, to))...).Map(nil)
+			actual := tm.Remove(from, to).toMap(vrw).Edit().SetM(toValuable(tm.Flatten(from, to))...).Map()
 			assert.Equal(expected.Len(), actual.Len())
 			assert.True(expected.Equals(actual))
 			diffMapTest(assert, expected, actual, 0, 0, 0)
@@ -838,14 +874,16 @@ func TestMapSet(t *testing.T) {
 
 func TestMapSetM(t *testing.T) {
 	assert := assert.New(t)
-	m1 := NewMap()
-	m2 := m1.Edit().SetM().Map(nil)
+	vrw := newTestValueStore()
+
+	m1 := NewMap(vrw)
+	m2 := m1.Edit().SetM().Map()
 	assert.True(m1.Equals(m2))
-	m3 := m2.Edit().SetM(String("foo"), String("bar"), String("hot"), String("dog")).Map(nil)
+	m3 := m2.Edit().SetM(String("foo"), String("bar"), String("hot"), String("dog")).Map()
 	assert.Equal(uint64(2), m3.Len())
 	assert.True(String("bar").Equals(m3.Get(String("foo"))))
 	assert.True(String("dog").Equals(m3.Get(String("hot"))))
-	m4 := m3.Edit().SetM(String("mon"), String("key")).Map(nil)
+	m4 := m3.Edit().SetM(String("mon"), String("key")).Map()
 	assert.Equal(uint64(2), m3.Len())
 	assert.Equal(uint64(3), m4.Len())
 }
@@ -858,20 +896,22 @@ func TestMapSetExistingKeyToNewValue(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	assert := assert.New(t)
 
 	tm := getTestNativeOrderMap(2)
-	original := tm.toMap()
+	original := tm.toMap(vrw)
 
 	expectedWorking := tm
 	actual := original
 	for i, entry := range tm.entries {
 		newValue := Number(int64(entry.value.(Number)) + 1)
 		expectedWorking = expectedWorking.SetValue(i, newValue)
-		actual = actual.Edit().Set(entry.key, newValue).Map(nil)
+		actual = actual.Edit().Set(entry.key, newValue).Map()
 	}
 
-	expected := expectedWorking.toMap()
+	expected := expectedWorking.toMap(vrw)
 	assert.Equal(expected.Len(), actual.Len())
 	assert.True(expected.Equals(actual))
 	assert.False(original.Equals(actual))
@@ -881,7 +921,9 @@ func TestMapSetExistingKeyToNewValue(t *testing.T) {
 // BUG 98
 func TestMapDuplicateSet(t *testing.T) {
 	assert := assert.New(t)
-	m1 := NewMap(Bool(true), Bool(true), Number(42), Number(42), Number(42), Number(42))
+	vrw := newTestValueStore()
+
+	m1 := NewMap(vrw, Bool(true), Bool(true), Number(42), Number(42), Number(42), Number(42))
 	assert.Equal(uint64(2), m1.Len())
 }
 
@@ -893,10 +935,12 @@ func TestMapMaybeGet(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	assert := assert.New(t)
 
 	doTest := func(tm testMap) {
-		m := tm.toMap()
+		m := tm.toMap(vrw)
 		for _, entry := range tm.entries {
 			v, ok := m.MaybeGet(entry.key)
 			if assert.True(ok, "%v should have been in the map!", entry.key) {
@@ -915,7 +959,9 @@ func TestMapMaybeGet(t *testing.T) {
 
 func TestMapIter(t *testing.T) {
 	assert := assert.New(t)
-	m := NewMap()
+	vrw := newTestValueStore()
+
+	m := NewMap(vrw)
 
 	type entry struct {
 		key   Value
@@ -942,7 +988,7 @@ func TestMapIter(t *testing.T) {
 	m.Iter(cb)
 	assert.Equal(0, len(results))
 
-	m = m.Edit().Set(String("a"), Number(0)).Set(String("b"), Number(1)).Map(nil)
+	m = m.Edit().Set(String("a"), Number(0)).Set(String("b"), Number(1)).Map()
 	m.Iter(cb)
 	assert.Equal(2, len(results))
 	assert.True(got(String("a"), Number(0)))
@@ -962,8 +1008,10 @@ func TestMapIter2(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	doTest := func(tm testMap) {
-		m := tm.toMap()
+		m := tm.toMap(vrw)
 		sort.Sort(tm.entries)
 		idx := uint64(0)
 		endAt := uint64(64)
@@ -990,13 +1038,15 @@ func TestMapIter2(t *testing.T) {
 func TestMapAny(t *testing.T) {
 	assert := assert.New(t)
 
+	vrw := newTestValueStore()
+
 	p := func(k, v Value) bool {
 		return k.Equals(String("foo")) && v.Equals(String("bar"))
 	}
 
-	assert.False(NewMap().Any(p))
-	assert.False(NewMap(String("foo"), String("baz")).Any(p))
-	assert.True(NewMap(String("foo"), String("bar")).Any(p))
+	assert.False(NewMap(vrw).Any(p))
+	assert.False(NewMap(vrw, String("foo"), String("baz")).Any(p))
+	assert.True(NewMap(vrw, String("foo"), String("bar")).Any(p))
 }
 
 func TestMapIterAll(t *testing.T) {
@@ -1007,10 +1057,12 @@ func TestMapIterAll(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
+	vrw := newTestValueStore()
+
 	assert := assert.New(t)
 
 	doTest := func(tm testMap) {
-		m := tm.toMap()
+		m := tm.toMap(vrw)
 		sort.Sort(tm.entries)
 		idx := uint64(0)
 
@@ -1030,9 +1082,11 @@ func TestMapIterAll(t *testing.T) {
 func TestMapEquals(t *testing.T) {
 	assert := assert.New(t)
 
-	m1 := NewMap()
+	vrw := newTestValueStore()
+
+	m1 := NewMap(vrw)
 	m2 := m1
-	m3 := NewMap()
+	m3 := NewMap(vrw)
 
 	assert.True(m1.Equals(m2))
 	assert.True(m2.Equals(m1))
@@ -1045,8 +1099,8 @@ func TestMapEquals(t *testing.T) {
 	diffMapTest(assert, m3, m1, 0, 0, 0)
 	diffMapTest(assert, m3, m2, 0, 0, 0)
 
-	m1 = NewMap(String("foo"), Number(0.0), String("bar"), NewList())
-	m2 = m2.Edit().Set(String("foo"), Number(0.0)).Set(String("bar"), NewList()).Map(nil)
+	m1 = NewMap(vrw, String("foo"), Number(0.0), String("bar"), NewList(vrw))
+	m2 = m2.Edit().Set(String("foo"), Number(0.0)).Set(String("bar"), NewList(vrw)).Map()
 	assert.True(m1.Equals(m2))
 	assert.True(m2.Equals(m1))
 	assert.False(m2.Equals(m3))
@@ -1062,8 +1116,10 @@ func TestMapEquals(t *testing.T) {
 func TestMapNotStringKeys(t *testing.T) {
 	assert := assert.New(t)
 
-	b1 := NewBlob(bytes.NewBufferString("blob1"))
-	b2 := NewBlob(bytes.NewBufferString("blob2"))
+	vrw := newTestValueStore()
+
+	b1 := NewBlob(vrw, bytes.NewBufferString("blob1"))
+	b2 := NewBlob(vrw, bytes.NewBufferString("blob2"))
 	l := []Value{
 		Bool(true), String("true"),
 		Bool(false), String("false"),
@@ -1071,14 +1127,14 @@ func TestMapNotStringKeys(t *testing.T) {
 		Number(0), String("Number: 0"),
 		b1, String("blob1"),
 		b2, String("blob2"),
-		NewList(), String("empty list"),
-		NewList(NewList()), String("list of list"),
-		NewMap(), String("empty map"),
-		NewMap(NewMap(), NewMap()), String("map of map/map"),
-		NewSet(), String("empty set"),
-		NewSet(NewSet()), String("map of set/set"),
+		NewList(vrw), String("empty list"),
+		NewList(vrw, NewList(vrw)), String("list of list"),
+		NewMap(vrw), String("empty map"),
+		NewMap(vrw, NewMap(vrw), NewMap(vrw)), String("map of map/map"),
+		NewSet(vrw), String("empty set"),
+		NewSet(vrw, NewSet(vrw)), String("map of set/set"),
 	}
-	m1 := NewMap(l...)
+	m1 := NewMap(vrw, l...)
 	assert.Equal(uint64(12), m1.Len())
 	for i := 0; i < len(l); i += 2 {
 		assert.True(m1.Get(l[i]).Equals(l[i+1]))
@@ -1086,8 +1142,8 @@ func TestMapNotStringKeys(t *testing.T) {
 	assert.Nil(m1.Get(Number(42)))
 }
 
-func testMapOrder(assert *assert.Assertions, keyType, valueType *Type, tuples []Value, expectOrdering []Value) {
-	m := NewMap(tuples...)
+func testMapOrder(assert *assert.Assertions, vrw ValueReadWriter, keyType, valueType *Type, tuples []Value, expectOrdering []Value) {
+	m := NewMap(vrw, tuples...)
 	i := 0
 	m.IterAll(func(key, value Value) {
 		assert.Equal(expectOrdering[i].Hash().String(), key.Hash().String())
@@ -1101,7 +1157,9 @@ func TestMapOrdering(t *testing.T) {
 	smallTestChunks()
 	defer normalProductionChunks()
 
-	testMapOrder(assert,
+	vrw := newTestValueStore()
+
+	testMapOrder(assert, vrw,
 		StringType, StringType,
 		[]Value{
 			String("a"), String("unused"),
@@ -1121,7 +1179,7 @@ func TestMapOrdering(t *testing.T) {
 		},
 	)
 
-	testMapOrder(assert,
+	testMapOrder(assert, vrw,
 		NumberType, StringType,
 		[]Value{
 			Number(0), String("unused"),
@@ -1141,7 +1199,7 @@ func TestMapOrdering(t *testing.T) {
 		},
 	)
 
-	testMapOrder(assert,
+	testMapOrder(assert, vrw,
 		NumberType, StringType,
 		[]Value{
 			Number(0), String("unused"),
@@ -1161,7 +1219,7 @@ func TestMapOrdering(t *testing.T) {
 		},
 	)
 
-	testMapOrder(assert,
+	testMapOrder(assert, vrw,
 		NumberType, StringType,
 		[]Value{
 			Number(0.0001), String("unused"),
@@ -1181,7 +1239,7 @@ func TestMapOrdering(t *testing.T) {
 		},
 	)
 
-	testMapOrder(assert,
+	testMapOrder(assert, vrw,
 		ValueType, StringType,
 		[]Value{
 			String("a"), String("unused"),
@@ -1201,7 +1259,7 @@ func TestMapOrdering(t *testing.T) {
 		},
 	)
 
-	testMapOrder(assert,
+	testMapOrder(assert, vrw,
 		BoolType, StringType,
 		[]Value{
 			Bool(true), String("unused"),
@@ -1217,53 +1275,59 @@ func TestMapOrdering(t *testing.T) {
 func TestMapEmpty(t *testing.T) {
 	assert := assert.New(t)
 
-	me := NewMap().Edit()
+	vrw := newTestValueStore()
+
+	me := NewMap(vrw).Edit()
 	empty := func() bool {
-		return me.Map(nil).Empty()
+		return me.Map().Empty()
 	}
 
 	assert.True(empty())
 	me.Set(Bool(false), String("hi"))
 	assert.False(empty())
-	me.Set(NewList(), NewMap())
+	me.Set(NewList(vrw), NewMap(vrw))
 	assert.False(empty())
 }
 
 func TestMapType(t *testing.T) {
 	assert := assert.New(t)
 
+	vrw := newTestValueStore()
+
 	emptyMapType := MakeMapType(MakeUnionType(), MakeUnionType())
-	m := NewMap()
+	m := NewMap(vrw)
 	assert.True(TypeOf(m).Equals(emptyMapType))
 
-	m2 := m.Edit().Remove(String("B")).Map(nil)
+	m2 := m.Edit().Remove(String("B")).Map()
 	assert.True(emptyMapType.Equals(TypeOf(m2)))
 
 	tr := MakeMapType(StringType, NumberType)
-	m2 = m.Edit().Set(String("A"), Number(1)).Map(nil)
+	m2 = m.Edit().Set(String("A"), Number(1)).Map()
 	assert.True(tr.Equals(TypeOf(m2)))
 
-	m2 = m.Edit().Set(String("B"), Number(2)).Set(String("C"), Number(2)).Map(nil)
+	m2 = m.Edit().Set(String("B"), Number(2)).Set(String("C"), Number(2)).Map()
 	assert.True(tr.Equals(TypeOf(m2)))
 
-	m3 := m2.Edit().Set(String("A"), Bool(true)).Map(nil)
+	m3 := m2.Edit().Set(String("A"), Bool(true)).Map()
 	assert.True(MakeMapType(StringType, MakeUnionType(BoolType, NumberType)).Equals(TypeOf(m3)), TypeOf(m3).Describe())
-	m4 := m3.Edit().Set(Bool(true), Number(1)).Map(nil)
+	m4 := m3.Edit().Set(Bool(true), Number(1)).Map()
 	assert.True(MakeMapType(MakeUnionType(BoolType, StringType), MakeUnionType(BoolType, NumberType)).Equals(TypeOf(m4)))
 }
 
 func TestMapChunks(t *testing.T) {
 	assert := assert.New(t)
 
-	l1 := NewMap(Number(0), Number(1))
+	vrw := newTestValueStore()
+
+	l1 := NewMap(vrw, Number(0), Number(1))
 	c1 := getChunks(l1)
 	assert.Len(c1, 0)
 
-	l2 := NewMap(NewRef(Number(0)), Number(1))
+	l2 := NewMap(vrw, NewRef(Number(0)), Number(1))
 	c2 := getChunks(l2)
 	assert.Len(c2, 1)
 
-	l3 := NewMap(Number(0), NewRef(Number(1)))
+	l3 := NewMap(vrw, Number(0), NewRef(Number(1)))
 	c3 := getChunks(l3)
 	assert.Len(c3, 1)
 }
@@ -1274,12 +1338,14 @@ func TestMapFirstNNumbers(t *testing.T) {
 	}
 	assert := assert.New(t)
 
+	vrw := newTestValueStore()
+
 	kvs := []Value{}
 	for i := 0; i < testMapSize; i++ {
 		kvs = append(kvs, Number(i), Number(i+1))
 	}
 
-	m := NewMap(kvs...)
+	m := NewMap(vrw, kvs...)
 	assert.Equal(deriveCollectionHeight(m), getRefHeightOfCollection(m))
 }
 
@@ -1299,7 +1365,7 @@ func TestMapRefOfStructFirstNNumbers(t *testing.T) {
 		kvs = append(kvs, k, v)
 	}
 
-	m := NewMap(kvs...)
+	m := NewMap(vs, kvs...)
 	// height + 1 because the leaves are Ref values (with height 1).
 	assert.Equal(deriveCollectionHeight(m)+1, getRefHeightOfCollection(m))
 }
@@ -1311,23 +1377,25 @@ func TestMapModifyAfterRead(t *testing.T) {
 	defer normalProductionChunks()
 
 	vs := newTestValueStore()
-	m := getTestNativeOrderMap(2).toMap()
+	m := getTestNativeOrderMap(2).toMap(vs)
 	// Drop chunk values.
 	m = vs.ReadValue(vs.WriteValue(m).TargetHash()).(Map)
 	// Modify/query. Once upon a time this would crash.
 	fst, fstval := m.First()
-	m = m.Edit().Remove(fst).Map(nil)
+	m = m.Edit().Remove(fst).Map()
 	assert.False(m.Has(fst))
 
 	fst2, _ := m.First()
 	assert.True(m.Has(fst2))
 
-	m = m.Edit().Set(fst, fstval).Map(nil)
+	m = m.Edit().Set(fst, fstval).Map()
 	assert.True(m.Has(fst))
 }
 
 func TestMapTypeAfterMutations(t *testing.T) {
 	assert := assert.New(t)
+
+	vrw := newTestValueStore()
 
 	test := func(n int, c interface{}) {
 		values := make([]Value, 2*n)
@@ -1336,17 +1404,17 @@ func TestMapTypeAfterMutations(t *testing.T) {
 			values[2*i+1] = Number(i)
 		}
 
-		m := NewMap(values...)
+		m := NewMap(vrw, values...)
 		assert.Equal(m.Len(), uint64(n))
 		assert.IsType(c, m.sequence())
 		assert.True(TypeOf(m).Equals(MakeMapType(NumberType, NumberType)))
 
-		m = m.Edit().Set(String("a"), String("a")).Map(nil)
+		m = m.Edit().Set(String("a"), String("a")).Map()
 		assert.Equal(m.Len(), uint64(n+1))
 		assert.IsType(c, m.sequence())
 		assert.True(TypeOf(m).Equals(MakeMapType(MakeUnionType(NumberType, StringType), MakeUnionType(NumberType, StringType))))
 
-		m = m.Edit().Remove(String("a")).Map(nil)
+		m = m.Edit().Remove(String("a")).Map()
 		assert.Equal(m.Len(), uint64(n))
 		assert.IsType(c, m.sequence())
 		assert.True(TypeOf(m).Equals(MakeMapType(NumberType, NumberType)))
@@ -1359,33 +1427,35 @@ func TestMapTypeAfterMutations(t *testing.T) {
 func TestCompoundMapWithValuesOfEveryType(t *testing.T) {
 	assert := assert.New(t)
 
+	vrw := newTestValueStore()
+
 	v := Number(42)
 	kvs := []Value{
 		// Values
 		Bool(true), v,
 		Number(0), v,
 		String("hello"), v,
-		NewBlob(bytes.NewBufferString("buf")), v,
-		NewSet(Bool(true)), v,
-		NewList(Bool(true)), v,
-		NewMap(Bool(true), Number(0)), v,
+		NewBlob(vrw, bytes.NewBufferString("buf")), v,
+		NewSet(vrw, Bool(true)), v,
+		NewList(vrw, Bool(true)), v,
+		NewMap(vrw, Bool(true), Number(0)), v,
 		NewStruct("", StructData{"field": Bool(true)}), v,
 		// Refs of values
 		NewRef(Bool(true)), v,
 		NewRef(Number(0)), v,
 		NewRef(String("hello")), v,
-		NewRef(NewBlob(bytes.NewBufferString("buf"))), v,
-		NewRef(NewSet(Bool(true))), v,
-		NewRef(NewList(Bool(true))), v,
-		NewRef(NewMap(Bool(true), Number(0))), v,
+		NewRef(NewBlob(vrw, bytes.NewBufferString("buf"))), v,
+		NewRef(NewSet(vrw, Bool(true))), v,
+		NewRef(NewList(vrw, Bool(true))), v,
+		NewRef(NewMap(vrw, Bool(true), Number(0))), v,
 		NewRef(NewStruct("", StructData{"field": Bool(true)})), v,
 	}
 
-	m := NewMap(kvs...)
+	m := NewMap(vrw, kvs...)
 	for i := 1; m.sequence().isLeaf(); i++ {
 		k := Number(i)
 		kvs = append(kvs, k, v)
-		m = m.Edit().Set(k, v).Map(nil)
+		m = m.Edit().Set(k, v).Map()
 	}
 
 	assert.Equal(len(kvs)/2, int(m.Len()))
@@ -1405,7 +1475,7 @@ func TestCompoundMapWithValuesOfEveryType(t *testing.T) {
 	for len(kvs) > 0 {
 		k := kvs[0]
 		kvs = kvs[2:]
-		m = m.Edit().Remove(k).Map(nil)
+		m = m.Edit().Remove(k).Map()
 		assert.False(m.Has(k))
 		assert.Equal(len(kvs)/2, int(m.Len()))
 	}
@@ -1423,20 +1493,22 @@ func TestMapRemoveLastWhenNotLoaded(t *testing.T) {
 	}
 
 	tm := getTestNativeOrderMap(4)
-	nm := tm.toMap()
+	nm := tm.toMap(vs)
 
 	for len(tm.entries) > 0 {
 		entr := tm.entries
 		last := entr[len(entr)-1]
 		entr = entr[:len(entr)-1]
 		tm.entries = entr
-		nm = reload(nm.Edit().Remove(last.key).Map(nil))
-		assert.True(tm.toMap().Equals(nm))
+		nm = reload(nm.Edit().Remove(last.key).Map())
+		assert.True(tm.toMap(vs).Equals(nm))
 	}
 }
 
 func TestMapIterFrom(t *testing.T) {
 	assert := assert.New(t)
+
+	vrw := newTestValueStore()
 
 	test := func(m Map, start, end Value) ValueSlice {
 		res := ValueSlice{}
@@ -1451,7 +1523,7 @@ func TestMapIterFrom(t *testing.T) {
 	}
 
 	kvs := generateNumbersAsValuesFromToBy(-50, 50, 1)
-	m1 := NewMap(kvs...)
+	m1 := NewMap(vrw, kvs...)
 	assert.True(kvs.Equals(test(m1, nil, Number(1000))))
 	assert.True(kvs.Equals(test(m1, Number(-1000), Number(1000))))
 	assert.True(kvs.Equals(test(m1, Number(-50), Number(1000))))
@@ -1466,8 +1538,10 @@ func TestMapIterFrom(t *testing.T) {
 func TestMapAt(t *testing.T) {
 	assert := assert.New(t)
 
+	vrw := newTestValueStore()
+
 	values := []Value{Bool(false), Number(42), String("a"), String("b"), String("c"), String("d")}
-	m := NewMap(values...)
+	m := NewMap(vrw, values...)
 
 	for i := 0; i < len(values); i += 2 {
 		k, v := m.At(uint64(i / 2))
@@ -1482,7 +1556,9 @@ func TestMapAt(t *testing.T) {
 
 func TestMapWithStructShouldHaveOptionalFields(t *testing.T) {
 	assert := assert.New(t)
-	list := NewMap(
+	vrw := newTestValueStore()
+
+	list := NewMap(vrw,
 		String("one"),
 		NewStruct("Foo", StructData{
 			"a": Number(1),
@@ -1502,7 +1578,7 @@ func TestMapWithStructShouldHaveOptionalFields(t *testing.T) {
 		).Equals(TypeOf(list)))
 
 	// transpose
-	list = NewMap(
+	list = NewMap(vrw,
 		NewStruct("Foo", StructData{
 			"a": Number(1),
 		}),
@@ -1525,63 +1601,67 @@ func TestMapWithStructShouldHaveOptionalFields(t *testing.T) {
 }
 
 func TestMapWithNil(t *testing.T) {
+	vrw := newTestValueStore()
+
 	assert.Panics(t, func() {
 		NewMap(nil, Number(42))
 	})
 	assert.Panics(t, func() {
-		NewSet(Number(42), nil)
+		NewSet(vrw, Number(42), nil)
 	})
 	assert.Panics(t, func() {
-		NewMap(String("a"), String("b"), nil, Number(42))
+		NewMap(vrw, String("a"), String("b"), nil, Number(42))
 	})
 	assert.Panics(t, func() {
-		NewSet(String("a"), String("b"), Number(42), nil)
+		NewSet(vrw, String("a"), String("b"), Number(42), nil)
 	})
 }
 
 func TestNestedEditing(t *testing.T) {
-	me0 := NewMap().Edit()
+	vrw := newTestValueStore()
+
+	me0 := NewMap(vrw).Edit()
 
 	// m.a.a
-	me1a := NewMap().Edit()
+	me1a := NewMap(vrw).Edit()
 	me0.Set(String("a"), me1a)
-	se2a := NewSet().Edit()
+	se2a := NewSet(vrw).Edit()
 	me1a.Set(String("a"), se2a)
 	se2a.Insert(String("a"))
 
 	// m.b.b
-	me1b := NewMap().Edit()
+	me1b := NewMap(vrw).Edit()
 	me0.Set(String("b"), me1b)
-	se2b := NewSet().Edit()
+	se2b := NewSet(vrw).Edit()
 	me1b.Set(String("b"), se2b)
 	se2b.Insert(String("b"))
 
-	mOut := me0.Map(nil)
-	assert.True(t, mOut.Equals(NewMap(
-		String("a"), NewMap(
-			String("a"), NewSet(String("a")),
+	mOut := me0.Map()
+	assert.True(t, mOut.Equals(NewMap(vrw,
+		String("a"), NewMap(vrw,
+			String("a"), NewSet(vrw, String("a")),
 		),
-		String("b"), NewMap(
-			String("b"), NewSet(String("b")),
+		String("b"), NewMap(vrw,
+			String("b"), NewSet(vrw, String("b")),
 		),
 	)))
 
 	se2a.Remove(String("a")).Insert(String("aa"))
 	se2b.Remove(String("b")).Insert(String("bb"))
 
-	mOut = me0.Map(nil)
-	assert.True(t, mOut.Equals(NewMap(
-		String("a"), NewMap(
-			String("a"), NewSet(String("aa")),
+	mOut = me0.Map()
+	assert.True(t, mOut.Equals(NewMap(vrw,
+		String("a"), NewMap(vrw,
+			String("a"), NewSet(vrw, String("aa")),
 		),
-		String("b"), NewMap(
-			String("b"), NewSet(String("bb")),
+		String("b"), NewMap(vrw,
+			String("b"), NewSet(vrw, String("bb")),
 		),
 	)))
 
 	se2a.Remove(String("aa"))
 	se2b.Remove(String("bb"))
 
-	mOut = me0.Map(nil)
-	assert.True(t, mOut.Equals(NewMap())) // remove empty
+	mOut = me0.Map()
+	assert.True(t, mOut.Equals(NewMap(vrw))) // remove empty
 }

--- a/go/types/number.go
+++ b/go/types/number.go
@@ -12,7 +12,7 @@ import (
 type Number float64
 
 // Value interface
-func (v Number) Value(vrw ValueReadWriter) Value {
+func (v Number) Value() Value {
 	return v
 }
 

--- a/go/types/opcache.go
+++ b/go/types/opcache.go
@@ -119,7 +119,7 @@ type ldbOpCache struct {
 
 type ldbOpCacheIterator struct {
 	iter ldbIterator.Iterator
-	vr   ValueReader
+	vrw  ValueReadWriter
 }
 
 func newLdbOpCacheStore(vrw ValueReadWriter) *ldbOpCacheStore {
@@ -158,13 +158,13 @@ func (opc *ldbOpCache) insertLdbOp(allKeys ValueSlice, opKind NomsKind, val Valu
 	ldbKeyBytes := [initialBufferSize]byte{}
 	ldbValBytes := [initialBufferSize]byte{}
 
-	ldbKey, valuesToEncode := encodeKeys(ldbKeyBytes[:0], opc.colId, opKind, allKeys, opc.vrw)
+	ldbKey, valuesToEncode := encodeKeys(ldbKeyBytes[:0], opc.colId, opKind, allKeys)
 
 	// val may be nil when dealing with sets, since the val is the key.
 	if val != nil {
 		valuesToEncode = append(valuesToEncode, val)
 	}
-	ldbVal := encodeValues(ldbValBytes[:0], valuesToEncode, opc.vrw)
+	ldbVal := encodeValues(ldbValBytes[:0], valuesToEncode)
 
 	err := opc.ldb.Put(ldbKey, ldbVal, nil)
 	d.Chk.NoError(err)
@@ -200,7 +200,7 @@ func (i *ldbOpCacheIterator) GraphOp() (ValueSlice, NomsKind, sequenceItem) {
 	graphKeys := ValueSlice{}
 	for pos := uint8(0); pos < numKeys; pos++ {
 		var gk Value
-		ldbKey, gk = decodeValue(ldbKey, false, i.vr)
+		ldbKey, gk = decodeValue(ldbKey, false, i.vrw)
 		graphKeys = append(graphKeys, gk)
 	}
 
@@ -213,7 +213,7 @@ func (i *ldbOpCacheIterator) GraphOp() (ValueSlice, NomsKind, sequenceItem) {
 	values := ValueSlice{}
 	for pos := uint8(0); pos < numEncodedValues; pos++ {
 		var gk Value
-		ldbVal, gk = decodeValue(ldbVal, true, i.vr)
+		ldbVal, gk = decodeValue(ldbVal, true, i.vrw)
 		values = append(values, gk)
 	}
 
@@ -248,7 +248,7 @@ func (i *ldbOpCacheIterator) GraphOp() (ValueSlice, NomsKind, sequenceItem) {
 func (opc *ldbOpCache) NewIterator() opCacheIterator {
 	prefix := [4]byte{}
 	binary.BigEndian.PutUint32(prefix[:], opc.colId)
-	return &ldbOpCacheIterator{iter: opc.ldb.NewIterator(util.BytesPrefix(prefix[:]), nil), vr: opc.vrw}
+	return &ldbOpCacheIterator{iter: opc.ldb.NewIterator(util.BytesPrefix(prefix[:]), nil), vrw: opc.vrw}
 }
 
 func (i *ldbOpCacheIterator) Next() bool {
@@ -260,7 +260,7 @@ func (i *ldbOpCacheIterator) Release() {
 }
 
 // encodeKeys() serializes a list of keys to the byte slice |bs|.
-func encodeKeys(bs []byte, colId uint32, opKind NomsKind, keys []Value, vrw ValueReadWriter) ([]byte, []Value) {
+func encodeKeys(bs []byte, colId uint32, opKind NomsKind, keys []Value) ([]byte, []Value) {
 	// All ldb keys start with a 4-byte collection id that serves as a namespace
 	// that keeps them separate from other collections.
 	idHolder := [4]byte{}
@@ -276,7 +276,7 @@ func encodeKeys(bs []byte, colId uint32, opKind NomsKind, keys []Value, vrw Valu
 
 	valuesToEncode := ValueSlice{}
 	for _, gk := range keys {
-		bs = encodeGraphKey(bs, gk, vrw)
+		bs = encodeGraphKey(bs, gk)
 		if !isKindOrderedByValue(gk.Kind()) {
 			valuesToEncode = append(valuesToEncode, gk)
 		}
@@ -284,24 +284,24 @@ func encodeKeys(bs []byte, colId uint32, opKind NomsKind, keys []Value, vrw Valu
 	return bs, valuesToEncode
 }
 
-func encodeValues(bs []byte, valuesToEncode []Value, vrw ValueReadWriter) []byte {
+func encodeValues(bs []byte, valuesToEncode []Value) []byte {
 	// Encode allValues into the ldbVal byte slice.
 	bs = append(bs, uint8(len(valuesToEncode)))
 	for _, k := range valuesToEncode {
-		bs = encodeGraphValue(bs, k, vrw)
+		bs = encodeGraphValue(bs, k)
 	}
 	return bs
 }
 
-func encodeGraphKey(bs []byte, v Value, vrw ValueReadWriter) []byte {
-	return encodeForGraph(bs, v, false, vrw)
+func encodeGraphKey(bs []byte, v Value) []byte {
+	return encodeForGraph(bs, v, false)
 }
 
-func encodeGraphValue(bs []byte, v Value, vrw ValueReadWriter) []byte {
-	return encodeForGraph(bs, v, true, vrw)
+func encodeGraphValue(bs []byte, v Value) []byte {
+	return encodeForGraph(bs, v, true)
 }
 
-func encodeForGraph(bs []byte, v Value, asValue bool, vrw ValueReadWriter) []byte {
+func encodeForGraph(bs []byte, v Value, asValue bool) []byte {
 	// Note: encToSlice() and append() will both grow the backing store of |bs|
 	// as necessary. Always call them when writing to |bs|.
 	if asValue || isKindOrderedByValue(v.Kind()) {
@@ -309,7 +309,7 @@ func encodeForGraph(bs []byte, v Value, asValue bool, vrw ValueReadWriter) []byt
 		// noms-kind(1-byte), serialization-len(4-bytes), serialization(n-bytes)
 		buf := [initialBufferSize]byte{}
 		uint32buf := [4]byte{}
-		encodedVal := encToSlice(v, buf[:], vrw)
+		encodedVal := encToSlice(v, buf[:])
 		binary.BigEndian.PutUint32(uint32buf[:], uint32(len(encodedVal)))
 		bs = append(bs, uint8(v.Kind()))
 		bs = append(bs, uint32buf[:]...)
@@ -323,29 +323,19 @@ func encodeForGraph(bs []byte, v Value, asValue bool, vrw ValueReadWriter) []byt
 	return bs
 }
 
-func decodeValue(bs []byte, asValue bool, vr ValueReader) ([]byte, Value) {
+func decodeValue(bs []byte, asValue bool, vrw ValueReadWriter) ([]byte, Value) {
 	kind := NomsKind(bs[0])
 	var v Value
 	if asValue || isKindOrderedByValue(kind) {
 		encodedLen := binary.BigEndian.Uint32(bs[1:5])
-		v = DecodeFromBytes(bs[5:5+encodedLen], vr)
+		v = DecodeFromBytes(bs[5:5+encodedLen], vrw)
 		return bs[5+encodedLen:], v
 	}
 	return bs[1+hash.ByteLen:], nil
 }
 
 // Note that, if 'v' are prolly trees, any in-memory child chunks will be written to vw at this time.
-func encToSlice(v Value, initBuf []byte, vw ValueWriter) []byte {
-	// TODO: This is really unfortunate because WriteValue, in the case of
-	// ValueStore will internally also iterateUncommittedChildren. The problem
-	// here is a lack of clarity in the contract of ValueWriter. It's not explicit
-	// that WriteValue is responsible for writing uncommitted child nodes of
-	// ptrees, nor is there sufficient public API for any implementor of it to do
-	// so.
-	iterateUncommittedChildren(v, func(sv Value) {
-		vw.WriteValue(v)
-	})
-
+func encToSlice(v Value, initBuf []byte) []byte {
 	// TODO: Are there enough calls to this that it's worth re-using a nomsWriter and valueEncoder?
 	w := &binaryNomsWriter{initBuf, 0}
 	enc := newValueEncoder(w, false)

--- a/go/types/opcache_test.go
+++ b/go/types/opcache_test.go
@@ -31,16 +31,17 @@ func (suite *OpCacheSuite) TearDownTest() {
 }
 
 func (suite *OpCacheSuite) TestMapSet() {
-	opCacheStore := newLdbOpCacheStore(suite.vs)
+	vs := suite.vs
+	opCacheStore := newLdbOpCacheStore(vs)
 	oc := opCacheStore.opCache()
 	defer opCacheStore.destroy()
 
 	entries := mapEntrySlice{
-		{NewList(Number(8), Number(0)), String("ahoy")},
-		{String("A key"), NewBlob(bytes.NewBufferString("A value"))},
+		{NewList(vs, Number(8), Number(0)), String("ahoy")},
+		{String("A key"), NewBlob(vs, bytes.NewBufferString("A value"))},
 		{Number(1), Bool(true)},
 		{Bool(false), Number(1)},
-		{NewBlob(bytes.NewBuffer([]byte{0xff, 0, 0})), NewMap()},
+		{NewBlob(vs, bytes.NewBuffer([]byte{0xff, 0, 0})), NewMap(vs)},
 		{Bool(true), Number(42)},
 		{NewStruct("thing1", StructData{"a": Number(7)}), Number(42)},
 		{String("struct"), NewStruct("thing2", nil)},
@@ -64,19 +65,20 @@ func (suite *OpCacheSuite) TestMapSet() {
 }
 
 func (suite *OpCacheSuite) TestSetInsert() {
-	opCacheStore := newLdbOpCacheStore(suite.vs)
+	vs := suite.vs
+	opCacheStore := newLdbOpCacheStore(vs)
 	oc := opCacheStore.opCache()
 	defer opCacheStore.destroy()
 
 	entries := ValueSlice{
-		NewList(Number(8), Number(0)),
+		NewList(vs, Number(8), Number(0)),
 		String("ahoy"),
-		NewBlob(bytes.NewBufferString("A value")),
+		NewBlob(vs, bytes.NewBufferString("A value")),
 		Number(1),
 		Bool(true),
 		Bool(false),
-		NewBlob(bytes.NewBuffer([]byte{0xff, 0, 0})),
-		NewMap(),
+		NewBlob(vs, bytes.NewBuffer([]byte{0xff, 0, 0})),
+		NewMap(vs),
 		Number(42),
 		NewStruct("thing1", StructData{"a": Number(7)}),
 		String("struct"),
@@ -101,19 +103,20 @@ func (suite *OpCacheSuite) TestSetInsert() {
 }
 
 func (suite *OpCacheSuite) TestListAppend() {
-	opCacheStore := newLdbOpCacheStore(suite.vs)
+	vs := suite.vs
+	opCacheStore := newLdbOpCacheStore(vs)
 	oc := opCacheStore.opCache()
 	defer opCacheStore.destroy()
 
 	entries := ValueSlice{
-		NewList(Number(8), Number(0)),
+		NewList(vs, Number(8), Number(0)),
 		String("ahoy"),
-		NewBlob(bytes.NewBufferString("A value")),
+		NewBlob(vs, bytes.NewBufferString("A value")),
 		Number(1),
 		Bool(true),
 		Bool(false),
-		NewBlob(bytes.NewBuffer([]byte{0xff, 0, 0})),
-		NewMap(),
+		NewBlob(vs, bytes.NewBuffer([]byte{0xff, 0, 0})),
+		NewMap(vs),
 		Number(42),
 		NewStruct("thing1", StructData{"a": Number(7)}),
 		String("struct"),

--- a/go/types/ordered_sequences.go
+++ b/go/types/ordered_sequences.go
@@ -15,12 +15,12 @@ type orderedSequence interface {
 	getKey(idx int) orderedKey
 }
 
-func newSetMetaSequence(level uint64, tuples []metaTuple, vr ValueReader) metaSequence {
-	return newMetaSequence(SetKind, level, tuples, vr)
+func newSetMetaSequence(level uint64, tuples []metaTuple, vrw ValueReadWriter) metaSequence {
+	return newMetaSequence(SetKind, level, tuples, vrw)
 }
 
-func newMapMetaSequence(level uint64, tuples []metaTuple, vr ValueReader) metaSequence {
-	return newMetaSequence(MapKind, level, tuples, vr)
+func newMapMetaSequence(level uint64, tuples []metaTuple, vrw ValueReadWriter) metaSequence {
+	return newMetaSequence(MapKind, level, tuples, vrw)
 }
 
 func newCursorAtValue(seq orderedSequence, val Value, forInsertion bool, last bool, readAhead bool) *sequenceCursor {
@@ -90,7 +90,7 @@ func getMapValue(cur *sequenceCursor) Value {
 
 // If |vw| is not nil, chunks will be eagerly written as they're created. Otherwise they are
 // written when the root is written.
-func newOrderedMetaSequenceChunkFn(kind NomsKind, vr ValueReader) makeChunkFn {
+func newOrderedMetaSequenceChunkFn(kind NomsKind, vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		tuples := make([]metaTuple, len(items))
 		numLeaves := uint64(0)
@@ -106,10 +106,10 @@ func newOrderedMetaSequenceChunkFn(kind NomsKind, vr ValueReader) makeChunkFn {
 
 		var col Collection
 		if kind == SetKind {
-			col = newSet(newSetMetaSequence(level, tuples, vr))
+			col = newSet(newSetMetaSequence(level, tuples, vrw))
 		} else {
 			d.PanicIfFalse(MapKind == kind)
-			col = newMap(newMapMetaSequence(level, tuples, vr))
+			col = newMap(newMapMetaSequence(level, tuples, vrw))
 		}
 
 		return col, tuples[len(tuples)-1].key, numLeaves

--- a/go/types/perf/perf_test.go
+++ b/go/types/perf/perf_test.go
@@ -86,7 +86,7 @@ func (s *perfSuite) Test05Concat10mValues2kTimes() {
 	l1Len, l2Len := l1.Len(), l2.Len()
 	l1Last, l2Last := last(l1), last(l2)
 
-	l3 := types.NewList()
+	l3 := types.NewList(s.Database)
 	for i := uint64(0); i < 1e3; i++ { // 1k iterations * 2 concat ops = 2k times
 		// Include some basic sanity checks.
 		l3 = l3.Concat(l1)
@@ -151,7 +151,7 @@ func (s *perfSuite) testBuild500megBlob(p int) {
 		}
 	})
 
-	b := types.NewBlob(readers...)
+	b := types.NewBlob(s.Database, readers...)
 	assert.Equal(uint64(size), b.Len())
 }
 

--- a/go/types/ref.go
+++ b/go/types/ref.go
@@ -55,7 +55,7 @@ func (r Ref) TargetType() *Type {
 }
 
 // Value interface
-func (r Ref) Value(vrw ValueReadWriter) Value {
+func (r Ref) Value() Value {
 	return r
 }
 

--- a/go/types/ref_test.go
+++ b/go/types/ref_test.go
@@ -13,9 +13,11 @@ import (
 func TestRefInList(t *testing.T) {
 	assert := assert.New(t)
 
-	l := NewList()
+	vs := newTestValueStore()
+
+	l := NewList(vs)
 	r := NewRef(l)
-	l = l.Edit().Append(r).List(nil)
+	l = l.Edit().Append(r).List()
 	r2 := l.Get(0)
 	assert.True(r.Equals(r2))
 }
@@ -23,9 +25,11 @@ func TestRefInList(t *testing.T) {
 func TestRefInSet(t *testing.T) {
 	assert := assert.New(t)
 
-	s := NewSet()
+	vs := newTestValueStore()
+
+	s := NewSet(vs)
 	r := NewRef(s)
-	s = s.Edit().Insert(r).Set(nil)
+	s = s.Edit().Insert(r).Set()
 	r2 := s.First()
 	assert.True(r.Equals(r2))
 }
@@ -33,9 +37,11 @@ func TestRefInSet(t *testing.T) {
 func TestRefInMap(t *testing.T) {
 	assert := assert.New(t)
 
-	m := NewMap()
+	vs := newTestValueStore()
+
+	m := NewMap(vs)
 	r := NewRef(m)
-	m = m.Edit().Set(Number(0), r).Set(r, Number(1)).Map(nil)
+	m = m.Edit().Set(Number(0), r).Set(r, Number(1)).Map()
 	r2 := m.Get(Number(0))
 	assert.True(r.Equals(r2))
 
@@ -46,7 +52,9 @@ func TestRefInMap(t *testing.T) {
 func TestRefChunks(t *testing.T) {
 	assert := assert.New(t)
 
-	l := NewList()
+	vs := newTestValueStore()
+
+	l := NewList(vs)
 	r := NewRef(l)
 	assert.Len(getChunks(r), 1)
 	assert.Equal(r, getChunks(r)[0])

--- a/go/types/sequence.go
+++ b/go/types/sequence.go
@@ -12,7 +12,7 @@ type sequence interface {
 	getItem(idx int) sequenceItem
 	seqLen() int
 	numLeaves() uint64
-	valueReader() ValueReader
+	valueReadWriter() ValueReadWriter
 	WalkRefs(cb RefCallback)
 	typeOf() *Type
 	Kind() NomsKind

--- a/go/types/sequence_concat.go
+++ b/go/types/sequence_concat.go
@@ -6,7 +6,7 @@ package types
 
 import "github.com/attic-labs/noms/go/d"
 
-type newSequenceChunkerFn func(cur *sequenceCursor, vr ValueReader) *sequenceChunker
+type newSequenceChunkerFn func(cur *sequenceCursor, vrw ValueReadWriter) *sequenceChunker
 
 func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence {
 	if fst.numLeaves() == 0 {
@@ -19,11 +19,11 @@ func concat(fst, snd sequence, newSequenceChunker newSequenceChunkerFn) sequence
 	// concat works by tricking the sequenceChunker into resuming chunking at a
 	// cursor to the end of fst, then finalizing chunking to the start of snd - by
 	// swapping fst cursors for snd cursors in the middle of chunking.
-	vr := fst.valueReader()
-	if vr != snd.valueReader() {
+	vrw := fst.valueReadWriter()
+	if vrw != snd.valueReadWriter() {
 		d.Panic("cannot concat sequences from different databases")
 	}
-	chunker := newSequenceChunker(newCursorAtIndex(fst, fst.numLeaves(), false), vr)
+	chunker := newSequenceChunker(newCursorAtIndex(fst, fst.numLeaves(), false), vrw)
 
 	for cur, ch := newCursorAtIndex(snd, 0, false), chunker; ch != nil; ch = ch.parent {
 		// Note that if snd is shallower than fst, then higher chunkers will have

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -80,7 +80,7 @@ func newSequenceCursor(parent *sequenceCursor, seq sequence, idx int, readAhead 
 		d.PanicIfFalse(idx >= 0)
 	}
 
-	readAhead = readAhead && !seq.isLeaf() && seq.valueReader() != nil
+	readAhead = readAhead && !seq.isLeaf() && seq.valueReadWriter() != nil
 	return &sequenceCursor{parent, seq, idx, readAhead, nil}
 }
 

--- a/go/types/sequence_cursor_test.go
+++ b/go/types/sequence_cursor_test.go
@@ -51,7 +51,7 @@ func (ts testSequence) getCompareFn(other sequence) compareFn {
 	}
 }
 
-func (ts testSequence) valueReader() ValueReader {
+func (ts testSequence) valueReadWriter() ValueReadWriter {
 	panic("not reached")
 }
 

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -47,6 +47,7 @@ func NewStreamingSet(vrw ValueReadWriter, vChan <-chan Value) <-chan Set {
 type streamingSetReadFunc func(vrw ValueReadWriter, vChan <-chan Value, outChan chan<- Set)
 
 func newStreamingSet(vrw ValueReadWriter, vChan <-chan Value, readFunc streamingSetReadFunc) <-chan Set {
+	d.PanicIfTrue(vrw == nil)
 	outChan := make(chan Set, 1)
 	readFunc(vrw, vChan, outChan)
 	return outChan

--- a/go/types/set.go
+++ b/go/types/set.go
@@ -21,9 +21,9 @@ func newSet(seq orderedSequence) Set {
 	return Set{seq, &hash.Hash{}}
 }
 
-func NewSet(v ...Value) Set {
+func NewSet(vrw ValueReadWriter, v ...Value) Set {
 	data := buildSetData(v)
-	ch := newEmptySetSequenceChunker(nil, nil)
+	ch := newEmptySetSequenceChunker(vrw)
 
 	for _, v := range data {
 		ch.Append(v)
@@ -54,7 +54,7 @@ func newStreamingSet(vrw ValueReadWriter, vChan <-chan Value, readFunc streaming
 
 func readSetInput(vrw ValueReadWriter, vChan <-chan Value, outChan chan<- Set) {
 	defer close(outChan)
-	ch := newEmptySetSequenceChunker(vrw, vrw)
+	ch := newEmptySetSequenceChunker(vrw)
 	var lastV Value
 	for v := range vChan {
 		d.PanicIfTrue(v == nil)
@@ -114,7 +114,7 @@ func (s Set) hashPointer() *hash.Hash {
 }
 
 // Value interface
-func (s Set) Value(vrw ValueReadWriter) Value {
+func (s Set) Value() Value {
 	return s
 }
 
@@ -240,7 +240,7 @@ func buildSetData(values ValueSlice) ValueSlice {
 	return append(uniqueSorted, last)
 }
 
-func makeSetLeafChunkFn(vr ValueReader) makeChunkFn {
+func makeSetLeafChunkFn(vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		d.PanicIfFalse(level == 0)
 		setData := make([]Value, len(items), len(items))
@@ -253,7 +253,7 @@ func makeSetLeafChunkFn(vr ValueReader) makeChunkFn {
 			setData[i] = v
 		}
 
-		set := newSet(newSetLeafSequence(vr, setData...))
+		set := newSet(newSetLeafSequence(vrw, setData...))
 		var key orderedKey
 		if len(setData) > 0 {
 			key = newOrderedKey(setData[len(setData)-1])
@@ -263,6 +263,6 @@ func makeSetLeafChunkFn(vr ValueReader) makeChunkFn {
 	}
 }
 
-func newEmptySetSequenceChunker(vr ValueReader, vw ValueWriter) *sequenceChunker {
-	return newEmptySequenceChunker(vr, vw, makeSetLeafChunkFn(vr), newOrderedMetaSequenceChunkFn(SetKind, vr), hashValueBytes)
+func newEmptySetSequenceChunker(vrw ValueReadWriter) *sequenceChunker {
+	return newEmptySequenceChunker(vrw, makeSetLeafChunkFn(vrw), newOrderedMetaSequenceChunkFn(SetKind, vrw), hashValueBytes)
 }

--- a/go/types/set_editor.go
+++ b/go/types/set_editor.go
@@ -30,19 +30,16 @@ func (se *SetEditor) Kind() NomsKind {
 	return SetKind
 }
 
-func (se *SetEditor) Value(vrw ValueReadWriter) Value {
-	return se.Set(vrw)
+func (se *SetEditor) Value() Value {
+	return se.Set()
 }
 
-func (se *SetEditor) Set(vrw ValueReadWriter) Set {
+func (se *SetEditor) Set() Set {
 	if len(se.edits) == 0 {
 		return se.s // no edits
 	}
 
-	vr := se.s.sequence().valueReader()
-	if vrw != nil {
-		vr = vrw
-	}
+	vrw := se.s.sequence().valueReadWriter()
 
 	se.normalize()
 
@@ -93,7 +90,7 @@ func (se *SetEditor) Set(vrw ValueReadWriter) Set {
 		}
 
 		if ch == nil {
-			ch = newSequenceChunker(cur, 0, vr, vrw, makeSetLeafChunkFn(vr), newOrderedMetaSequenceChunkFn(SetKind, vr), hashValueBytes)
+			ch = newSequenceChunker(cur, 0, vrw, makeSetLeafChunkFn(vrw), newOrderedMetaSequenceChunkFn(SetKind, vrw), hashValueBytes)
 		} else {
 			ch.advanceTo(cur)
 		}

--- a/go/types/set_iterator_test.go
+++ b/go/types/set_iterator_test.go
@@ -14,11 +14,13 @@ import (
 func TestSetIterator(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+
 	numbers := append(generateNumbersAsValues(10), Number(20), Number(25))
-	s := NewSet(numbers...)
+	s := NewSet(vs, numbers...)
 	i := s.Iterator()
-	vs := iterToSlice(i)
-	assert.True(vs.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
+	vals := iterToSlice(i)
+	assert.True(vals.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
 
 	i = s.Iterator()
 	assert.Panics(func() { i.SkipTo(nil) })
@@ -39,90 +41,96 @@ func TestSetIterator(t *testing.T) {
 	assert.Equal(Number(3), i.SkipTo(Number(3)))
 	assert.Equal(Number(4), i.Next())
 
-	empty := NewSet()
+	empty := NewSet(vs)
 	assert.Nil(empty.Iterator().Next())
 	assert.Nil(empty.Iterator().SkipTo(Number(-30)))
 
-	single := NewSet(Number(42)).Iterator()
+	single := NewSet(vs, Number(42)).Iterator()
 	assert.Equal(Number(42), single.SkipTo(Number(42)))
 	assert.Equal(nil, single.SkipTo(Number(42)))
 
-	single = NewSet(Number(42)).Iterator()
+	single = NewSet(vs, Number(42)).Iterator()
 	assert.Equal(Number(42), single.SkipTo(Number(42)))
 	assert.Equal(nil, single.Next())
 
-	single = NewSet(Number(42)).Iterator()
+	single = NewSet(vs, Number(42)).Iterator()
 	assert.Equal(Number(42), single.SkipTo(Number(21)))
 }
 
 func TestSetIteratorAt(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+
 	numbers := append(generateNumbersAsValues(5), Number(10))
-	s := NewSet(numbers...)
+	s := NewSet(vs, numbers...)
 	i := s.IteratorAt(0)
-	vs := iterToSlice(i)
-	assert.True(vs.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
+	vals := iterToSlice(i)
+	assert.True(vals.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
 
 	i = s.IteratorAt(2)
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(numbers[2:]), "Expected: %v != actual: %v", numbers[2:], vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(numbers[2:]), "Expected: %v != actual: %v", numbers[2:], vs)
 
 	i = s.IteratorAt(10)
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(nil), "Expected: %v != actual: %v", nil, vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(nil), "Expected: %v != actual: %v", nil, vs)
 }
 
 func TestSetIteratorFrom(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+
 	numbers := append(generateNumbersAsValues(5), Number(10), Number(20))
-	s := NewSet(numbers...)
+	s := NewSet(vs, numbers...)
 	i := s.IteratorFrom(Number(0))
-	vs := iterToSlice(i)
-	assert.True(vs.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
+	vals := iterToSlice(i)
+	assert.True(vals.Equals(numbers), "Expected: %v != actual: %v", numbers, vs)
 
 	i = s.IteratorFrom(Number(2))
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(numbers[2:]), "Expected: %v != actual: %v", numbers[2:], vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(numbers[2:]), "Expected: %v != actual: %v", numbers[2:], vs)
 
 	i = s.IteratorFrom(Number(10))
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(ValueSlice{Number(10), Number(20)}), "Expected: %v != actual: %v", nil, vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(ValueSlice{Number(10), Number(20)}), "Expected: %v != actual: %v", nil, vs)
 
 	i = s.IteratorFrom(Number(20))
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(ValueSlice{Number(20)}), "Expected: %v != actual: %v", nil, vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(ValueSlice{Number(20)}), "Expected: %v != actual: %v", nil, vs)
 
 	i = s.IteratorFrom(Number(100))
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(nil), "Expected: %v != actual: %v", nil, vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(nil), "Expected: %v != actual: %v", nil, vs)
 
 	// Not present. Starts at next larger.
 	i = s.IteratorFrom(Number(15))
-	vs = iterToSlice(i)
-	assert.True(vs.Equals(ValueSlice{Number(20)}), "Expected: %v != actual: %v", nil, vs)
+	vals = iterToSlice(i)
+	assert.True(vals.Equals(ValueSlice{Number(20)}), "Expected: %v != actual: %v", nil, vs)
 }
 
 func TestUnionIterator(t *testing.T) {
 	assert := assert.New(t)
 
-	set1 := NewSet(generateNumbersAsValuesFromToBy(0, 10, 1)...)
-	set2 := NewSet(generateNumbersAsValuesFromToBy(5, 15, 1)...)
-	set3 := NewSet(generateNumbersAsValuesFromToBy(10, 20, 1)...)
-	set4 := NewSet(generateNumbersAsValuesFromToBy(15, 25, 1)...)
+	vs := newTestValueStore()
+
+	set1 := NewSet(vs, generateNumbersAsValuesFromToBy(0, 10, 1)...)
+	set2 := NewSet(vs, generateNumbersAsValuesFromToBy(5, 15, 1)...)
+	set3 := NewSet(vs, generateNumbersAsValuesFromToBy(10, 20, 1)...)
+	set4 := NewSet(vs, generateNumbersAsValuesFromToBy(15, 25, 1)...)
 
 	ui1 := NewUnionIterator(set1.Iterator(), set2.Iterator())
-	vs := iterToSlice(ui1)
+	vals := iterToSlice(ui1)
 	expectedRes := generateNumbersAsValues(15)
-	assert.True(vs.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
 
 	ui1 = NewUnionIterator(set1.Iterator(), set4.Iterator())
 	ui2 := NewUnionIterator(set3.Iterator(), set2.Iterator())
 	ui3 := NewUnionIterator(ui1, ui2)
-	vs = iterToSlice(ui3)
+	vals = iterToSlice(ui3)
 	expectedRes = generateNumbersAsValues(25)
-	assert.True(vs.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
 
 	ui1 = NewUnionIterator(set1.Iterator(), set4.Iterator())
 	ui2 = NewUnionIterator(set3.Iterator(), set2.Iterator())
@@ -140,34 +148,36 @@ func TestUnionIterator(t *testing.T) {
 	assert.Equal(Number(24), ui3.SkipTo(Number(24)))
 	assert.Nil(ui3.SkipTo(Number(25)))
 
-	singleElemSet := NewSet(Number(4))
-	emptySet := NewSet()
+	singleElemSet := NewSet(vs, Number(4))
+	emptySet := NewSet(vs)
 
 	ui10 := NewUnionIterator(singleElemSet.Iterator(), singleElemSet.Iterator())
 	ui20 := NewUnionIterator(emptySet.Iterator(), emptySet.Iterator())
 	ui30 := NewUnionIterator(ui10, ui20)
-	vs = iterToSlice(ui30)
+	vals = iterToSlice(ui30)
 	expectedRes = ValueSlice{Number(4)}
-	assert.True(vs.Equals(expectedRes), "%v != %v\n", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "%v != %v\n", expectedRes, vs)
 }
 
 func TestIntersectionIterator(t *testing.T) {
 	assert := assert.New(t)
 
-	byTwos := NewSet(generateNumbersAsValuesFromToBy(0, 200, 2)...)
-	byThrees := NewSet(generateNumbersAsValuesFromToBy(0, 200, 3)...)
-	byFives := NewSet(generateNumbersAsValuesFromToBy(0, 200, 5)...)
+	vs := newTestValueStore()
+
+	byTwos := NewSet(vs, generateNumbersAsValuesFromToBy(0, 200, 2)...)
+	byThrees := NewSet(vs, generateNumbersAsValuesFromToBy(0, 200, 3)...)
+	byFives := NewSet(vs, generateNumbersAsValuesFromToBy(0, 200, 5)...)
 
 	i1 := NewIntersectionIterator(byTwos.Iterator(), byThrees.Iterator())
-	vs := iterToSlice(i1)
+	vals := iterToSlice(i1)
 	expectedRes := generateNumbersAsValuesFromToBy(0, 200, 6)
-	assert.True(vs.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
 
 	it1 := NewIntersectionIterator(byTwos.Iterator(), byThrees.Iterator())
 	it2 := NewIntersectionIterator(it1, byFives.Iterator())
-	vs = iterToSlice(it2)
+	vals = iterToSlice(it2)
 	expectedRes = generateNumbersAsValuesFromToBy(0, 200, 30)
-	assert.True(vs.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
 
 	it1 = NewIntersectionIterator(byThrees.Iterator(), byFives.Iterator())
 	it2 = NewIntersectionIterator(it1, byTwos.Iterator())
@@ -184,24 +194,26 @@ func TestIntersectionIterator(t *testing.T) {
 func TestCombinationIterator(t *testing.T) {
 	assert := assert.New(t)
 
-	byTwos := NewSet(generateNumbersAsValuesFromToBy(0, 70, 2)...)
-	byThrees := NewSet(generateNumbersAsValuesFromToBy(0, 70, 3)...)
-	byFives := NewSet(generateNumbersAsValuesFromToBy(0, 70, 5)...)
-	bySevens := NewSet(generateNumbersAsValuesFromToBy(0, 70, 7)...)
+	vs := newTestValueStore()
+
+	byTwos := NewSet(vs, generateNumbersAsValuesFromToBy(0, 70, 2)...)
+	byThrees := NewSet(vs, generateNumbersAsValuesFromToBy(0, 70, 3)...)
+	byFives := NewSet(vs, generateNumbersAsValuesFromToBy(0, 70, 5)...)
+	bySevens := NewSet(vs, generateNumbersAsValuesFromToBy(0, 70, 7)...)
 
 	it1 := NewIntersectionIterator(byTwos.Iterator(), bySevens.Iterator())
 	it2 := NewIntersectionIterator(byFives.Iterator(), byThrees.Iterator())
 	ut1 := NewUnionIterator(it1, it2)
-	vs := iterToSlice(ut1)
+	vals := iterToSlice(ut1)
 	expectedRes := intsToValueSlice(0, 14, 15, 28, 30, 42, 45, 56, 60)
-	assert.True(vs.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
 
 	ut1 = NewUnionIterator(byTwos.Iterator(), bySevens.Iterator())
 	it2 = NewIntersectionIterator(byFives.Iterator(), byThrees.Iterator())
 	ut2 := NewIntersectionIterator(ut1, it2)
-	vs = iterToSlice(ut2)
+	vals = iterToSlice(ut2)
 	expectedRes = intsToValueSlice(0, 30, 60)
-	assert.True(vs.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
+	assert.True(vals.Equals(expectedRes), "Expected: %v != actual: %v", expectedRes, vs)
 }
 
 type UnionTestIterator struct {
@@ -230,6 +242,8 @@ func NewUnionTestIterator(i1, i2 SetIterator, cntr *int) SetIterator {
 func TestUnionComplexity(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+
 	numSets := 256
 	numElemsPerSet := 1000
 	logNumSets := int(math.Ceil(math.Log2(float64(numSets))))
@@ -237,17 +251,17 @@ func TestUnionComplexity(t *testing.T) {
 	expectedMax := logNumSets*totalElems + numSets
 
 	callCount1 := 0
-	iter := iterize(createSetsWithDistinctNumbers(numSets, numElemsPerSet), NewUnionTestIterator, &callCount1)
-	vs := iterToSlice(iter)
+	iter := iterize(createSetsWithDistinctNumbers(vs, numSets, numElemsPerSet), NewUnionTestIterator, &callCount1)
+	vals := iterToSlice(iter)
 	expected := generateNumbersAsValueSlice(numSets * numElemsPerSet)
-	assert.True(expected.Equals(vs), "expected: %v != actual: %v", expected, vs)
+	assert.True(expected.Equals(vals), "expected: %v != actual: %v", expected, vals)
 	assert.True(expectedMax > callCount1, "callCount: %d exceeds expectedMax: %d", callCount1, expectedMax)
 
 	callCount2 := 0
-	iter = iterize(createSetsWithSameNumbers(numSets, numElemsPerSet), NewUnionTestIterator, &callCount2)
-	vs = iterToSlice(iter)
+	iter = iterize(createSetsWithSameNumbers(vs, numSets, numElemsPerSet), NewUnionTestIterator, &callCount2)
+	vals = iterToSlice(iter)
 	expected = generateNumbersAsValueSlice(numElemsPerSet)
-	assert.True(expected.Equals(vs), "expected: %v != actual: %v", expected, vs)
+	assert.True(expected.Equals(vals), "expected: %v != actual: %v", expected, vals)
 	assert.True(expectedMax > callCount2, "callCount: %d exceeds expectedMax: %d", callCount2, expectedMax)
 }
 
@@ -277,6 +291,8 @@ func NewIntersectionTestIterator(i1, i2 SetIterator, cntr *int) SetIterator {
 func TestIntersectComplexity(t *testing.T) {
 	assert := assert.New(t)
 
+	vs := newTestValueStore()
+
 	numSets := 256
 	numElemsPerSet := 1000
 	logNumSets := int(math.Ceil(math.Log2(float64(numSets))))
@@ -284,41 +300,42 @@ func TestIntersectComplexity(t *testing.T) {
 	expectedMax := logNumSets*totalElems + numSets
 
 	callCount1 := 0
-	iter := iterize(createSetsWithDistinctNumbers(numSets, numElemsPerSet), NewIntersectionTestIterator, &callCount1)
-	vs := iterToSlice(iter)
+	iter := iterize(createSetsWithDistinctNumbers(vs, numSets, numElemsPerSet), NewIntersectionTestIterator, &callCount1)
+	vals := iterToSlice(iter)
 	expected := ValueSlice{}
-	assert.True(expected.Equals(vs), "expected: %v != actual: %v", expected, vs)
+	assert.True(expected.Equals(vals), "expected: %v != actual: %v", expected, vals)
 	assert.True(expectedMax > callCount1, "callCount: %d exceeds expectedMax: %d", callCount1, expectedMax)
 
 	callCount2 := 0
-	iter = iterize(createSetsWithSameNumbers(numSets, numElemsPerSet), NewIntersectionTestIterator, &callCount2)
-	vs = iterToSlice(iter)
+	iter = iterize(createSetsWithSameNumbers(vs, numSets, numElemsPerSet), NewIntersectionTestIterator, &callCount2)
+	vals = iterToSlice(iter)
 	expected = generateNumbersAsValueSlice(numElemsPerSet)
-	assert.True(expected.Equals(vs), "expected: %v != actual: %v", expected, vs)
+	assert.True(expected.Equals(vals), "expected: %v != actual: %v", expected, vals)
 	assert.True(expectedMax > callCount2, "callCount: %d exceeds expectedMax: %d", callCount2, expectedMax)
 }
 
-func createSetsWithDistinctNumbers(numSets, numElemsPerSet int) []SetIterator {
+func createSetsWithDistinctNumbers(vrw ValueReadWriter, numSets, numElemsPerSet int) []SetIterator {
 	iterSlice := []SetIterator{}
+
 	for i := 0; i < numSets; i++ {
-		vs := ValueSlice{}
+		vals := ValueSlice{}
 		for j := 0; j < numElemsPerSet; j++ {
-			vs = append(vs, Number(i+(numSets*j)))
+			vals = append(vals, Number(i+(numSets*j)))
 		}
-		s := NewSet(vs...)
+		s := NewSet(vrw, vals...)
 		iterSlice = append(iterSlice, s.Iterator())
 	}
 	return iterSlice
 }
 
-func createSetsWithSameNumbers(numSets, numElemsPerSet int) []SetIterator {
+func createSetsWithSameNumbers(vrw ValueReadWriter, numSets, numElemsPerSet int) []SetIterator {
 	vs := ValueSlice{}
 	for j := 0; j < numElemsPerSet; j++ {
 		vs = append(vs, Number(j))
 	}
 	iterSlice := []SetIterator{}
 	for i := 0; i < numSets; i++ {
-		iterSlice = append(iterSlice, NewSet(vs...).Iterator())
+		iterSlice = append(iterSlice, NewSet(vrw, vs...).Iterator())
 	}
 	return iterSlice
 }

--- a/go/types/set_leaf_sequence.go
+++ b/go/types/set_leaf_sequence.go
@@ -4,13 +4,16 @@
 
 package types
 
+import "github.com/attic-labs/noms/go/d"
+
 type setLeafSequence struct {
 	leafSequence
 	data []Value // sorted by Hash()
 }
 
-func newSetLeafSequence(vr ValueReader, v ...Value) orderedSequence {
-	return setLeafSequence{leafSequence{vr, len(v), SetKind}, v}
+func newSetLeafSequence(vrw ValueReadWriter, v ...Value) orderedSequence {
+	d.PanicIfTrue(vrw == nil)
+	return setLeafSequence{leafSequence{vrw, len(v), SetKind}, v}
 }
 
 // sequence interface

--- a/go/types/string.go
+++ b/go/types/string.go
@@ -10,7 +10,7 @@ import "github.com/attic-labs/noms/go/hash"
 type String string
 
 // Value interface
-func (s String) Value(vrw ValueReadWriter) Value {
+func (s String) Value() Value {
 	return s
 }
 

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -110,7 +110,7 @@ func (s Struct) hashPointer() *hash.Hash {
 }
 
 // Value interface
-func (s Struct) Value(vrw ValueReadWriter) Value {
+func (s Struct) Value() Value {
 	return s
 }
 

--- a/go/types/struct_test.go
+++ b/go/types/struct_test.go
@@ -54,6 +54,7 @@ func TestGenericStructNew(t *testing.T) {
 
 func TestGenericStructSet(t *testing.T) {
 	assert := assert.New(t)
+	vs := newTestValueStore()
 
 	s := NewStruct("S3", StructData{"b": Bool(true), "o": String("hi")})
 	s2 := s.Set("b", Bool(false))
@@ -77,8 +78,8 @@ func TestGenericStructSet(t *testing.T) {
 	).Equals(TypeOf(s5)))
 
 	// Subtype is not equal.
-	s6 := NewStruct("", StructData{"l": NewList(Number(0), Number(1), Bool(false), Bool(true))})
-	s7 := s6.Set("l", NewList(Number(2), Number(3)))
+	s6 := NewStruct("", StructData{"l": NewList(vs, Number(0), Number(1), Bool(false), Bool(true))})
+	s7 := s6.Set("l", NewList(vs, Number(2), Number(3)))
 	t7 := MakeStructTypeFromFields("", FieldMap{
 		"l": MakeListType(NumberType),
 	})
@@ -119,6 +120,7 @@ func assertValueChangeEqual(assert *assert.Assertions, c1, c2 ValueChanged) {
 
 func TestStructDiff(t *testing.T) {
 	assert := assert.New(t)
+	vs := newTestValueStore()
 
 	assertDiff := func(expect []ValueChanged, s1, s2 Struct) {
 		changes := make(chan ValueChanged)
@@ -165,46 +167,46 @@ func TestStructDiff(t *testing.T) {
 		s1, NewStruct("NewType", StructData{"a": Bool(true), "c": Number(4), "d": Number(5)}))
 
 	s2 := NewStruct("", StructData{
-		"a": NewList(Number(0), Number(1)),
-		"b": NewMap(String("foo"), Bool(false), String("bar"), Bool(true)),
-		"c": NewSet(Number(0), Number(1), String("foo")),
+		"a": NewList(vs, Number(0), Number(1)),
+		"b": NewMap(vs, String("foo"), Bool(false), String("bar"), Bool(true)),
+		"c": NewSet(vs, Number(0), Number(1), String("foo")),
 	})
 
 	assertDiff([]ValueChanged{},
 		s2, NewStruct("", StructData{
-			"a": NewList(Number(0), Number(1)),
-			"b": NewMap(String("foo"), Bool(false), String("bar"), Bool(true)),
-			"c": NewSet(Number(0), Number(1), String("foo")),
+			"a": NewList(vs, Number(0), Number(1)),
+			"b": NewMap(vs, String("foo"), Bool(false), String("bar"), Bool(true)),
+			"c": NewSet(vs, Number(0), Number(1), String("foo")),
 		}))
 
 	assertDiff([]ValueChanged{
-		vc(DiffChangeModified, "a", NewList(Number(1), Number(1)), NewList(Number(0), Number(1))),
-		vc(DiffChangeModified, "b", NewMap(String("foo"), Bool(true), String("bar"), Bool(true)), NewMap(String("foo"), Bool(false), String("bar"), Bool(true))),
+		vc(DiffChangeModified, "a", NewList(vs, Number(1), Number(1)), NewList(vs, Number(0), Number(1))),
+		vc(DiffChangeModified, "b", NewMap(vs, String("foo"), Bool(true), String("bar"), Bool(true)), NewMap(vs, String("foo"), Bool(false), String("bar"), Bool(true))),
 	},
 		s2, NewStruct("", StructData{
-			"a": NewList(Number(1), Number(1)),
-			"b": NewMap(String("foo"), Bool(true), String("bar"), Bool(true)),
-			"c": NewSet(Number(0), Number(1), String("foo")),
+			"a": NewList(vs, Number(1), Number(1)),
+			"b": NewMap(vs, String("foo"), Bool(true), String("bar"), Bool(true)),
+			"c": NewSet(vs, Number(0), Number(1), String("foo")),
 		}))
 
 	assertDiff([]ValueChanged{
-		vc(DiffChangeModified, "a", NewList(Number(0)), NewList(Number(0), Number(1))),
-		vc(DiffChangeModified, "c", NewSet(Number(0), Number(2), String("foo")), NewSet(Number(0), Number(1), String("foo"))),
+		vc(DiffChangeModified, "a", NewList(vs, Number(0)), NewList(vs, Number(0), Number(1))),
+		vc(DiffChangeModified, "c", NewSet(vs, Number(0), Number(2), String("foo")), NewSet(vs, Number(0), Number(1), String("foo"))),
 	},
 		s2, NewStruct("", StructData{
-			"a": NewList(Number(0)),
-			"b": NewMap(String("foo"), Bool(false), String("bar"), Bool(true)),
-			"c": NewSet(Number(0), Number(2), String("foo")),
+			"a": NewList(vs, Number(0)),
+			"b": NewMap(vs, String("foo"), Bool(false), String("bar"), Bool(true)),
+			"c": NewSet(vs, Number(0), Number(2), String("foo")),
 		}))
 
 	assertDiff([]ValueChanged{
-		vc(DiffChangeModified, "b", NewMap(String("boo"), Bool(false), String("bar"), Bool(true)), NewMap(String("foo"), Bool(false), String("bar"), Bool(true))),
-		vc(DiffChangeModified, "c", NewSet(Number(0), Number(1), String("bar")), NewSet(Number(0), Number(1), String("foo"))),
+		vc(DiffChangeModified, "b", NewMap(vs, String("boo"), Bool(false), String("bar"), Bool(true)), NewMap(vs, String("foo"), Bool(false), String("bar"), Bool(true))),
+		vc(DiffChangeModified, "c", NewSet(vs, Number(0), Number(1), String("bar")), NewSet(vs, Number(0), Number(1), String("foo"))),
 	},
 		s2, NewStruct("", StructData{
-			"a": NewList(Number(0), Number(1)),
-			"b": NewMap(String("boo"), Bool(false), String("bar"), Bool(true)),
-			"c": NewSet(Number(0), Number(1), String("bar")),
+			"a": NewList(vs, Number(0), Number(1)),
+			"b": NewMap(vs, String("boo"), Bool(false), String("bar"), Bool(true)),
+			"c": NewSet(vs, Number(0), Number(1), String("bar")),
 		}))
 }
 

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -38,7 +38,7 @@ func (t *Type) TargetKind() NomsKind {
 }
 
 // Value interface
-func (t *Type) Value(vrw ValueReadWriter) Value {
+func (t *Type) Value() Value {
 	return t
 }
 

--- a/go/types/value.go
+++ b/go/types/value.go
@@ -16,7 +16,7 @@ type Valuable interface {
 	// Kind is the NomsKind describing the kind of value this is.
 	Kind() NomsKind
 
-	Value(vrw ValueReadWriter) Value
+	Value() Value
 }
 
 // Emptyable is an interface for Values which may or may not be empty

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -199,14 +199,6 @@ func (lvs *ValueStore) ReadManyValues(hashes hash.HashSet, foundValues chan<- Va
 // an appropriately-typed types.Ref. v is not guaranteed to be actually
 // written until after Flush().
 func (lvs *ValueStore) WriteValue(v Value) Ref {
-	iterateUncommittedChildren(v, func(sv Value) {
-		lvs.writeValueInternal(sv)
-	})
-
-	return lvs.writeValueInternal(v)
-}
-
-func (lvs *ValueStore) writeValueInternal(v Value) Ref {
 	lvs.versOnce.Do(lvs.expectVersion)
 	d.PanicIfFalse(v != nil)
 

--- a/go/types/value_store_test.go
+++ b/go/types/value_store_test.go
@@ -142,21 +142,21 @@ func TestFlushOrder(t *testing.T) {
 	n := Number(42)
 	sr, nr := vs.WriteValue(s), vs.WriteValue(n)
 	ccs.expect(sr, nr)
-	ml := NewList(sr, nr)
+	ml := NewList(vs, sr, nr)
 
-	b := NewEmptyBlob()
+	b := NewEmptyBlob(vs)
 	br, mlr := vs.WriteValue(b), vs.WriteValue(ml)
 	ccs.expect(br, mlr)
-	ml1 := NewList(br, mlr)
+	ml1 := NewList(vs, br, mlr)
 
 	f := Bool(false)
 	fr := vs.WriteValue(f)
 	ccs.expect(fr)
-	ml2 := NewList(fr)
+	ml2 := NewList(vs, fr)
 
 	ml1r, ml2r := vs.WriteValue(ml1), vs.WriteValue(ml2)
 	ccs.expect(ml1r, ml2r)
-	l := NewList(ml1r, ml2r)
+	l := NewList(vs, ml1r, ml2r)
 
 	r := vs.WriteValue(l)
 	ccs.expect(r)
@@ -171,7 +171,7 @@ func TestFlushOverSize(t *testing.T) {
 
 	s := String("oy")
 	sr := vs.WriteValue(s)
-	l := NewList(sr)
+	l := NewList(vs, sr)
 	ccs.expect(sr, NewRef(l))
 
 	vs.WriteValue(l)
@@ -193,11 +193,11 @@ func TestTolerateTopDown(t *testing.T) {
 	sr := vs.WriteValue(S)
 	ccs.expect(sr)
 
-	ML := NewList(sr)
+	ML := NewList(vs, sr)
 	mlr := vs.WriteValue(ML)
 	ccs.expect(mlr)
 
-	L := NewList(mlr)
+	L := NewList(vs, mlr)
 	lr := vs.WriteValue(L)
 	ccs.expect(lr)
 
@@ -225,7 +225,7 @@ func TestPanicOnBadVersion(t *testing.T) {
 	t.Run("Write", func(t *testing.T) {
 		cvs := NewValueStore(&badVersionStore{ChunkStore: storage.NewView()})
 		assert.Panics(t, func() {
-			cvs.WriteValue(NewEmptyBlob())
+			cvs.WriteValue(NewEmptyBlob(cvs))
 			cvs.Commit(cvs.Root(), cvs.Root())
 		})
 	})
@@ -236,7 +236,7 @@ func TestPanicIfDangling(t *testing.T) {
 	vs := newTestValueStore()
 
 	r := NewRef(Bool(true))
-	l := NewList(r)
+	l := NewList(vs, r)
 	vs.WriteValue(l)
 
 	assert.Panics(func() {
@@ -249,7 +249,7 @@ func TestSkipEnforceCompleteness(t *testing.T) {
 	vs.SetEnforceCompleteness(false)
 
 	r := NewRef(Bool(true))
-	l := NewList(r)
+	l := NewList(vs, r)
 	vs.WriteValue(l)
 
 	vs.Commit(vs.Root(), vs.Root())

--- a/go/types/walk.go
+++ b/go/types/walk.go
@@ -46,11 +46,7 @@ func WalkValues(target Value, vr ValueReader, cb SkipValueCallback) {
 			if col, ok := v.(Collection); ok && !col.sequence().isLeaf() {
 				ms := col.sequence().(metaSequence)
 				for _, mt := range ms.tuples {
-					if mt.child != nil {
-						values = append(values, valueRec{mt.child, false})
-					} else {
-						refs[mt.ref.TargetHash()] = false
-					}
+					refs[mt.ref.TargetHash()] = false
 				}
 				continue
 			}

--- a/go/util/datetime/date_time.go
+++ b/go/util/datetime/date_time.go
@@ -39,7 +39,7 @@ func Now() DateTime {
 
 // MarshalNoms makes DateTime implement marshal.Marshaler and it makes
 // DateTime marshal into a Noms struct with type DateTimeType.
-func (dt DateTime) MarshalNoms() (types.Value, error) {
+func (dt DateTime) MarshalNoms(vrw types.ValueReadWriter) (types.Value, error) {
 	return dateTimeTemplate.NewStruct([]types.Value{types.Number(float64(dt.Unix()) + float64(dt.Nanosecond())*1e-9)}), nil
 }
 

--- a/go/util/jsontonoms/json_to_noms.go
+++ b/go/util/jsontonoms/json_to_noms.go
@@ -11,7 +11,7 @@ import (
 	"github.com/attic-labs/noms/go/types"
 )
 
-func nomsValueFromDecodedJSONBase(o interface{}, useStruct bool, namedStructs bool) types.Value {
+func nomsValueFromDecodedJSONBase(vrw types.ValueReadWriter, o interface{}, useStruct bool, namedStructs bool) types.Value {
 	switch o := o.(type) {
 	case string:
 		return types.String(o)
@@ -24,12 +24,12 @@ func nomsValueFromDecodedJSONBase(o interface{}, useStruct bool, namedStructs bo
 	case []interface{}:
 		items := make([]types.Value, 0, len(o))
 		for _, v := range o {
-			nv := nomsValueFromDecodedJSONBase(v, useStruct, namedStructs)
+			nv := nomsValueFromDecodedJSONBase(vrw, v, useStruct, namedStructs)
 			if nv != nil {
 				items = append(items, nv)
 			}
 		}
-		return types.NewList(items...)
+		return types.NewList(vrw, items...)
 	case map[string]interface{}:
 		var v types.Value
 		if useStruct {
@@ -42,7 +42,7 @@ func nomsValueFromDecodedJSONBase(o interface{}, useStruct bool, namedStructs bo
 						continue
 					}
 				}
-				nv := nomsValueFromDecodedJSONBase(v, useStruct, namedStructs)
+				nv := nomsValueFromDecodedJSONBase(vrw, v, useStruct, namedStructs)
 				if nv != nil {
 					k := types.EscapeStructField(k)
 					fields[k] = nv
@@ -52,12 +52,12 @@ func nomsValueFromDecodedJSONBase(o interface{}, useStruct bool, namedStructs bo
 		} else {
 			kv := make([]types.Value, 0, len(o)*2)
 			for k, v := range o {
-				nv := nomsValueFromDecodedJSONBase(v, useStruct, namedStructs)
+				nv := nomsValueFromDecodedJSONBase(vrw, v, useStruct, namedStructs)
 				if nv != nil {
 					kv = append(kv, types.String(k), nv)
 				}
 			}
-			v = types.NewMap(kv...)
+			v = types.NewMap(vrw, kv...)
 		}
 		return v
 
@@ -81,14 +81,14 @@ func nomsValueFromDecodedJSONBase(o interface{}, useStruct bool, namedStructs bo
 // Composites:
 //  - []interface{}
 //  - map[string]interface{}
-func NomsValueFromDecodedJSON(o interface{}, useStruct bool) types.Value {
-	return nomsValueFromDecodedJSONBase(o, useStruct, false)
+func NomsValueFromDecodedJSON(vrw types.ValueReadWriter, o interface{}, useStruct bool) types.Value {
+	return nomsValueFromDecodedJSONBase(vrw, o, useStruct, false)
 }
 
 // NomsValueUsingNamedStructsFromDecodedJSON performs the same function as
 // NomsValueFromDecodedJson except that it always decodes JSON objects into
 // structs. If the JSON object has a string field name '_name' it uses the
 // value of that field as the name of the Noms struct.
-func NomsValueUsingNamedStructsFromDecodedJSON(o interface{}) types.Value {
-	return nomsValueFromDecodedJSONBase(o, true, true)
+func NomsValueUsingNamedStructsFromDecodedJSON(vrw types.ValueReadWriter, o interface{}) types.Value {
+	return nomsValueFromDecodedJSONBase(vrw, o, true, true)
 }

--- a/samples/go/csv/csv-export/exporter_test.go
+++ b/samples/go/csv/csv-export/exporter_test.go
@@ -94,7 +94,7 @@ func (s *testSuite) TestCSVExportFromList() {
 
 	// Build data rows
 	structs := createTestData(s, false)
-	db.CommitValue(ds, types.NewList(structs...))
+	db.CommitValue(ds, types.NewList(db, structs...))
 	db.Close()
 
 	// Run exporter
@@ -114,7 +114,7 @@ func (s *testSuite) TestCSVExportFromMap() {
 
 	// Build data rows
 	structs := createTestData(s, true)
-	db.CommitValue(ds, types.NewMap(structs...))
+	db.CommitValue(ds, types.NewMap(db, structs...))
 	db.Close()
 
 	// Run exporter

--- a/samples/go/csv/csv-import/importer_test.go
+++ b/samples/go/csv/csv-import/importer_test.go
@@ -133,7 +133,7 @@ func (s *testSuite) TestCSVImporterFromBlob() {
 		rawDS := db.GetDataset("raw")
 		csv := &bytes.Buffer{}
 		writeCSV(csv)
-		db.CommitValue(rawDS, types.NewBlob(csv))
+		db.CommitValue(rawDS, types.NewBlob(db, csv))
 		db.Close()
 
 		stdout, stderr := s.MustRun(main, []string{

--- a/samples/go/csv/csv-import/perf_test.go
+++ b/samples/go/csv/csv-import/perf_test.go
@@ -43,7 +43,7 @@ func (s *perfSuite) Test01ImportSfCrimeBlobFromTestdata() {
 	files := s.OpenGlob(s.Testdata, "sf-crime", "2016-07-28.*")
 	defer s.CloseGlob(files)
 
-	blob := types.NewBlob(files...)
+	blob := types.NewBlob(s.Database, files...)
 	fmt.Fprintf(s.W, "\tsf-crime is %s\n", humanize.Bytes(blob.Len()))
 
 	ds := s.Database.GetDataset("sf-crime/raw")
@@ -61,7 +61,7 @@ func (s *perfSuite) Test03ImportSfRegisteredBusinessesFromBlobAsMap() {
 	files := s.OpenGlob(s.Testdata, "sf-registered-businesses", "2016-07-25.csv")
 	defer s.CloseGlob(files)
 
-	blob := types.NewBlob(files...)
+	blob := types.NewBlob(s.Database, files...)
 	fmt.Fprintf(s.W, "\tsf-reg-bus is %s\n", humanize.Bytes(blob.Len()))
 
 	ds := s.Database.GetDataset("sf-reg-bus/raw")

--- a/samples/go/hr/main.go
+++ b/samples/go/hr/main.go
@@ -77,13 +77,13 @@ func addPerson(db datas.Database, ds datas.Dataset) {
 		return
 	}
 
-	np, err := marshal.Marshal(Person{flag.Arg(2), flag.Arg(3), id})
+	np, err := marshal.Marshal(db, Person{flag.Arg(2), flag.Arg(3), id})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 
-	_, err = db.CommitValue(ds, getPersons(ds).Edit().Set(types.Number(id), np).Map(nil))
+	_, err = db.CommitValue(ds, getPersons(ds).Edit().Set(types.Number(id), np).Map())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error committing: %s\n", err)
 		return
@@ -113,5 +113,5 @@ func getPersons(ds datas.Dataset) types.Map {
 	if ok {
 		return hv.(types.Map)
 	}
-	return types.NewMap()
+	return types.NewMap(ds.Database())
 }

--- a/samples/go/ipfs-chat/pubsub.go
+++ b/samples/go/ipfs-chat/pubsub.go
@@ -68,7 +68,7 @@ func Replicate(sub *floodsub.Subscription, source, dest datas.Dataset, didChange
 			continue
 		}
 
-		dest, err = destDB.SetHead(dest, destDB.WriteValue(datas.NewCommit(merged, types.NewSet(dest.HeadRef(), sourceRef), types.EmptyStruct)))
+		dest, err = destDB.SetHead(dest, destDB.WriteValue(datas.NewCommit(merged, types.NewSet(destDB, dest.HeadRef(), sourceRef), types.EmptyStruct)))
 		if err != nil {
 			dbg.Debug("call failed to SetHead on destDB, err: %s", err)
 		}

--- a/samples/go/json-import/json_importer.go
+++ b/samples/go/json-import/json_importer.go
@@ -89,10 +89,10 @@ func main() {
 		additionalMetaInfo := map[string]string{"url": url}
 		meta, err := spec.CreateCommitMetaStruct(ds.Database(), "", "", additionalMetaInfo, nil)
 		d.CheckErrorNoUsage(err)
-		_, err = db.Commit(ds, jsontonoms.NomsValueFromDecodedJSON(jsonObject, true), datas.CommitOptions{Meta: meta})
+		_, err = db.Commit(ds, jsontonoms.NomsValueFromDecodedJSON(db, jsonObject, true), datas.CommitOptions{Meta: meta})
 		d.PanicIfError(err)
 	} else {
-		ref := db.WriteValue(jsontonoms.NomsValueFromDecodedJSON(jsonObject, true))
+		ref := db.WriteValue(jsontonoms.NomsValueFromDecodedJSON(db, jsonObject, true))
 		fmt.Fprintf(os.Stdout, "#%s\n", ref.TargetHash().String())
 	}
 }

--- a/samples/go/nomdex/nomdex_test.go
+++ b/samples/go/nomdex/nomdex_test.go
@@ -66,7 +66,7 @@ func makeTestDb(s *testSuite, dsId string) datas.Database {
 	}
 
 	m := map[string]interface{}{"actors": l1, "musicians": m1}
-	v, err := marshal.Marshal(m)
+	v, err := marshal.Marshal(db, m)
 	s.NoError(err)
 	_, err = db.CommitValue(db.GetDataset(dsId), v)
 	s.NoError(err)

--- a/samples/go/nomdex/parser_test.go
+++ b/samples/go/nomdex/parser_test.go
@@ -108,7 +108,7 @@ func TestParsing(t *testing.T) {
 
 	storage := &chunks.MemoryStorage{}
 	db := datas.NewDatabase(storage.NewView())
-	_, err := db.CommitValue(db.GetDataset("index1"), types.NewMap(types.String("one"), types.NewSet(types.String("two"))))
+	_, err := db.CommitValue(db.GetDataset("index1"), types.NewMap(db, types.String("one"), types.NewSet(db, types.String("two"))))
 	assert.NoError(err)
 
 	im := &indexManager{db: db, indexes: map[string]types.Map{}}

--- a/samples/go/url-fetch/fetch.go
+++ b/samples/go/url-fetch/fetch.go
@@ -100,7 +100,7 @@ func main() {
 	if !*noProgress {
 		r = progressreader.New(r, getStatusPrinter(contentLength))
 	}
-	b := types.NewStreamingBlob(db, r)
+	b := types.NewBlob(db, r)
 
 	if *performCommit {
 		var additionalMetaInfo map[string]string

--- a/samples/go/url-fetch/fetch_test.go
+++ b/samples/go/url-fetch/fetch_test.go
@@ -50,10 +50,11 @@ func (s *testSuite) TestImportFromStdin() {
 	assert.NoError(err)
 	defer sp.Close()
 
-	expected := types.NewBlob(bytes.NewBufferString("abcdef"))
+	ds := sp.GetDatabase().GetDataset("ds")
+
+	expected := types.NewBlob(ds.Database(), bytes.NewBufferString("abcdef"))
 	assert.True(expected.Equals(sp.GetValue()))
 
-	ds := sp.GetDatabase().GetDataset("ds")
 	meta := ds.Head().Get(datas.MetaField).(types.Struct)
 	// The meta should only have a "date" field.
 	metaDesc := types.TypeOf(meta).Desc.(types.StructDesc)
@@ -77,10 +78,11 @@ func (s *testSuite) TestImportFromFile() {
 	assert.NoError(err)
 	defer sp.Close()
 
-	expected := types.NewBlob(bytes.NewBufferString("abcdef"))
+	ds := sp.GetDatabase().GetDataset("ds")
+
+	expected := types.NewBlob(ds.Database(), bytes.NewBufferString("abcdef"))
 	assert.True(expected.Equals(sp.GetValue()))
 
-	ds := sp.GetDatabase().GetDataset("ds")
 	meta := ds.Head().Get(datas.MetaField).(types.Struct)
 	metaDesc := types.TypeOf(meta).Desc.(types.StructDesc)
 	assert.Equal(2, metaDesc.Len())

--- a/samples/go/xml-import/xml_importer.go
+++ b/samples/go/xml-import/xml_importer.go
@@ -96,7 +96,7 @@ func main() {
 
 		wg := sync.WaitGroup{}
 		importXML := func() {
-			expectedType := types.NewMap()
+			expectedType := types.NewMap(db)
 			for f := range filesChan {
 				file, err := os.Open(f.path)
 				if err != nil {
@@ -110,7 +110,7 @@ func main() {
 				object := xmlObject.Old()
 				file.Close()
 
-				nomsObj := jsontonoms.NomsValueFromDecodedJSON(object, false)
+				nomsObj := jsontonoms.NomsValueFromDecodedJSON(db, object, false)
 				d.Chk.IsType(expectedType, nomsObj)
 
 				var r types.Ref
@@ -145,7 +145,7 @@ func main() {
 			refs[idx] = r.ref
 		}
 
-		rl := types.NewList(refs...)
+		rl := types.NewList(db, refs...)
 
 		if !*noIO {
 			if *performCommit {


### PR DESCRIPTION
Hey @arv,

This patch isn't complete. There's still a bunch of mechanical changes to be made that are fall out of requiring Collections to have a ValueReadWriter upon creation.

I was hoping to get this finished today, but I ran out of time and tomorrow I won't have a ton of time. I know that your lazy decode patch is blocked on this, so I wanted to give you option of taking this over.

The number of files touched (already) is very large, but the interesting code changes here are deeply un-interesting. It's basically just making sequences have a ValueReadWriter (as opposed to ValueReader), making that required (as opposed to nil-able), and then removing `MetaTuple.child`. The rest is just fixing up-stream compile errors.

Don't feel obliged, but if you feel like taking the baton, it'd be helpful