### PR TITLE
Add List.IterRange

### DIFF
--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -147,6 +147,22 @@ func (suite *listTestSuite) TestIter() {
 	suite.Equal(endAt, expectIdx)
 }
 
+func (suite *listTestSuite) TestIterRange() {
+	list := suite.col.(List)
+
+	for s := uint64(0); s < 6; s++ {
+		batchSize := list.Len() / (2 << s)
+		expectIdx := uint64(0)
+		for i := uint64(0); i < list.Len(); i += batchSize {
+			list.IterRange(i, i+batchSize, func(v Value, idx uint64) {
+				suite.Equal(expectIdx, idx)
+				expectIdx++
+				suite.Equal(suite.elems[idx], v)
+			})
+		}
+	}
+}
+
 func TestListSuite4K(t *testing.T) {
 	suite.Run(t, newListTestSuite(12, 9, 2, 2))
 }

--- a/go/types/sequence_cursor.go
+++ b/go/types/sequence_cursor.go
@@ -46,16 +46,6 @@ func (cur *sequenceCursor) sync() {
 	cur.seqLen = cur.seq.seqLen()
 }
 
-func (cur *sequenceCursor) preloadChildren() {
-	if cur.childSeqs != nil {
-		return
-	}
-
-	cur.childSeqs = make([]sequence, cur.seq.seqLen())
-	ms := cur.seq.(metaSequence)
-	copy(cur.childSeqs[cur.idx:], ms.getChildren(uint64(cur.idx), uint64(cur.seq.seqLen())))
-}
-
 // getChildSequence retrieves the child at the current cursor position.
 func (cur *sequenceCursor) getChildSequence() sequence {
 	return cur.seq.getChildSequence(cur.idx)


### PR DESCRIPTION
Adds explicit API to list to iterate a range of indices. The implementation of this uses the most eager read of the required data.