### PR TITLE
Don't write a sequence chunk if there is no parent

### DIFF
--- a/go/datas/http_chunk_store_test.go
+++ b/go/datas/http_chunk_store_test.go
@@ -151,7 +151,7 @@ func (suite *HTTPChunkStoreSuite) TestPutChunk() {
 	suite.True(suite.http.Has(c.Hash()))
 
 	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
-	suite.Equal(2, suite.serverCS.Writes)
+	suite.Equal(1, suite.serverCS.Writes)
 }
 
 func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
@@ -169,7 +169,7 @@ func (suite *HTTPChunkStoreSuite) TestPutChunksInOrder() {
 	suite.http.Put(types.EncodeValue(le.List()))
 	suite.True(suite.http.Commit(hash.Hash{}, hash.Hash{}))
 
-	suite.Equal(4, suite.serverCS.Writes)
+	suite.Equal(3, suite.serverCS.Writes)
 }
 
 func (suite *HTTPChunkStoreSuite) TestRebase() {

--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -251,7 +251,6 @@ func chunkBlobLeaf(vrw ValueReadWriter, buff []byte) (Collection, orderedKey, ui
 
 // NewBlob creates a Blob by reading from every Reader in rs and
 // concatenating the result. NewBlob uses one goroutine per Reader.
-// If vrw is not nil, chunks are written to vrw instead of kept in memory.
 func NewBlob(vrw ValueReadWriter, rs ...io.Reader) Blob {
 	return readBlobsP(vrw, rs...)
 }

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -49,9 +49,7 @@ func advanceCursorToOffset(cur *sequenceCursor, idx uint64) uint64 {
 	return uint64(cur.idx)
 }
 
-// If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are
-// written when the root is written.
-func newIndexedMetaSequenceChunkFn(kind NomsKind, source ValueReadWriter) makeChunkFn {
+func newIndexedMetaSequenceChunkFn(kind NomsKind, vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		tuples := make([]metaTuple, len(items))
 		numLeaves := uint64(0)
@@ -64,10 +62,10 @@ func newIndexedMetaSequenceChunkFn(kind NomsKind, source ValueReadWriter) makeCh
 
 		var col Collection
 		if kind == ListKind {
-			col = newList(newListMetaSequence(level, tuples, source))
+			col = newList(newListMetaSequence(level, tuples, vrw))
 		} else {
 			d.PanicIfFalse(BlobKind == kind)
-			col = newBlob(newBlobMetaSequence(level, tuples, source))
+			col = newBlob(newBlobMetaSequence(level, tuples, vrw))
 		}
 		return col, orderedKeyFromSum(tuples), numLeaves
 	}

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -229,8 +229,6 @@ func (l List) newChunker(cur *sequenceCursor, vrw ValueReadWriter) *sequenceChun
 	return newSequenceChunker(cur, 0, vrw, makeListLeafChunkFn(vrw), newIndexedMetaSequenceChunkFn(ListKind, vrw), hashValueBytes)
 }
 
-// If |sink| is not nil, chunks will be eagerly written as they're created. Otherwise they are
-// written when the root is written.
 func makeListLeafChunkFn(vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		d.PanicIfFalse(level == 0)

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -1215,3 +1215,20 @@ func TestListWithNil(t *testing.T) {
 		NewList(vrw, Number(42), nil)
 	})
 }
+
+func TestListOfListsDoesNotWriteRoots(t *testing.T) {
+	assert := assert.New(t)
+	vrw := newTestValueStore()
+
+	l1 := NewList(vrw, String("a"), String("b"))
+	l2 := NewList(vrw, String("c"), String("d"))
+	l3 := NewList(vrw, l1, l2)
+
+	assert.Nil(vrw.ReadValue(l1.Hash()))
+	assert.Nil(vrw.ReadValue(l2.Hash()))
+	assert.Nil(vrw.ReadValue(l3.Hash()))
+
+	vrw.WriteValue(l3)
+	assert.Nil(vrw.ReadValue(l1.Hash()))
+	assert.Nil(vrw.ReadValue(l2.Hash()))
+}

--- a/go/types/map.go
+++ b/go/types/map.go
@@ -316,8 +316,6 @@ func buildMapData(values []Value) mapEntrySlice {
 	return append(uniqueSorted, last)
 }
 
-// If |vw| is not nil, chunks will be eagerly written as they're created. Otherwise they are
-// written when the root is written.
 func makeMapLeafChunkFn(vrw ValueReadWriter) makeChunkFn {
 	return func(level uint64, items []sequenceItem) (Collection, orderedKey, uint64) {
 		d.PanicIfFalse(level == 0)

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -444,7 +444,7 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 
 	assert.Equal(t, uint64(2), NewRef(m).Height())
 	assert.Equal(t, 40, cs.Reads)
-	assert.Equal(t, 17, cs.Writes)
+	assert.Equal(t, 16, cs.Writes)
 }
 
 func TestMapInfiniteChunkBug(t *testing.T) {

--- a/go/types/sequence_chunker.go
+++ b/go/types/sequence_chunker.go
@@ -19,6 +19,7 @@ type sequenceChunker struct {
 	hashValueBytes             hashValueBytesFn
 	rv                         *rollingValueHasher
 	done                       bool
+	unwrittenCol               Collection
 }
 
 // makeChunkFn takes a sequence of items to chunk, and returns the result of chunking those items, a tuple of a reference to that chunk which can itself be chunked + its underlying value.
@@ -47,6 +48,7 @@ func newSequenceChunker(cur *sequenceCursor, level uint64, vrw ValueReadWriter, 
 		hashValueBytes,
 		newRollingValueHasher(byte(level % 256)),
 		false,
+		nil,
 	}
 
 	if cur != nil {
@@ -165,16 +167,37 @@ func (sc *sequenceChunker) createParent() {
 	}
 	sc.parent = newSequenceChunker(parent, sc.level+1, sc.vrw, sc.parentMakeChunk, sc.parentMakeChunk, metaHashValueBytes)
 	sc.parent.isLeaf = false
+
+	if sc.unwrittenCol != nil {
+		// There is an unwritten collection, but this chunker now has a parent, so
+		// write it. See comment in createSequence().
+		sc.vrw.WriteValue(sc.unwrittenCol)
+		sc.unwrittenCol = nil
+	}
 }
 
 func (sc *sequenceChunker) createSequence() (sequence, metaTuple) {
 	// If the sequence chunker has a ValueWriter, eagerly write sequences.
 	col, key, numLeaves := sc.makeChunk(sc.level, sc.current)
 	seq := col.sequence()
-	mt := newMetaTuple(sc.vrw.WriteValue(col), key, numLeaves)
+
+	var ref Ref
+	if sc.parent == nil {
+		// If there is no parent, this chunker (so far) is either the root of the
+		// resulting tree, or *above* the root, and either way don't write it yet
+		// because we might not need to.
+		ref = NewRef(col)
+		sc.unwrittenCol = col
+	} else {
+		// There is a parent, so either this sequence is internal to the tree, or
+		// we'll find out later in Done() that it was a *possible* (but not
+		// necessarily *canonical*) root. In the latter case we'll unecessarily
+		// write a chunk, but it's unlikely and a fair trade off for simplicity.
+		ref = sc.vrw.WriteValue(col)
+	}
 
 	sc.current = []sequenceItem{}
-	return seq, mt
+	return seq, newMetaTuple(ref, key, numLeaves)
 }
 
 func (sc *sequenceChunker) handleChunkBoundary() {


### PR DESCRIPTION
In most cases this will avoid writing the root chunk of a prolly tree,
which is the behavior we're aiming for: a prolly tree might be used
inline in which case the root never needs to be written.

The solution in this patch is imperfect because it may unnecessarily
write chunks, but this is rare.

Fixes https://github.com/attic-labs/noms/issues/3645