### PR TITLE
Remove HRS tagged versions

### DIFF
--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -195,27 +195,6 @@ func (w *hrsWriter) writeStruct(v Struct, printStructName bool) {
 	w.write("}")
 }
 
-func (w *hrsWriter) WriteTagged(v Value) {
-	t := TypeOf(v)
-	switch t.TargetKind() {
-	case BoolKind, NumberKind, StringKind:
-		w.Write(v)
-	case BlobKind, ListKind, MapKind, RefKind, SetKind, TypeKind, CycleKind:
-		w.writeType(t, map[*Type]struct{}{})
-		w.write("(")
-		w.Write(v)
-		w.write(")")
-	case StructKind:
-		w.writeType(t, map[*Type]struct{}{})
-		w.write("(")
-		w.writeStruct(v.(Struct), false)
-		w.write(")")
-	case ValueKind:
-	default:
-		panic("unreachable")
-	}
-}
-
 func (w *hrsWriter) writeSize(v Value) {
 	switch v.Kind() {
 	case ListKind, MapKind, SetKind:
@@ -356,20 +335,5 @@ func WriteEncodedValueMaxLines(w io.Writer, v Value, maxLines uint32) error {
 	mlw := &writers.MaxLineWriter{Dest: w, MaxLines: maxLines}
 	hrs := &hrsWriter{w: mlw, floatFormat: 'g'}
 	hrs.Write(v)
-	return hrs.err
-}
-
-func EncodedValueWithTags(v Value) string {
-	var buf bytes.Buffer
-	w := &hrsWriter{w: &buf, floatFormat: 'g'}
-	w.WriteTagged(v)
-	d.Chk.NoError(w.err)
-	return buf.String()
-}
-
-// WriteEncodedValueWithTags writes the serialization of a value prefixed by its type.
-func WriteEncodedValueWithTags(w io.Writer, v Value) error {
-	hrs := &hrsWriter{w: w, floatFormat: 'g'}
-	hrs.WriteTagged(v)
 	return hrs.err
 }

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -22,14 +22,6 @@ func assertWriteHRSEqual(t *testing.T, expected string, v Value) {
 	assert.Equal(test.RemoveHashes(expected), test.RemoveHashes(buf.String()))
 }
 
-func assertWriteTaggedHRSEqual(t *testing.T, expected string, v Value) {
-	assert := assert.New(t)
-	var buf bytes.Buffer
-	w := &hrsWriter{w: &buf, floatFormat: 'g'}
-	w.WriteTagged(v)
-	assert.Equal(test.RemoveHashes(expected), test.RemoveHashes(buf.String()))
-}
-
 func TestWriteHumanReadablePrimitiveValues(t *testing.T) {
 	assertWriteHRSEqual(t, "true", Bool(true))
 	assertWriteHRSEqual(t, "false", Bool(false))
@@ -65,7 +57,6 @@ func TestWriteHumanReadableRef(t *testing.T) {
 	x := Number(42)
 	rv := vs.WriteValue(x)
 	assertWriteHRSEqual(t, "0123456789abcdefghijklmnopqrstuv", rv)
-	assertWriteTaggedHRSEqual(t, "Ref<Number>(0123456789abcdefghijklmnopqrstuv)", rv)
 }
 
 func TestWriteHumanReadableCollections(t *testing.T) {
@@ -73,30 +64,25 @@ func TestWriteHumanReadableCollections(t *testing.T) {
 
 	l := NewList(vrw, Number(0), Number(1), Number(2), Number(3))
 	assertWriteHRSEqual(t, "[  // 4 items\n  0,\n  1,\n  2,\n  3,\n]", l)
-	assertWriteTaggedHRSEqual(t, "List<Number>([  // 4 items\n  0,\n  1,\n  2,\n  3,\n])", l)
 
 	s := NewSet(vrw, Number(0), Number(1), Number(2), Number(3))
 	assertWriteHRSEqual(t, "{  // 4 items\n  0,\n  1,\n  2,\n  3,\n}", s)
-	assertWriteTaggedHRSEqual(t, "Set<Number>({  // 4 items\n  0,\n  1,\n  2,\n  3,\n})", s)
 
 	m := NewMap(vrw, Number(0), Bool(false), Number(1), Bool(true))
 	assertWriteHRSEqual(t, "{\n  0: false,\n  1: true,\n}", m)
-	assertWriteTaggedHRSEqual(t, "Map<Number, Bool>({\n  0: false,\n  1: true,\n})", m)
 
 	l2 := NewList(vrw)
 	assertWriteHRSEqual(t, "[]", l2)
-	assertWriteTaggedHRSEqual(t, "List<>([])", l2)
 
 	l3 := NewList(vrw, Number(0))
 	assertWriteHRSEqual(t, "[\n  0,\n]", l3)
-	assertWriteTaggedHRSEqual(t, "List<Number>([\n  0,\n])", l3)
 
 	nums := make([]Value, 2000)
 	for i := range nums {
 		nums[i] = Number(0)
 	}
 	l4 := NewList(vrw, nums...)
-	assertWriteTaggedHRSEqual(t, "List<Number>([  // 2,000 items\n"+strings.Repeat("  0,\n", 2000)+"])", l4)
+	assertWriteHRSEqual(t, "[  // 2,000 items\n"+strings.Repeat("  0,\n", 2000)+"]", l4)
 }
 
 func TestWriteHumanReadableNested(t *testing.T) {
@@ -125,22 +111,6 @@ func TestWriteHumanReadableNested(t *testing.T) {
     1,
   ],
 }`, m)
-	assertWriteTaggedHRSEqual(t, `Map<Set<String>, List<Number>>({
-  {
-    "c",
-    "d",
-  }: [
-    2,
-    3,
-  ],
-  {
-    "a",
-    "b",
-  }: [
-    0,
-    1,
-  ],
-})`, m)
 }
 
 func TestWriteHumanReadableStruct(t *testing.T) {
@@ -149,7 +119,6 @@ func TestWriteHumanReadableStruct(t *testing.T) {
 		"y": Number(2),
 	})
 	assertWriteHRSEqual(t, "S1 {\n  x: 1,\n  y: 2,\n}", str)
-	assertWriteTaggedHRSEqual(t, "struct S1 {\n  x: Number,\n  y: Number,\n}({\n  x: 1,\n  y: 2,\n})", str)
 }
 
 func TestWriteHumanReadableListOfStruct(t *testing.T) {
@@ -176,41 +145,23 @@ func TestWriteHumanReadableListOfStruct(t *testing.T) {
     x: 3,
   },
 ]`, l)
-	assertWriteTaggedHRSEqual(t, `List<struct S3 {
-  x: Number,
-}>([
-  S3 {
-    x: 1,
-  },
-  S3 {
-    x: 2,
-  },
-  S3 {
-    x: 3,
-  },
-])`, l)
 }
 
 func TestWriteHumanReadableBlob(t *testing.T) {
 	vrw := newTestValueStore()
-
 	assertWriteHRSEqual(t, "", NewEmptyBlob(vrw))
-	assertWriteTaggedHRSEqual(t, "Blob()", NewEmptyBlob(vrw))
 
 	b1 := NewBlob(vrw, bytes.NewBuffer([]byte{0x01}))
 	assertWriteHRSEqual(t, "01", b1)
-	assertWriteTaggedHRSEqual(t, "Blob(01)", b1)
 
 	b2 := NewBlob(vrw, bytes.NewBuffer([]byte{0x01, 0x02}))
 	assertWriteHRSEqual(t, "01 02", b2)
-	assertWriteTaggedHRSEqual(t, "Blob(01 02)", b2)
 
 	b3 := NewBlob(vrw, bytes.NewBuffer([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 	}))
 	assertWriteHRSEqual(t, "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f", b3)
-	assertWriteTaggedHRSEqual(t, "Blob(00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f)", b3)
 
 	b4 := NewBlob(vrw, bytes.NewBuffer([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -218,7 +169,6 @@ func TestWriteHumanReadableBlob(t *testing.T) {
 		0x10,
 	}))
 	assertWriteHRSEqual(t, "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 17 B\n10", b4)
-	assertWriteTaggedHRSEqual(t, "Blob(00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 17 B\n10)", b4)
 
 	bs := make([]byte, 256)
 	for i := range bs {
@@ -227,12 +177,11 @@ func TestWriteHumanReadableBlob(t *testing.T) {
 
 	b5 := NewBlob(vrw, bytes.NewBuffer(bs))
 	assertWriteHRSEqual(t, "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 256 B\n10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f\n20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f\n30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f\n40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f\n50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f\n60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f\n70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f\n80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f\n90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f\na0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af\nb0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf\nc0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf\nd0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df\ne0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef\nf0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff", b5)
-	assertWriteTaggedHRSEqual(t, "Blob(00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 256 B\n10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f\n20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f\n30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f\n40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f\n50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f\n60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f\n70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f\n80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f\n90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f\na0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af\nb0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf\nc0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf\nd0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df\ne0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef\nf0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff)", b5)
 
 	b6 := NewBlob(vrw, bytes.NewBuffer(make([]byte, 16*100)))
 	row := strings.Repeat("00 ", 15) + "00"
 	s := strings.Repeat(row+"\n", 98) + row
-	assertWriteTaggedHRSEqual(t, "Blob("+row+"  // 1.6 kB\n"+s+")", b6)
+	assertWriteHRSEqual(t, row+"  // 1.6 kB\n"+s, b6)
 }
 
 func TestWriteHumanReadableListOfBlob(t *testing.T) {
@@ -247,7 +196,6 @@ func TestWriteHumanReadableListOfBlob(t *testing.T) {
 	}))
 	l := NewList(vrw, b1, NewEmptyBlob(vrw), b2, b3)
 	assertWriteHRSEqual(t, "[  // 4 items\n  01,\n  ,\n  02,\n  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 17 B\n  10,\n]", l)
-	assertWriteTaggedHRSEqual(t, "List<Blob>([  // 4 items\n  01,\n  ,\n  02,\n  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  // 17 B\n  10,\n])", l)
 }
 
 func TestWriteHumanReadableType(t *testing.T) {
@@ -265,48 +213,6 @@ func TestWriteHumanReadableType(t *testing.T) {
 	assertWriteHRSEqual(t, "", MakeUnionType())
 	assertWriteHRSEqual(t, "List<Number | String>", MakeListType(MakeUnionType(NumberType, StringType)))
 	assertWriteHRSEqual(t, "List<>", MakeListType(MakeUnionType()))
-}
-
-func TestWriteHumanReadableTaggedPrimitiveValues(t *testing.T) {
-	assertWriteHRSEqual(t, "true", Bool(true))
-	assertWriteHRSEqual(t, "false", Bool(false))
-
-	assertWriteTaggedHRSEqual(t, "0", Number(0))
-	assertWriteTaggedHRSEqual(t, "42", Number(42))
-	assertWriteTaggedHRSEqual(t, "-42", Number(-42))
-
-	assertWriteTaggedHRSEqual(t, "3.1415926535", Number(3.1415926535))
-
-	assertWriteTaggedHRSEqual(t, "314159.26535", Number(3.1415926535e5))
-
-	assertWriteTaggedHRSEqual(t, "3.1415926535e+20", Number(3.1415926535e20))
-
-	assertWriteTaggedHRSEqual(t, `"abc"`, String("abc"))
-	assertWriteTaggedHRSEqual(t, `" "`, String(" "))
-	assertWriteTaggedHRSEqual(t, `"\t"`, String("\t"))
-	assertWriteTaggedHRSEqual(t, `"\t"`, String("	"))
-	assertWriteTaggedHRSEqual(t, `"\n"`, String("\n"))
-	assertWriteTaggedHRSEqual(t, `"\n"`, String(`
-`))
-	assertWriteTaggedHRSEqual(t, `"\r"`, String("\r"))
-	assertWriteTaggedHRSEqual(t, `"\r\n"`, String("\r\n"))
-	assertWriteTaggedHRSEqual(t, `"\xff"`, String("\xff"))
-	assertWriteTaggedHRSEqual(t, `"💩"`, String("\xf0\x9f\x92\xa9"))
-	assertWriteTaggedHRSEqual(t, `"💩"`, String("💩"))
-	assertWriteTaggedHRSEqual(t, `"\a"`, String("\007"))
-	assertWriteTaggedHRSEqual(t, `"☺"`, String("\u263a"))
-}
-
-func TestWriteHumanReadableTaggedType(t *testing.T) {
-	assertWriteTaggedHRSEqual(t, "Type(Bool)", BoolType)
-	assertWriteTaggedHRSEqual(t, "Type(Blob)", BlobType)
-	assertWriteTaggedHRSEqual(t, "Type(String)", StringType)
-	assertWriteTaggedHRSEqual(t, "Type(Number)", NumberType)
-	assertWriteTaggedHRSEqual(t, "Type(List<Number>)", MakeListType(NumberType))
-	assertWriteTaggedHRSEqual(t, "Type(Set<Number>)", MakeSetType(NumberType))
-	assertWriteTaggedHRSEqual(t, "Type(Ref<Number>)", MakeRefType(NumberType))
-	assertWriteTaggedHRSEqual(t, "Type(Map<Number, String>)", MakeMapType(NumberType, StringType))
-
 }
 
 func TestRecursiveStruct(t *testing.T) {
@@ -336,14 +242,6 @@ func TestRecursiveStruct(t *testing.T) {
     f: Cycle<A>,
   },
 }`, a)
-	assertWriteTaggedHRSEqual(t, `Type(struct A {
-  b: Cycle<A>,
-  c: List<Cycle<A>>,
-  d: struct D {
-    e: Cycle<D>,
-    f: Cycle<A>,
-  },
-})`, a)
 
 	d, _ := a.Desc.(StructDesc).Field("d")
 
@@ -355,14 +253,6 @@ func TestRecursiveStruct(t *testing.T) {
     d: Cycle<D>,
   },
 }`, d)
-	assertWriteTaggedHRSEqual(t, `Type(struct D {
-  e: Cycle<D>,
-  f: struct A {
-    b: Cycle<A>,
-    c: List<Cycle<A>>,
-    d: Cycle<D>,
-  },
-})`, d)
 }
 
 func TestUnresolvedRecursiveStruct(t *testing.T) {
@@ -379,10 +269,6 @@ func TestUnresolvedRecursiveStruct(t *testing.T) {
   a: Cycle<A>,
   b: UnresolvedCycle<X>,
 }`, a)
-	assertWriteTaggedHRSEqual(t, `Type(struct A {
-  a: Cycle<A>,
-  b: UnresolvedCycle<X>,
-})`, a)
 }
 
 type errorWriter struct {
@@ -397,24 +283,24 @@ func TestWriteHumanReadableWriterError(t *testing.T) {
 	assert := assert.New(t)
 	err := errors.New("test")
 	w := &errorWriter{err}
-	assert.Equal(err, WriteEncodedValueWithTags(w, Number(42)))
+	assert.Equal(err, WriteEncodedValue(w, Number(42)))
 }
 
 func TestEmptyCollections(t *testing.T) {
 	vrw := newTestValueStore()
 
 	a := MakeStructType("Nothing")
-	assertWriteTaggedHRSEqual(t, "Type(struct Nothing {})", a)
+	assertWriteHRSEqual(t, "struct Nothing {}", a)
 	b := NewStruct("Rien", StructData{})
-	assertWriteTaggedHRSEqual(t, "struct Rien {}({})", b)
+	assertWriteHRSEqual(t, "Rien {}", b)
 	c := MakeMapType(BlobType, NumberType)
-	assertWriteTaggedHRSEqual(t, "Type(Map<Blob, Number>)", c)
+	assertWriteHRSEqual(t, "Map<Blob, Number>", c)
 	d := NewMap(vrw)
-	assertWriteTaggedHRSEqual(t, "Map<>({})", d)
+	assertWriteHRSEqual(t, "{}", d)
 	e := MakeSetType(StringType)
-	assertWriteTaggedHRSEqual(t, "Type(Set<String>)", e)
+	assertWriteHRSEqual(t, "Set<String>", e)
 	f := NewSet(vrw)
-	assertWriteTaggedHRSEqual(t, "Set<>({})", f)
+	assertWriteHRSEqual(t, "{}", f)
 }
 
 func TestEncodedValueMaxLines(t *testing.T) {
@@ -435,5 +321,4 @@ func TestWriteHumanReadableStructOptionalFields(t *testing.T) {
 		StructField{"a", BoolType, false},
 		StructField{"b", BoolType, true})
 	assertWriteHRSEqual(t, "struct S1 {\n  a: Bool,\n  b?: Bool,\n}", typ)
-	assertWriteTaggedHRSEqual(t, "Type(struct S1 {\n  a: Bool,\n  b?: Bool,\n})", typ)
 }

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -201,11 +201,11 @@ func newMapTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff int
 				l2.Iter(func(key, value Value) (stop bool) {
 					entry := elems.entries[idx]
 					if !key.Equals(entry.key) {
-						fmt.Printf("%d: %s (%s)\n!=\n%s (%s)\n", idx, EncodedValueWithTags(key), key.Hash(), EncodedValueWithTags(entry.key), entry.key.Hash())
+						fmt.Printf("%d: %s (%s)\n!=\n%s (%s)\n", idx, EncodedValue(key), key.Hash(), EncodedValue(entry.key), entry.key.Hash())
 						stop = true
 					}
 					if !value.Equals(entry.value) {
-						fmt.Printf("%s (%s) !=\n%s (%s)\n", EncodedValueWithTags(value), value.Hash(), EncodedValueWithTags(entry.value), entry.value.Hash())
+						fmt.Printf("%s (%s) !=\n%s (%s)\n", EncodedValue(value), value.Hash(), EncodedValue(entry.value), entry.value.Hash())
 						stop = true
 					}
 					idx++


### PR DESCRIPTION
This removes the type tagged version of the human readable encoding.

Motivation: Simplify this in preparation to make the HRS unambiguous so that we can write a parser.

Towards #1466