### PR TITLE
Add readTypeOfValue

### DIFF
--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -121,8 +121,7 @@ func (seq leafSequence) typeOf() *Type {
 	count := dec.readCount()
 	ts := make([]*Type, count)
 	for i := uint64(0); i < count; i++ {
-		v := dec.readValue()
-		ts[i] = v.typeOf()
+		ts[i] = dec.readTypeOfValue()
 	}
 	return makeCompoundType(kind, makeCompoundType(UnionKind, ts...))
 }

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -159,6 +159,10 @@ func (s Struct) WalkRefs(cb RefCallback) {
 
 func (s Struct) typeOf() *Type {
 	dec := s.decoder()
+	return readStructTypeOfValue(&dec)
+}
+
+func readStructTypeOfValue(dec *valueDecoder) *Type {
 	dec.skipKind()
 	name := dec.readString()
 	count := dec.readCount()
@@ -167,7 +171,7 @@ func (s Struct) typeOf() *Type {
 		typeFields[i] = StructField{
 			Name:     dec.readString(),
 			Optional: false,
-			Type:     dec.readValue().typeOf(),
+			Type:     dec.readTypeOfValue(),
 		}
 	}
 	return makeStructTypeQuickly(name, typeFields)


### PR DESCRIPTION
This improves csv-import a bit since it allows us to skip allocation of
values in the struct when we only want the type.