### PR TITLE
Avoid creating gigantic chunks with Lists of very long repeated values

### DIFF
--- a/go/constants/version.go
+++ b/go/constants/version.go
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-const NomsVersion = "7.16"
+const NomsVersion = "7.17"
 const NOMS_VERSION_NEXT_ENV_NAME = "NOMS_VERSION_NEXT"
 const NOMS_VERSION_NEXT_ENV_VALUE = "1"
 

--- a/go/sloppy/sloppy.go
+++ b/go/sloppy/sloppy.go
@@ -4,7 +4,9 @@
 
 package sloppy
 
-import "github.com/attic-labs/noms/go/d"
+import (
+	"github.com/attic-labs/noms/go/d"
+)
 
 const (
 	maxOffsetPOT = uint16(12)
@@ -63,7 +65,7 @@ type Sloppy struct {
 	idx                      int
 	matching                 bool
 	matchOffset, matchLength int
-	table                    [maxTableSize]uint16
+	table                    [maxTableSize]uint32
 }
 
 // New returns a new sloppy encoder which will encode to |f|. If |f| ever
@@ -76,7 +78,7 @@ func New(f func(b byte) bool) *Sloppy {
 		0,
 		false,
 		0, 0,
-		[maxTableSize]uint16{},
+		[maxTableSize]uint32{},
 	}
 }
 
@@ -126,7 +128,7 @@ func (sl *Sloppy) Update(src []byte) {
 		}
 
 		// Store new hashed offset
-		sl.table[nextHash&tableMask] = uint16(sl.idx)
+		sl.table[nextHash&tableMask] = uint32(sl.idx)
 
 		if sl.matching {
 			sl.matchLength++
@@ -143,7 +145,7 @@ func (sl *Sloppy) Reset() {
 	sl.matching = false
 	sl.matchOffset = 0
 	sl.matchLength = 0
-	sl.table = [maxTableSize]uint16{}
+	sl.table = [maxTableSize]uint32{}
 }
 
 // len >= 2^(2 + log2(maxOffset) - log2(maxOffset-off)). IOW, for the first 1/2

--- a/go/types/blob_test.go
+++ b/go/types/blob_test.go
@@ -67,19 +67,19 @@ func newBlobTestSuite(size uint, expectChunkCount int, expectPrependChunkDiff in
 }
 
 func TestBlobSuite4K(t *testing.T) {
-	suite.Run(t, newBlobTestSuite(12, 1, 2, 2))
+	suite.Run(t, newBlobTestSuite(12, 2, 2, 2))
 }
 
 func TestBlobSuite64K(t *testing.T) {
-	suite.Run(t, newBlobTestSuite(16, 14, 2, 2))
+	suite.Run(t, newBlobTestSuite(16, 15, 2, 2))
 }
 
 func TestBlobSuite256K(t *testing.T) {
-	suite.Run(t, newBlobTestSuite(18, 59, 2, 2))
+	suite.Run(t, newBlobTestSuite(18, 64, 2, 2))
 }
 
 func TestBlobSuite1M(t *testing.T) {
-	suite.Run(t, newBlobTestSuite(20, 247, 2, 2))
+	suite.Run(t, newBlobTestSuite(20, 245, 2, 2))
 }
 
 // Checks the first 1/2 of the bytes, then 1/2 of the remainder, then 1/2 of the remainder, etc...

--- a/go/types/list_test.go
+++ b/go/types/list_test.go
@@ -164,11 +164,11 @@ func (suite *listTestSuite) TestIterRange() {
 }
 
 func TestListSuite4K(t *testing.T) {
-	suite.Run(t, newListTestSuite(12, 9, 2, 2))
+	suite.Run(t, newListTestSuite(12, 8, 2, 2))
 }
 
 func TestListSuite8K(t *testing.T) {
-	suite.Run(t, newListTestSuite(14, 16, 2, 2))
+	suite.Run(t, newListTestSuite(14, 22, 2, 2))
 }
 
 func TestListInsert(t *testing.T) {
@@ -1042,8 +1042,8 @@ func TestListDiffLargeWithSameMiddle(t *testing.T) {
 
 	// should only read/write a "small & reasonably sized portion of the total"
 	assert.Equal(9, cs1.Writes)
-	assert.Equal(4, cs1.Reads)
-	assert.Equal(8, cs2.Writes)
+	assert.Equal(3, cs1.Reads)
+	assert.Equal(9, cs2.Writes)
 	assert.Equal(3, cs2.Reads)
 }
 

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -304,11 +304,11 @@ func (suite *mapTestSuite) TestStreamingMap2() {
 }
 
 func TestMapSuite4K(t *testing.T) {
-	suite.Run(t, newMapTestSuite(12, 9, 2, 2, newNumber))
+	suite.Run(t, newMapTestSuite(12, 4, 2, 2, newNumber))
 }
 
 func TestMapSuite4KStructs(t *testing.T) {
-	suite.Run(t, newMapTestSuite(12, 16, 2, 2, newNumberStruct))
+	suite.Run(t, newMapTestSuite(12, 11, 2, 2, newNumberStruct))
 }
 
 func newNumber(i int) Value {
@@ -414,7 +414,7 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 	vs := newValueStoreWithCacheAndPending(cs, 0, 0)
 
 	me := NewMap(vs).Edit()
-	for i := 0; i < 4000; i++ {
+	for i := 0; i < 10000; i++ {
 		me.Set(Number(i), newLargeStruct(i))
 	}
 	m := me.Map()
@@ -425,7 +425,7 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 	every := 100
 
 	me = m.Edit()
-	for i := 0; i < 4000; i++ {
+	for i := 0; i < 10000; i++ {
 		if i%every == 0 {
 			k := Number(i)
 			s := me.Get(Number(i)).(Struct)
@@ -442,9 +442,9 @@ func TestMapMutationReadWriteCount(t *testing.T) {
 
 	vs.Commit(vs.Root(), vs.Root())
 
-	assert.Equal(t, uint64(2), NewRef(m).Height())
-	assert.Equal(t, 40, cs.Reads)
-	assert.Equal(t, 16, cs.Writes)
+	assert.Equal(t, uint64(3), NewRef(m).Height())
+	assert.Equal(t, 105, cs.Reads)
+	assert.Equal(t, 62, cs.Writes)
 }
 
 func TestMapInfiniteChunkBug(t *testing.T) {

--- a/go/types/rolling_value_hasher.go
+++ b/go/types/rolling_value_hasher.go
@@ -15,9 +15,9 @@ import (
 const (
 	defaultChunkPattern = uint32(1<<12 - 1) // Avg Chunk Size of 4k
 
-	// The window size to use for computing the rolling hash. This is way more than necessary assuming random data (two bytes would be sufficient with a target chunk size of 4k). The benefit of a larger window is it allows for better distribution on input with lower entropy. At a target chunk size of 4k, any given byte changing has roughly a 1.5% chance of affecting an existing boundary, which seems like an acceptable trade-off.
+	// The window size to use for computing the rolling hash. This is way more than necessary assuming random data (two bytes would be sufficient with a target chunk size of 4k). The benefit of a larger window is it allows for better distribution on input with lower entropy. At a target chunk size of 4k, any given byte changing has roughly a 1.5% chance of affecting an existing boundary, which seems like an acceptable trade-off. The choice of a prime number provides better distribution for repeating input.
 	chunkWindow  = uint32(67)
-	maxChunkSize = 1 << 24
+	maxChunkSize = 1 << 24 // TODO: Remove when https://github.com/attic-labs/noms/issues/3743 is fixed.
 )
 
 // Only set by tests

--- a/go/types/rolling_value_hasher.go
+++ b/go/types/rolling_value_hasher.go
@@ -16,7 +16,8 @@ const (
 	defaultChunkPattern = uint32(1<<12 - 1) // Avg Chunk Size of 4k
 
 	// The window size to use for computing the rolling hash. This is way more than necessary assuming random data (two bytes would be sufficient with a target chunk size of 4k). The benefit of a larger window is it allows for better distribution on input with lower entropy. At a target chunk size of 4k, any given byte changing has roughly a 1.5% chance of affecting an existing boundary, which seems like an acceptable trade-off.
-	defaultChunkWindow = uint32(64)
+	defaultChunkWindow = uint32(67)
+	maxChunkSize       = 1 << 24
 )
 
 // Only set by tests
@@ -84,6 +85,9 @@ func (rv *rollingValueHasher) HashByte(b byte) bool {
 	if !rv.crossedBoundary {
 		rv.bz.HashByte(b ^ rv.salt)
 		rv.crossedBoundary = (rv.bz.Sum32()&rv.pattern == rv.pattern)
+		if rv.bw.offset > maxChunkSize {
+			rv.crossedBoundary = true
+		}
 	}
 	return rv.crossedBoundary
 }

--- a/go/types/rolling_value_hasher.go
+++ b/go/types/rolling_value_hasher.go
@@ -16,14 +16,13 @@ const (
 	defaultChunkPattern = uint32(1<<12 - 1) // Avg Chunk Size of 4k
 
 	// The window size to use for computing the rolling hash. This is way more than necessary assuming random data (two bytes would be sufficient with a target chunk size of 4k). The benefit of a larger window is it allows for better distribution on input with lower entropy. At a target chunk size of 4k, any given byte changing has roughly a 1.5% chance of affecting an existing boundary, which seems like an acceptable trade-off.
-	defaultChunkWindow = uint32(67)
-	maxChunkSize       = 1 << 24
+	chunkWindow  = uint32(67)
+	maxChunkSize = 1 << 24
 )
 
 // Only set by tests
 var (
 	chunkPattern  = defaultChunkPattern
-	chunkWindow   = defaultChunkWindow
 	chunkConfigMu = &sync.Mutex{}
 )
 
@@ -37,14 +36,12 @@ func smallTestChunks() {
 	chunkConfigMu.Lock()
 	defer chunkConfigMu.Unlock()
 	chunkPattern = uint32(1<<8 - 1) // Avg Chunk Size of 256 bytes
-	chunkWindow = uint32(64)
 }
 
 func normalProductionChunks() {
 	chunkConfigMu.Lock()
 	defer chunkConfigMu.Unlock()
 	chunkPattern = defaultChunkPattern
-	chunkWindow = defaultChunkWindow
 }
 
 type rollingValueHasher struct {

--- a/go/types/set_test.go
+++ b/go/types/set_test.go
@@ -236,11 +236,11 @@ func (suite *setTestSuite) TestStreamingSet2() {
 }
 
 func TestSetSuite4K(t *testing.T) {
-	suite.Run(t, newSetTestSuite(12, 9, 2, 2, newNumber))
+	suite.Run(t, newSetTestSuite(12, 8, 2, 2, newNumber))
 }
 
 func TestSetSuite4KStructs(t *testing.T) {
-	suite.Run(t, newSetTestSuite(12, 2, 2, 2, newNumberStruct))
+	suite.Run(t, newSetTestSuite(12, 9, 2, 2, newNumberStruct))
 }
 
 func getTestNativeOrderSet(scale int, vrw ValueReadWriter) testSet {

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-4:7.16:8s92pdafhd4hkhav6r4748u1rjlosh1k:5b1e9knhol2orv0a8ej6tvelc46jp92l:bsvid54jt8pjto211lcdl14tbfd39jmn:2:998se5i5mf15fld7f318818i6ie0c8rr:2
+4:7.17:8s92pdafhd4hkhav6r4748u1rjlosh1k:5b1e9knhol2orv0a8ej6tvelc46jp92l:bsvid54jt8pjto211lcdl14tbfd39jmn:2:998se5i5mf15fld7f318818i6ie0c8rr:2


### PR DESCRIPTION
Towards #3743 

Includes a set of changes aimed at better handling of Lists which contain long subsequences of repeated values (e.g. 1.1 Billion "yellow" strings).

Turns out a few things were happening here

1) The sloppy lookup table was only 16 bits and so when the input byte stream crossed 64k it stopped find matches. Fix: the lookup table now stores 32 bit offsets

2) "yellow" repeated encodes as patterns of 8 bytes, this (by chance) drove the rolling hash to zero from which it never recovers. Fix: make the hash window a prime value (67 bytes).

3) There already is a maxCopy in sloppy, but this effectively results in the rolling hash seeing long repeated sequences of 3 bytes (just repeats of the copy). The reduces entropy further and the input sequence never chunks (just by chance). Fix: add a `maxChunkSize` of 16MB.

4) Bump the noms version

Note that this patch leaves in place the problem that if you inserted another yellow at start of the 1.1 billion yellows, it'll cascade all the way to the end. I think the right solution to that *has* to be something like the repeat kind. For now, this will allow us to successfully import insanely large columns which have one value.