### PR TITLE
Add a multi-stage-build dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+docs
+codecov.yml
+CONTRIBUTING.md
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:latest AS build
+
+ENV NOMS_SRC=$GOPATH/src/github.com/attic-labs/noms
+
+RUN mkdir -pv $NOMS_SRC
+COPY . ${NOMS_SRC}
+RUN go install -v github.com/attic-labs/noms/cmd/noms
+RUN cp $GOPATH/bin/noms /bin/noms
+
+FROM alpine:latest
+
+COPY --from=build /bin/noms /bin/noms
+
+VOLUME /data
+EXPOSE 8000
+
+ENV NOMS_VERSION_NEXT=1
+ENTRYPOINT [ "noms" ]
+
+CMD ["serve", "/data"]


### PR DESCRIPTION
This is substantially based on https://hub.docker.com/r/scjalliance/noms/
but has been updated in two ways:

 1. It uses a multi-stage build to substantially reduce the size of the
    resultant image. The naive build image clocks in at ~1gb; the output
    image here is ~30mb.
 2. It takes advantage of the fact that the build context is already
    present, so we can speed up the build process by simply copying
    the context instead of cloning the data again.

This is intended to be compatible with #3790, and does not address
any of the issues mentioned there except simple creation of a dockerfile.
If the source repository for that PR were publicly available, this PR
would have targeted that branch instead of master.