### PR TITLE
Add integer type

### DIFF
--- a/cmd/noms/splore/noms_splore.go
+++ b/cmd/noms/splore/noms_splore.go
@@ -308,7 +308,7 @@ func getMetaChildren(v types.Value) (children []nodeChild) {
 
 func nodeHasChildren(v types.Value) bool {
 	switch k := v.Kind(); k {
-	case types.BlobKind, types.BoolKind, types.NumberKind, types.StringKind:
+	case types.BlobKind, types.BoolKind, types.NumberKind, types.IntegerKind, types.StringKind:
 		return false
 	case types.RefKind:
 		return true

--- a/go/marshal/decode_test.go
+++ b/go/marshal/decode_test.go
@@ -55,29 +55,29 @@ func TestDecode(tt *testing.T) {
 
 	for _, n := range []int8{0, 42, math.MaxInt8} {
 		var i8 int8
-		t(types.Number(n), &i8, int8(n))
+		t(types.Integer(n), &i8, int8(n))
 	}
 
 	for _, n := range []int16{0, 42, math.MaxInt16} {
 		var i16 int16
-		t(types.Number(n), &i16, int16(n))
+		t(types.Integer(n), &i16, int16(n))
 	}
 
 	for _, n := range []int32{0, 42, math.MaxInt32} {
 		var i32 int32
-		t(types.Number(n), &i32, int32(n))
+		t(types.Integer(n), &i32, int32(n))
 	}
 
 	// int is at least int32
 	for _, n := range []int{0, 42, math.MaxInt32} {
 		var i int
-		t(types.Number(n), &i, int(n))
+		t(types.Integer(n), &i, int(n))
 	}
 
 	// There is precision loss for values above Math.pow(2, 53) - 1
 	for _, n := range []int64{0, 42, int64(math.Pow(2, 53) - 1)} {
 		var i64 int64
-		t(types.Number(n), &i64, int64(n))
+		t(types.Integer(n), &i64, int64(n))
 	}
 
 	for _, n := range []uint8{0, 42, math.MaxUint8} {
@@ -156,7 +156,7 @@ func TestDecode(tt *testing.T) {
 	}
 	t(types.NewStruct("", types.StructData{
 		"y": types.Bool(true),
-		"x": types.Number(42),
+		"x": types.Integer(42),
 	}), &as, struct {
 		X int32
 		Y bool
@@ -193,19 +193,19 @@ func TestDecode(tt *testing.T) {
 	}
 	var t5 SomeOtherName
 	t(types.NewStruct("aeiou", types.StructData{
-		"a": types.Number(42),
+		"a": types.Integer(42),
 	}), &t5, SomeOtherName{42})
 
 	var t6 SomeOtherName
 	t(types.NewStruct("SomeOtherName", types.StructData{
-		"a": types.Number(42),
+		"a": types.Integer(42),
 	}), &t6, SomeOtherName{42})
 
 	var t7 struct {
 		A int
 	}
 	t(types.NewStruct("SomeOtherName", types.StructData{
-		"a": types.Number(42),
+		"a": types.Integer(42),
 	}), &t7, struct{ A int }{42})
 }
 
@@ -322,18 +322,6 @@ func TestDecodeOverflows(tt *testing.T) {
 	var ui32 uint32
 	t(&ui32, math.Pow(2, 32), "uint32")
 	t(&ui32, -1, "uint32")
-
-	var i8 int8
-	t(&i8, 128, "int8")
-	t(&i8, -128-1, "int8")
-
-	var i16 int16
-	t(&i16, math.Pow(2, 15), "int16")
-	t(&i16, -math.Pow(2, 15)-1, "int16")
-
-	var i32 int32
-	t(&i32, math.Pow(2, 31), "int32")
-	t(&i32, -math.Pow(2, 31)-1, "int32")
 }
 
 func TestDecodeMissingField(t *testing.T) {
@@ -343,8 +331,8 @@ func TestDecodeMissingField(t *testing.T) {
 	}
 	var s S
 	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
-		"a": types.Number(42),
-	}), &s, "Cannot unmarshal Struct S {\n  a: Number,\n} into Go value of type marshal.S, missing field \"b\"")
+		"a": types.Integer(42),
+	}), &s, "Cannot unmarshal Struct S {\n  a: Int,\n} into Go value of type marshal.S, missing field \"b\"")
 }
 
 func TestDecodeEmbeddedStruct(tt *testing.T) {
@@ -358,7 +346,7 @@ func TestDecodeEmbeddedStruct(tt *testing.T) {
 	}
 	var ts TestStruct
 	err := Unmarshal(types.NewStruct("S", types.StructData{
-		"x": types.Number(1),
+		"x": types.Integer(1),
 	}), &ts)
 	assert.NoError(err)
 	assert.Equal(TestStruct{EmbeddedStruct{1}}, ts)
@@ -369,7 +357,7 @@ func TestDecodeEmbeddedStruct(tt *testing.T) {
 	}
 	var ts2 OuterTest
 	err = Unmarshal(types.NewStruct("S", types.StructData{
-		"x": types.Number(2),
+		"x": types.Integer(2),
 		"y": types.Bool(true),
 	}), &ts2)
 	assert.NoError(err)
@@ -388,7 +376,7 @@ func TestDecodeEmbeddedStructSkip(tt *testing.T) {
 	}
 	ts := TestStruct{EmbeddedStruct: EmbeddedStruct{42}}
 	err := Unmarshal(types.NewStruct("S", types.StructData{
-		"y": types.Number(2),
+		"y": types.Integer(2),
 	}), &ts)
 	assert.NoError(err)
 	assert.Equal(TestStruct{EmbeddedStruct{42}, 2}, ts)
@@ -398,11 +386,11 @@ func TestDecodeEmbeddedStructNamed(tt *testing.T) {
 	assert := assert.New(tt)
 
 	type EmbeddedStruct struct {
-		X int
+		X float64
 	}
 	type TestStruct struct {
 		EmbeddedStruct `noms:"em"`
-		Y              int
+		Y              float64
 	}
 	ts := TestStruct{EmbeddedStruct: EmbeddedStruct{42}}
 	err := Unmarshal(types.NewStruct("S", types.StructData{
@@ -419,7 +407,7 @@ func TestDecodeEmbeddedStructOriginal(tt *testing.T) {
 	assert := assert.New(tt)
 
 	type EmbeddedStruct struct {
-		X int
+		X float64
 		O types.Struct `noms:",original"`
 	}
 	type TestStruct struct {
@@ -427,13 +415,13 @@ func TestDecodeEmbeddedStructOriginal(tt *testing.T) {
 	}
 	var ts TestStruct
 	nomsStruct := types.NewStruct("S", types.StructData{
-		"x": types.Number(1),
+		"x": types.Number(1.234),
 	})
 	err := Unmarshal(nomsStruct, &ts)
 	assert.NoError(err)
 	expected := TestStruct{
 		EmbeddedStruct: EmbeddedStruct{
-			X: 1,
+			X: 1.234,
 			O: nomsStruct,
 		},
 	}
@@ -488,7 +476,7 @@ func TestDecodeNamedFields(t *testing.T) {
 	}
 	var s S
 	err := Unmarshal(types.NewStruct("S", types.StructData{
-		"a":   types.Number(42),
+		"a":   types.Integer(42),
 		"B":   types.Bool(true),
 		"ccc": types.String("Hi"),
 	}), &s)
@@ -502,7 +490,7 @@ func TestDecodeInvalidNamedFields(t *testing.T) {
 	}
 	var s S
 	assertDecodeErrorMessage(t, types.NewStruct("S", types.StructData{
-		"a": types.Number(42),
+		"a": types.Integer(42),
 	}), &s, "Invalid struct field name: 1a")
 }
 
@@ -669,13 +657,13 @@ func TestDecodeStructWithSlice(t *testing.T) {
 	}
 	var s S
 	err := Unmarshal(types.NewStruct("S", types.StructData{
-		"list": types.NewList(vs, types.Number(1), types.Number(2), types.Number(3)),
+		"list": types.NewList(vs, types.Integer(1), types.Integer(2), types.Integer(3)),
 	}), &s)
 	assert.NoError(err)
 	assert.Equal(S{[]int{1, 2, 3}}, s)
 
 	err = Unmarshal(types.NewStruct("S", types.StructData{
-		"list": types.NewSet(vs, types.Number(1), types.Number(2), types.Number(3)),
+		"list": types.NewSet(vs, types.Integer(1), types.Integer(2), types.Integer(3)),
 	}), &s)
 	assert.NoError(err)
 	assert.Equal(S{[]int{1, 2, 3}}, s)
@@ -754,14 +742,14 @@ func TestDecodeRecursive(t *testing.T) {
 			vs,
 			types.NewStruct("Node", types.StructData{
 				"children": types.NewList(vs),
-				"value":    types.Number(2),
+				"value":    types.Integer(2),
 			}),
 			types.NewStruct("Node", types.StructData{
 				"children": types.NewList(vs),
-				"value":    types.Number(3),
+				"value":    types.Integer(3),
 			}),
 		),
-		"value": types.Number(1),
+		"value": types.Integer(1),
 	})
 
 	var n Node
@@ -786,9 +774,9 @@ func TestDecodeMap(t *testing.T) {
 
 	testMap := types.NewMap(
 		vs,
-		types.String("a"), types.Number(1),
-		types.String("b"), types.Number(2),
-		types.String("c"), types.Number(3))
+		types.String("a"), types.Integer(1),
+		types.String("b"), types.Integer(2),
+		types.String("c"), types.Integer(3))
 	expectedMap := map[string]int{"a": 1, "b": 2, "c": 3}
 	err := Unmarshal(testMap, &m)
 	assert.NoError(err)
@@ -797,8 +785,8 @@ func TestDecodeMap(t *testing.T) {
 	m = map[string]int{"b": 2, "c": 333}
 	err = Unmarshal(types.NewMap(
 		vs,
-		types.String("a"), types.Number(1),
-		types.String("c"), types.Number(3)), &m)
+		types.String("a"), types.Integer(1),
+		types.String("c"), types.Integer(3)), &m)
 	assert.NoError(err)
 	assert.Equal(expectedMap, m)
 
@@ -897,13 +885,13 @@ func TestDecodeSet(t *testing.T) {
 	defer vs.Close()
 
 	type T struct {
-		A map[int]struct{} `noms:",set"`
-		B map[int]struct{}
+		A map[float64]struct{} `noms:",set"`
+		B map[float64]struct{}
 		C map[string]struct{} `noms:",set"`
 		D map[string]struct{}
-		E []int
-		F []int `noms:",set"`
-		G []int
+		E []float64
+		F []float64 `noms:",set"`
+		G []float64
 	}
 
 	ns := types.NewStruct("T", types.StructData{
@@ -919,13 +907,13 @@ func TestDecodeSet(t *testing.T) {
 	gs := T{}
 	assert.NoError(Unmarshal(ns, &gs))
 	assert.Equal(T{
-		A: map[int]struct{}{0: {}, 1: {}, 2: {}},
-		B: map[int]struct{}{3: {}, 4: {}, 5: {}},
+		A: map[float64]struct{}{0: {}, 1: {}, 2: {}},
+		B: map[float64]struct{}{3: {}, 4: {}, 5: {}},
 		C: map[string]struct{}{"0": {}, "1": {}, "2": {}},
 		D: map[string]struct{}{"3": {}, "4": {}, "5": {}},
-		E: []int{6, 7, 8},
-		F: []int{9, 10, 11},
-		G: []int{12, 13, 14},
+		E: []float64{6, 7, 8},
+		F: []float64{9, 10, 11},
+		G: []float64{12, 13, 14},
 	}, gs)
 
 	ns2 := types.NewStruct("T", types.StructData{
@@ -939,11 +927,11 @@ func TestDecodeSet(t *testing.T) {
 	})
 
 	gs2 := T{
-		A: map[int]struct{}{},
+		A: map[float64]struct{}{},
 	}
 	assert.NoError(Unmarshal(ns2, &gs2))
 	assert.Equal(T{
-		A: map[int]struct{}{},
+		A: map[float64]struct{}{},
 	}, gs2)
 }
 
@@ -1012,8 +1000,8 @@ func TestDecodeNamedSet(t *testing.T) {
 	}
 
 	ns := types.NewStruct("T", types.StructData{
-		"a":   types.NewSet(vs, types.Number(0)),
-		"foo": types.NewSet(vs, types.Number(1)),
+		"a":   types.NewSet(vs, types.Integer(0)),
+		"foo": types.NewSet(vs, types.Integer(1)),
 	})
 
 	gs := T{}
@@ -1066,14 +1054,14 @@ func TestDecodeOmitEmpty(t *testing.T) {
 	type S struct {
 		Foo int `noms:",omitempty"`
 		Bar struct {
-			Baz    int
-			Hotdog int `noms:",omitempty"`
+			Baz    float64
+			Hotdog float64 `noms:",omitempty"`
 		}
 	}
 	expected := S{
 		Bar: struct {
-			Baz    int
-			Hotdog int `noms:",omitempty"`
+			Baz    float64
+			Hotdog float64 `noms:",omitempty"`
 		}{
 			Baz: 42,
 		},
@@ -1097,7 +1085,7 @@ func TestDecodeOriginal(t *testing.T) {
 		Baz types.Struct `noms:",original"`
 	}
 	input := types.NewStruct("S", types.StructData{
-		"foo": types.Number(42),
+		"foo": types.Integer(42),
 	})
 	expected := S{
 		Foo: 42,

--- a/go/marshal/encode.go
+++ b/go/marshal/encode.go
@@ -208,9 +208,10 @@ func float64Encoder(v reflect.Value, vrw types.ValueReadWriter) types.Value {
 }
 
 func intEncoder(v reflect.Value, vrw types.ValueReadWriter) types.Value {
-	return types.Number(float64(v.Int()))
+	return types.Integer(int64(v.Int()))
 }
 
+// TODO(ORBAT): unsigned integer type
 func uintEncoder(v reflect.Value, vrw types.ValueReadWriter) types.Value {
 	return types.Number(float64(v.Uint()))
 }

--- a/go/marshal/encode_test.go
+++ b/go/marshal/encode_test.go
@@ -43,29 +43,29 @@ func TestEncode(tt *testing.T) {
 	}
 
 	for _, n := range []int8{0, 42, math.MaxInt8} {
-		t(types.Number(n), n)
-		t(types.Number(-n), -n)
+		t(types.Integer(n), n)
+		t(types.Integer(-n), -n)
 	}
 
 	for _, n := range []int16{0, 42, math.MaxInt16} {
-		t(types.Number(n), n)
-		t(types.Number(-n), -n)
+		t(types.Integer(n), n)
+		t(types.Integer(-n), -n)
 	}
 
 	for _, n := range []int32{0, 42, math.MaxInt32} {
-		t(types.Number(n), n)
-		t(types.Number(-n), -n)
+		t(types.Integer(n), n)
+		t(types.Integer(-n), -n)
 	}
 
 	// int is at least int32
 	for _, n := range []int{0, 42, math.MaxInt32} {
-		t(types.Number(n), n)
-		t(types.Number(-n), -n)
+		t(types.Integer(n), n)
+		t(types.Integer(-n), -n)
 	}
 
 	for _, n := range []int64{0, 42, math.MaxInt64} {
-		t(types.Number(n), n)
-		t(types.Number(-n), -n)
+		t(types.Integer(n), n)
+		t(types.Integer(-n), -n)
 	}
 
 	for _, n := range []uint8{0, 42, math.MaxUint8} {
@@ -96,7 +96,7 @@ func TestEncode(tt *testing.T) {
 		t(types.String(s), s)
 	}
 
-	t(types.NewList(vs, types.Number(42)), types.NewList(vs, types.Number(42)))
+	t(types.NewList(vs, types.Integer(42)), types.NewList(vs, types.Integer(42)))
 	t(types.NewMap(vs, types.Number(42), types.String("hi")), types.NewMap(vs, types.Number(42), types.String("hi")))
 	t(types.NewSet(vs, types.String("bye")), types.NewSet(vs, types.String("bye")))
 	t(types.NewBlob(vs, bytes.NewBufferString("hello")), types.NewBlob(vs, bytes.NewBufferString("hello")))

--- a/go/merge/candidate.go
+++ b/go/merge/candidate.go
@@ -36,7 +36,8 @@ func (mc mapCandidate) get(k types.Value) types.Value {
 
 func (mc mapCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
 	out = append(out, path...)
-	if kind := change.Key.Kind(); kind == types.BoolKind || kind == types.StringKind || kind == types.NumberKind {
+
+	if kind := change.Key.Kind(); types.IsPrimitiveKind(kind) {
 		out = append(out, types.NewIndexPath(change.Key))
 	} else {
 		out = append(out, types.NewHashIndexPath(change.Key.Hash()))
@@ -62,7 +63,7 @@ func (sc setCandidate) get(k types.Value) types.Value {
 
 func (sc setCandidate) pathConcat(change types.ValueChanged, path types.Path) (out types.Path) {
 	out = append(out, path...)
-	if kind := change.Key.Kind(); kind == types.BoolKind || kind == types.StringKind || kind == types.NumberKind {
+	if kind := change.Key.Kind(); types.IsPrimitiveKind(kind) {
 		out = append(out, types.NewIndexPath(change.Key))
 	} else {
 		out = append(out, types.NewHashIndexPath(change.Key.Hash()))

--- a/go/ngql/query_test.go
+++ b/go/ngql/query_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/attic-labs/noms/go/marshal"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/attic-labs/noms/go/util/test"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -1021,19 +1022,19 @@ func (suite *QueryGraphQLSuite) TestMutationCollectionArgs() {
 
 func (suite *QueryGraphQLSuite) TestMapWithComplexKeys() {
 	m := types.NewMap(suite.vs,
-		types.NewList(suite.vs, types.String("a")), types.Number(1),
-		types.NewList(suite.vs, types.String("c")), types.Number(2),
-		types.NewList(suite.vs, types.String("e")), types.Number(3),
-		types.NewList(suite.vs, types.String("g")), types.Number(4),
+		types.NewList(suite.vs, types.String("a")), types.Number(1.1),
+		types.NewList(suite.vs, types.String("c")), types.Number(2.3),
+		types.NewList(suite.vs, types.String("e")), types.Number(3.4),
+		types.NewList(suite.vs, types.String("g")), types.Number(4.5),
 	)
 
-	suite.assertQueryResult(m, `{root{values(key: ["e"])}}`, `{"data":{"root":{"values":[3]}}}`)
+	suite.assertQueryResult(m, `{root{values(key: ["e"])}}`, `{"data":{"root":{"values":[3.4]}}}`)
 	suite.assertQueryResult(m, `{root{values(key: [])}}`, `{"data":{"root":{"values":[]}}}`)
 
 	// The ordering here depends on the hash of the value...
-	suite.assertQueryResult(m, `{root{values(key: ["a"], through: ["e"])}}`, `{"data":{"root":{"values":[1, 2, 3]}}}`)
+	suite.assertQueryResult(m, `{root{values(key: ["a"], through: ["e"])}}`, `{"data":{"root":{"values":[1.1, 2.3, 3.4]}}}`)
 
-	suite.assertQueryResult(m, `{root{values(keys: [["a"],["b"],["c"]])}}`, `{"data":{"root":{"values":[1, null, 2]}}}`)
+	suite.assertQueryResult(m, `{root{values(keys: [["a"],["b"],["c"]])}}`, `{"data":{"root":{"values":[1.1, null, 2.3]}}}`)
 	suite.assertQueryResult(m, `{
                 root {
                         keys(keys: [["a"],["b"],["c"]]) {
@@ -1118,8 +1119,11 @@ func (suite *QueryGraphQLSuite) TestInputToNomsValue() {
 		suite.True(expected.Equals(InputToNomsValue(suite.vs, val, types.TypeOf(expected))))
 	}
 
-	test(types.Number(42), int(42))
-	test(types.Number(0), int(0))
+	test(types.Integer(42), int(42))
+	test(types.Integer(0), int(0))
+	test(types.Integer(math.MaxInt64), math.MaxInt64)
+	test(types.Integer(42), int64(42))
+	test(types.Integer(0), int64(0))
 
 	test(types.Number(1.23), float64(1.23))
 	test(types.Number(0), float64(0))
@@ -1137,23 +1141,23 @@ func (suite *QueryGraphQLSuite) TestInputToNomsValue() {
 	test(types.NewSet(suite.vs, types.Number(1), types.Number(2)), []interface{}{float64(1), float64(2)})
 
 	test(types.NewMap(suite.vs,
-		types.String("a"), types.Number(1),
-		types.String("b"), types.Number(2),
+		types.String("a"), types.Number(1.2),
+		types.String("b"), types.Number(2.3),
 	), []interface{}{
-		map[string]interface{}{"key": "a", "value": 1},
-		map[string]interface{}{"key": "b", "value": 2},
+		map[string]interface{}{"key": "a", "value": 1.2},
+		map[string]interface{}{"key": "b", "value": 2.3},
 	})
 	test(types.NewMap(suite.vs,
-		types.NewList(suite.vs, types.String("a")), types.Number(1),
-		types.NewList(suite.vs, types.String("b")), types.Number(2),
+		types.NewList(suite.vs, types.String("a")), types.Number(1.2),
+		types.NewList(suite.vs, types.String("b")), types.Number(2.3),
 	), []interface{}{
-		map[string]interface{}{"key": []interface{}{"a"}, "value": 1},
-		map[string]interface{}{"key": []interface{}{"b"}, "value": 2},
+		map[string]interface{}{"key": []interface{}{"a"}, "value": 1.2},
+		map[string]interface{}{"key": []interface{}{"b"}, "value": 2.3},
 	})
 
 	test(types.NewMap(suite.vs,
-		types.NewStruct("S", types.StructData{"a": types.Number(1)}), types.Number(11),
-		types.NewStruct("S", types.StructData{"a": types.Number(2)}), types.Number(22),
+		types.NewStruct("S", types.StructData{"a": types.Number(1)}), types.Integer(11),
+		types.NewStruct("S", types.StructData{"a": types.Number(2)}), types.Integer(22),
 	), []interface{}{
 		map[string]interface{}{"key": map[string]interface{}{"a": float64(1)}, "value": 11},
 		map[string]interface{}{"key": map[string]interface{}{"a": float64(2)}, "value": 22},

--- a/go/ngql/types.go
+++ b/go/ngql/types.go
@@ -151,7 +151,11 @@ func (tc *TypeConverter) nomsTypeToGraphQLType(nomsType *types.Type, boxedIfScal
 		if boxedIfScalar {
 			gqlType = tc.scalarToValue(nomsType, gqlType)
 		}
-
+	case types.IntegerKind:
+		gqlType = graphql.Int
+		if boxedIfScalar {
+			gqlType = tc.scalarToValue(nomsType, gqlType)
+		}
 	case types.StringKind:
 		gqlType = graphql.String
 		if boxedIfScalar {
@@ -219,7 +223,8 @@ func (tc *TypeConverter) nomsTypeToGraphQLInputType(nomsType *types.Type) (graph
 	switch nomsType.TargetKind() {
 	case types.NumberKind:
 		gqlType = graphql.Float
-
+	case types.IntegerKind:
+		gqlType = graphql.Int
 	case types.StringKind:
 		gqlType = graphql.String
 
@@ -707,7 +712,8 @@ func getTypeName(nomsType *types.Type, suffix string) string {
 
 	case types.NumberKind:
 		return "Number"
-
+	case types.IntegerKind:
+		return "Int"
 	case types.StringKind:
 		return "String"
 
@@ -969,8 +975,16 @@ func InputToNomsValue(vrw types.ValueReadWriter, arg interface{}, nomsType *type
 	case types.BoolKind:
 		return types.Bool(arg.(bool))
 	case types.NumberKind:
-		if i, ok := arg.(int); ok {
+		if i, ok := arg.(float64); ok {
 			return types.Number(i)
+		}
+		return types.Number(arg.(float64))
+	case types.IntegerKind:
+		switch i := arg.(type) {
+		case int:
+			return types.Integer(i)
+		case int64:
+			return types.Integer(i)
 		}
 		return types.Number(arg.(float64))
 	case types.StringKind:

--- a/go/types/codec.go
+++ b/go/types/codec.go
@@ -60,7 +60,7 @@ type nomsWriter interface {
 	writeNumber(v Number)
 	writeString(v string)
 	writeUint8(v uint8)
-
+	writeInteger(i Integer)
 	writeRaw(buff []byte)
 }
 
@@ -147,6 +147,17 @@ func (b *binaryNomsReader) skipString() {
 	b.offset += size
 }
 
+func (b *binaryNomsReader) readInteger() Integer {
+	v, count := binary.Varint(b.buff[b.offset:])
+	b.offset += uint32(count)
+	return Integer(v)
+}
+
+func (b *binaryNomsReader) skipInteger() {
+	_, count := binary.Varint(b.buff[b.offset:])
+	b.offset += uint32(count)
+}
+
 func (b *binaryNomsReader) readHash() hash.Hash {
 	h := hash.Hash{}
 	copy(h[:], b.buff[b.offset:b.offset+hash.ByteLen])
@@ -220,6 +231,12 @@ func (b *binaryNomsWriter) writeNumber(v Number) {
 	count := binary.PutVarint(b.buff[b.offset:], i)
 	b.offset += uint32(count)
 	count = binary.PutVarint(b.buff[b.offset:], int64(exp))
+	b.offset += uint32(count)
+}
+
+func (b *binaryNomsWriter) writeInteger(i Integer) {
+	b.ensureCapacity(binary.MaxVarintLen64)
+	count := binary.PutVarint(b.buff[b.offset:], int64(i))
 	b.offset += uint32(count)
 }
 

--- a/go/types/encode_human_readable.go
+++ b/go/types/encode_human_readable.go
@@ -175,7 +175,8 @@ func (w *hrsWriter) Write(v Value) {
 		w.write(strconv.FormatBool(bool(v.(Bool))))
 	case NumberKind:
 		w.write(strconv.FormatFloat(float64(v.(Number)), w.floatFormat, -1, 64))
-
+	case IntegerKind:
+		w.write(strconv.FormatInt(int64(v.(Integer)), 10))
 	case StringKind:
 		w.write(strconv.Quote(string(v.(String))))
 
@@ -314,9 +315,12 @@ func (w *hrsWriter) writeSize(v Value) {
 }
 
 func (w *hrsWriter) writeType(t *Type, seenStructs map[*Type]struct{}) {
-	switch t.TargetKind() {
-	case BlobKind, BoolKind, NumberKind, StringKind, TypeKind, ValueKind:
+	tk := t.TargetKind()
+	if IsPrimitiveKind(tk) {
 		w.write(t.TargetKind().String())
+		return
+	}
+	switch tk {
 	case ListKind, RefKind, SetKind, MapKind:
 		w.write(t.TargetKind().String())
 		w.write("<")

--- a/go/types/encode_human_readable_test.go
+++ b/go/types/encode_human_readable_test.go
@@ -62,13 +62,13 @@ func TestWriteHumanReadableRef(t *testing.T) {
 func TestWriteHumanReadableCollections(t *testing.T) {
 	vrw := newTestValueStore()
 
-	l := NewList(vrw, Number(0), Number(1), Number(2), Number(3))
+	l := NewList(vrw, Integer(0), Integer(1), Integer(2), Integer(3))
 	assertWriteHRSEqual(t, "[  // 4 items\n  0,\n  1,\n  2,\n  3,\n]", l)
 
 	s := NewSet(vrw, Number(0), Number(1), Number(2), Number(3))
 	assertWriteHRSEqual(t, "set {  // 4 items\n  0,\n  1,\n  2,\n  3,\n}", s)
 
-	m := NewMap(vrw, Number(0), Bool(false), Number(1), Bool(true))
+	m := NewMap(vrw, Number(0), Bool(false), Integer(1), Bool(true))
 	assertWriteHRSEqual(t, "map {\n  0: false,\n  1: true,\n}", m)
 
 	l2 := NewList(vrw)
@@ -79,7 +79,7 @@ func TestWriteHumanReadableCollections(t *testing.T) {
 
 	nums := make([]Value, 2000)
 	for i := range nums {
-		nums[i] = Number(0)
+		nums[i] = Integer(0)
 	}
 	l4 := NewList(vrw, nums...)
 	assertWriteHRSEqual(t, "[  // 2,000 items\n"+strings.Repeat("  0,\n", 2000)+"]", l4)
@@ -88,8 +88,8 @@ func TestWriteHumanReadableCollections(t *testing.T) {
 func TestWriteHumanReadableNested(t *testing.T) {
 	vrw := newTestValueStore()
 
-	l := NewList(vrw, Number(0), Number(1))
-	l2 := NewList(vrw, Number(2), Number(3))
+	l := NewList(vrw, Number(0.1), Number(1.2))
+	l2 := NewList(vrw, Integer(2), Integer(3))
 
 	s := NewSet(vrw, String("a"), String("b"))
 	s2 := NewSet(vrw, String("c"), String("d"))
@@ -97,18 +97,18 @@ func TestWriteHumanReadableNested(t *testing.T) {
 	m := NewMap(vrw, s, l, s2, l2)
 	assertWriteHRSEqual(t, `map {
   set {
+    "a",
+    "b",
+  }: [
+    0.1,
+    1.2,
+  ],
+  set {
     "c",
     "d",
   }: [
     2,
     3,
-  ],
-  set {
-    "a",
-    "b",
-  }: [
-    0,
-    1,
   ],
 }`, m)
 }

--- a/go/types/integer.go
+++ b/go/types/integer.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package types
+
+import (
+	"encoding/binary"
+
+	"github.com/attic-labs/noms/go/hash"
+)
+
+// Integer is a Noms Value wrapper around the primitive int64 type.
+type Integer int64
+
+// Value interface
+func (v Integer) Value() Value {
+	return v
+}
+
+func (v Integer) Equals(other Value) bool {
+	return v == other
+}
+
+func (v Integer) Less(other Value) bool {
+	if v2, ok := other.(Integer); ok {
+		return v < v2
+	}
+	return IntegerKind < other.Kind()
+}
+
+func (v Integer) Hash() hash.Hash {
+	return getHash(v)
+}
+
+func (v Integer) WalkValues(cb ValueCallback) {
+}
+
+func (v Integer) WalkRefs(cb RefCallback) {
+}
+
+func (v Integer) typeOf() *Type {
+	return IntegerType
+}
+
+func (v Integer) Kind() NomsKind {
+	return IntegerKind
+}
+
+func (v Integer) valueReadWriter() ValueReadWriter {
+	return nil
+}
+
+func (v Integer) writeTo(w nomsWriter) {
+	IntegerKind.writeTo(w)
+	w.writeInteger(v)
+}
+
+func (v Integer) valueBytes() []byte {
+	// We know the size of the buffer here so allocate it once.
+	// IntegerKind, int (Varint), exp (Varint)
+	buff := make([]byte, 1+binary.MaxVarintLen64)
+	w := binaryNomsWriter{buff, 0}
+	v.writeTo(&w)
+	// TODO(ORBAT): note that the backing array of the returned slice is still of length 1+binary.MaxVarintLen64.
+	return buff[:w.offset]
+}

--- a/go/types/less.go
+++ b/go/types/less.go
@@ -15,7 +15,7 @@ type kindAndHash interface {
 
 func valueLess(v1, v2 kindAndHash) bool {
 	switch v2.Kind() {
-	case BoolKind, NumberKind, StringKind:
+	case BoolKind, NumberKind, IntegerKind, StringKind:
 		return false
 	default:
 		return v1.Hash().Less(v2.Hash())

--- a/go/types/make_type.go
+++ b/go/types/make_type.go
@@ -16,6 +16,8 @@ func MakePrimitiveType(k NomsKind) *Type {
 		return BoolType
 	case NumberKind:
 		return NumberType
+	case IntegerKind:
+		return IntegerType
 	case StringKind:
 		return StringType
 	case BlobKind:
@@ -75,6 +77,7 @@ func makePrimitiveType(k NomsKind) *Type {
 
 var BoolType = makePrimitiveType(BoolKind)
 var NumberType = makePrimitiveType(NumberKind)
+var IntegerType = makePrimitiveType(IntegerKind)
 var StringType = makePrimitiveType(StringKind)
 var BlobType = makePrimitiveType(BlobKind)
 var TypeType = makePrimitiveType(TypeKind)

--- a/go/types/noms_kind.go
+++ b/go/types/noms_kind.go
@@ -12,6 +12,7 @@ type NomsKind uint8
 const (
 	BoolKind NomsKind = iota
 	NumberKind
+	IntegerKind
 	StringKind
 	BlobKind
 	ValueKind
@@ -32,19 +33,20 @@ const (
 )
 
 var KindToString = map[NomsKind]string{
-	BlobKind:   "Blob",
-	BoolKind:   "Bool",
-	CycleKind:  "Cycle",
-	ListKind:   "List",
-	MapKind:    "Map",
-	NumberKind: "Number",
-	RefKind:    "Ref",
-	SetKind:    "Set",
-	StructKind: "Struct",
-	StringKind: "String",
-	TypeKind:   "Type",
-	UnionKind:  "Union",
-	ValueKind:  "Value",
+	BlobKind:    "Blob",
+	BoolKind:    "Bool",
+	CycleKind:   "Cycle",
+	ListKind:    "List",
+	MapKind:     "Map",
+	NumberKind:  "Number",
+	IntegerKind: "Int",
+	RefKind:     "Ref",
+	SetKind:     "Set",
+	StructKind:  "Struct",
+	StringKind:  "String",
+	TypeKind:    "Type",
+	UnionKind:   "Union",
+	ValueKind:   "Value",
 }
 
 // String returns the name of the kind.
@@ -55,7 +57,7 @@ func (k NomsKind) String() string {
 // IsPrimitiveKind returns true if k represents a Noms primitive type, which excludes collections (List, Map, Set), Refs, Structs, Symbolic and Unresolved types.
 func IsPrimitiveKind(k NomsKind) bool {
 	switch k {
-	case BoolKind, NumberKind, StringKind, BlobKind, ValueKind, TypeKind:
+	case BoolKind, NumberKind, IntegerKind, StringKind, BlobKind, ValueKind, TypeKind:
 		return true
 	default:
 		return false

--- a/go/types/opcache_compare.go
+++ b/go/types/opcache_compare.go
@@ -130,6 +130,18 @@ func compareEncodedNomsValues(a, b []byte) int {
 	switch aKind {
 	case BoolKind:
 		return bytes.Compare(a, b)
+	case IntegerKind:
+		reader := binaryNomsReader{a[1:], 0}
+		aInt := reader.readInteger()
+		reader.buff, reader.offset = b[1:], 0
+		bInt := reader.readInteger()
+		if aInt == bInt {
+			return 0
+		}
+		if aInt < bInt {
+			return -1
+		}
+		return 1
 	case NumberKind:
 		reader := binaryNomsReader{a[1:], 0}
 		aNum := reader.readNumber()

--- a/go/types/path.go
+++ b/go/types/path.go
@@ -244,8 +244,12 @@ func NewIndexIntoKeyPath(idx Value) IndexPath {
 }
 
 func ValueCanBePathIndex(v Value) bool {
-	k := v.Kind()
-	return k == StringKind || k == BoolKind || k == NumberKind
+	switch v.Kind() {
+	case StringKind, BoolKind, NumberKind, IntegerKind:
+		return true
+	default:
+		return false
+	}
 }
 
 func newIndexPath(idx Value, intoKey bool) IndexPath {

--- a/go/types/primitives_test.go
+++ b/go/types/primitives_test.go
@@ -15,6 +15,7 @@ func TestPrimitives(t *testing.T) {
 		Bool(true), Bool(false),
 		Number(0), Number(-1),
 		Number(-0.1), Number(0.1),
+		Integer(-1), Integer(1),
 	}
 
 	for i := range data {
@@ -35,6 +36,7 @@ func TestPrimitivesType(t *testing.T) {
 	}{
 		{Bool(false), BoolKind},
 		{Number(0), NumberKind},
+		{Integer(0), IntegerKind},
 	}
 
 	for _, d := range data {

--- a/go/types/simplify.go
+++ b/go/types/simplify.go
@@ -114,9 +114,10 @@ func cloneTypeTreeAndReplaceNamedStructs(t *Type, namedStructs map[string]struct
 	var rec func(t *Type) *Type
 	rec = func(t *Type) *Type {
 		kind := t.TargetKind()
-		switch kind {
-		case BoolKind, NumberKind, StringKind, BlobKind, ValueKind, TypeKind:
+		if IsPrimitiveKind(kind) {
 			return t
+		}
+		switch kind {
 		case ListKind, MapKind, RefKind, SetKind, UnionKind:
 			elemTypes := make(typeSlice, len(t.Desc.(CompoundDesc).ElemTypes))
 			for i, et := range t.Desc.(CompoundDesc).ElemTypes {
@@ -166,10 +167,10 @@ func cloneTypeTreeAndReplaceNamedStructs(t *Type, namedStructs map[string]struct
 
 func foldUnions(t *Type, seenStructs typeset, intersectStructs bool) *Type {
 	kind := t.TargetKind()
+	if IsPrimitiveKind(kind) || kind == CycleKind {
+		return t
+	}
 	switch kind {
-	case BoolKind, NumberKind, StringKind, BlobKind, ValueKind, TypeKind, CycleKind:
-		break
-
 	case ListKind, MapKind, RefKind, SetKind:
 		elemTypes := t.Desc.(CompoundDesc).ElemTypes
 		for i, et := range elemTypes {

--- a/go/types/subtype.go
+++ b/go/types/subtype.go
@@ -196,7 +196,7 @@ func IsValueSubtypeOfDetails(v Value, t *Type) (bool, bool) {
 
 func isValueSubtypeOfDetails(v Value, t *Type, hasExtra bool) (bool, bool) {
 	switch t.TargetKind() {
-	case BoolKind, NumberKind, StringKind, BlobKind, TypeKind:
+	case BoolKind, NumberKind, IntegerKind, StringKind, BlobKind, TypeKind:
 		return v.Kind() == t.TargetKind(), hasExtra
 	case ValueKind:
 		return true, hasExtra

--- a/go/types/value_decoder.go
+++ b/go/types/value_decoder.go
@@ -190,6 +190,9 @@ func (r *valueDecoder) readValue() Value {
 	case NumberKind:
 		r.skipKind()
 		return r.readNumber()
+	case IntegerKind:
+		r.skipKind()
+		return r.readInteger()
 	case StringKind:
 		r.skipKind()
 		return String(r.readString())
@@ -224,6 +227,9 @@ func (r *valueDecoder) skipValue() {
 	case NumberKind:
 		r.skipKind()
 		r.skipNumber()
+	case IntegerKind:
+		r.skipKind()
+		r.skipInteger()
 	case StringKind:
 		r.skipKind()
 		r.skipString()
@@ -263,6 +269,10 @@ func (r *valueDecoder) readTypeOfValue() *Type {
 		r.skipKind()
 		r.skipNumber()
 		return NumberType
+	case IntegerKind:
+		r.skipKind()
+		r.skipInteger()
+		return IntegerType
 	case StringKind:
 		r.skipKind()
 		r.skipString()
@@ -284,7 +294,7 @@ func (r *valueDecoder) readTypeOfValue() *Type {
 }
 
 // isValueSameTypeForSure may return false even though the type of the value is
-// equal. We do that in cases wherer it would be too expensive to compute the
+// equal. We do that in cases where it would be too expensive to compute the
 // type.
 // If this returns false the decoder might not have visited the whole value and
 // its offset is no longer valid.
@@ -295,7 +305,7 @@ func (r *valueDecoder) isValueSameTypeForSure(t *Type) bool {
 	}
 
 	switch k {
-	case BlobKind, BoolKind, NumberKind, StringKind:
+	case BlobKind, BoolKind, NumberKind, IntegerKind, StringKind:
 		r.skipValue()
 		return true
 	case ListKind, MapKind, RefKind, SetKind:

--- a/go/types/walk_refs.go
+++ b/go/types/walk_refs.go
@@ -122,6 +122,9 @@ func (r *refWalker) walkValue(cb RefCallback) {
 	case NumberKind:
 		r.skipKind()
 		r.skipNumber()
+	case IntegerKind:
+		r.skipKind()
+		r.skipInteger()
 	case StringKind:
 		r.skipKind()
 		r.skipString()

--- a/samples/go/csv/csv-invert/main.go
+++ b/samples/go/csv/csv-invert/main.go
@@ -51,9 +51,10 @@ func main() {
 
 	// I don't want to allocate a new types.Value every time someone calls zeroVal(), so instead have a map of canned Values to reference.
 	zeroVals := map[types.NomsKind]types.Value{
-		types.BoolKind:   types.Bool(false),
-		types.NumberKind: types.Number(0),
-		types.StringKind: types.String(""),
+		types.BoolKind:    types.Bool(false),
+		types.NumberKind:  types.Number(0),
+		types.IntegerKind: types.Integer(0),
+		types.StringKind:  types.String(""),
 	}
 
 	zeroVal := func(t *types.Type) types.Value {

--- a/samples/go/csv/read_test.go
+++ b/samples/go/csv/read_test.go
@@ -29,7 +29,7 @@ b,2,false
 	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
 
 	headers := []string{"A", "B", "C"}
-	kinds := KindSlice{types.StringKind, types.NumberKind, types.BoolKind}
+	kinds := KindSlice{types.StringKind, types.IntegerKind, types.BoolKind}
 	l := ReadToList(r, "test", headers, kinds, db, LIMIT)
 
 	assert.Equal(uint64(2), l.Len())
@@ -37,8 +37,8 @@ b,2,false
 	assert.True(l.Get(0).(types.Struct).Get("A").Equals(types.String("a")))
 	assert.True(l.Get(1).(types.Struct).Get("A").Equals(types.String("b")))
 
-	assert.True(l.Get(0).(types.Struct).Get("B").Equals(types.Number(1)))
-	assert.True(l.Get(1).(types.Struct).Get("B").Equals(types.Number(2)))
+	assert.True(l.Get(0).(types.Struct).Get("B").Equals(types.Integer(1)))
+	assert.True(l.Get(1).(types.Struct).Get("B").Equals(types.Integer(2)))
 
 	assert.True(l.Get(0).(types.Struct).Get("C").Equals(types.Bool(true)))
 	assert.True(l.Get(1).(types.Struct).Get("C").Equals(types.Bool(false)))
@@ -55,25 +55,25 @@ b,2,false
 	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
 
 	headers := []string{"A", "B", "C"}
-	kinds := KindSlice{types.StringKind, types.NumberKind, types.BoolKind}
+	kinds := KindSlice{types.StringKind, types.IntegerKind, types.BoolKind}
 	m := ReadToMap(r, "test", headers, []string{"0"}, kinds, db, LIMIT)
 
 	assert.Equal(uint64(2), m.Len())
 	assert.True(types.TypeOf(m).Equals(
 		types.MakeMapType(types.StringType, types.MakeStructType("test",
 			types.StructField{"A", types.StringType, false},
-			types.StructField{"B", types.NumberType, false},
+			types.StructField{"B", types.IntegerType, false},
 			types.StructField{"C", types.BoolType, false},
 		))))
 
 	assert.True(m.Get(types.String("a")).Equals(types.NewStruct("test", types.StructData{
 		"A": types.String("a"),
-		"B": types.Number(1),
+		"B": types.Integer(1),
 		"C": types.Bool(true),
 	})))
 	assert.True(m.Get(types.String("b")).Equals(types.NewStruct("test", types.StructData{
 		"A": types.String("b"),
-		"B": types.Number(2),
+		"B": types.Integer(2),
 		"C": types.Bool(false),
 	})))
 }
@@ -187,16 +187,16 @@ func TestEscapeFieldNames(t *testing.T) {
 	dataString := "1,2\n"
 	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
 	headers := []string{"A A", "B"}
-	kinds := KindSlice{types.NumberKind, types.NumberKind}
+	kinds := KindSlice{types.IntegerKind, types.IntegerKind}
 
 	l := ReadToList(r, "test", headers, kinds, db, LIMIT)
 	assert.Equal(uint64(1), l.Len())
-	assert.Equal(types.Number(1), l.Get(0).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
+	assert.Equal(types.Integer(1), l.Get(0).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 
 	r = NewCSVReader(bytes.NewBufferString(dataString), ',')
 	m := ReadToMap(r, "test", headers, []string{"1"}, kinds, db, LIMIT)
 	assert.Equal(uint64(1), l.Len())
-	assert.Equal(types.Number(1), m.Get(types.Number(2)).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
+	assert.Equal(types.Integer(1), m.Get(types.Integer(2)).(types.Struct).Get(EscapeStructFieldFromCSV("A A")))
 }
 
 func TestDefaults(t *testing.T) {
@@ -206,13 +206,13 @@ func TestDefaults(t *testing.T) {
 	dataString := "42,,,\n"
 	r := NewCSVReader(bytes.NewBufferString(dataString), ',')
 	headers := []string{"A", "B", "C", "D"}
-	kinds := KindSlice{types.NumberKind, types.NumberKind, types.BoolKind, types.StringKind}
+	kinds := KindSlice{types.IntegerKind, types.IntegerKind, types.BoolKind, types.StringKind}
 
 	l := ReadToList(r, "test", headers, kinds, db, LIMIT)
 	assert.Equal(uint64(1), l.Len())
 	row := l.Get(0).(types.Struct)
-	assert.Equal(types.Number(42), row.Get("A"))
-	assert.Equal(types.Number(0), row.Get("B"))
+	assert.Equal(types.Integer(42), row.Get("A"))
+	assert.Equal(types.Integer(0), row.Get("B"))
 	assert.Equal(types.Bool(false), row.Get("C"))
 	assert.Equal(types.String(""), row.Get("D"))
 }

--- a/samples/go/csv/schema.go
+++ b/samples/go/csv/schema.go
@@ -222,9 +222,18 @@ func StringToValue(s string, k types.NomsKind) (types.Value, error) {
 		}
 		fval, err := strconv.ParseFloat(s, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Could not parse '%s' into number (%s)", s, err)
+			return nil, fmt.Errorf("could not parse '%s' into number (%s)", s, err)
 		}
 		return types.Number(fval), nil
+	case types.IntegerKind:
+		if s == "" {
+			return types.Integer(int64(0)), nil
+		}
+		ival, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse '%s' into integer (%s)", s, err)
+		}
+		return types.Integer(ival), nil
 	case types.BoolKind:
 		// TODO: This should probably be configurable.
 		switch s {
@@ -233,7 +242,7 @@ func StringToValue(s string, k types.NomsKind) (types.Value, error) {
 		case "false", "0", "n", "no", "N", "NO", "":
 			return types.Bool(false), nil
 		default:
-			return nil, fmt.Errorf("Could not parse '%s' into bool", s)
+			return nil, fmt.Errorf("could not parse '%s' into bool", s)
 		}
 	case types.StringKind:
 		return types.String(s), nil


### PR DESCRIPTION
Hi folks!

To fix #3801, I've started work on adding an integer type backed by `int64`.  This PR is more of an RFC, so the feature should not be considered finished.

What I'd like is some feedback on whether what I'm doing is

1. sensible
2. backwards-compatible
3. the correct way to do this

My current idea is to not do `uint*` support, at least for the time being. It might be a good idea to add that while I'm at it, but this has turned out to be a, uh, non-trivial change.

Still to do (at least):

- [ ] diff code & tests
- [ ] rest of the marshaling tests (+ code if needed)
- [ ] CSV schema-related code & tests
- [ ] GraphQL-related code & tests
- [ ] `TestMapSuite4KStructs/TestChunkCountAndType`. Why did chunk count go from expected 11 to actual 14 without any changes to the test‽
- [ ] `TestMapMutationReadWriteCount`. Why did read count go from expected 105 to 206 without any changes to the test‽
- [ ] conversions/coercions?
- [ ] what to do with `DateTimeType`?
