### PR TITLE
Using Dockerhub as a basic CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
-docs
+doc
 codecov.yml
 CONTRIBUTING.md
 LICENSE
 README.md
+samples

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: required
+services:
+- docker
+script: docker build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: required
 services:
 - docker
-script: docker build
+script: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV GOOS=linux
 
 RUN mkdir -pv $NOMS_SRC
 COPY . ${NOMS_SRC}
+RUN cd $NOMS_SRC/cmd/noms; \
+  go build; \
+  go test
 RUN go install -v github.com/attic-labs/noms/cmd/noms
 RUN cp $GOPATH/bin/noms /bin/noms
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM golang:latest AS build
 ENV NOMS_SRC=$GOPATH/src/github.com/attic-labs/noms
 ENV CGO_ENABLED=0
 ENV GOOS=linux
+ENV NOMS_VERSION_NEXT=1
 
 RUN mkdir -pv $NOMS_SRC
 COPY . ${NOMS_SRC}
-RUN cd $NOMS_SRC/cmd/noms; \
-  go build; \
-  go test
+RUN go test github.com/attic-labs/noms/...
 RUN go install -v github.com/attic-labs/noms/cmd/noms
 RUN cp $GOPATH/bin/noms /bin/noms
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Use Cases](#use-cases)&nbsp; | &nbsp;[Setup](#setup)&nbsp; | &nbsp;[Status](#status)&nbsp; | &nbsp;[Documentation](./doc/intro.md)&nbsp; | &nbsp;[Contact](#contact-us)
 <br><br>
+
+[![Docker Build Status](https://img.shields.io/docker/build/noms/noms.svg)](https://hub.docker.com/r/noms/noms/)
 [![GoDoc](https://godoc.org/github.com/attic-labs/noms?status.svg)](https://godoc.org/github.com/attic-labs/noms)
 
 # Welcome


### PR DESCRIPTION
Regarding #3792 
Wanted to start the discussion on picking the low hanging fruit here. 

- Are there any other steps that should go into CI at this point? Linting, formatting, etc.
- Is it important to run on PRs ala Travis? If so can we just run docker build as our travis script?

If we'd like to do that I'm happy to write the `.travis.yml` if someone can enable travis for the repo

Note: tests have two actual failures at this point so this will fail to build at dockerhub. Accepting this pull as is though will show that failures do get correctly reported in the badge so should perhaps proceed before fixing the two issues.

Even if we move to travis and don't use docker build as the script, which is also fine, it might be worth considering accepting this change so that we don't publish broken code to the `latest` tag on dockerhub.