### PR TITLE
HRS: Struct printing cleanup

### DIFF
--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -166,16 +166,16 @@ func (w *hrsWriter) Write(v Value) {
 		w.writeType(v.(*Type), map[*Type]struct{}{})
 
 	case StructKind:
-		w.writeStruct(v.(Struct), true)
+		w.writeStruct(v.(Struct))
 
 	default:
 		panic("unreachable")
 	}
 }
 
-func (w *hrsWriter) writeStruct(v Struct, printStructName bool) {
+func (w *hrsWriter) writeStruct(v Struct) {
 	w.write("struct ")
-	if printStructName && v.name != "" {
+	if v.name != "" {
 		w.write(v.name)
 		w.write(" ")
 	}


### PR DESCRIPTION
We always write the struct name now so no point in passing the
param.