### PR TITLE
Optimize typeOf for sequences and simplifyType

### DIFF
--- a/go/types/make_type.go
+++ b/go/types/make_type.go
@@ -31,7 +31,7 @@ func MakePrimitiveType(k NomsKind) *Type {
 
 // MakeUnionType creates a new union type unless the elemTypes can be folded into a single non union type.
 func MakeUnionType(elemTypes ...*Type) *Type {
-	return simplifyType(makeCompoundType(UnionKind, elemTypes...), false)
+	return simplifyType(makeUnionType(elemTypes...), false)
 }
 
 func MakeListType(elemType *Type) *Type {
@@ -61,7 +61,7 @@ func MakeStructType(name string, fields ...StructField) *Type {
 // types.
 // This function will go away so do not use it!
 func MakeUnionTypeIntersectStructs(elemTypes ...*Type) *Type {
-	return simplifyType(makeCompoundType(UnionKind, elemTypes...), true)
+	return simplifyType(makeUnionType(elemTypes...), true)
 }
 
 func MakeCycleType(name string) *Type {
@@ -82,6 +82,13 @@ var ValueType = makePrimitiveType(ValueKind)
 
 func makeCompoundType(kind NomsKind, elemTypes ...*Type) *Type {
 	return newType(CompoundDesc{kind, elemTypes})
+}
+
+func makeUnionType(elemTypes ...*Type) *Type {
+	if len(elemTypes) == 1 {
+		return elemTypes[0]
+	}
+	return makeCompoundType(UnionKind, elemTypes...)
 }
 
 func makeStructTypeQuickly(name string, fields structTypeFields) *Type {

--- a/go/types/ref.go
+++ b/go/types/ref.go
@@ -5,6 +5,8 @@
 package types
 
 import (
+	"bytes"
+
 	"github.com/attic-labs/noms/go/hash"
 )
 
@@ -86,8 +88,12 @@ func maxChunkHeight(v Value) (max uint64) {
 	return
 }
 
+func (r Ref) offsetAtPart(part refPart) uint32 {
+	return r.offsets[part] - r.offsets[refPartKind]
+}
+
 func (r Ref) decoderAtPart(part refPart) valueDecoder {
-	offset := r.offsets[part] - r.offsets[refPartKind]
+	offset := r.offsetAtPart(part)
 	return newValueDecoder(r.buff[offset:], nil)
 }
 
@@ -120,4 +126,10 @@ func (r Ref) WalkValues(cb ValueCallback) {
 
 func (r Ref) typeOf() *Type {
 	return makeCompoundType(RefKind, r.TargetType())
+}
+
+func (r Ref) isSameTargetType(other Ref) bool {
+	targetTypeBytes := r.buff[r.offsetAtPart(refPartTargetType):r.offsetAtPart(refPartHeight)]
+	otherTargetTypeBytes := other.buff[other.offsetAtPart(refPartTargetType):other.offsetAtPart(refPartHeight)]
+	return bytes.Equal(targetTypeBytes, otherTargetTypeBytes)
 }

--- a/go/types/simplify.go
+++ b/go/types/simplify.go
@@ -41,10 +41,14 @@ import (
 //
 // All the above rules are applied recursively.
 func simplifyType(t *Type, intersectStructs bool) *Type {
+	if t.Desc.isSimplifiedForSure() {
+		return t
+	}
+
 	// 1. Clone tree because we are going to mutate it
 	//    1.1 Replace all named structs and cycle types with a single `struct Name {}`
-	// 2. When a union type is found change its elemtypes as needed
-	//    2.1 Merge unamed structs
+	// 2. When a union type is found change its elemTypes as needed
+	//    2.1 Merge unnamed structs
 	// 3. Update the fields of all named structs
 
 	namedStructs := map[string]structInfo{}
@@ -343,7 +347,7 @@ func simplifyStructFields(in []structTypeFields, seenStructs typeset, intersectS
 	fields := make(structTypeFields, len(allFields))
 	i := 0
 	for name, fti := range allFields {
-		nt := makeCompoundType(UnionKind, fti.ts...)
+		nt := makeUnionType(fti.ts...)
 		fields[i] = StructField{
 			Name:     name,
 			Type:     foldUnions(nt, seenStructs, intersectStructs),

--- a/go/types/simplify_test.go
+++ b/go/types/simplify_test.go
@@ -86,15 +86,15 @@ func TestSimplifyType(t *testing.T) {
 			assert.Equal(in, act)
 		}
 
-		test(makeCompoundType(UnionKind, BoolType), BoolType)
-		test(makeCompoundType(UnionKind, BoolType, BoolType), BoolType)
-		testSame(makeCompoundType(UnionKind, BoolType, NumberType))
-		test(makeCompoundType(UnionKind, NumberType, BoolType), makeCompoundType(UnionKind, BoolType, NumberType))
-		test(makeCompoundType(UnionKind, NumberType, BoolType), makeCompoundType(UnionKind, BoolType, NumberType))
+		test(makeUnionType(BoolType), BoolType)
+		test(makeUnionType(BoolType, BoolType), BoolType)
+		testSame(makeUnionType(BoolType, NumberType))
+		test(makeUnionType(NumberType, BoolType), makeUnionType(BoolType, NumberType))
+		test(makeUnionType(NumberType, BoolType), makeUnionType(BoolType, NumberType))
 
-		testSame(makeCompoundType(ListKind, makeCompoundType(UnionKind, BoolType, NumberType)))
-		test(makeCompoundType(ListKind, makeCompoundType(UnionKind, BoolType)), makeCompoundType(ListKind, BoolType))
-		test(makeCompoundType(ListKind, makeCompoundType(UnionKind, BoolType, BoolType)), makeCompoundType(ListKind, BoolType))
+		testSame(makeCompoundType(ListKind, makeUnionType(BoolType, NumberType)))
+		test(makeCompoundType(ListKind, makeUnionType(BoolType)), makeCompoundType(ListKind, BoolType))
+		test(makeCompoundType(ListKind, makeUnionType(BoolType, BoolType)), makeCompoundType(ListKind, BoolType))
 
 		testSame(makeStructType("", nil))
 		testSame(makeStructType("", structTypeFields{}))
@@ -105,7 +105,7 @@ func TestSimplifyType(t *testing.T) {
 		test(
 			makeStructType("", structTypeFields{
 				StructField{"a", BoolType, false},
-				StructField{"b", makeCompoundType(UnionKind, NumberType, NumberType), false},
+				StructField{"b", makeUnionType(NumberType, NumberType), false},
 			}),
 			makeStructType("", structTypeFields{
 				StructField{"a", BoolType, false},
@@ -150,7 +150,7 @@ func TestSimplifyType(t *testing.T) {
 					makeCompoundType(k, BoolType),
 				),
 				makeCompoundType(k,
-					makeCompoundType(UnionKind, BoolType, NumberType),
+					makeUnionType(BoolType, NumberType),
 				),
 			)
 		}
@@ -163,7 +163,7 @@ func TestSimplifyType(t *testing.T) {
 				makeCompoundType(MapKind, BoolType, NumberType),
 			),
 			makeCompoundType(MapKind,
-				makeCompoundType(UnionKind, BoolType, NumberType),
+				makeUnionType(BoolType, NumberType),
 				NumberType,
 			),
 		)
@@ -177,19 +177,19 @@ func TestSimplifyType(t *testing.T) {
 			),
 			makeCompoundType(MapKind,
 				NumberType,
-				makeCompoundType(UnionKind, BoolType, NumberType),
+				makeUnionType(BoolType, NumberType),
 			),
 		)
 
 		// union flattening
 		test(
-			makeCompoundType(UnionKind, NumberType, makeCompoundType(UnionKind, NumberType, BoolType)),
-			makeCompoundType(UnionKind, BoolType, NumberType),
+			makeUnionType(NumberType, makeUnionType(NumberType, BoolType)),
+			makeUnionType(BoolType, NumberType),
 		)
 
 		{
 			// Cannot do equals on cycle types
-			in := makeCompoundType(UnionKind, MakeCycleType("A"), MakeCycleType("A"))
+			in := makeUnionType(MakeCycleType("A"), MakeCycleType("A"))
 			exp := MakeCycleType("A")
 			act := simplifyType(in, intersectStructs)
 			assert.Equal(exp, act)
@@ -212,10 +212,10 @@ func TestSimplifyType(t *testing.T) {
 		}))
 		test(
 			makeStructType("A", structTypeFields{
-				StructField{"a", makeCompoundType(UnionKind, BoolType, BoolType, NumberType), false},
+				StructField{"a", makeUnionType(BoolType, BoolType, NumberType), false},
 			}),
 			makeStructType("A", structTypeFields{
-				StructField{"a", makeCompoundType(UnionKind, BoolType, NumberType), false},
+				StructField{"a", makeUnionType(BoolType, NumberType), false},
 			}),
 		)
 
@@ -268,7 +268,7 @@ func TestSimplifyType(t *testing.T) {
 		{
 			a := makeStructType("S", structTypeFields{
 				StructField{"a", BoolType, !intersectStructs},
-				StructField{"b", makeCompoundType(UnionKind, BoolType, StringType), false},
+				StructField{"b", makeUnionType(BoolType, StringType), false},
 			})
 			exp := makeCompoundType(MapKind, a, a)
 			test(
@@ -308,7 +308,7 @@ func TestSimplifyType(t *testing.T) {
 				},
 			})
 			a.Desc.(StructDesc).fields[0].Type = a
-			exp := makeCompoundType(UnionKind, NumberType, a, TypeType)
+			exp := makeUnionType(NumberType, a, TypeType)
 			test(
 				makeCompoundType(UnionKind,
 					makeStructType("A", structTypeFields{
@@ -332,7 +332,7 @@ func TestSimplifyType(t *testing.T) {
 						BoolType,
 					),
 					makeCompoundType(SetKind,
-						makeCompoundType(UnionKind, StringType, NumberType),
+						makeUnionType(StringType, NumberType),
 					),
 				),
 			),
@@ -342,7 +342,7 @@ func TestSimplifyType(t *testing.T) {
 						BoolType,
 					),
 					makeCompoundType(SetKind,
-						makeCompoundType(UnionKind, NumberType, StringType),
+						makeUnionType(NumberType, StringType),
 					),
 				),
 			),

--- a/go/types/type.go
+++ b/go/types/type.go
@@ -41,7 +41,16 @@ func (t *Type) Value() Value {
 }
 
 func (t *Type) Equals(other Value) (res bool) {
-	return t == other || t.Hash() == other.Hash()
+	// This is highly optimized to not having to encode a *Type unless we have too.
+	if t == other {
+		return true
+	}
+
+	if otherType, ok := other.(*Type); ok {
+		return t.TargetKind() == otherType.TargetKind() && t.Hash() == other.Hash()
+	}
+
+	return false
 }
 
 func (t *Type) Less(other Value) (res bool) {

--- a/go/types/value_decoder.go
+++ b/go/types/value_decoder.go
@@ -313,38 +313,23 @@ func (r *valueDecoder) readTypeOfValue() *Type {
 // isValueSameTypeForSure may return false even though the type of the value is
 // equal. We do that in cases wherer it would be too expensive to compute the
 // type.
+// If this returns false the decoder might not have visited the whole value and
+// its offset is no longer valid.
 func (r *valueDecoder) isValueSameTypeForSure(t *Type) bool {
 	k := r.peekKind()
 	if k != t.TargetKind() {
-		r.skipValue()
 		return false
 	}
 
 	switch k {
-	case BlobKind:
-		r.skipBlob()
-		return true
-	case BoolKind:
-		r.skipKind()
-		r.skipBool()
-		return true
-	case NumberKind:
-		r.skipKind()
-		r.skipNumber()
-		return true
-	case StringKind:
-		r.skipKind()
-		r.skipString()
+	case BlobKind, BoolKind, NumberKind, StringKind:
+		r.skipValue()
 		return true
 	case ListKind, MapKind, RefKind, SetKind:
-		// TODO: Do the same thing as for struct. In other words find the true cases.
-		r.skipValue()
 		return false
 	case StructKind:
 		return isStructSameTypeForSure(r, t)
 	case TypeKind:
-		r.skipKind()
-		r.skipType()
 		return false
 	case CycleKind, UnionKind, ValueKind:
 		d.Panic("A value instance can never have type %s", k)

--- a/go/types/value_decoder.go
+++ b/go/types/value_decoder.go
@@ -326,6 +326,9 @@ func (r *valueDecoder) isValueSameTypeForSure(t *Type) bool {
 		r.skipValue()
 		return true
 	case ListKind, MapKind, RefKind, SetKind:
+		// TODO: Maybe do some simple cases here too. Performance metrics should determine
+		// what is going to be worth doing.
+		// https://github.com/attic-labs/noms/issues/3776
 		return false
 	case StructKind:
 		return isStructSameTypeForSure(r, t)


### PR DESCRIPTION
When we compute the type of a sequence we used to compute the type of
every value in the sequence and then simplify the union. Now we check
if the type of the value is the same as the type of the last element, in
which case we do not need to include it in the union. This is the common
case and it allows us top skip allocating a lot of Types and it makes
the Type to simplify smaller which makes simplifying the type faster.

Also, handle the simple cases where the type is already simplified.

Optimize `*Type` `Equals` to reduce the number of times we have to
encode it.

Introducing `makeUnionType` that removes the `Union<T>` earlier so that
there is less work to do in `simplifyType`.

This halves the amount of time spent in TypeOf for csv import, going
from 18 MB/s to 27 MB/s

Towards #3710, #3747