### PR TITLE
Use refWalker for Value.WalkRefs

### DIFF
--- a/go/types/leaf_sequence.go
+++ b/go/types/leaf_sequence.go
@@ -138,10 +138,7 @@ func (seq leafSequence) getItem(idx int) sequenceItem {
 }
 
 func (seq leafSequence) WalkRefs(cb RefCallback) {
-	dec, count := seq.decoderSkipToValues()
-	for i := uint64(0); i < count; i++ {
-		dec.readValue().WalkRefs(cb)
-	}
+	walkRefs(seq.valueBytes(), cb)
 }
 
 func (seq leafSequence) Len() uint64 {

--- a/go/types/map_leaf_sequence.go
+++ b/go/types/map_leaf_sequence.go
@@ -81,10 +81,7 @@ func (ml mapLeafSequence) getItem(idx int) sequenceItem {
 }
 
 func (ml mapLeafSequence) WalkRefs(cb RefCallback) {
-	dec, count := ml.decoderSkipToValues()
-	for i := uint64(0); i < count*2; i++ { // * 2 because we have keys and values.
-		dec.readValue().WalkRefs(cb)
-	}
+	walkRefs(ml.valueBytes(), cb)
 }
 
 func (ml mapLeafSequence) entries() mapEntrySlice {

--- a/go/types/meta_sequence.go
+++ b/go/types/meta_sequence.go
@@ -252,13 +252,7 @@ func (ms metaSequence) getItem(idx int) sequenceItem {
 }
 
 func (ms metaSequence) WalkRefs(cb RefCallback) {
-	dec, count := ms.decoderSkipToValues()
-	for i := uint64(0); i < count; i++ {
-		ref := dec.readRef()
-		cb(ref)
-		dec.skipValue() // v
-		dec.skipCount() // numLeaves
-	}
+	walkRefs(ms.valueBytes(), cb)
 }
 
 func (ms metaSequence) typeOf() *Type {

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -137,9 +137,7 @@ func (s Struct) WalkValues(cb ValueCallback) {
 }
 
 func (s Struct) WalkRefs(cb RefCallback) {
-	s.WalkValues(func(v Value) {
-		v.WalkRefs(cb)
-	})
+	walkRefs(s.valueBytes(), cb)
 }
 
 func (s Struct) typeOf() *Type {

--- a/go/types/value_store.go
+++ b/go/types/value_store.go
@@ -250,8 +250,7 @@ func (lvs *ValueStore) bufferChunk(v Value, c chunks.Chunk, height uint64) {
 		if !isBuffered {
 			return
 		}
-		pv := DecodeValue(pending, lvs)
-		pv.WalkRefs(func(grandchildRef Ref) {
+		WalkRefs(pending, func(grandchildRef Ref) {
 			gch := grandchildRef.TargetHash()
 			if pending, present := lvs.bufferedChunks[gch]; present {
 				put(gch, pending)
@@ -329,8 +328,7 @@ func (lvs *ValueStore) Commit(current, last hash.Hash) bool {
 
 		for parent := range lvs.withBufferedChildren {
 			if pending, present := lvs.bufferedChunks[parent]; present {
-				v := DecodeValue(pending, lvs)
-				v.WalkRefs(func(reachable Ref) {
+				WalkRefs(pending, func(reachable Ref) {
 					if pending, present := lvs.bufferedChunks[reachable.TargetHash()]; present {
 						put(reachable.TargetHash(), pending)
 					}

--- a/go/types/walk_refs.go
+++ b/go/types/walk_refs.go
@@ -13,7 +13,11 @@ import (
 // are precisely equal to DecodeValue(c).WalkRefs(cb), but this should be much
 // faster.
 func WalkRefs(c chunks.Chunk, cb RefCallback) {
-	rw := newRefWalker(c.Data())
+	walkRefs(c.Data(), cb)
+}
+
+func walkRefs(data []byte, cb RefCallback) {
+	rw := newRefWalker(data)
 	rw.walkValue(cb)
 }
 

--- a/go/types/walk_refs.go
+++ b/go/types/walk_refs.go
@@ -95,9 +95,10 @@ func (r *refWalker) walkMapLeafSequence(cb RefCallback) {
 func (r *refWalker) walkMetaSequence(k NomsKind, level uint64, cb RefCallback) {
 	count := r.readCount()
 	for i := uint64(0); i < count; i++ {
-		r.walkRef(cb)   // ref
-		r.walkValue(cb) // v
-		r.skipCount()   // numLeaves
+		r.walkRef(cb) // ref to child sequence
+		// TODO: The maxValue encoded here can be a scalar or a Hash that's hacked into the encoding as a Ref<Bool>. Calling r.walkValue() here with a no-op callback is a slightly wasteful hack, but until we figure out a better way to share code between refWalker and valueDecoder, it will have to do. BUG 3757
+		r.walkValue(func(r Ref) {}) // max Value in subtree reachable from here
+		r.skipCount()               // numLeaves
 	}
 }
 

--- a/go/types/walk_refs_test.go
+++ b/go/types/walk_refs_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
-	"strconv"
 	"testing"
 
 	"github.com/attic-labs/noms/go/hash"
@@ -34,7 +33,9 @@ func TestWalkRefs(t *testing.T) {
 	t.Run("SingleRef", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Typed", func(t *testing.T) {
-			runTest(NewRef(Bool(false)), t)
+			vrw := newTestValueStore()
+			s := NewStruct("", StructData{"n": Number(1)})
+			runTest(NewRef(NewMap(vrw, s, Number(2))), t)
 		})
 		t.Run("OfValue", func(t *testing.T) {
 			runTest(ToRefOfValue(NewRef(Bool(false))), t)
@@ -54,7 +55,7 @@ func TestWalkRefs(t *testing.T) {
 	newValueSlice := func(r *rand.Rand) ValueSlice {
 		vs := make(ValueSlice, 256)
 		for i := range vs {
-			vs[i] = String(strconv.FormatUint(r.Uint64(), 10))
+			vs[i] = NewStruct("", StructData{"n": Number(r.Uint64())})
 		}
 		return vs
 	}


### PR DESCRIPTION
For values that are currently backed by byte-slices in memory, use `refWalker` as the implementation for `WalkRefs`. This is preferable ATM because it avoids allocating (in particular, strings in structs).