### PR TITLE
use refWalker for Value.WalkRefs

### DIFF
--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -138,10 +138,7 @@ func (seq leafSequence) getItem(idx int) sequenceItem {
 }
 
 func (seq leafSequence) WalkRefs(cb RefCallback) {
-	dec, count := seq.decoderSkipToValues()
-	for i := uint64(0); i < count; i++ {
-		dec.readValue().WalkRefs(cb)
-	}
+	walkRefs(seq.valueBytes(), cb)
 }
 
 func (seq leafSequence) Len() uint64 {

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -81,10 +81,7 @@ func (ml mapLeafSequence) getItem(idx int) sequenceItem {
 }
 
 func (ml mapLeafSequence) WalkRefs(cb RefCallback) {
-	dec, count := ml.decoderSkipToValues()
-	for i := uint64(0); i < count*2; i++ { // * 2 because we have keys and values.
-		dec.readValue().WalkRefs(cb)
-	}
+	walkRefs(ml.valueBytes(), cb)
 }
 
 func (ml mapLeafSequence) entries() mapEntrySlice {

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -252,13 +252,7 @@ func (ms metaSequence) getItem(idx int) sequenceItem {
 }
 
 func (ms metaSequence) WalkRefs(cb RefCallback) {
-	dec, count := ms.decoderSkipToValues()
-	for i := uint64(0); i < count; i++ {
-		ref := dec.readRef()
-		cb(ref)
-		dec.skipValue() // v
-		dec.skipCount() // numLeaves
-	}
+	walkRefs(ms.valueBytes(), cb)
 }
 
 func (ms metaSequence) typeOf() *Type {

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -137,9 +137,7 @@ func (s Struct) WalkValues(cb ValueCallback) {
 }
 
 func (s Struct) WalkRefs(cb RefCallback) {
-	s.WalkValues(func(v Value) {
-		v.WalkRefs(cb)
-	})
+	walkRefs(s.valueBytes(), cb)
 }
 
 func (s Struct) typeOf() *Type {

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -250,8 +250,7 @@ func (lvs *ValueStore) bufferChunk(v Value, c chunks.Chunk, height uint64) {
 		if !isBuffered {
 			return
 		}
-		pv := DecodeValue(pending, lvs)
-		pv.WalkRefs(func(grandchildRef Ref) {
+		WalkRefs(pending, func(grandchildRef Ref) {
 			gch := grandchildRef.TargetHash()
 			if pending, present := lvs.bufferedChunks[gch]; present {
 				put(gch, pending)
@@ -329,8 +328,7 @@ func (lvs *ValueStore) Commit(current, last hash.Hash) bool {
 
 		for parent := range lvs.withBufferedChildren {
 			if pending, present := lvs.bufferedChunks[parent]; present {
-				v := DecodeValue(pending, lvs)
-				v.WalkRefs(func(reachable Ref) {
+				WalkRefs(pending, func(reachable Ref) {
 					if pending, present := lvs.bufferedChunks[reachable.TargetHash()]; present {
 						put(reachable.TargetHash(), pending)
 					}

--- a/go/types/walk_refs.go
+++ b/go/types/walk_refs.go
@@ -13,7 +13,11 @@ import (
 // are precisely equal to DecodeValue(c).WalkRefs(cb), but this should be much
 // faster.
 func WalkRefs(c chunks.Chunk, cb RefCallback) {
-	rw := newRefWalker(c.Data())
+	walkRefs(c.Data(), cb)
+}
+
+func walkRefs(data []byte, cb RefCallback) {
+	rw := newRefWalker(data)
 	rw.walkValue(cb)
 }
 


### PR DESCRIPTION
@cmasone-attic this resulted in about 13% improvement in csv-import. From looking at the profile, the main issue was that String.WalkRefs was calling WalkValues, which was allocating strings as it decoded them. using the refWalker avoid this.

I'm not totally sure why this causes tests to fail. Can you investigate?

Also, FWIW, after this patch, if I do the experiment of short-circuiting the grandchild strategy and eagerly writing values, it has no noticeable affect, so maybe the other stuff about refactoring layering of snappy encode/decode isn't high value right now.