### PR TITLE
Don't ignore spec split error in ForDatasetOpts

### DIFF
--- a/go/spec/spec.go
+++ b/go/spec/spec.go
@@ -90,6 +90,9 @@ func ForDataset(spec string) (Spec, error) {
 // ForDatasetOpts parses a spec for a Dataset.
 func ForDatasetOpts(spec string, opts SpecOptions) (Spec, error) {
 	dbSpec, pathStr, err := splitDatabaseSpec(spec)
+	if err != nil {
+		return Spec{}, err
+	}
 
 	sp, err := newSpec(dbSpec, opts)
 	if err != nil {

--- a/go/spec/spec_test.go
+++ b/go/spec/spec_test.go
@@ -91,7 +91,7 @@ func TestMemDatasetPathSpec(t *testing.T) {
 
 	db := spec.GetDatabase()
 	ds := db.GetDataset("test")
-	ds, err = db.CommitValue(ds, types.NewList(db, types.Number(42)))
+	_, err = db.CommitValue(ds, types.NewList(db, types.Number(42)))
 	assert.NoError(err)
 
 	assert.Equal(types.Number(42), spec.GetValue())


### PR DESCRIPTION
Tests detect error from later in function but we can catch invalid specs earlier by handling the error returned from splitDatabaseSpec