### PR TITLE
Modifications to ipfs-chat can ipfs chunkstore

### DIFF
--- a/go/ipfs/cs.go
+++ b/go/ipfs/cs.go
@@ -17,7 +17,6 @@ import (
 	"github.com/attic-labs/noms/go/chunks"
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
-	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/mitchellh/go-homedir"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
 	"github.com/ipfs/go-ipfs/blockservice"
 	"github.com/ipfs/go-ipfs/core"
@@ -26,37 +25,50 @@ import (
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 )
 
-var (
-	CurrentNode *core.IpfsNode
-
-	// Ugg, such a hack. Setting this to an integer >= 0 ** <= 9 will cause
-	// NewChunkStore to alter the api, http, and swarm ports for this IPFS node
-	// to get reset to a port ending in that digit.
-	NodeIndex int = -1
-)
-
 // NewChunkStore creates a new ChunkStore backed by IPFS.
 //
 // Noms chunks written to this ChunkStore are converted to IPFS blocks and
 // stored in an IPFS BlockStore.
 //
-// The name distinguishes this chunkstore on the local machine. A corresponding
-// file is created in ~/.noms/ipfs which stores the root of the noms database.
-// This should ideally be done with IPNS, but that is currently too slow to be
-// practical.
+// Noms repositories that are build on top of IPFS are identified by paths of
+// the following form:
+//   ipfs://<path-to-ipfs-dir>
+// where 'ipfs' indicates the noms protocol and the path indicates the path to
+// the directory where the ipfs repo resides. The chunkstore creates two files
+// in the ipfs directory called 'noms' and 'noms-local' which stores the root
+// of the noms database. This should ideally be done with IPNS, but that is
+// currently too slow to be practical.
 //
 // This function creates an IPFS repo at the appropriate path if one doesn't
-// already exist. The default location is ~/.ipfs, but this can be configured with
-// the IPFS_PATH environment variable, or IPFS_LOCAL_PATH if "local" is true. If
-// the global NodeIndex variable has been set to a number between 0 and 9
-// inclusive, the api, http, and swarm ports will be modified to end in with
-// that digit. (e.g. if NodeIndex == 3, API port will be set to 5003)
+// already exist. If the global NodeIndex variable has been set to a number
+// between 0 and 9 inclusive, the api, http, and swarm ports will be modified to
+// end in with that digit. (e.g. if NodeIndex == 3, API port will be set to 5003)
 //
 // If local is true, only the local IPFS blockstore is used for both reads and
 // write. If local is false, then reads will fall through to the network and
 // blocks stored will be exposed to the entire IPFS network.
-func NewChunkStore(name string, local bool) *chunkStore {
-	p := getIPFSDir(local)
+func NewChunkStore(p string, local bool) *chunkStore {
+	node := OpenIPFSRepo(p, -1)
+	return NewChunkStorePrimitive(p, local, node)
+}
+
+// Creates a new chunchStore using a pre-existing IpfsNode. This is currently
+// used to create a second 'local' chunkStore using the same IpfsNode as another
+// non-local chunkStore.
+func NewChunkStorePrimitive(p string, local bool, node *core.IpfsNode) *chunkStore {
+	return &chunkStore{
+		node:      node,
+		name:      p,
+		local:     local,
+		rateLimit: make(chan struct{}, 1024),
+	}
+}
+
+// Opens a pre-existing ipfs repo for use as a noms store. This function will
+// create a new IPFS repos at this indictated path if one doesn't already exist.
+// Also if portIdx is a number between 0 and 1 inclusive, the config file will
+// be modified to change external facing port numbers to end in 'portIdx'.
+func OpenIPFSRepo(p string, portIdx int) *core.IpfsNode {
 	r, err := fsrepo.Open(p)
 	if _, ok := err.(fsrepo.NoRepoError); ok {
 		var conf *config.Config
@@ -68,7 +80,7 @@ func NewChunkStore(name string, local bool) *chunkStore {
 	}
 	d.CheckError(err)
 
-	resetRepoConfigPorts(r)
+	resetRepoConfigPorts(r, portIdx)
 
 	cfg := &core.BuildCfg{
 		Repo:   r,
@@ -78,15 +90,9 @@ func NewChunkStore(name string, local bool) *chunkStore {
 		},
 	}
 
-	CurrentNode, err = core.NewNode(context.Background(), cfg)
+	node, err := core.NewNode(context.Background(), cfg)
 	d.CheckError(err)
-
-	return &chunkStore{
-		node:      CurrentNode,
-		name:      name,
-		local:     local,
-		rateLimit: make(chan struct{}, 1024),
-	}
+	return node
 }
 
 type chunkStore struct {
@@ -242,7 +248,7 @@ func (cs *chunkStore) Version() string {
 func (cs *chunkStore) Rebase() {
 	h := hash.Hash{}
 	var sp string
-	f := cs.getLocalNameFile(cs.name)
+	f := cs.getLocalNameFile(cs.local)
 	b, err := ioutil.ReadFile(f)
 	if !os.IsNotExist(err) {
 		d.PanicIfError(err)
@@ -281,32 +287,22 @@ func (cs *chunkStore) Commit(current, last hash.Hash) bool {
 	// TODO: Optimistic concurrency?
 
 	cid := nomsHashToCID(current)
-	dir := getIPFSDir(cs.local)
-	err := os.MkdirAll(dir, 0755)
-	d.PanicIfError(err)
-	err = ioutil.WriteFile(cs.getLocalNameFile(cs.name), []byte(cid.String()), 0644)
+	if cs.local {
+		err := ioutil.WriteFile(cs.getLocalNameFile(true), []byte(cid.String()), 0644)
+		d.PanicIfError(err)
+	}
+	err := ioutil.WriteFile(cs.getLocalNameFile(false), []byte(cid.String()), 0644)
 	d.PanicIfError(err)
 
 	cs.root = &current
 	return true
 }
 
-func getIPFSDir(local bool) string {
-	env := "IPFS_PATH"
+func (cs *chunkStore) getLocalNameFile(local bool) string {
 	if local {
-		env = "IPFS_LOCAL_PATH"
+		return path.Join(cs.name, "noms-local")
 	}
-	p := os.Getenv(env)
-	if p == "" {
-		p = "~/.ipfs"
-	}
-	p, err := homedir.Expand(p)
-	d.Chk.NoError(err)
-	return p
-}
-
-func (cs *chunkStore) getLocalNameFile(name string) string {
-	return path.Join(getIPFSDir(cs.local), name)
+	return path.Join(cs.name, "noms")
 }
 
 func (cs *chunkStore) Stats() interface{} {
@@ -317,14 +313,14 @@ func (cs *chunkStore) Close() error {
 	return cs.node.Close()
 }
 
-func resetRepoConfigPorts(r repo.Repo) {
-	if NodeIndex < 0 || NodeIndex > 9 {
+func resetRepoConfigPorts(r repo.Repo, nodeIdx int) {
+	if nodeIdx < 0 || nodeIdx > 9 {
 		return
 	}
 
-	apiPort := fmt.Sprintf("500%d", NodeIndex)
-	gatewayPort := fmt.Sprintf("808%d", NodeIndex)
-	swarmPort := fmt.Sprintf("400%d", NodeIndex)
+	apiPort := fmt.Sprintf("500%d", nodeIdx)
+	gatewayPort := fmt.Sprintf("808%d", nodeIdx)
+	swarmPort := fmt.Sprintf("400%d", nodeIdx)
 
 	rc, err := r.Config()
 	d.CheckError(err)

--- a/go/ipfs/cs.go
+++ b/go/ipfs/cs.go
@@ -30,8 +30,7 @@ import (
 // Noms chunks written to this ChunkStore are converted to IPFS blocks and
 // stored in an IPFS BlockStore.
 //
-// Noms repositories that are build on top of IPFS are identified by paths of
-// the following form:
+// IPFS database specs have the form:
 //   ipfs://<path-to-ipfs-dir>
 // where 'ipfs' indicates the noms protocol and the path indicates the path to
 // the directory where the ipfs repo resides. The chunkstore creates two files
@@ -49,13 +48,13 @@ import (
 // blocks stored will be exposed to the entire IPFS network.
 func NewChunkStore(p string, local bool) *chunkStore {
 	node := OpenIPFSRepo(p, -1)
-	return NewChunkStorePrimitive(p, local, node)
+	return ChunkStoreFromIPFSNode(p, local, node)
 }
 
 // Creates a new chunchStore using a pre-existing IpfsNode. This is currently
 // used to create a second 'local' chunkStore using the same IpfsNode as another
 // non-local chunkStore.
-func NewChunkStorePrimitive(p string, local bool, node *core.IpfsNode) *chunkStore {
+func ChunkStoreFromIPFSNode(p string, local bool, node *core.IpfsNode) *chunkStore {
 	return &chunkStore{
 		node:      node,
 		name:      p,
@@ -171,12 +170,6 @@ func (cs *chunkStore) Has(h hash.Hash) bool {
 	defer cs.RateLimitSub()
 
 	id := nomsHashToCID(h)
-	ok, err := cs.node.Blockstore.Has(id)
-	if ok {
-		return true
-	}
-	d.PanicIfError(err)
-
 	if cs.local {
 		ok, err := cs.node.Blockstore.Has(id)
 		d.PanicIfError(err)

--- a/samples/go/ipfs-chat/daemon.go
+++ b/samples/go/ipfs-chat/daemon.go
@@ -5,10 +5,16 @@
 package main
 
 import (
+    "bytes"
 	"context"
 	"encoding/base64"
+    "fmt"
 	"log"
 	"os"
+    "os/signal"
+    "runtime"
+    "strings"
+    "syscall"
 	"time"
 
 	"github.com/attic-labs/noms/go/d"
@@ -20,33 +26,42 @@ import (
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/samples/go/ipfs-chat/dbg"
 	"github.com/ipfs/go-ipfs/core"
+    "github.com/attic-labs/noms/go/util/writers"
 )
 
 func runDaemon(topic string, interval time.Duration, ipfsSpec string, nodeIdx int) {
 	dbg.SetLogger(log.New(os.Stdout, "", 0))
-
+    
+    stackDumpOnSIGQUIT()
 	sp, err := spec.ForDataset(ipfsSpec)
 	d.CheckErrorNoUsage(err)
-	ds := sp.GetDataset()
 
-	node, cs := reconfigureIPFSChunkStore(sp, topic, nodeIdx)
-	sourceDB := datas.NewDatabase(cs)
-	sourceDS := sourceDB.GetDataset(ds.ID())
+    // Create/Open a new network chunkstore 
+	node, nwCS := initChunkStore(sp, nodeIdx)
+    nwDB := datas.NewDatabase(nwCS)
 
-	cs = ipfs.NewChunkStorePrimitive(sp.DatabaseName, true, node)
-	destDB := datas.NewDatabase(cs)
-	destDS := destDB.GetDataset(ds.ID())
-	destDS, err = InitDatabase(destDS)
+    // Use the same ipfs node to create a second chunkstore that restricts data
+    // access to it's local blockstore
+	csLocal := ipfs.ChunkStoreFromIPFSNode(sp.DatabaseName, true, node)
+	localDB := datas.NewDatabase(csLocal)
+	localDS := localDB.GetDataset(sp.Path.Dataset)
+    
+    // Initial the database, if necessary, to an empty commit. Committing to
+    // the local database will also reset the head for the network database.
+    localDS, err = InitDatabase(localDS)
 	d.PanicIfError(err)
 
-	dbg.Debug("Storing locally to:", sp.String())
+    // Get the head of the network dataset.
+    nwDS := nwDB.GetDataset(sp.Path.Dataset)
+    
+	dbg.Debug("Storing locally to: %s", sp.String())
 
-	go replicate(node, topic, sourceDS, destDS, func(ds1 datas.Dataset) {
-		destDS = ds1
+	go replicate(node, topic, nwDS, localDS, func(ds1 datas.Dataset) {
+        nwDS = ds1
 	})
 
 	for {
-		Publish(node, topic, destDS.HeadRef().TargetHash())
+		Publish(node, topic, nwDS.HeadRef().TargetHash())
 		time.Sleep(interval)
 	}
 }
@@ -54,87 +69,143 @@ func runDaemon(topic string, interval time.Duration, ipfsSpec string, nodeIdx in
 // replicate continually listens for commit hashes published by ipfs-chat nodes,
 // ensures that all nodes are replicated locally, and merges new data into it's
 // dataset when necessary.
-func replicate(node *core.IpfsNode, topic string, sourceDS, destDS datas.Dataset, didChange func(ds datas.Dataset)) {
+func replicate(node *core.IpfsNode, topic string, nwDS, localDS datas.Dataset, didChange func(ds datas.Dataset)) {
 	sub, err := node.Floodsub.Subscribe(topic)
 	d.Chk.NoError(err)
 
 	var lastHash hash.Hash
 	for {
 		dbg.Debug("looking for msgs")
-		msg, err := sub.Next(context.Background())
-		d.PanicIfError(err)
-		msgHash := hash.Parse(string(msg.Data))
-		dbg.Debug("got msg, msgHash: %s, lastHash: %s", msgHash.String(), lastHash.String())
-		if lastHash == msgHash {
-			continue
-		}
-		lastHash = msgHash
+        msg, err := sub.Next(context.Background())
+        d.PanicIfError(err)
+        hstring := strings.TrimSpace(string(msg.Data))
+        h, ok := hash.MaybeParse(hstring)
+        if !ok {
+            // if something comes across the pubsub channel that doesn't look
+            // like a valid hash, just print a message and ignore it.
+            dbg.Debug("replicate: received unknown msg: %s", hstring)
+            continue
+        }
+        // If we just saw this hash, then don't need to do anything
+        if lastHash == h {
+            continue
+        }
+        
+        // we're going to process this hash
+		dbg.Debug("got update: %s, lastHash: %s, sender %s", h, lastHash, base64.StdEncoding.EncodeToString(msg.From))
+        lastHash = h
+        
+        // Get the current head of the local dataset
+        localDB := localDS.Database()
+        destHeadRef := localDS.HeadRef()
 
-		dbg.Debug("got update: %s from %s", msgHash, base64.StdEncoding.EncodeToString(msg.From))
-		destDB := destDS.Database()
-		destDB.Rebase()
-		destDS = destDB.GetDataset(destDS.ID())
-		d.PanicIfFalse(destDS.HasHead())
-
-		dbg.Debug("syncing commits")
-		pullCommits(msgHash, sourceDS.Database(), destDB)
-
-		if msgHash == destDS.HeadRef().TargetHash() {
+        // If the headRef of the local dataset is equal to the hash we just
+        // received, there's nothing to do
+		if h == localDS.HeadRef().TargetHash() {
 			dbg.Debug("received hash same as current head, nothing to do")
 			continue
 		}
-		sourceCommit := destDB.ReadValue(msgHash)
+
+        // PullCommits() iterates through all the commits that are parents of this
+        // commit and reads every chunk. This should ensure that all blocks are
+        // local.
+		dbg.Debug("syncing commits")
+		pullCommits(h, nwDS.Database(), localDS.Database(), 0)
+
+        // Everything should be local at this point, now check to see if a
+        // merge or fast-forward needs to be performed.
+		sourceCommit := localDB.ReadValue(h)
 		sourceRef := types.NewRef(sourceCommit)
-		a, ok := datas.FindCommonAncestor(sourceRef, destDS.HeadRef(), destDB)
+        
+        dbg.Debug("Finding common ancestor for merge")
+		a, ok := datas.FindCommonAncestor(sourceRef, destHeadRef, localDB)
 		if !ok {
 			dbg.Debug("no common ancestor, cannot merge update!")
 			continue
 		}
+        dbg.Debug("Checking if source commit is ancestor")
 		if a.Equals(sourceRef) {
 			dbg.Debug("source commit was ancestor, nothing to do")
 			continue
 		}
-		if a.Equals(destDS.HeadRef()) {
+		if a.Equals(localDS.HeadRef()) {
 			dbg.Debug("fast-forward to source commit")
-			destDS, err = destDB.SetHead(destDS, sourceRef)
-			didChange(destDS)
+			localDS, err = localDB.SetHead(localDS, sourceRef)
+			didChange(localDS)
 			continue
 		}
 
-		left := destDS.HeadValue()
+        dbg.Debug("We have mergeable commit")
+		left := localDS.HeadValue()
 		right := sourceCommit.(types.Struct).Get("value")
-		parent := a.TargetValue(destDB).(types.Struct).Get("value")
+		parent := a.TargetValue(localDB).(types.Struct).Get("value")
 
-		merged, err := merge.ThreeWay(left, right, parent, destDB, nil, nil)
+        dbg.Debug("Starting three-way commit")
+		merged, err := merge.ThreeWay(left, right, parent, localDB, nil, nil)
 		if err != nil {
 			dbg.Debug("could not merge received data: " + err.Error())
 			continue
 		}
 
-		destDS, err = destDB.SetHead(destDS, destDB.WriteValue(datas.NewCommit(merged, types.NewSet(destDB, destDS.HeadRef(), sourceRef), types.EmptyStruct)))
+        dbg.Debug("setting new datasetHead on localDB")
+        localDS, err = localDB.SetHead(localDS, localDB.WriteValue(datas.NewCommit(merged, types.NewSet(localDB, localDS.HeadRef(), sourceRef), types.EmptyStruct)))
 		if err != nil {
-			dbg.Debug("call failed to SetHead on destDB, err: %s", err)
+			dbg.Debug("call failed to SetHead on localDB, err: %s", err)
 		}
-		didChange(destDS)
+        dbg.Debug("merged commit, new dataset head is: %ss", localDS.HeadRef().TargetHash())
+		didChange(localDS)
 	}
 }
 
-func pullCommits(h hash.Hash, sourceDB, destDB datas.Database) {
-	dbg.Debug("pullCommits, h: %s", h)
-
-	// read
-	v := destDB.ReadValue(h)
-	if v != nil {
-		dbg.Debug("pullCommits, found h: %s, commit:", h, types.EncodedValueMaxLines(v, 10))
+// One of the problem that this daemon currently has is that it hangs which
+// effectively stops are 'replicate' loop. I can't figure out why that is
+// happening.
+func pullCommits(h hash.Hash, netDB, localDB datas.Database, level int) {
+    // This is so we can easily tell in the log that we are not blocked in this
+    // function
+    defer func() {
+        if level == 0 {
+            dbg.Debug("EXITING PULL-COMMITS!!!")
+        }
+    }()
+    
+    // This is an optimization that can lead us to a bad place, if for some
+    // reason we find a commit in the localDB that doesn't have all of it's
+    // parents then something is wrong.
+	dbg.Debug("pullCommits, checking in local, h: %s", h)
+	if localDB.ReadValue(h) != nil {
+		dbg.Debug("pullCommits, found local h: %s", h)
 		return
-	}
-	v = sourceDB.ReadValue(h)
-	types.EncodedValue(v)
-	dbg.Debug("pullCommits, read h: %s, commit:", h, types.EncodedValueMaxLines(v, 10))
+    }
+    
+    dbg.Debug("pullCommits, not found in local, reading from net h: %s", h)
+    v := netDB.ReadValue(h)
+    d.Chk.NotNil(v)
+    
+    dbg.Debug("pullCommits, encoding value from net, h: %s", h)
+    s1 := types.EncodedValue(v)
+    buf := bytes.Buffer{}
+    fmt.Fprintf(&writers.MaxLineWriter{Dest: &bytes.Buffer{}, MaxLines: 10}, s1)
+    dbg.Debug("pullCommits, read from net, h: %s", h)
+    dbg.Debug("pullCommits, read from net, h: %s, commit: %s", h, buf.String())
+    
+    // Call this function recursively on all of this commit's parents.
 	commit := v.(types.Struct)
 	parents := commit.Get("parents").(types.Set)
 	parents.IterAll(func(v types.Value) {
 		ph := v.(types.Ref).TargetHash()
-		pullCommits(ph, sourceDB, destDB)
+		pullCommits(ph, netDB, localDB, level+1)
 	})
+}
+
+func stackDumpOnSIGQUIT() {
+    sigChan := make(chan os.Signal)
+    go func() {
+        stacktrace := make([]byte, 1024*1024)
+        for range sigChan {
+            length := runtime.Stack(stacktrace, true)
+            fmt.Println(string(stacktrace[:length]))
+        }
+    }()
+    signal.Notify(sigChan, syscall.SIGQUIT)
 }

--- a/samples/go/ipfs-chat/daemon.go
+++ b/samples/go/ipfs-chat/daemon.go
@@ -5,49 +5,136 @@
 package main
 
 import (
-	"fmt"
+	"context"
+	"encoding/base64"
 	"log"
 	"os"
 	"time"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/hash"
 	"github.com/attic-labs/noms/go/ipfs"
+	"github.com/attic-labs/noms/go/merge"
 	"github.com/attic-labs/noms/go/spec"
+	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/samples/go/ipfs-chat/dbg"
+	"github.com/ipfs/go-ipfs/core"
 )
 
-func runDaemon(topic string, interval time.Duration, networkDS, localDS string, netNodeIdx, localNodeIdx int) {
+func runDaemon(topic string, interval time.Duration, ipfsSpec string, nodeIdx int) {
 	dbg.SetLogger(log.New(os.Stdout, "", 0))
 
-	ipfs.NodeIndex = netNodeIdx
-	sourceSp, err := spec.ForDataset(networkDS)
+	sp, err := spec.ForDataset(ipfsSpec)
 	d.CheckErrorNoUsage(err)
-	source := sourceSp.GetDataset()
-	source, err = InitDatabase(source)
+	ds := sp.GetDataset()
+
+	node, cs := reconfigureIPFSChunkStore(sp, topic, nodeIdx)
+	sourceDB := datas.NewDatabase(cs)
+	sourceDS := sourceDB.GetDataset(ds.ID())
+
+	cs = ipfs.NewChunkStorePrimitive(sp.DatabaseName, true, node)
+	destDB := datas.NewDatabase(cs)
+	destDS := destDB.GetDataset(ds.ID())
+	destDS, err = InitDatabase(destDS)
 	d.PanicIfError(err)
 
-	ipfs.NodeIndex = localNodeIdx
-	destSp, err := spec.ForDataset(localDS)
-	d.CheckErrorNoUsage(err)
-	dest := destSp.GetDataset()
-	dest, err = InitDatabase(dest)
-	d.PanicIfError(err)
+	dbg.Debug("Storing locally to:", sp.String())
 
-	ipfs.NodeIndex = -1
-
-	fmt.Printf("Replicating %s to %s...\n", sourceSp.String(), destSp.String())
-
-	sub, err := ipfs.CurrentNode.Floodsub.Subscribe(topic)
-	d.PanicIfError(err)
-	go Replicate(sub, source, dest, func(ds datas.Dataset) {
-		dest = ds
+	go replicate(node, topic, sourceDS, destDS, func(ds1 datas.Dataset) {
+		destDS = ds1
 	})
 
 	for {
-		s := dest.HeadRef().TargetHash().String()
-		fmt.Println("publishing: " + s)
-		Publish(sub, topic, s)
+		Publish(node, topic, destDS.HeadRef().TargetHash())
 		time.Sleep(interval)
 	}
+}
+
+// replicate continually listens for commit hashes published by ipfs-chat nodes,
+// ensures that all nodes are replicated locally, and merges new data into it's
+// dataset when necessary.
+func replicate(node *core.IpfsNode, topic string, sourceDS, destDS datas.Dataset, didChange func(ds datas.Dataset)) {
+	sub, err := node.Floodsub.Subscribe(topic)
+	d.Chk.NoError(err)
+
+	var lastHash hash.Hash
+	for {
+		dbg.Debug("looking for msgs")
+		msg, err := sub.Next(context.Background())
+		d.PanicIfError(err)
+		msgHash := hash.Parse(string(msg.Data))
+		dbg.Debug("got msg, msgHash: %s, lastHash: %s", msgHash.String(), lastHash.String())
+		if lastHash == msgHash {
+			continue
+		}
+		lastHash = msgHash
+
+		dbg.Debug("got update: %s from %s", msgHash, base64.StdEncoding.EncodeToString(msg.From))
+		destDB := destDS.Database()
+		destDB.Rebase()
+		destDS = destDB.GetDataset(destDS.ID())
+		d.PanicIfFalse(destDS.HasHead())
+
+		dbg.Debug("syncing commits")
+		pullCommits(msgHash, sourceDS.Database(), destDB)
+
+		if msgHash == destDS.HeadRef().TargetHash() {
+			dbg.Debug("received hash same as current head, nothing to do")
+			continue
+		}
+		sourceCommit := destDB.ReadValue(msgHash)
+		sourceRef := types.NewRef(sourceCommit)
+		a, ok := datas.FindCommonAncestor(sourceRef, destDS.HeadRef(), destDB)
+		if !ok {
+			dbg.Debug("no common ancestor, cannot merge update!")
+			continue
+		}
+		if a.Equals(sourceRef) {
+			dbg.Debug("source commit was ancestor, nothing to do")
+			continue
+		}
+		if a.Equals(destDS.HeadRef()) {
+			dbg.Debug("fast-forward to source commit")
+			destDS, err = destDB.SetHead(destDS, sourceRef)
+			didChange(destDS)
+			continue
+		}
+
+		left := destDS.HeadValue()
+		right := sourceCommit.(types.Struct).Get("value")
+		parent := a.TargetValue(destDB).(types.Struct).Get("value")
+
+		merged, err := merge.ThreeWay(left, right, parent, destDB, nil, nil)
+		if err != nil {
+			dbg.Debug("could not merge received data: " + err.Error())
+			continue
+		}
+
+		destDS, err = destDB.SetHead(destDS, destDB.WriteValue(datas.NewCommit(merged, types.NewSet(destDB, destDS.HeadRef(), sourceRef), types.EmptyStruct)))
+		if err != nil {
+			dbg.Debug("call failed to SetHead on destDB, err: %s", err)
+		}
+		didChange(destDS)
+	}
+}
+
+func pullCommits(h hash.Hash, sourceDB, destDB datas.Database) {
+	dbg.Debug("pullCommits, h: %s", h)
+
+	// read
+	v := destDB.ReadValue(h)
+	if v != nil {
+		dbg.Debug("pullCommits, found h: %s, commit:", h, types.EncodedValueMaxLines(v, 10))
+		return
+	}
+	v = sourceDB.ReadValue(h)
+	types.EncodedValue(v)
+	dbg.Debug("pullCommits, read h: %s, commit:", h, types.EncodedValueMaxLines(v, 10))
+	commit := v.(types.Struct)
+	parents := commit.Get("parents").(types.Set)
+	parents.IterAll(func(v types.Value) {
+		ph := v.(types.Ref).TargetHash()
+		pullCommits(ph, sourceDB, destDB)
+	})
 }

--- a/samples/go/ipfs-chat/model.go
+++ b/samples/go/ipfs-chat/model.go
@@ -122,7 +122,7 @@ func GetTerms(m Message) []string {
 }
 
 func ListMessages(ds datas.Dataset, searchIds *types.Map, doneChan chan struct{}) (msgMap types.Map, mc chan types.String, err error) {
-	dbg.Debug("##### listMessages: entered")
+	//dbg.Debug("##### listMessages: entered")
 
 	root, err := getRoot(ds)
 	db := ds.Database()
@@ -137,7 +137,7 @@ func ListMessages(ds datas.Dataset, searchIds *types.Map, doneChan chan struct{}
 		<-doneChan
 		done = true
 		<-mc
-		dbg.Debug("##### listMessages: exiting 'done' goroutine")
+		//dbg.Debug("##### listMessages: exiting 'done' goroutine")
 	}()
 
 	go func() {
@@ -150,7 +150,7 @@ func ListMessages(ds datas.Dataset, searchIds *types.Map, doneChan chan struct{}
 			key, _ := keyMap.At(keyMap.Len() - i - 1)
 			mc <- key.(types.String)
 		}
-		dbg.Debug("##### listMessages: exiting 'for loop' goroutine, examined: %d", i)
+		//dbg.Debug("##### listMessages: exiting 'for loop' goroutine, examined: %d", i)
 		close(mc)
 	}()
 	return

--- a/samples/go/ipfs-chat/pubsub.go
+++ b/samples/go/ipfs-chat/pubsub.go
@@ -21,7 +21,7 @@ import (
 // MergeMessages continually listens for commit hashes published by ipfs-chat. It
 // merges new messages into it's existing dataset when necessary and if an actual
 // merge was necessary, it re-publishes the new commit.
-func MergeMessages(node *core.IpfsNode, topic string, ds datas.Dataset, didChange func(ds datas.Dataset)) {
+func mergeMessages(node *core.IpfsNode, topic string, ds datas.Dataset, didChange func(ds datas.Dataset)) {
 	sub, err := node.Floodsub.Subscribe(topic)
 	d.Chk.NoError(err)
 
@@ -97,6 +97,6 @@ func MergeMessages(node *core.IpfsNode, topic string, ds datas.Dataset, didChang
 }
 
 func Publish(node *core.IpfsNode, topic string, h hash.Hash) {
-	dbg.Debug("publishing: %s", h)
+	dbg.Debug("publishing to topic: %s, hash: %s", topic, h)
 	node.Floodsub.Publish(topic, []byte(h.String()+"\r\n"))
 }

--- a/samples/go/ipfs-chat/pubsub.go
+++ b/samples/go/ipfs-chat/pubsub.go
@@ -7,46 +7,55 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/datas"
 	"github.com/attic-labs/noms/go/hash"
-	"github.com/attic-labs/noms/go/ipfs"
 	"github.com/attic-labs/noms/go/merge"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/samples/go/ipfs-chat/dbg"
-	"gx/ipfs/QmddZj8gx1Ceisj3QEWeAzPEjCPWpXzneN1ANdkZdwUdc3/floodsub"
+	"github.com/ipfs/go-ipfs/core"
 )
 
-func Replicate(sub *floodsub.Subscription, source, dest datas.Dataset, didChange func(ds datas.Dataset)) {
-	lastHash := ""
+// MergeMessages continually listens for commit hashes published by ipfs-chat. It
+// merges new messages into it's existing dataset when necessary and if an actual
+// merge was necessary, it re-publishes the new commit.
+func MergeMessages(node *core.IpfsNode, topic string, ds datas.Dataset, didChange func(ds datas.Dataset)) {
+	sub, err := node.Floodsub.Subscribe(topic)
+	d.Chk.NoError(err)
+
+	var lastHash hash.Hash
 	for {
 		dbg.Debug("looking for msgs")
 		msg, err := sub.Next(context.Background())
 		d.PanicIfError(err)
-		h := hash.Parse(string(msg.Data))
-		if lastHash == h.String() {
+		hstring := strings.TrimSpace(string(msg.Data))
+		h, ok := hash.MaybeParse(hstring)
+		if !ok {
+			dbg.Debug("MergeMsgs: received unknown msg: %s", hstring)
 			continue
 		}
-		lastHash = h.String()
+		if lastHash == h {
+			continue
+		}
+		lastHash = h
 
-		dbg.Debug("got update: %s from %s", h.String(), base64.StdEncoding.EncodeToString(msg.From))
-		destDB := dest.Database()
-		destDB.Rebase()
-		dest = destDB.GetDataset(dest.ID())
-		d.PanicIfFalse(dest.HasHead())
+		dbg.Debug("got update: %s from %s", h, base64.StdEncoding.EncodeToString(msg.From))
+		db := ds.Database()
+		db.Rebase()
 
-		source.Database().Rebase()
-		r := types.NewRef(source.Database().ReadValue(h))
-		datas.Pull(source.Database(), destDB, r, nil)
+		ds = db.GetDataset(ds.ID())
+		d.PanicIfFalse(ds.HasHead())
 
-		if h == dest.HeadRef().TargetHash() {
+		if h == ds.HeadRef().TargetHash() {
 			dbg.Debug("received hash same as current head, nothing to do")
 			continue
 		}
-		sourceCommit := destDB.ReadValue(h)
+
+		sourceCommit := db.ReadValue(h)
 		sourceRef := types.NewRef(sourceCommit)
-		a, ok := datas.FindCommonAncestor(sourceRef, dest.HeadRef(), destDB)
+		a, ok := datas.FindCommonAncestor(sourceRef, ds.HeadRef(), db)
 		if !ok {
 			dbg.Debug("no common ancestor, cannot merge update!")
 			continue
@@ -55,31 +64,39 @@ func Replicate(sub *floodsub.Subscription, source, dest datas.Dataset, didChange
 			dbg.Debug("source commit was ancestor, nothing to do")
 			continue
 		}
-		if a.Equals(dest.HeadRef()) {
+		if a.Equals(ds.HeadRef()) {
 			dbg.Debug("fast-forward to source commit")
-			dest, err = destDB.SetHead(dest, sourceRef)
-			didChange(dest)
+			ds, err = db.SetHead(ds, sourceRef)
+			didChange(ds)
 			continue
 		}
 
-		left := dest.HeadValue()
+		dbg.Debug("Merging new messages into existing data")
+		// we have a mergeable difference
+		left := ds.HeadValue()
 		right := sourceCommit.(types.Struct).Get("value")
-		parent := a.TargetValue(destDB).(types.Struct).Get("value")
+		parent := a.TargetValue(db).(types.Struct).Get("value")
 
-		merged, err := merge.ThreeWay(left, right, parent, destDB, nil, nil)
+		merged, err := merge.ThreeWay(left, right, parent, db, nil, nil)
 		if err != nil {
 			dbg.Debug("could not merge received data: " + err.Error())
 			continue
 		}
 
-		dest, err = destDB.SetHead(dest, destDB.WriteValue(datas.NewCommit(merged, types.NewSet(destDB, dest.HeadRef(), sourceRef), types.EmptyStruct)))
+		newCommit := datas.NewCommit(merged, types.NewSet(db, ds.HeadRef(), sourceRef), types.EmptyStruct)
+		commitRef := db.WriteValue(newCommit)
+		dbg.Debug("wrote new commit: %s", commitRef.TargetHash())
+		ds, err = db.SetHead(ds, commitRef)
 		if err != nil {
 			dbg.Debug("call failed to SetHead on destDB, err: %s", err)
 		}
-		didChange(dest)
+		dbg.Debug("set new head ref: %s on ds.ID: %s", commitRef.TargetHash(), ds.ID())
+		Publish(node, topic, commitRef.TargetHash())
+		didChange(ds)
 	}
 }
 
-func Publish(sub *floodsub.Subscription, topic string, s string) {
-	ipfs.CurrentNode.Floodsub.Publish(topic, []byte(s))
+func Publish(node *core.IpfsNode, topic string, h hash.Hash) {
+	dbg.Debug("publishing: %s", h)
+	node.Floodsub.Publish(topic, []byte(h.String()+"\r\n"))
 }


### PR DESCRIPTION
 * Change ipfs paths to include directory where ipfs repo is stored.
 * Rework ipfs-chat to create ipfs chunkstores manually rather than
   relying on Spec.ForDataset. This enables creating two chunkstores
   (one local and one network) using the same IpfsNode (ipfs repo).
 * Create separate replicate function for daemon and mergeMessage
   function for client to experiment with slightly different behaviors
   for each.