### PR TITLE
NOMSFS: only build for darwin/linux

### DIFF
--- a/samples/go/nomsfs/basics_test.go
+++ b/samples/go/nomsfs/basics_test.go
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
+// +build darwin linux
+
 package main
 
 import (

--- a/samples/go/nomsfs/dir_test.go
+++ b/samples/go/nomsfs/dir_test.go
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
+// +build darwin linux
+
 package main
 
 import (

--- a/samples/go/nomsfs/nomsfs.go
+++ b/samples/go/nomsfs/nomsfs.go
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
+// +build darwin linux
+
 package main
 
 import (

--- a/samples/go/nomsfs/rw_test.go
+++ b/samples/go/nomsfs/rw_test.go
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, version 2.0:
 // http://www.apache.org/licenses/LICENSE-2.0
 
+// +build darwin linux
+
 package main
 
 import (


### PR DESCRIPTION
Fixes test errors on non darwin/linux machines.

```
FAIL  github.com/attic-labs/noms/samples/nomsfs [build failed]
# github.com/attic-labs/noms/vendor/github.com/hanwen/go-fuse/fuse
src/github.com/attic-labs/noms/vendor/github.com/hanwen/go-fuse/fuse/types.go:369.2: undefined: Attr
```