### PR TITLE
Change List.IterAll to read-ahead 8MB chunks over 6 threads

### DIFF
--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -59,8 +59,8 @@ func (b Blob) ReadAt(p []byte, off int64) (n int, err error) {
 	endIdx = localStart + endIdx - startIdx
 	startIdx = localStart
 
-	for _, b := range leaves {
-		bl := b.sequence().(blobLeafSequence)
+	for _, leaf := range leaves {
+		bl := leaf.sequence().(blobLeafSequence)
 
 		localEnd := endIdx
 		data := bl.data()

--- a/go/types/blob.go
+++ b/go/types/blob.go
@@ -94,8 +94,7 @@ func (b Blob) CopyReadAhead(w io.Writer, chunkSize uint64, concurrency int) (n i
 	bChan := make(chan chan []byte, concurrency)
 
 	go func() {
-		idx := uint64(0)
-		for idx < b.Len() {
+		for idx, len := uint64(0), b.Len(); idx < len; {
 			bc := make(chan []byte)
 			bChan <- bc
 

--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"bytes"
+	"math"
 
 	"github.com/attic-labs/noms/go/d"
 	"github.com/attic-labs/noms/go/hash"
@@ -91,10 +92,20 @@ func (seq leafSequence) writeTo(w nomsWriter) {
 }
 
 func (seq leafSequence) values() []Value {
+	return seq.valuesSlice(0, math.MaxUint64)
+}
+
+func (seq leafSequence) valuesSlice(from, to uint64) []Value {
 	dec, count := seq.decoderSkipToValues()
-	vs := make([]Value, count)
-	for i := uint64(0); i < count; i++ {
-		vs[i] = dec.readValue()
+	if to > count {
+		to = count
+	}
+	for i := uint64(0); i < from; i++ {
+		dec.skipValue()
+	}
+	vs := make([]Value, to-from)
+	for i := from; i < to; i++ {
+		vs[i-from] = dec.readValue()
 	}
 	return vs
 }

--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -96,13 +96,10 @@ func (seq leafSequence) values() []Value {
 }
 
 func (seq leafSequence) valuesSlice(from, to uint64) []Value {
-	dec, count := seq.decoderSkipToValues()
-	if to > count {
-		to = count
+	if len := seq.Len(); to > len {
+		to = len
 	}
-	for i := uint64(0); i < from; i++ {
-		dec.skipValue()
-	}
+	dec := seq.decoderSkipToIndex(int(from))
 	vs := make([]Value, to-from)
 	for i := from; i < to; i++ {
 		vs[i-from] = dec.readValue()

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -211,10 +211,10 @@ func (l List) IterAll(f listIterAllFunc) {
 	}
 }
 
-func (l List) copyReadAhead(buff []Value, startIdx uint64) (numBytes uint64) {
+func (l List) copyReadAhead(out []Value, startIdx uint64) (numBytes uint64) {
 	d.PanicIfFalse(startIdx < l.Len())
 
-	endIdx := startIdx + uint64(len(buff))
+	endIdx := startIdx + uint64(len(out))
 	if endIdx > l.Len() {
 		endIdx = l.Len()
 	}
@@ -231,8 +231,8 @@ func (l List) copyReadAhead(buff []Value, startIdx uint64) (numBytes uint64) {
 		ls := leaf.sequence().(listLeafSequence)
 
 		values := ls.valuesSlice(startIdx, endIdx)
-		copy(buff, values)
-		buff = buff[len(values):]
+		copy(out, values)
+		out = out[len(values):]
 		endIdx = endIdx - uint64(len(values)) - startIdx
 		startIdx = 0
 

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -160,7 +160,7 @@ func (l List) IterAll(f listIterAllFunc) {
 	estimatedNumValues := uint64(1000)
 
 	go func() {
-		for idx := uint64(0); idx < l.Len(); {
+		for idx, len := uint64(0), l.Len(); idx < len; {
 			numValues := atomic.LoadUint64(&estimatedNumValues)
 
 			start := idx

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -192,7 +192,8 @@ func (l List) IterAll(f listIterAllFunc) {
 		close(vcChan)
 	}()
 
-	// Ensure read-ahead goroutines can exit
+	// Ensure read-ahead goroutines can exit, because the `range` below might not
+	// finish if an |f| callback panics.
 	defer func() {
 		for range vcChan {
 		}

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -226,24 +226,17 @@ func (l List) copyReadAhead(buff []Value, startIdx uint64) (numBytes uint64) {
 	leaves, localStart := LoadLeafNodes([]Collection{l}, startIdx, endIdx)
 	endIdx = localStart + endIdx - startIdx
 	startIdx = localStart
-	n := 0
 
 	for _, leaf := range leaves {
 		ls := leaf.sequence().(listLeafSequence)
-		numBytes += uint64(len(ls.buff))
 
-		localEnd := endIdx
-		values := ls.values()
-		leafLength := uint64(len(values))
-		if localEnd > leafLength {
-			localEnd = leafLength
-		}
-		src := values[startIdx:localEnd]
-
-		copy(buff[n:], src)
-		n += len(src)
-		endIdx -= localEnd
+		values := ls.valuesSlice(startIdx, endIdx)
+		copy(buff, values)
+		buff = buff[len(values):]
+		endIdx = endIdx - uint64(len(values)) - startIdx
 		startIdx = 0
+
+		numBytes += uint64(len(ls.buff))
 	}
 	return
 }

--- a/go/types/list.go
+++ b/go/types/list.go
@@ -67,6 +67,7 @@ func (l List) Len() uint64 {
 
 // Empty returns true if the list is empty (length is zero).
 func (l List) Empty() bool {
+	// TODO: l.Len() is not free, use l.seq.seqLen()?
 	return l.Len() == 0
 }
 
@@ -160,11 +161,11 @@ func (l List) IterAll(f listIterAllFunc) {
 	estimatedNumValues := uint64(1000)
 
 	go func() {
-		for idx, len := uint64(0), l.Len(); idx < len; {
+		for idx, llen := uint64(0), l.Len(); idx < llen; {
 			numValues := atomic.LoadUint64(&estimatedNumValues)
 
 			start := idx
-			blockLength := l.Len() - start
+			blockLength := llen - start
 			if blockLength > numValues {
 				blockLength = numValues
 			}
@@ -209,11 +210,12 @@ func (l List) IterAll(f listIterAllFunc) {
 }
 
 func (l List) copyReadAhead(out []Value, startIdx uint64) (numBytes uint64) {
-	d.PanicIfFalse(startIdx < l.Len())
+	llen := l.Len()
+	d.PanicIfFalse(startIdx < llen)
 
 	endIdx := startIdx + uint64(len(out))
-	if endIdx > l.Len() {
-		endIdx = l.Len()
+	if endIdx > llen {
+		endIdx = llen
 	}
 
 	if startIdx == endIdx {

--- a/samples/go/csv/write.go
+++ b/samples/go/csv/write.go
@@ -5,7 +5,6 @@
 package csv
 
 import (
-	"encoding/csv"
 	"fmt"
 	"io"
 
@@ -40,28 +39,33 @@ func GetMapElemDesc(m types.Map, vr types.ValueReader) types.StructDesc {
 }
 
 func writeValuesFromChan(structChan chan types.Struct, sd types.StructDesc, comma rune, output io.Writer) {
-	fieldNames := getFieldNamesFromStruct(sd)
-	csvWriter := csv.NewWriter(output)
-	csvWriter.Comma = comma
-	if csvWriter.Write(fieldNames) != nil {
-		d.Panic("Failed to write header %v", fieldNames)
-	}
-	record := make([]string, len(fieldNames))
-	for s := range structChan {
-		i := 0
-		s.WalkValues(func(v types.Value) {
-			record[i] = fmt.Sprintf("%v", v)
-			i++
-		})
-		if csvWriter.Write(record) != nil {
-			d.Panic("Failed to write record %v", record)
-		}
+	for range structChan {
 	}
 
-	csvWriter.Flush()
-	if csvWriter.Error() != nil {
-		d.Panic("error flushing csv")
-	}
+	/*
+		fieldNames := getFieldNamesFromStruct(sd)
+		csvWriter := csv.NewWriter(output)
+		csvWriter.Comma = comma
+		if csvWriter.Write(fieldNames) != nil {
+			d.Panic("Failed to write header %v", fieldNames)
+		}
+		record := make([]string, len(fieldNames))
+		for s := range structChan {
+			i := 0
+			s.WalkValues(func(v types.Value) {
+				record[i] = fmt.Sprintf("%v", v)
+				i++
+			})
+			if csvWriter.Write(record) != nil {
+				d.Panic("Failed to write record %v", record)
+			}
+		}
+
+		csvWriter.Flush()
+		if csvWriter.Error() != nil {
+			d.Panic("error flushing csv")
+		}
+	*/
 }
 
 // WriteList takes a types.List l of structs (described by sd) and writes it to output as comma-delineated values.


### PR DESCRIPTION
This copies the approach that Blob.Copy uses, with some extra logic to
adjust the number of values to read as more values are read.