### PR TITLE
Print ref with pound

### DIFF
--- a/cmd/noms/noms_show_test.go
+++ b/cmd/noms/noms_show_test.go
@@ -25,11 +25,11 @@ type nomsShowTestSuite struct {
 }
 
 const (
-	res1 = "Commit {\n  meta:  {},\n  parents: {},\n  value: nl181uu1ioc2j6t7mt9paidjlhlcjtgj,\n}\n"
+	res1 = "Commit {\n  meta:  {},\n  parents: {},\n  value: #nl181uu1ioc2j6t7mt9paidjlhlcjtgj,\n}\n"
 	res2 = "\"test string\"\n"
-	res3 = "Commit {\n  meta:  {},\n  parents: {\n    4g7ggl6999v5mlucl4a507n7k3kvckiq,\n  },\n  value: 82adk7hfcudg8fktittm672to66t6qeu,\n}\n"
+	res3 = "Commit {\n  meta:  {},\n  parents: {\n    #4g7ggl6999v5mlucl4a507n7k3kvckiq,\n  },\n  value: #82adk7hfcudg8fktittm672to66t6qeu,\n}\n"
 	res4 = "[\n  \"elem1\",\n  2,\n  \"elem3\",\n]\n"
-	res5 = "Commit {\n  meta:  {},\n  parents: {\n    3tmg89vabs2k6hotdock1kuo13j4lmqv,\n  },\n  value: 5cgfu2vk4nc21m1vjkjjpd2kvcm2df7q,\n}\n"
+	res5 = "Commit {\n  meta:  {},\n  parents: {\n    #3tmg89vabs2k6hotdock1kuo13j4lmqv,\n  },\n  value: #5cgfu2vk4nc21m1vjkjjpd2kvcm2df7q,\n}\n"
 )
 
 func (s *nomsShowTestSuite) spec(str string) spec.Spec {

--- a/go/diff/diff_test.go
+++ b/go/diff/diff_test.go
@@ -474,7 +474,7 @@ func TestNomsDiffPrintType(t *testing.T) {
 func TestNomsDiffPrintRef(t *testing.T) {
 	assert := assert.New(t)
 
-	expected := "-   fckcbt7nk5jl4arco2dk7r9nj7abb6ci\n+   i7d3u5gekm48ot419t2cot6cnl7ltcah\n"
+	expected := "-   #fckcbt7nk5jl4arco2dk7r9nj7abb6ci\n+   #i7d3u5gekm48ot419t2cot6cnl7ltcah\n"
 	expectedPaths1 := []string{``}
 	l1 := createList(1)
 	l2 := createList(2)

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -143,6 +143,7 @@ func (w *hrsWriter) Write(v Value) {
 		w.write("}")
 
 	case RefKind:
+		w.write("#")
 		w.write(v.(Ref).TargetHash().String())
 
 	case SetKind:

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -56,7 +56,7 @@ func TestWriteHumanReadableRef(t *testing.T) {
 
 	x := Number(42)
 	rv := vs.WriteValue(x)
-	assertWriteHRSEqual(t, "0123456789abcdefghijklmnopqrstuv", rv)
+	assertWriteHRSEqual(t, "#0123456789abcdefghijklmnopqrstuv", rv)
 }
 
 func TestWriteHumanReadableCollections(t *testing.T) {


### PR DESCRIPTION
Print Ref values as `#123` instead of `123`

Since our hashes are SHA-512 and we write them using Base32 there are a lot of overlaps with other parts of NomDL. This makes them unambiguous.

Towards #1466 