### PR TITLE
HRS: Cleanup struct head

### DIFF
--- a/cmd/noms/noms_show_test.go
+++ b/cmd/noms/noms_show_test.go
@@ -25,11 +25,11 @@ type nomsShowTestSuite struct {
 }
 
 const (
-	res1 = "Commit {\n  meta:  {},\n  parents: {},\n  value: #nl181uu1ioc2j6t7mt9paidjlhlcjtgj,\n}\n"
+	res1 = "struct Commit {\n  meta: struct {},\n  parents: {},\n  value: #nl181uu1ioc2j6t7mt9paidjlhlcjtgj,\n}\n"
 	res2 = "\"test string\"\n"
-	res3 = "Commit {\n  meta:  {},\n  parents: {\n    #4g7ggl6999v5mlucl4a507n7k3kvckiq,\n  },\n  value: #82adk7hfcudg8fktittm672to66t6qeu,\n}\n"
+	res3 = "struct Commit {\n  meta: struct {},\n  parents: {\n    #4g7ggl6999v5mlucl4a507n7k3kvckiq,\n  },\n  value: #82adk7hfcudg8fktittm672to66t6qeu,\n}\n"
 	res4 = "[\n  \"elem1\",\n  2,\n  \"elem3\",\n]\n"
-	res5 = "Commit {\n  meta:  {},\n  parents: {\n    #3tmg89vabs2k6hotdock1kuo13j4lmqv,\n  },\n  value: #5cgfu2vk4nc21m1vjkjjpd2kvcm2df7q,\n}\n"
+	res5 = "struct Commit {\n  meta: struct {},\n  parents: {\n    #3tmg89vabs2k6hotdock1kuo13j4lmqv,\n  },\n  value: #5cgfu2vk4nc21m1vjkjjpd2kvcm2df7q,\n}\n"
 )
 
 func (s *nomsShowTestSuite) spec(str string) spec.Spec {

--- a/go/diff/diff_test.go
+++ b/go/diff/diff_test.go
@@ -320,11 +320,11 @@ func TestNomsDiffPrintMapWithStructKeys(t *testing.T) {
 	k1 := createStruct("TestKey", "name", "n1", "label", "l1")
 
 	expected1 := `(root) {
--   TestKey {
+-   struct TestKey {
 -     label: "l1",
 -     name: "n1",
 -   }: true
-+   TestKey {
++   struct TestKey {
 +     label: "l1",
 +     name: "n1",
 +   }: false

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -327,7 +327,7 @@ func TestDecodeMissingField(t *testing.T) {
 	var s S
 	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
 		"a": types.Number(42),
-	}), &s, "Cannot unmarshal struct S {\n  a: Number,\n} into Go value of type marshal.S, missing field \"b\"")
+	}), &s, "Cannot unmarshal Struct S {\n  a: Number,\n} into Go value of type marshal.S, missing field \"b\"")
 }
 
 func TestDecodeEmbeddedStruct(tt *testing.T) {
@@ -873,7 +873,7 @@ func TestDecodeOntoNonSupportedInterface(t *testing.T) {
 func TestDecodeOntoInterfaceStruct(t *testing.T) {
 	// Not implemented because it requires Go 1.7.
 	var i interface{}
-	assertDecodeErrorMessage(t, types.NewStruct("", types.StructData{}), &i, "Cannot unmarshal struct {} into Go value of type interface {}")
+	assertDecodeErrorMessage(t, types.NewStruct("", types.StructData{}), &i, "Cannot unmarshal Struct {} into Go value of type interface {}")
 }
 
 func TestDecodeSet(t *testing.T) {
@@ -1043,7 +1043,7 @@ func TestDecodeSetWrongMapType(t *testing.T) {
 		"a": types.NewMap(vs, types.Number(0), types.EmptyStruct),
 	}), &T3{})
 	assert.Error(err)
-	assert.Equal(`Cannot unmarshal Map<Number, struct {}> into Go value of type map[int]struct {}, field has "set" tag`, err.Error())
+	assert.Equal(`Cannot unmarshal Map<Number, Struct {}> into Go value of type map[int]struct {}, field has "set" tag`, err.Error())
 }
 
 func TestDecodeOmitEmpty(t *testing.T) {
@@ -1106,7 +1106,7 @@ func TestDecodeOriginalReceiveTypeError(t *testing.T) {
 	var actual S
 	err := Unmarshal(input, &actual)
 	assert.Error(err)
-	assert.Equal(`Cannot unmarshal struct S {} into Go value of type marshal.S, field with tag "original" must have type Struct`, err.Error())
+	assert.Equal(`Cannot unmarshal Struct S {} into Go value of type marshal.S, field with tag "original" must have type Struct`, err.Error())
 }
 
 func TestDecodeCanSkipUnexportedField(t *testing.T) {

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -275,7 +275,7 @@ func ExampleMarshalType() {
 	}
 
 	fmt.Println(personNomsType.Describe())
-	// Output: struct Person {
+	// Output: Struct Person {
 	//   female: Bool,
 	//   given: String,
 	// }

--- a/go/merge/three_way_keyval_test.go
+++ b/go/merge/three_way_keyval_test.go
@@ -98,7 +98,7 @@ func (s *ThreeWayStructMergeSuite) SetupSuite() {
 		}
 		return
 	}
-	s.typeStr = "struct"
+	s.typeStr = "Struct"
 }
 
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_DoNothing() {
@@ -221,8 +221,8 @@ func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_RefConflict() {
 	ma := kvs{"r1", strRef, "r2", strRef}
 	mb := kvs{"r1", numRef, "r2", strRef}
 
-	s.tryThreeWayConflict(s.create(ma), s.create(mb), s.create(m), "Cannot merge struct Foo")
-	s.tryThreeWayConflict(s.create(mb), s.create(ma), s.create(m), "Cannot merge Number and struct")
+	s.tryThreeWayConflict(s.create(ma), s.create(mb), s.create(m), "Cannot merge Struct Foo")
+	s.tryThreeWayConflict(s.create(mb), s.create(ma), s.create(m), "Cannot merge Number and Struct Foo")
 }
 
 func (s *ThreeWayKeyValMergeSuite) TestThreeWayMerge_NestedConflict() {

--- a/go/spec/commit_meta_test.go
+++ b/go/spec/commit_meta_test.go
@@ -23,7 +23,7 @@ func TestCreateCommitMetaStructBasic(t *testing.T) {
 	meta, err := CreateCommitMetaStruct(nil, "", "", nil, nil)
 	assert.NoError(err)
 	assert.False(isEmptyStruct(meta))
-	assert.Equal("struct Meta {\n  date: String,\n}", types.TypeOf(meta).Describe())
+	assert.Equal("Struct Meta {\n  date: String,\n}", types.TypeOf(meta).Describe())
 }
 
 func TestCreateCommitMetaStructFromFlags(t *testing.T) {
@@ -33,7 +33,7 @@ func TestCreateCommitMetaStructFromFlags(t *testing.T) {
 	commitMetaKeyValueStrings = "k1=v1,k2=v2,k3=v3"
 	meta, err := CreateCommitMetaStruct(nil, "", "", nil, nil)
 	assert.NoError(err)
-	assert.Equal("struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  message: String,\n}",
+	assert.Equal("Struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  message: String,\n}",
 		types.TypeOf(meta).Describe())
 	assert.Equal(types.String(commitMetaDate), meta.Get("date"))
 	assert.Equal(types.String(commitMetaMessage), meta.Get("message"))
@@ -54,7 +54,7 @@ func TestCreateCommitMetaStructFromArgs(t *testing.T) {
 	keyValueArg := map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"}
 	meta, err := CreateCommitMetaStruct(nil, dateArg, messageArg, keyValueArg, nil)
 	assert.NoError(err)
-	assert.Equal("struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  message: String,\n}",
+	assert.Equal("Struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  message: String,\n}",
 		types.TypeOf(meta).Describe())
 	assert.Equal(types.String(dateArg), meta.Get("date"))
 	assert.Equal(types.String(messageArg), meta.Get("message"))
@@ -76,7 +76,7 @@ func TestCreateCommitMetaStructFromFlagsAndArgs(t *testing.T) {
 	// args passed in should win over the ones in the flags
 	meta, err := CreateCommitMetaStruct(nil, dateArg, messageArg, keyValueArg, nil)
 	assert.NoError(err)
-	assert.Equal("struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  k4: String,\n  message: String,\n}",
+	assert.Equal("Struct Meta {\n  date: String,\n  k1: String,\n  k2: String,\n  k3: String,\n  k4: String,\n  message: String,\n}",
 		types.TypeOf(meta).Describe())
 	assert.Equal(types.String(dateArg), meta.Get("date"))
 	assert.Equal(types.String(messageArg), meta.Get("message"))

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -174,7 +174,8 @@ func (w *hrsWriter) Write(v Value) {
 }
 
 func (w *hrsWriter) writeStruct(v Struct, printStructName bool) {
-	if printStructName {
+	w.write("struct ")
+	if printStructName && v.name != "" {
 		w.write(v.name)
 		w.write(" ")
 	}
@@ -266,7 +267,7 @@ func (w *hrsWriter) writeStructType(t *Type, seenStructs map[*Type]struct{}) {
 	seenStructs[t] = struct{}{}
 
 	desc := t.Desc.(StructDesc)
-	w.write("struct ")
+	w.write("Struct ")
 	if desc.Name != "" {
 		w.write(desc.Name + " ")
 	}

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -118,7 +118,7 @@ func TestWriteHumanReadableStruct(t *testing.T) {
 		"x": Number(1),
 		"y": Number(2),
 	})
-	assertWriteHRSEqual(t, "S1 {\n  x: 1,\n  y: 2,\n}", str)
+	assertWriteHRSEqual(t, "struct S1 {\n  x: 1,\n  y: 2,\n}", str)
 }
 
 func TestWriteHumanReadableListOfStruct(t *testing.T) {
@@ -135,13 +135,13 @@ func TestWriteHumanReadableListOfStruct(t *testing.T) {
 	})
 	l := NewList(vrw, str1, str2, str3)
 	assertWriteHRSEqual(t, `[
-  S3 {
+  struct S3 {
     x: 1,
   },
-  S3 {
+  struct S3 {
     x: 2,
   },
-  S3 {
+  struct S3 {
     x: 3,
   },
 ]`, l)
@@ -234,10 +234,10 @@ func TestRecursiveStruct(t *testing.T) {
 		), false},
 	)
 
-	assertWriteHRSEqual(t, `struct A {
+	assertWriteHRSEqual(t, `Struct A {
   b: Cycle<A>,
   c: List<Cycle<A>>,
-  d: struct D {
+  d: Struct D {
     e: Cycle<D>,
     f: Cycle<A>,
   },
@@ -245,9 +245,9 @@ func TestRecursiveStruct(t *testing.T) {
 
 	d, _ := a.Desc.(StructDesc).Field("d")
 
-	assertWriteHRSEqual(t, `struct D {
+	assertWriteHRSEqual(t, `Struct D {
   e: Cycle<D>,
-  f: struct A {
+  f: Struct A {
     b: Cycle<A>,
     c: List<Cycle<A>>,
     d: Cycle<D>,
@@ -265,7 +265,7 @@ func TestUnresolvedRecursiveStruct(t *testing.T) {
 		StructField{"b", MakeCycleType("X"), false},
 	)
 
-	assertWriteHRSEqual(t, `struct A {
+	assertWriteHRSEqual(t, `Struct A {
   a: Cycle<A>,
   b: UnresolvedCycle<X>,
 }`, a)
@@ -290,9 +290,9 @@ func TestEmptyCollections(t *testing.T) {
 	vrw := newTestValueStore()
 
 	a := MakeStructType("Nothing")
-	assertWriteHRSEqual(t, "struct Nothing {}", a)
+	assertWriteHRSEqual(t, "Struct Nothing {}", a)
 	b := NewStruct("Rien", StructData{})
-	assertWriteHRSEqual(t, "Rien {}", b)
+	assertWriteHRSEqual(t, "struct Rien {}", b)
 	c := MakeMapType(BlobType, NumberType)
 	assertWriteHRSEqual(t, "Map<Blob, Number>", c)
 	d := NewMap(vrw)
@@ -320,5 +320,5 @@ func TestWriteHumanReadableStructOptionalFields(t *testing.T) {
 	typ := MakeStructType("S1",
 		StructField{"a", BoolType, false},
 		StructField{"b", BoolType, true})
-	assertWriteHRSEqual(t, "struct S1 {\n  a: Bool,\n  b?: Bool,\n}", typ)
+	assertWriteHRSEqual(t, "Struct S1 {\n  a: Bool,\n  b?: Bool,\n}", typ)
 }

--- a/go/types/type_test.go
+++ b/go/types/type_test.go
@@ -52,7 +52,7 @@ func TestTypeRefDescribe(t *testing.T) {
 		StructField{"Field1", StringType, false},
 		StructField{"Field2", BoolType, false},
 	)
-	assert.Equal("struct MahStruct {\n  Field1: String,\n  Field2: Bool,\n}", mahType.Describe())
+	assert.Equal("Struct MahStruct {\n  Field1: String,\n  Field2: Bool,\n}", mahType.Describe())
 }
 
 func TestTypeOrdered(t *testing.T) {


### PR DESCRIPTION
For struct values we always prefix with `struct `.

For struct types we always prefix with `Struct `.

Towards #1466