### PR TITLE
HRS: Prefix map/set values with map/set

### DIFF
--- a/cmd/noms/noms_show_test.go
+++ b/cmd/noms/noms_show_test.go
@@ -25,11 +25,11 @@ type nomsShowTestSuite struct {
 }
 
 const (
-	res1 = "struct Commit {\n  meta: struct {},\n  parents: {},\n  value: #nl181uu1ioc2j6t7mt9paidjlhlcjtgj,\n}\n"
+	res1 = "struct Commit {\n  meta: struct {},\n  parents: set {},\n  value: #nl181uu1ioc2j6t7mt9paidjlhlcjtgj,\n}\n"
 	res2 = "\"test string\"\n"
-	res3 = "struct Commit {\n  meta: struct {},\n  parents: {\n    #4g7ggl6999v5mlucl4a507n7k3kvckiq,\n  },\n  value: #82adk7hfcudg8fktittm672to66t6qeu,\n}\n"
+	res3 = "struct Commit {\n  meta: struct {},\n  parents: set {\n    #4g7ggl6999v5mlucl4a507n7k3kvckiq,\n  },\n  value: #82adk7hfcudg8fktittm672to66t6qeu,\n}\n"
 	res4 = "[\n  \"elem1\",\n  2,\n  \"elem3\",\n]\n"
-	res5 = "struct Commit {\n  meta: struct {},\n  parents: {\n    #3tmg89vabs2k6hotdock1kuo13j4lmqv,\n  },\n  value: #5cgfu2vk4nc21m1vjkjjpd2kvcm2df7q,\n}\n"
+	res5 = "struct Commit {\n  meta: struct {},\n  parents: set {\n    #3tmg89vabs2k6hotdock1kuo13j4lmqv,\n  },\n  value: #5cgfu2vk4nc21m1vjkjjpd2kvcm2df7q,\n}\n"
 )
 
 func (s *nomsShowTestSuite) spec(str string) spec.Spec {

--- a/go/diff/diff_test.go
+++ b/go/diff/diff_test.go
@@ -148,10 +148,10 @@ func TestNomsDiffPrintSet(t *testing.T) {
 	}
 
 	expected2 := `(root) {
--   {  // 4 items
+-   map {  // 4 items
 -     "m1": "m-one",
 -     "m3": "m-three",
--     "m4": {  // 4 items
+-     "m4": map {  // 4 items
 -       "a1": "a-one",
 -       "a2": "a-two",
 -       "a3": "a-three",
@@ -159,10 +159,10 @@ func TestNomsDiffPrintSet(t *testing.T) {
 -     },
 -     "v2": "m-two",
 -   }
-+   {  // 4 items
++   map {  // 4 items
 +     "m1": "m-one",
 +     "m3": "m-three-diff",
-+     "m4": {  // 4 items
++     "m4": map {  // 4 items
 +       "a1": "a-one-diff",
 +       "a2": "a-two",
 +       "a3": "a-three",
@@ -211,7 +211,7 @@ func TestNomsDiffPrintStop(t *testing.T) {
 `
 
 	expected2 := `(root) {
--   {  // 4 items
+-   map {  // 4 items
 `
 
 	s1 := createSet("one", "three", "five", "seven", "nine")

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -135,7 +135,7 @@ func (w *hrsWriter) Write(v Value) {
 		w.write("]")
 
 	case MapKind:
-		w.write("{")
+		w.write("map {")
 		w.writeSize(v)
 		w.indent()
 		if !v.(Map).Empty() {
@@ -157,7 +157,7 @@ func (w *hrsWriter) Write(v Value) {
 		w.write(v.(Ref).TargetHash().String())
 
 	case SetKind:
-		w.write("{")
+		w.write("set {")
 		w.writeSize(v)
 		w.indent()
 		if !v.(Set).Empty() {

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -66,10 +66,10 @@ func TestWriteHumanReadableCollections(t *testing.T) {
 	assertWriteHRSEqual(t, "[  // 4 items\n  0,\n  1,\n  2,\n  3,\n]", l)
 
 	s := NewSet(vrw, Number(0), Number(1), Number(2), Number(3))
-	assertWriteHRSEqual(t, "{  // 4 items\n  0,\n  1,\n  2,\n  3,\n}", s)
+	assertWriteHRSEqual(t, "set {  // 4 items\n  0,\n  1,\n  2,\n  3,\n}", s)
 
 	m := NewMap(vrw, Number(0), Bool(false), Number(1), Bool(true))
-	assertWriteHRSEqual(t, "{\n  0: false,\n  1: true,\n}", m)
+	assertWriteHRSEqual(t, "map {\n  0: false,\n  1: true,\n}", m)
 
 	l2 := NewList(vrw)
 	assertWriteHRSEqual(t, "[]", l2)
@@ -95,15 +95,15 @@ func TestWriteHumanReadableNested(t *testing.T) {
 	s2 := NewSet(vrw, String("c"), String("d"))
 
 	m := NewMap(vrw, s, l, s2, l2)
-	assertWriteHRSEqual(t, `{
-  {
+	assertWriteHRSEqual(t, `map {
+  set {
     "c",
     "d",
   }: [
     2,
     3,
   ],
-  {
+  set {
     "a",
     "b",
   }: [
@@ -296,11 +296,11 @@ func TestEmptyCollections(t *testing.T) {
 	c := MakeMapType(BlobType, NumberType)
 	assertWriteHRSEqual(t, "Map<Blob, Number>", c)
 	d := NewMap(vrw)
-	assertWriteHRSEqual(t, "{}", d)
+	assertWriteHRSEqual(t, "map {}", d)
 	e := MakeSetType(StringType)
 	assertWriteHRSEqual(t, "Set<String>", e)
 	f := NewSet(vrw)
-	assertWriteHRSEqual(t, "{}", f)
+	assertWriteHRSEqual(t, "set {}", f)
 }
 
 func TestEncodedValueMaxLines(t *testing.T) {


### PR DESCRIPTION
We now print map and set values as:

```
map {
  "string": 42,
  "set": set {
    true,
    false,
  },
}
```

Towards #1466