### PR TITLE
Enable walking refs in a Chunk without decoding to a Value

### DIFF
--- a/go/datas/pull.go
+++ b/go/datas/pull.go
@@ -66,7 +66,7 @@ func Pull(srcDB, sinkDB Database, sourceRef types.Ref, progressCh chan PullProgr
 		for _, h := range absent {
 			c := neededChunks[h]
 			sinkDB.chunkStore().Put(*c)
-			types.DecodeValue(*c, srcDB).WalkRefs(func(r types.Ref) {
+			types.WalkRefs(*c, func(r types.Ref) {
 				if !nextLevel.Has(r.TargetHash()) {
 					uniqueOrdered = append(uniqueOrdered, r.TargetHash())
 					nextLevel.Insert(r.TargetHash())

--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -87,6 +87,18 @@ func (b *binaryNomsReader) skipUint8() {
 	b.offset++
 }
 
+func (b *binaryNomsReader) peekKind() NomsKind {
+	return NomsKind(b.peekUint8())
+}
+
+func (b *binaryNomsReader) readKind() NomsKind {
+	return NomsKind(b.readUint8())
+}
+
+func (b *binaryNomsReader) skipKind() {
+	b.skipUint8()
+}
+
 func (b *binaryNomsReader) readCount() uint64 {
 	v, count := binary.Uvarint(b.buff[b.offset:])
 	b.offset += uint32(count)

--- a/go/types/list_editor.go
+++ b/go/types/list_editor.go
@@ -61,10 +61,10 @@ func (le *ListEditor) List() List {
 				}
 
 				subEditors = true
-				idx := i
+				idx, val := i, v
 				wg.Add(1)
 				go func() {
-					edit.inserted[idx] = v.Value()
+					edit.inserted[idx] = val.Value()
 					wg.Done()
 				}()
 			}

--- a/go/types/ref.go
+++ b/go/types/ref.go
@@ -55,16 +55,16 @@ func writeRefPartsTo(w nomsWriter, targetHash hash.Hash, targetType *Type, heigh
 	w.writeCount(height)
 }
 
-// readRef reads the data provided by a decoder and moves the decoder forward.
-func readRef(dec *valueDecoder) Ref {
+// readRef reads the data provided by a reader and moves the reader forward.
+func readRef(dec *typedBinaryNomsReader) Ref {
 	start := dec.pos()
 	offsets := skipRef(dec)
 	end := dec.pos()
 	return Ref{valueImpl{nil, dec.byteSlice(start, end), offsets}}
 }
 
-// readRef reads the data provided by a decoder and moves the decoder forward.
-func skipRef(dec *valueDecoder) []uint32 {
+// skipRef moves the reader forward, past the data representing the Ref, and returns the offsets of the component parts.
+func skipRef(dec *typedBinaryNomsReader) []uint32 {
 	offsets := make([]uint32, refPartEnd)
 	offsets[refPartKind] = dec.pos()
 	dec.skipKind()

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -41,6 +41,16 @@ func skipStruct(dec *valueDecoder) {
 	}
 }
 
+func walkStruct(r *refWalker, cb RefCallback) {
+	r.skipKind()
+	r.skipString() // name
+	count := r.readCount()
+	for i := uint64(0); i < count; i++ {
+		r.skipString()
+		r.walkValue(cb)
+	}
+}
+
 func newStruct(name string, fieldNames []string, values []Value) Struct {
 	var vrw ValueReadWriter
 	w := newBinaryNomsWriter()

--- a/go/types/walk.go
+++ b/go/types/walk.go
@@ -18,7 +18,7 @@ type valueRec struct {
 
 const maxRefCount = 1 << 12 // ~16MB of data
 
-// WalkValues recursively walks over all types. Values reachable from r and calls cb on them.
+// WalkValues recursively walks over all types.Values reachable from r and calls cb on them.
 func WalkValues(target Value, vr ValueReader, cb SkipValueCallback) {
 	visited := hash.HashSet{}
 	refs := map[hash.Hash]bool{}

--- a/go/types/walk_refs.go
+++ b/go/types/walk_refs.go
@@ -1,0 +1,136 @@
+// Copyright 2017 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"github.com/attic-labs/noms/go/chunks"
+	"github.com/attic-labs/noms/go/d"
+)
+
+// WalkRefs calls cb() on each Ref that can be decoded from |c|. The results
+// are precisely equal to DecodeValue(c).WalkRefs(cb), but this should be much
+// faster.
+func WalkRefs(c chunks.Chunk, cb RefCallback) {
+	rw := newRefWalker(c.Data())
+	rw.walkValue(cb)
+}
+
+type refWalker struct {
+	typedBinaryNomsReader
+}
+
+func newRefWalker(buff []byte) refWalker {
+	nr := binaryNomsReader{buff, 0}
+	return refWalker{typedBinaryNomsReader{nr, false}}
+}
+
+func (r *refWalker) walkRef(cb RefCallback) {
+	cb(readRef(&(r.typedBinaryNomsReader)))
+}
+
+func (r *refWalker) walkBlobLeafSequence() {
+	size := r.readCount()
+	r.offset += uint32(size)
+}
+
+func (r *refWalker) walkValueSequence(cb RefCallback) {
+	count := int(r.readCount())
+	for i := 0; i < count; i++ {
+		r.walkValue(cb)
+	}
+}
+
+func (r *refWalker) walkList(cb RefCallback) {
+	r.walkListOrSet(ListKind, cb)
+}
+
+func (r *refWalker) walkSet(cb RefCallback) {
+	r.walkListOrSet(SetKind, cb)
+}
+
+func (r *refWalker) walkListOrSet(kind NomsKind, cb RefCallback) {
+	r.skipKind()
+	level := r.readCount()
+	if level > 0 {
+		r.walkMetaSequence(kind, level, cb)
+	} else {
+		r.walkValueSequence(cb)
+	}
+}
+
+func (r *refWalker) walkMap(cb RefCallback) {
+	r.skipKind()
+	level := r.readCount()
+	if level > 0 {
+		r.walkMetaSequence(MapKind, level, cb)
+	} else {
+		r.walkMapLeafSequence(cb)
+	}
+}
+
+func (r *refWalker) walkBlob(cb RefCallback) {
+	r.skipKind()
+	level := r.readCount()
+	if level > 0 {
+		r.walkMetaSequence(BlobKind, level, cb)
+	} else {
+		r.walkBlobLeafSequence()
+	}
+}
+
+func (r *refWalker) walkMapLeafSequence(cb RefCallback) {
+	count := r.readCount()
+	for i := uint64(0); i < count; i++ {
+		r.walkValue(cb) // k
+		r.walkValue(cb) // v
+	}
+}
+
+func (r *refWalker) walkMetaSequence(k NomsKind, level uint64, cb RefCallback) {
+	count := r.readCount()
+	for i := uint64(0); i < count; i++ {
+		r.walkRef(cb)   // ref
+		r.walkValue(cb) // v
+		r.skipCount()   // numLeaves
+	}
+}
+
+func (r *refWalker) walkValue(cb RefCallback) {
+	k := r.peekKind()
+	switch k {
+	case BlobKind:
+		r.walkBlob(cb)
+	case BoolKind:
+		r.skipKind()
+		r.skipBool()
+	case NumberKind:
+		r.skipKind()
+		r.skipNumber()
+	case StringKind:
+		r.skipKind()
+		r.skipString()
+	case ListKind:
+		r.walkList(cb)
+	case MapKind:
+		r.walkMap(cb)
+	case RefKind:
+		r.walkRef(cb)
+	case SetKind:
+		r.walkSet(cb)
+	case StructKind:
+		r.walkStruct(cb)
+	case TypeKind:
+		r.skipKind()
+		r.skipType()
+	case CycleKind, UnionKind, ValueKind:
+		d.Panic("A value instance can never have type %s", k)
+	default:
+		panic("not reachable")
+	}
+}
+
+func (r *refWalker) walkStruct(cb RefCallback) {
+	walkStruct(r, cb)
+}

--- a/go/types/walk_refs_test.go
+++ b/go/types/walk_refs_test.go
@@ -1,0 +1,142 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/attic-labs/noms/go/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalkRefs(t *testing.T) {
+	runTest := func(v Value, t *testing.T) {
+		assert := assert.New(t)
+		expected := hash.HashSlice{}
+		v.WalkRefs(func(r Ref) {
+			expected = append(expected, r.TargetHash())
+		})
+		WalkRefs(EncodeValue(v), func(r Ref) {
+			if assert.True(len(expected) > 0) {
+				assert.Equal(expected[0], r.TargetHash())
+				expected = expected[1:]
+			}
+		})
+		assert.Len(expected, 0)
+	}
+
+	t.Run("SingleRef", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Typed", func(t *testing.T) {
+			runTest(NewRef(Bool(false)), t)
+		})
+		t.Run("OfValue", func(t *testing.T) {
+			runTest(ToRefOfValue(NewRef(Bool(false))), t)
+		})
+	})
+
+	t.Run("Struct", func(t *testing.T) {
+		t.Parallel()
+		data := StructData{
+			"ref": NewRef(Bool(false)),
+			"num": Number(42),
+		}
+		runTest(NewStruct("nom", data), t)
+	})
+
+	// must return a slice with an even number of elements
+	newValueSlice := func(r *rand.Rand) ValueSlice {
+		vs := make(ValueSlice, 256)
+		for i := range vs {
+			vs[i] = String(strconv.FormatUint(r.Uint64(), 10))
+		}
+		return vs
+	}
+
+	t.Run("List", func(t *testing.T) {
+		t.Parallel()
+		vrw := newTestValueStore()
+		r := rand.New(rand.NewSource(0))
+
+		t.Run("OfRefs", func(t *testing.T) {
+			l := NewList(vrw, vrw.WriteValue(Number(42)), vrw.WriteValue(Number(0)))
+			runTest(l, t)
+		})
+
+		t.Run("Chunked", func(t *testing.T) {
+			l := NewList(vrw, newValueSlice(r)...)
+			for l.sequence.isLeaf() {
+				l = l.Concat(NewList(vrw, newValueSlice(r)...))
+			}
+			runTest(l, t)
+		})
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		t.Parallel()
+		vrw := newTestValueStore()
+		r := rand.New(rand.NewSource(0))
+
+		t.Run("OfRefs", func(t *testing.T) {
+			s := NewSet(vrw, vrw.WriteValue(Number(42)), vrw.WriteValue(Number(0)))
+			runTest(s, t)
+		})
+
+		t.Run("Chunked", func(t *testing.T) {
+			s := NewSet(vrw, newValueSlice(r)...)
+			for s.isLeaf() {
+				e := s.Edit()
+				e = e.Insert(newValueSlice(r)...)
+				s = e.Set()
+			}
+			runTest(s, t)
+		})
+	})
+
+	t.Run("Map", func(t *testing.T) {
+		t.Parallel()
+		vrw := newTestValueStore()
+		r := rand.New(rand.NewSource(0))
+
+		t.Run("OfRefs", func(t *testing.T) {
+			m := NewMap(vrw, vrw.WriteValue(Number(42)), vrw.WriteValue(Number(0)))
+			runTest(m, t)
+		})
+
+		t.Run("Chunked", func(t *testing.T) {
+			m := NewMap(vrw, newValueSlice(r)...)
+			for m.isLeaf() {
+				e := m.Edit()
+				vs := newValueSlice(r)
+				for i := 0; i < len(vs); i += 2 {
+					e = e.Set(vs[i], vs[i+1])
+				}
+				m = e.Map()
+			}
+			runTest(m, t)
+		})
+	})
+
+	t.Run("Blob", func(t *testing.T) {
+		t.Parallel()
+		vrw := newTestValueStore()
+		r := rand.New(rand.NewSource(0))
+
+		scratch := make([]byte, 1024)
+		freshRandomBytes := func() io.Reader {
+			r.Read(scratch)
+			return bytes.NewReader(scratch)
+		}
+		b := NewBlob(vrw, freshRandomBytes())
+		for b.sequence.isLeaf() {
+			b = b.Concat(NewBlob(vrw, freshRandomBytes()))
+		}
+		runTest(b, t)
+	})
+}


### PR DESCRIPTION
This patch introduces WalkRefs(c chunks.Chunk, cb RefCallback), which
allows the refs in a Chunk to be walked without first decoding the
Chunk into a Value. It's useful in e.g. datas.Pull(), which needs to
walk the Chunk graph, but doesn't actually care about the Values.
    
On my macbook, syncing e.g. a large dataset imported from a .csv file
is about 4x faster.