### PR TITLE
 Remove hack for meta tuples of refs

### DIFF
--- a/go/constants/version.go
+++ b/go/constants/version.go
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-const NomsVersion = "7.17"
+const NomsVersion = "7.18"
 const NOMS_VERSION_NEXT_ENV_NAME = "NOMS_VERSION_NEXT"
 const NOMS_VERSION_NEXT_ENV_VALUE = "1"
 

--- a/go/types/encoding_test.go
+++ b/go/types/encoding_test.go
@@ -421,9 +421,8 @@ func TestWriteCompoundSetOfBlobs(t *testing.T) {
 	assertEncoding(t,
 		[]interface{}{
 			SetKind, uint64(1), uint64(2), // len,
-			// See https://github.com/attic-labs/noms/issues/1688#issuecomment-227528987
-			RefKind, set1.Hash(), SetKind, BlobKind, uint64(1), RefKind, blob1.Hash(), BoolKind, uint64(0), uint64(2),
-			RefKind, set2.Hash(), SetKind, BlobKind, uint64(1), RefKind, blob4.Hash(), BoolKind, uint64(0), uint64(3),
+			RefKind, set1.Hash(), SetKind, BlobKind, uint64(1), hashKind, blob1.Hash(), uint64(2),
+			RefKind, set2.Hash(), SetKind, BlobKind, uint64(1), hashKind, blob4.Hash(), uint64(3),
 		},
 		newSet(newSetMetaSequence(1, []metaTuple{
 			newMetaTuple(NewRef(set1), newOrderedKey(blob1), 2),

--- a/go/types/noms_kind.go
+++ b/go/types/noms_kind.go
@@ -26,6 +26,9 @@ const (
 
 	TypeKind
 	UnionKind
+
+	// Internal to decoder
+	hashKind
 )
 
 var KindToString = map[NomsKind]string{

--- a/go/types/walk_refs.go
+++ b/go/types/walk_refs.go
@@ -96,9 +96,18 @@ func (r *refWalker) walkMetaSequence(k NomsKind, level uint64, cb RefCallback) {
 	count := r.readCount()
 	for i := uint64(0); i < count; i++ {
 		r.walkRef(cb) // ref to child sequence
-		// TODO: The maxValue encoded here can be a scalar or a Hash that's hacked into the encoding as a Ref<Bool>. Calling r.walkValue() here with a no-op callback is a slightly wasteful hack, but until we figure out a better way to share code between refWalker and valueDecoder, it will have to do. BUG 3757
+		r.skipOrderedKey()
+		r.skipCount() // numLeaves
+	}
+}
+
+func (r *refWalker) skipOrderedKey() {
+	switch r.peekKind() {
+	case hashKind:
+		r.skipKind()
+		r.skipHash()
+	default:
 		r.walkValue(func(r Ref) {}) // max Value in subtree reachable from here
-		r.skipCount()               // numLeaves
 	}
 }
 

--- a/samples/go/hr/test-data/manifest
+++ b/samples/go/hr/test-data/manifest
@@ -1,1 +1,1 @@
-4:7.17:8s92pdafhd4hkhav6r4748u1rjlosh1k:5b1e9knhol2orv0a8ej6tvelc46jp92l:bsvid54jt8pjto211lcdl14tbfd39jmn:2:998se5i5mf15fld7f318818i6ie0c8rr:2
+4:7.18:8s92pdafhd4hkhav6r4748u1rjlosh1k:5b1e9knhol2orv0a8ej6tvelc46jp92l:bsvid54jt8pjto211lcdl14tbfd39jmn:2:998se5i5mf15fld7f318818i6ie0c8rr:2


### PR DESCRIPTION
Instead introduce a new NomsKind (called hashKind) which is internal
only.

Fixes #1688

Update version to 7.18