### PR TITLE
ensure directories aren't copied

### DIFF
--- a/tools/file/file.go
+++ b/tools/file/file.go
@@ -5,6 +5,7 @@
 package file
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,6 +20,10 @@ func DumbCopy(srcPath, dstPath string) {
 
 	info, err := os.Stat(srcPath)
 	d.PanicIfError(err)
+
+	if info.IsDir() {
+		d.PanicIfError(ErrNoCopyDir)
+	}
 
 	src, err := os.Open(srcPath)
 	d.PanicIfError(err)
@@ -39,3 +44,5 @@ func MyDir() string {
 	}
 	return filepath.Dir(path)
 }
+
+var ErrNoCopyDir = fmt.Errorf("attempted to copy a directory")


### PR DESCRIPTION
On FreeBSD, attempting to copy a directory using DumbCopy returns successfully.

```
--- FAIL: TestSerialRunnerTestSuite/TestNoCopyDir (0.00s)
     Error Trace:     file_test.go:85
     Error:              An error is expected but got nil.
```