### PR TITLE
Refactor Value to share implementations

### DIFF
--- a/go/types/blob_editor.go
+++ b/go/types/blob_editor.go
@@ -37,7 +37,7 @@ func (be *BlobEditor) Blob() Blob {
 		return be.b // no edits
 	}
 
-	seq := be.b.sequence()
+	seq := be.b.sequence
 	vrw := seq.valueReadWriter()
 
 	curs := make([]chan *sequenceCursor, 0)

--- a/go/types/blob_leaf_sequence.go
+++ b/go/types/blob_leaf_sequence.go
@@ -22,7 +22,7 @@ func newBlobLeafSequence(vrw ValueReadWriter, data []byte) sequence {
 	w.writeCount(uint64(len(data)))
 	offsets[sequencePartValues] = w.offset
 	w.writeBytes(data)
-	return blobLeafSequence{leafSequence{vrw, w.data(), offsets}}
+	return blobLeafSequence{newLeafSequence(vrw, w.data(), offsets)}
 }
 
 func (bl blobLeafSequence) writeTo(w nomsWriter) {

--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -20,8 +20,6 @@ type valueBytes interface {
 
 func EncodeValue(v Value) chunks.Chunk {
 	switch v := v.(type) {
-	case Collection:
-		return chunks.NewChunk(v.sequence().bytes())
 	case valueBytes:
 		return chunks.NewChunk(v.valueBytes())
 	case *Type:

--- a/go/types/collection.go
+++ b/go/types/collection.go
@@ -8,5 +8,5 @@ type Collection interface {
 	Value
 	Emptyable
 	Len() uint64
-	sequence() sequence
+	asSequence() sequence
 }

--- a/go/types/collection_test.go
+++ b/go/types/collection_test.go
@@ -60,9 +60,9 @@ func (suite *collectionTestSuite) TestAppendChunkDiff() {
 }
 
 func deriveCollectionHeight(c Collection) uint64 {
-	return c.sequence().treeLevel()
+	return c.asSequence().treeLevel()
 }
 
 func getRefHeightOfCollection(c Collection) uint64 {
-	return c.sequence().getItem(0).(metaTuple).ref.Height()
+	return c.asSequence().getItem(0).(metaTuple).ref.Height()
 }

--- a/go/types/indexed_sequences.go
+++ b/go/types/indexed_sequences.go
@@ -10,11 +10,11 @@ import (
 )
 
 func newListMetaSequence(level uint64, tuples []metaTuple, vrw ValueReadWriter) metaSequence {
-	return newMetaSequence(ListKind, level, tuples, vrw)
+	return newMetaSequenceFromTuples(ListKind, level, tuples, vrw)
 }
 
 func newBlobMetaSequence(level uint64, tuples []metaTuple, vrw ValueReadWriter) metaSequence {
-	return newMetaSequence(BlobKind, level, tuples, vrw)
+	return newMetaSequenceFromTuples(BlobKind, level, tuples, vrw)
 }
 
 // advanceCursorToOffset advances the cursor as close as possible to idx
@@ -90,23 +90,23 @@ func orderedKeyFromSum(msd []metaTuple) orderedKey {
 // [startIdx -> endIdx).  Returns the set of nodes and the offset within
 // the first sequence which corresponds to |startIdx|.
 func LoadLeafNodes(cols []Collection, startIdx, endIdx uint64) ([]Collection, uint64) {
-	vrw := cols[0].sequence().valueReadWriter()
+	vrw := cols[0].asSequence().valueReadWriter()
 	d.PanicIfTrue(vrw == nil)
 
-	if cols[0].sequence().isLeaf() {
+	if cols[0].asSequence().isLeaf() {
 		for _, c := range cols {
-			d.PanicIfFalse(c.sequence().isLeaf())
+			d.PanicIfFalse(c.asSequence().isLeaf())
 		}
 
 		return cols, startIdx
 	}
 
-	level := cols[0].sequence().treeLevel()
+	level := cols[0].asSequence().treeLevel()
 	childTuples := []metaTuple{}
 
 	cum := uint64(0)
 	for _, c := range cols {
-		s := c.sequence()
+		s := c.asSequence()
 		d.PanicIfFalse(s.treeLevel() == level)
 		ms := s.(metaSequence)
 

--- a/go/types/less.go
+++ b/go/types/less.go
@@ -4,7 +4,16 @@
 
 package types
 
-func valueLess(v1, v2 Value) bool {
+import (
+	"github.com/attic-labs/noms/go/hash"
+)
+
+type kindAndHash interface {
+	Kind() NomsKind
+	Hash() hash.Hash
+}
+
+func valueLess(v1, v2 kindAndHash) bool {
 	switch v2.Kind() {
 	case BoolKind, NumberKind, StringKind:
 		return false

--- a/go/types/list_editor.go
+++ b/go/types/list_editor.go
@@ -32,7 +32,7 @@ func (le *ListEditor) List() List {
 		return le.l // no edits
 	}
 
-	seq := le.l.sequence()
+	seq := le.l.sequence
 	vrw := seq.valueReadWriter()
 
 	cursChan := make(chan chan *sequenceCursor)

--- a/go/types/list_leaf_sequence.go
+++ b/go/types/list_leaf_sequence.go
@@ -9,8 +9,7 @@ type listLeafSequence struct {
 }
 
 func newListLeafSequence(vrw ValueReadWriter, vs ...Value) sequence {
-	ls := newLeafSequence(ListKind, uint64(len(vs)), vrw, vs...)
-	return listLeafSequence{ls}
+	return listLeafSequence{newLeafSequenceFromValues(ListKind, vrw, vs...)}
 }
 
 // sequence interface

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -1070,17 +1070,17 @@ func TestListTypeAfterMutations(t *testing.T) {
 
 		l := NewList(vrw, values...)
 		assert.Equal(l.Len(), uint64(n))
-		assert.IsType(c, l.sequence())
+		assert.IsType(c, l.asSequence())
 		assert.True(TypeOf(l).Equals(MakeListType(NumberType)))
 
 		l = l.Edit().Append(String("a")).List()
 		assert.Equal(l.Len(), uint64(n+1))
-		assert.IsType(c, l.sequence())
+		assert.IsType(c, l.asSequence())
 		assert.True(TypeOf(l).Equals(MakeListType(MakeUnionType(NumberType, StringType))))
 
 		l = l.Edit().Splice(l.Len()-1, 1).List()
 		assert.Equal(l.Len(), uint64(n))
-		assert.IsType(c, l.sequence())
+		assert.IsType(c, l.asSequence())
 		assert.True(TypeOf(l).Equals(MakeListType(NumberType)))
 	}
 

--- a/go/types/map_editor.go
+++ b/go/types/map_editor.go
@@ -39,7 +39,8 @@ func (me *MapEditor) Map() Map {
 		return me.m // no edits
 	}
 
-	vrw := me.m.sequence().valueReadWriter()
+	seq := me.m.orderedSequence
+	vrw := seq.valueReadWriter()
 
 	me.normalize()
 
@@ -59,7 +60,7 @@ func (me *MapEditor) Map() Map {
 			cursChan <- cc
 
 			go func() {
-				cc <- newCursorAtValue(me.m.seq, edit.key, true, false, false)
+				cc <- newCursorAtValue(seq, edit.key, true, false, false)
 			}()
 
 			kvc := make(chan mapEntry, 1)

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -66,7 +66,7 @@ func newMapLeafSequence(vrw ValueReadWriter, data ...mapEntry) orderedSequence {
 		me.writeTo(&w)
 		offsets[i+sequencePartValues+1] = w.offset
 	}
-	return mapLeafSequence{leafSequence{vrw, w.data(), offsets}}
+	return mapLeafSequence{newLeafSequence(vrw, w.data(), offsets)}
 }
 
 func (ml mapLeafSequence) writeTo(w nomsWriter) {

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -1409,17 +1409,17 @@ func TestMapTypeAfterMutations(t *testing.T) {
 
 		m := NewMap(vrw, values...)
 		assert.Equal(m.Len(), uint64(n))
-		assert.IsType(c, m.sequence())
+		assert.IsType(c, m.asSequence())
 		assert.True(TypeOf(m).Equals(MakeMapType(NumberType, NumberType)))
 
 		m = m.Edit().Set(String("a"), String("a")).Map()
 		assert.Equal(m.Len(), uint64(n+1))
-		assert.IsType(c, m.sequence())
+		assert.IsType(c, m.asSequence())
 		assert.True(TypeOf(m).Equals(MakeMapType(MakeUnionType(NumberType, StringType), MakeUnionType(NumberType, StringType))))
 
 		m = m.Edit().Remove(String("a")).Map()
 		assert.Equal(m.Len(), uint64(n))
-		assert.IsType(c, m.sequence())
+		assert.IsType(c, m.asSequence())
 		assert.True(TypeOf(m).Equals(MakeMapType(NumberType, NumberType)))
 	}
 
@@ -1455,7 +1455,7 @@ func TestCompoundMapWithValuesOfEveryType(t *testing.T) {
 	}
 
 	m := NewMap(vrw, kvs...)
-	for i := 1; m.sequence().isLeaf(); i++ {
+	for i := 1; m.asSequence().isLeaf(); i++ {
 		k := Number(i)
 		kvs = append(kvs, k, v)
 		m = m.Edit().Set(k, v).Map()

--- a/go/types/ordered_sequences.go
+++ b/go/types/ordered_sequences.go
@@ -15,11 +15,11 @@ type orderedSequence interface {
 }
 
 func newSetMetaSequence(level uint64, tuples []metaTuple, vrw ValueReadWriter) metaSequence {
-	return newMetaSequence(SetKind, level, tuples, vrw)
+	return newMetaSequenceFromTuples(SetKind, level, tuples, vrw)
 }
 
 func newMapMetaSequence(level uint64, tuples []metaTuple, vrw ValueReadWriter) metaSequence {
-	return newMetaSequence(MapKind, level, tuples, vrw)
+	return newMetaSequenceFromTuples(MapKind, level, tuples, vrw)
 }
 
 func newCursorAtValue(seq orderedSequence, val Value, forInsertion bool, last bool, readAhead bool) *sequenceCursor {

--- a/go/types/ordered_sequences_diff_test.go
+++ b/go/types/ordered_sequences_diff_test.go
@@ -77,8 +77,8 @@ func (suite *diffTestSuite) TestDiff() {
 		col1 := cf(vf(suite.from1, suite.to1, suite.by1))
 		col2 := cf(vf(suite.from2, suite.to2, suite.by2))
 		suite.added, suite.removed, suite.modified = accumulateOrderedSequenceDiffChanges(
-			col1.sequence().(orderedSequence),
-			col2.sequence().(orderedSequence),
+			col1.asSequence().(orderedSequence),
+			col2.asSequence().(orderedSequence),
 			df)
 		suite.Equal(suite.numAddsExpected, len(suite.added), "test %s: num added is not as expected", name)
 		suite.Equal(suite.numRemovesExpected, len(suite.removed), "test %s: num removed is not as expected", name)
@@ -160,9 +160,9 @@ func TestOrderedSequencesDiffCloseWithoutReading(t *testing.T) {
 	vs := newTestValueStore()
 
 	runTest := func(df diffFn) {
-		s1 := NewSet(vs).seq
+		s1 := NewSet(vs).orderedSequence
 		// A single item should be enough, but generate lots anyway.
-		s2 := NewSet(vs, generateNumbersAsValuesFromToBy(0, 1000, 1)...).seq
+		s2 := NewSet(vs, generateNumbersAsValuesFromToBy(0, 1000, 1)...).orderedSequence
 
 		changeChan := make(chan ValueChanged)
 		closeChan := make(chan struct{})

--- a/go/types/path.go
+++ b/go/types/path.go
@@ -339,10 +339,10 @@ func (hip HashIndexPath) Resolve(v Value, vr ValueReader) (res Value) {
 	switch v := v.(type) {
 	case Set:
 		// Unclear what the behavior should be if |hip.IntoKey| is true, but ignoring it for sets is arguably correct.
-		seq = v.seq
+		seq = v.orderedSequence
 		getCurrentValue = func(cur *sequenceCursor) Value { return cur.current().(Value) }
 	case Map:
-		seq = v.seq
+		seq = v.orderedSequence
 		if hip.IntoKey {
 			getCurrentValue = func(cur *sequenceCursor) Value { return cur.current().(mapEntry).key }
 		} else {

--- a/go/types/sequence_chunker.go
+++ b/go/types/sequence_chunker.go
@@ -204,7 +204,7 @@ func (sc *sequenceChunker) createSequence(write bool) (sequence, metaTuple) {
 	}
 
 	mt := newMetaTuple(ref, key, numLeaves)
-	return col.sequence(), mt
+	return col.asSequence(), mt
 }
 
 func (sc *sequenceChunker) handleChunkBoundary() {

--- a/go/types/sequence_cursor_test.go
+++ b/go/types/sequence_cursor_test.go
@@ -68,11 +68,11 @@ func (ts testSequence) isLeaf() bool {
 	panic("not reached")
 }
 
-func (ts testSequence) equals(other sequence) bool {
+func (ts testSequence) Equals(other Value) bool {
 	panic("not reached")
 }
 
-func (ts testSequence) bytes() []byte {
+func (ts testSequence) valueBytes() []byte {
 	panic("not reached")
 }
 
@@ -80,7 +80,7 @@ func (ts testSequence) Less(other Value) bool {
 	panic("not reached")
 }
 
-func (ts testSequence) hash() hash.Hash {
+func (ts testSequence) Hash() hash.Hash {
 	panic("not reached")
 }
 
@@ -93,6 +93,18 @@ func (ts testSequence) WalkRefs(cb RefCallback) {
 }
 
 func (ts testSequence) typeOf() *Type {
+	panic("not reached")
+}
+
+func (ts testSequence) Len() uint64 {
+	panic("not reached")
+}
+
+func (ts testSequence) Empty() bool {
+	panic("not reached")
+}
+
+func (ts testSequence) asValueImpl() valueImpl {
 	panic("not reached")
 }
 

--- a/go/types/set_editor.go
+++ b/go/types/set_editor.go
@@ -39,7 +39,8 @@ func (se *SetEditor) Set() Set {
 		return se.s // no edits
 	}
 
-	vrw := se.s.sequence().valueReadWriter()
+	seq := se.s.orderedSequence
+	vrw := seq.valueReadWriter()
 
 	se.normalize()
 
@@ -59,7 +60,7 @@ func (se *SetEditor) Set() Set {
 			cursChan <- cc
 
 			go func() {
-				cc <- newCursorAtValue(se.s.seq, edit.value, true, false, false)
+				cc <- newCursorAtValue(seq, edit.value, true, false, false)
 			}()
 
 			editChan <- edit

--- a/go/types/set_leaf_sequence.go
+++ b/go/types/set_leaf_sequence.go
@@ -11,8 +11,7 @@ type setLeafSequence struct {
 }
 
 func newSetLeafSequence(vrw ValueReadWriter, vs ...Value) orderedSequence {
-	ls := newLeafSequence(SetKind, uint64(len(vs)), vrw, vs...)
-	return setLeafSequence{ls}
+	return setLeafSequence{newLeafSequenceFromValues(SetKind, vrw, vs...)}
 }
 
 func (sl setLeafSequence) getCompareFn(other sequence) compareFn {

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -979,17 +979,17 @@ func TestSetTypeAfterMutations(t *testing.T) {
 
 		s := NewSet(vs, values...)
 		assert.Equal(s.Len(), uint64(n))
-		assert.IsType(c, s.sequence())
+		assert.IsType(c, s.asSequence())
 		assert.True(TypeOf(s).Equals(MakeSetType(NumberType)))
 
 		s = s.Edit().Insert(String("a")).Set()
 		assert.Equal(s.Len(), uint64(n+1))
-		assert.IsType(c, s.sequence())
+		assert.IsType(c, s.asSequence())
 		assert.True(TypeOf(s).Equals(MakeSetType(MakeUnionType(NumberType, StringType))))
 
 		s = s.Edit().Remove(String("a")).Set()
 		assert.Equal(s.Len(), uint64(n))
-		assert.IsType(c, s.sequence())
+		assert.IsType(c, s.asSequence())
 		assert.True(TypeOf(s).Equals(MakeSetType(NumberType)))
 	}
 
@@ -1026,7 +1026,7 @@ func TestChunkedSetWithValuesOfEveryType(t *testing.T) {
 	}
 
 	s := NewSet(vs, vals...)
-	for i := 1; s.sequence().isLeaf(); i++ {
+	for i := 1; s.asSequence().isLeaf(); i++ {
 		v := Number(i)
 		vals = append(vals, v)
 		s = s.Edit().Insert(v).Set()

--- a/go/types/subtype.go
+++ b/go/types/subtype.go
@@ -283,7 +283,7 @@ func isValueSubtypeOfDetails(v Value, t *Type, hasExtra bool) (bool, bool) {
 		case Map:
 			kt := desc.ElemTypes[0]
 			vt := desc.ElemTypes[1]
-			if seq, ok := v.seq.(mapLeafSequence); ok {
+			if seq, ok := v.orderedSequence.(mapLeafSequence); ok {
 				for _, entry := range seq.entries() {
 					isSub, hasMore := isValueSubtypeOfDetails(entry.key, kt, hasExtra)
 					if !isSub {
@@ -298,10 +298,10 @@ func isValueSubtypeOfDetails(v Value, t *Type, hasExtra bool) (bool, bool) {
 				}
 				return true, hasExtra
 			}
-			return isMetaSequenceSubtypeOf(v.seq.(metaSequence), t, hasExtra)
+			return isMetaSequenceSubtypeOf(v.orderedSequence.(metaSequence), t, hasExtra)
 		case Set:
 			et := desc.ElemTypes[0]
-			if seq, ok := v.seq.(setLeafSequence); ok {
+			if seq, ok := v.orderedSequence.(setLeafSequence); ok {
 				for _, v := range seq.values() {
 					isSub, hasMore := isValueSubtypeOfDetails(v, et, hasExtra)
 					if !isSub {
@@ -311,10 +311,10 @@ func isValueSubtypeOfDetails(v Value, t *Type, hasExtra bool) (bool, bool) {
 				}
 				return true, hasExtra
 			}
-			return isMetaSequenceSubtypeOf(v.seq.(metaSequence), t, hasExtra)
+			return isMetaSequenceSubtypeOf(v.orderedSequence.(metaSequence), t, hasExtra)
 		case List:
 			et := desc.ElemTypes[0]
-			if seq, ok := v.seq.(listLeafSequence); ok {
+			if seq, ok := v.sequence.(listLeafSequence); ok {
 				for _, v := range seq.values() {
 					isSub, hasMore := isValueSubtypeOfDetails(v, et, hasExtra)
 					if !isSub {
@@ -324,7 +324,7 @@ func isValueSubtypeOfDetails(v Value, t *Type, hasExtra bool) (bool, bool) {
 				}
 				return true, hasExtra
 			}
-			return isMetaSequenceSubtypeOf(v.seq.(metaSequence), t, hasExtra)
+			return isMetaSequenceSubtypeOf(v.sequence.(metaSequence), t, hasExtra)
 		}
 	}
 	panic("unreachable")

--- a/go/types/value_decoder.go
+++ b/go/types/value_decoder.go
@@ -147,10 +147,10 @@ func (r *valueDecoder) readListSequence() sequence {
 	end := r.pos()
 
 	if level > 0 {
-		return metaSequence{r.vrw, r.byteSlice(start, end), offsets}
+		return newMetaSequence(r.vrw, r.byteSlice(start, end), offsets)
 	}
 
-	return listLeafSequence{leafSequence{r.vrw, r.byteSlice(start, end), offsets}}
+	return listLeafSequence{newLeafSequence(r.vrw, r.byteSlice(start, end), offsets)}
 }
 
 func (r *valueDecoder) readBlobSequence() sequence {
@@ -168,10 +168,10 @@ func (r *valueDecoder) readBlobSequence() sequence {
 	end := r.pos()
 
 	if level > 0 {
-		return metaSequence{r.vrw, r.byteSlice(start, end), offsets}
+		return newMetaSequence(r.vrw, r.byteSlice(start, end), offsets)
 	}
 
-	return blobLeafSequence{leafSequence{r.vrw, r.byteSlice(start, end), offsets}}
+	return blobLeafSequence{newLeafSequence(r.vrw, r.byteSlice(start, end), offsets)}
 }
 
 func (r *valueDecoder) readSetSequence() orderedSequence {
@@ -189,10 +189,10 @@ func (r *valueDecoder) readSetSequence() orderedSequence {
 	end := r.pos()
 
 	if level > 0 {
-		return metaSequence{r.vrw, r.byteSlice(start, end), offsets}
+		return newMetaSequence(r.vrw, r.byteSlice(start, end), offsets)
 	}
 
-	return setLeafSequence{leafSequence{r.vrw, r.byteSlice(start, end), offsets}}
+	return setLeafSequence{newLeafSequence(r.vrw, r.byteSlice(start, end), offsets)}
 }
 
 func (r *valueDecoder) readMapSequence() orderedSequence {
@@ -210,10 +210,10 @@ func (r *valueDecoder) readMapSequence() orderedSequence {
 	end := r.pos()
 
 	if level > 0 {
-		return metaSequence{r.vrw, r.byteSlice(start, end), offsets}
+		return newMetaSequence(r.vrw, r.byteSlice(start, end), offsets)
 	}
 
-	return mapLeafSequence{leafSequence{r.vrw, r.byteSlice(start, end), offsets}}
+	return mapLeafSequence{newLeafSequence(r.vrw, r.byteSlice(start, end), offsets)}
 }
 
 func (r *valueDecoder) skipList() {

--- a/go/types/value_stats.go
+++ b/go/types/value_stats.go
@@ -41,7 +41,7 @@ func writePtreeStats(w io.Writer, v Value, vr ValueReader) {
 	fmt.Fprintf(w, "Kind: %s\n", v.Kind().String())
 	fmt.Fprintf(w, treeLevelHeader)
 
-	level := int64(v.(Collection).sequence().treeLevel())
+	level := int64(v.(Collection).asSequence().treeLevel())
 	nodes := ValueSlice{v}
 
 	// TODO: For level 0, use NBS to fetch leaf sizes without actually reading leaf data.
@@ -58,7 +58,7 @@ func writePtreeStats(w io.Writer, v Value, vr ValueReader) {
 				})
 			}
 
-			s := n.(Collection).sequence()
+			s := n.(Collection).asSequence()
 			valueCount += uint64(s.seqLen())
 
 			h := n.Hash()

--- a/go/types/walk.go
+++ b/go/types/walk.go
@@ -43,7 +43,7 @@ func WalkValues(target Value, vr ValueReader, cb SkipValueCallback) {
 				continue
 			}
 
-			if col, ok := v.(Collection); ok && !col.sequence().isLeaf() {
+			if col, ok := v.(Collection); ok && !col.asSequence().isLeaf() {
 				col.WalkRefs(func(r Ref) {
 					refs[r.TargetHash()] = false
 				})


### PR DESCRIPTION
All values that are backed by a buffer now embed valueImpl which
implements all the shared logic.

All sequences now embed sequenceImpl which implements all the shared
logic.