### PR TITLE
Fix issue with marshal caching vrw

### DIFF
--- a/go/marshal/encode_type.go
+++ b/go/marshal/encode_type.go
@@ -22,12 +22,12 @@ import (
 //
 // If a Go struct contains a noms tag with original the field is skipped since
 // the Noms type depends on the original Noms value which is not available.
-func MarshalType(vrw types.ValueReadWriter, v interface{}) (nt *types.Type, err error) {
-	return MarshalTypeOpt(vrw, v, Opt{})
+func MarshalType(v interface{}) (nt *types.Type, err error) {
+	return MarshalTypeOpt(v, Opt{})
 }
 
 // MarshalTypeOpt is like MarshalType but with additional options.
-func MarshalTypeOpt(vrw types.ValueReadWriter, v interface{}, opt Opt) (nt *types.Type, err error) {
+func MarshalTypeOpt(v interface{}, opt Opt) (nt *types.Type, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			switch r := r.(type) {
@@ -40,23 +40,23 @@ func MarshalTypeOpt(vrw types.ValueReadWriter, v interface{}, opt Opt) (nt *type
 			}
 		}
 	}()
-	nt = MustMarshalTypeOpt(vrw, v, opt)
+	nt = MustMarshalTypeOpt(v, opt)
 	return
 }
 
 // MustMarshalType computes a Noms type from a Go type or panics if there is an
 // error.
-func MustMarshalType(vrw types.ValueReadWriter, v interface{}) (nt *types.Type) {
-	return MustMarshalTypeOpt(vrw, v, Opt{})
+func MustMarshalType(v interface{}) (nt *types.Type) {
+	return MustMarshalTypeOpt(v, Opt{})
 }
 
 // MustMarshalTypeOpt is like MustMarshalType but provides additional options.
-func MustMarshalTypeOpt(vrw types.ValueReadWriter, v interface{}, opt Opt) (nt *types.Type) {
+func MustMarshalTypeOpt(v interface{}, opt Opt) (nt *types.Type) {
 	rv := reflect.ValueOf(v)
 	tags := nomsTags{
 		set: opt.Set,
 	}
-	nt = encodeType(vrw, rv.Type(), map[string]reflect.Type{}, tags)
+	nt = encodeType(rv.Type(), map[string]reflect.Type{}, tags)
 
 	if nt == nil {
 		panic(&UnsupportedTypeError{Type: rv.Type()})
@@ -77,7 +77,7 @@ type TypeMarshaler interface {
 var typeOfTypesType = reflect.TypeOf((*types.Type)(nil))
 var typeMarshalerInterface = reflect.TypeOf((*TypeMarshaler)(nil)).Elem()
 
-func encodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTags) *types.Type {
+func encodeType(t reflect.Type, seenStructs map[string]reflect.Type, tags nomsTags) *types.Type {
 	if t.Implements(typeMarshalerInterface) {
 		v := reflect.Zero(t)
 		typ, err := v.Interface().(TypeMarshaler).MarshalNomsType()
@@ -137,9 +137,9 @@ func encodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[strin
 	case reflect.String:
 		return types.StringType
 	case reflect.Struct:
-		return structEncodeType(vrw, t, seenStructs)
+		return structEncodeType(t, seenStructs)
 	case reflect.Array, reflect.Slice:
-		elemType := encodeType(vrw, t.Elem(), seenStructs, nomsTags{})
+		elemType := encodeType(t.Elem(), seenStructs, nomsTags{})
 		if elemType == nil {
 			break
 		}
@@ -148,7 +148,7 @@ func encodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[strin
 		}
 		return types.MakeListType(elemType)
 	case reflect.Map:
-		keyType := encodeType(vrw, t.Key(), seenStructs, nomsTags{})
+		keyType := encodeType(t.Key(), seenStructs, nomsTags{})
 		if keyType == nil {
 			break
 		}
@@ -157,7 +157,7 @@ func encodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[strin
 			return types.MakeSetType(keyType)
 		}
 
-		valueType := encodeType(vrw, t.Elem(), seenStructs, nomsTags{})
+		valueType := encodeType(t.Elem(), seenStructs, nomsTags{})
 		if valueType != nil {
 			return types.MakeMapType(keyType, valueType)
 		}
@@ -172,7 +172,7 @@ func encodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[strin
 // the type but we also need to look at the value. In these cases this returns
 // nil and we have to wait until we have a value to be able to determine the
 // type.
-func structEncodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map[string]reflect.Type) *types.Type {
+func structEncodeType(t reflect.Type, seenStructs map[string]reflect.Type) *types.Type {
 	name := getStructName(t)
 	if name != "" {
 		if _, ok := seenStructs[name]; ok {
@@ -181,7 +181,7 @@ func structEncodeType(vrw types.ValueReadWriter, t reflect.Type, seenStructs map
 		seenStructs[name] = t
 	}
 
-	fields, knownShape, _ := typeFields(vrw, t, seenStructs, true, false)
+	fields, knownShape, _ := typeFields(t, seenStructs, true, false)
 
 	var structType *types.Type
 	if knownShape {

--- a/go/marshal/encode_type_test.go
+++ b/go/marshal/encode_type_test.go
@@ -16,13 +16,10 @@ import (
 )
 
 func TestMarshalTypeType(tt *testing.T) {
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	t := func(exp *types.Type, ptr interface{}) {
 		p := reflect.ValueOf(ptr)
 		assert.NotEqual(tt, reflect.Ptr, p.Type().Kind())
-		actual, err := MarshalType(vs, p.Interface())
+		actual, err := MarshalType(p.Interface())
 		assert.NoError(tt, err)
 		assert.NotNil(tt, actual, "%#v", p.Interface())
 		assert.True(tt, exp.Equals(actual))
@@ -108,10 +105,7 @@ func TestMarshalTypeType(tt *testing.T) {
 
 //
 func assertMarshalTypeErrorMessage(t *testing.T, v interface{}, expectedMessage string) {
-	vs := newTestValueStore()
-	defer vs.Close()
-
-	_, err := MarshalType(vs, v)
+	_, err := MarshalType(v)
 	assert.Error(t, err)
 	assert.Equal(t, expectedMessage, err.Error())
 }
@@ -123,9 +117,6 @@ func TestMarshalTypeInvalidTypes(t *testing.T) {
 func TestMarshalTypeEmbeddedStruct(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type EmbeddedStruct struct {
 		B bool
 	}
@@ -135,7 +126,7 @@ func TestMarshalTypeEmbeddedStruct(t *testing.T) {
 	}
 
 	var s TestStruct
-	typ := MustMarshalType(vs, s)
+	typ := MustMarshalType(s)
 
 	assert.True(types.MakeStructTypeFromFields("TestStruct", types.FieldMap{
 		"a": types.NumberType,
@@ -146,9 +137,6 @@ func TestMarshalTypeEmbeddedStruct(t *testing.T) {
 func TestMarshalTypeEmbeddedStructSkip(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type EmbeddedStruct struct {
 		B bool
 	}
@@ -158,7 +146,7 @@ func TestMarshalTypeEmbeddedStructSkip(t *testing.T) {
 	}
 
 	var s TestStruct
-	typ := MustMarshalType(vs, s)
+	typ := MustMarshalType(s)
 
 	assert.True(types.MakeStructTypeFromFields("TestStruct", types.FieldMap{
 		"a": types.NumberType,
@@ -167,9 +155,6 @@ func TestMarshalTypeEmbeddedStructSkip(t *testing.T) {
 
 func TestMarshalTypeEmbeddedStructNamed(t *testing.T) {
 	assert := assert.New(t)
-
-	vs := newTestValueStore()
-	defer vs.Close()
 
 	type EmbeddedStruct struct {
 		B bool
@@ -180,7 +165,7 @@ func TestMarshalTypeEmbeddedStructNamed(t *testing.T) {
 	}
 
 	var s TestStruct
-	typ := MustMarshalType(vs, s)
+	typ := MustMarshalType(s)
 
 	assert.True(types.MakeStructTypeFromFields("TestStruct", types.FieldMap{
 		"a": types.NumberType,
@@ -200,15 +185,12 @@ func TestMarshalTypeEncodeNonExportedField(t *testing.T) {
 func TestMarshalTypeEncodeTaggingSkip(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		Abc int `noms:"-"`
 		Def bool
 	}
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructTypeFromFields("S", types.FieldMap{
 		"def": types.BoolType,
@@ -218,16 +200,13 @@ func TestMarshalTypeEncodeTaggingSkip(t *testing.T) {
 func TestMarshalTypeNamedFields(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		Aaa int  `noms:"a"`
 		Bbb bool `noms:"B"`
 		Ccc string
 	}
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructTypeFromFields("S", types.FieldMap{
 		"a":   types.NumberType,
@@ -247,28 +226,23 @@ func TestMarshalTypeInvalidNamedFields(t *testing.T) {
 func TestMarshalTypeOmitEmpty(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		String string `noms:",omitempty"`
 	}
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructType("S", types.StructField{"string", types.StringType, true}).Equals(typ))
 }
 
 func ExampleMarshalType() {
-	vs := newTestValueStore()
-	defer vs.Close()
 
 	type Person struct {
 		Given  string
 		Female bool
 	}
 	var person Person
-	personNomsType, err := MarshalType(vs, person)
+	personNomsType, err := MarshalType(person)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -284,11 +258,8 @@ func ExampleMarshalType() {
 func TestMarshalTypeSlice(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	s := []string{"a", "b", "c"}
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeListType(types.StringType).Equals(typ))
 }
@@ -296,11 +267,8 @@ func TestMarshalTypeSlice(t *testing.T) {
 func TestMarshalTypeArray(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	a := [3]int{1, 2, 3}
-	typ, err := MarshalType(vs, a)
+	typ, err := MarshalType(a)
 	assert.NoError(err)
 	assert.True(types.MakeListType(types.NumberType).Equals(typ))
 }
@@ -308,14 +276,11 @@ func TestMarshalTypeArray(t *testing.T) {
 func TestMarshalTypeStructWithSlice(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		List []int
 	}
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructTypeFromFields("S", types.FieldMap{
 		"list": types.MakeListType(types.NumberType),
@@ -325,15 +290,12 @@ func TestMarshalTypeStructWithSlice(t *testing.T) {
 func TestMarshalTypeRecursive(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type Node struct {
 		Value    int
 		Children []Node
 	}
 	var n Node
-	typ, err := MarshalType(vs, n)
+	typ, err := MarshalType(n)
 	assert.NoError(err)
 
 	typ2 := types.MakeStructType("Node",
@@ -352,11 +314,8 @@ func TestMarshalTypeRecursive(t *testing.T) {
 func TestMarshalTypeMap(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var m map[string]int
-	typ, err := MarshalType(vs, m)
+	typ, err := MarshalType(m)
 	assert.NoError(err)
 	assert.True(types.MakeMapType(types.StringType, types.NumberType).Equals(typ))
 
@@ -365,7 +324,7 @@ func TestMarshalTypeMap(t *testing.T) {
 	}
 
 	var m2 map[S]bool
-	typ, err = MarshalType(vs, m2)
+	typ, err = MarshalType(m2)
 	assert.NoError(err)
 	assert.True(types.MakeMapType(
 		types.MakeStructTypeFromFields("S", types.FieldMap{
@@ -376,9 +335,6 @@ func TestMarshalTypeMap(t *testing.T) {
 
 func TestMarshalTypeSet(t *testing.T) {
 	assert := assert.New(t)
-
-	vs := newTestValueStore()
-	defer vs.Close()
 
 	type S struct {
 		A map[int]struct{} `noms:",set"`
@@ -391,7 +347,7 @@ func TestMarshalTypeSet(t *testing.T) {
 		H string         `noms:",set"`
 	}
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 
 	emptyStructType := types.MakeStructTypeFromFields("", types.FieldMap{})
@@ -410,9 +366,6 @@ func TestMarshalTypeSet(t *testing.T) {
 
 func TestEncodeTypeOpt(t *testing.T) {
 	assert := assert.New(t)
-
-	vs := newTestValueStore()
-	defer vs.Close()
 
 	tc := []struct {
 		in       interface{}
@@ -442,7 +395,7 @@ func TestEncodeTypeOpt(t *testing.T) {
 	}
 
 	for _, t := range tc {
-		r, err := MarshalTypeOpt(vs, t.in, t.opt)
+		r, err := MarshalTypeOpt(t.in, t.opt)
 		assert.True(t.wantType.Equals(r))
 		assert.Nil(err)
 	}
@@ -451,9 +404,6 @@ func TestEncodeTypeOpt(t *testing.T) {
 func TestMarshalTypeSetWithTags(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		A map[int]struct{} `noms:"foo,set"`
 		B map[int]struct{} `noms:",omitempty,set"`
@@ -461,7 +411,7 @@ func TestMarshalTypeSetWithTags(t *testing.T) {
 	}
 
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructType("S",
 		types.StructField{"foo", types.MakeSetType(types.NumberType), false},
@@ -471,14 +421,12 @@ func TestMarshalTypeSetWithTags(t *testing.T) {
 }
 
 func TestMarshalTypeInvalidTag(t *testing.T) {
-	vs := newTestValueStore()
-	defer vs.Close()
 
 	type S struct {
 		F string `noms:",omitEmpty"`
 	}
 	var s S
-	_, err := MarshalType(vs, s)
+	_, err := MarshalType(s)
 	assert.Error(t, err)
 	assert.Equal(t, `Unrecognized tag: omitEmpty`, err.Error())
 }
@@ -486,15 +434,12 @@ func TestMarshalTypeInvalidTag(t *testing.T) {
 func TestMarshalTypeCanSkipUnexportedField(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		Abc         int
 		notExported bool `noms:"-"`
 	}
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructTypeFromFields("S", types.FieldMap{
 		"abc": types.NumberType,
@@ -504,16 +449,13 @@ func TestMarshalTypeCanSkipUnexportedField(t *testing.T) {
 func TestMarshalTypeOriginal(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		Foo int          `noms:",omitempty"`
 		Bar types.Struct `noms:",original"`
 	}
 
 	var s S
-	typ, err := MarshalType(vs, s)
+	typ, err := MarshalType(s)
 	assert.NoError(err)
 	assert.True(types.MakeStructType("S",
 		types.StructField{"foo", types.NumberType, true},
@@ -523,9 +465,6 @@ func TestMarshalTypeOriginal(t *testing.T) {
 func TestMarshalTypeNomsTypes(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type S struct {
 		Blob   types.Blob
 		Bool   types.Bool
@@ -534,7 +473,7 @@ func TestMarshalTypeNomsTypes(t *testing.T) {
 		Type   *types.Type
 	}
 	var s S
-	assert.True(MustMarshalType(vs, s).Equals(
+	assert.True(MustMarshalType(s).Equals(
 		types.MakeStructTypeFromFields("S", types.FieldMap{
 			"blob":   types.BlobType,
 			"bool":   types.BoolType,
@@ -552,11 +491,8 @@ func (t primitiveType) MarshalNomsType() (*types.Type, error) {
 func TestTypeMarshalerPrimitiveType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var u primitiveType
-	typ := MustMarshalType(vs, u)
+	typ := MustMarshalType(u)
 	assert.Equal(types.NumberType, typ)
 }
 
@@ -567,11 +503,8 @@ func (u primitiveSliceType) MarshalNomsType() (*types.Type, error) {
 func TestTypeMarshalerPrimitiveSliceType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var u primitiveSliceType
-	typ := MustMarshalType(vs, u)
+	typ := MustMarshalType(u)
 	assert.Equal(types.StringType, typ)
 }
 
@@ -582,22 +515,16 @@ func (u primitiveMapType) MarshalNomsType() (*types.Type, error) {
 func TestTypeMarshalerPrimitiveMapType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var u primitiveMapType
-	typ := MustMarshalType(vs, u)
+	typ := MustMarshalType(u)
 	assert.Equal(types.MakeSetType(types.StringType), typ)
 }
 
 func TestTypeMarshalerPrimitiveStructTypeNoMarshalNomsType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var u primitiveStructType
-	_, err := MarshalType(vs, u)
+	_, err := MarshalType(u)
 	assert.Error(err)
 	assert.Equal("Cannot marshal type which implements marshal.Marshaler, perhaps implement marshal.TypeMarshaler for marshal.primitiveStructType", err.Error())
 }
@@ -609,11 +536,8 @@ func (u builtinType) MarshalNomsType() (*types.Type, error) {
 func TestTypeMarshalerBuiltinType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var u builtinType
-	typ := MustMarshalType(vs, u)
+	typ := MustMarshalType(u)
 	assert.Equal(types.StringType, typ)
 }
 
@@ -624,11 +548,8 @@ func (u wrappedMarshalerType) MarshalNomsType() (*types.Type, error) {
 func TestTypeMarshalerWrapperMarshalerType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var u wrappedMarshalerType
-	typ := MustMarshalType(vs, u)
+	typ := MustMarshalType(u)
 	assert.Equal(types.NumberType, typ)
 }
 
@@ -647,40 +568,31 @@ func (u panicsMarshaler) MarshalNomsType() (*types.Type, error) {
 func TestTypeMarshalerErrors(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	expErr := errors.New("expected error")
 	var m1 returnsMarshalerError
-	_, actErr := MarshalType(vs, m1)
+	_, actErr := MarshalType(m1)
 	assert.Equal(expErr, actErr)
 
 	var m2 returnsMarshalerNil
-	assert.Panics(func() { MarshalType(vs, m2) })
+	assert.Panics(func() { MarshalType(m2) })
 
 	var m3 panicsMarshaler
-	assert.Panics(func() { MarshalType(vs, m3) })
+	assert.Panics(func() { MarshalType(m3) })
 }
 
 func TestMarshalTypeStructName(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var ts TestStructWithNameImpl
-	typ := MustMarshalType(vs, ts)
+	typ := MustMarshalType(ts)
 	assert.True(types.MakeStructType("A", types.StructField{"x", types.NumberType, false}).Equals(typ), typ.Describe())
 }
 
 func TestMarshalTypeStructName2(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	var ts TestStructWithNameImpl2
-	typ := MustMarshalType(vs, ts)
+	typ := MustMarshalType(ts)
 	assert.True(types.MakeStructType("", types.StructField{"x", types.NumberType, false}).Equals(typ), typ.Describe())
 }
 
@@ -698,10 +610,8 @@ func (f OutFace) MarshalNomsStructName() string {
 }
 
 func TestMarshalTypeOutface(t *testing.T) {
-	vs := newTestValueStore()
-	defer vs.Close()
 
-	typ := MustMarshalType(vs, OutPhoto{})
+	typ := MustMarshalType(OutPhoto{})
 	expectedType := nomdl.MustParseType(`Struct OutPhoto {
           faces: Set<Struct Face {
             blob: Ref<Value>,

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -1506,9 +1506,6 @@ func TestGetListElementsWithSet(t *testing.T) {
 func TestNoErrorOnNonCyclicTypeRefsInputType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type User struct {
 		ID string `noms:"id"`
 	}
@@ -1518,7 +1515,7 @@ func TestNoErrorOnNonCyclicTypeRefsInputType(t *testing.T) {
 	}
 
 	var a Account
-	typ := marshal.MustMarshalType(vs, a)
+	typ := marshal.MustMarshalType(a)
 	tc := NewTypeConverter()
 	_, err := tc.NomsTypeToGraphQLInputType(typ)
 	assert.NoError(err)
@@ -1527,15 +1524,12 @@ func TestNoErrorOnNonCyclicTypeRefsInputType(t *testing.T) {
 func TestErrorOnCyclicTypeRefsInputType(t *testing.T) {
 	assert := assert.New(t)
 
-	vs := newTestValueStore()
-	defer vs.Close()
-
 	type Node struct {
 		Children map[string]Node
 	}
 
 	var n Node
-	typ := marshal.MustMarshalType(vs, n)
+	typ := marshal.MustMarshalType(n)
 	tc := NewTypeConverter()
 	_, err := tc.NomsTypeToGraphQLInputType(typ)
 	assert.Error(err)

--- a/go/util/datetime/date_time_test.go
+++ b/go/util/datetime/date_time_test.go
@@ -109,7 +109,7 @@ func TestMarshalType(t *testing.T) {
 	defer vs.Close()
 
 	dt := DateTime{time.Unix(0, 0)}
-	typ := marshal.MustMarshalType(vs, dt)
+	typ := marshal.MustMarshalType(dt)
 	assert.Equal(DateTimeType, typ)
 
 	v := marshal.MustMarshal(vs, dt)


### PR DESCRIPTION
We were caching the encoder function enclosing over the passed in
ValueReadWriter. This causes problems when the encoder is used again but
with another ValueReadWriter.

Instead, make the internal encoder function take a ValueReadWriter.