### PR TITLE
Enable to stop in struct's IterFields method

### DIFF
--- a/cmd/noms/splore/noms_splore.go
+++ b/cmd/noms/splore/noms_splore.go
@@ -203,12 +203,14 @@ func getNodeChildren(v types.Value, parentPath string) (children []nodeChild) {
 	case types.Struct:
 		children = make([]nodeChild, v.Len())
 		i := 0
-		v.IterFields(func(name string, v types.Value) {
+		v.IterFields(func(name string, v types.Value) bool {
 			children[i] = nodeChild{
 				Label: name,
 				Value: info(v, childPath(".%s", name)),
 			}
 			i++
+
+			return false
 		})
 	case *types.Type:
 		switch d := v.Desc.(type) {

--- a/go/merge/three_way.go
+++ b/go/merge/three_way.go
@@ -258,10 +258,12 @@ func (m *merger) threeWayStructMerge(a, b, parent types.Struct, path types.Path)
 		if f, ok := change.Key.(types.String); ok {
 			field := string(f)
 			data := types.StructData{}
-			targetVal.IterFields(func(name string, v types.Value) {
+			targetVal.IterFields(func(name string, v types.Value) bool {
 				if name != field {
 					data[name] = v
 				}
+
+				return false
 			})
 			if change.ChangeType == types.DiffChangeAdded || change.ChangeType == types.DiffChangeModified {
 				data[field] = newVal

--- a/go/types/struct.go
+++ b/go/types/struct.go
@@ -204,10 +204,12 @@ func (s Struct) Name() string {
 
 // IterFields iterates over the fields, calling cb for every field in the
 // struct.
-func (s Struct) IterFields(cb func(name string, value Value)) {
+func (s Struct) IterFields(cb func(name string, value Value) (stop bool)) {
 	dec, count := s.decoderSkipToFields()
 	for i := uint64(0); i < count; i++ {
-		cb(dec.readString(), dec.readValue())
+		if cb(dec.readString(), dec.readValue()) {
+			break
+		}
 	}
 }
 

--- a/go/types/struct_test.go
+++ b/go/types/struct_test.go
@@ -330,3 +330,39 @@ func TestStructWithNil(t *testing.T) {
 		})
 	})
 }
+
+func TestStructIterFields(t *testing.T) {
+	assert := assert.New(t)
+
+	tstruct := NewStruct("A", StructData{
+		"a": String("aaa"),
+		"b": String("bbb"),
+		"c": String("ccc"),
+	})
+
+	// Iterate over all.
+	i := 0
+	tstruct.IterFields(func(k string, v Value) bool {
+		assert.True(tstruct.Get(k).Equals(v))
+
+		i += 1
+
+		return false
+	})
+
+	assert.Equal(3, i)
+
+	// Iterate and stop.
+	i = 0
+	tstruct.IterFields(func(k string, v Value) bool {
+		if k == "b" {
+			return true
+		}
+
+		i += 1
+
+		return false
+	})
+
+	assert.Equal(1, i)
+}

--- a/samples/go/csv/csv-import/importer.go
+++ b/samples/go/csv/csv-import/importer.go
@@ -206,12 +206,14 @@ func main() {
 					d.PanicIfFalse(isStruct)
 					d.PanicIfFalse(hstr.Name() == "Columnar")
 					str := value.(types.Struct)
-					hstr.IterFields(func(fieldname string, v types.Value) {
+					hstr.IterFields(func(fieldname string, v types.Value) bool {
 						hl := v.(types.Ref).TargetValue(db).(types.List)
 						nl := str.Get(fieldname).(types.Ref).TargetValue(db).(types.List)
 						l := hl.Concat(nl)
 						r := db.WriteValue(l)
 						str = str.Set(fieldname, r)
+
+						return false
 					})
 					value = str
 				default:

--- a/samples/go/csv/csv-invert/main.go
+++ b/samples/go/csv/csv-invert/main.go
@@ -87,10 +87,12 @@ func main() {
 	filledCols := make(map[string]struct{}, len(streams))
 	l.IterAll(func(v types.Value, index uint64) {
 		// First, iterate the fields that are present in |v| and append values to the correct lists
-		v.(types.Struct).IterFields(func(name string, value types.Value) {
+		v.(types.Struct).IterFields(func(name string, value types.Value) bool {
 			ln := lowers[name]
 			filledCols[ln] = struct{}{}
 			streams[ln].ch <- value
+
+			return false
 		})
 		// Second, iterate all the streams, skipping the ones we already sent a value for, and send an empty String for the remaining ones.
 		for lowerName, stream := range streams {


### PR DESCRIPTION
As well as list and map, I would like to write the following the code by struct's iteration method.
```
var error err
str.IterFields(func(name string, value types.Value) bool {
    err = SomeMethod()
    if err != nil {
        return true
    }
    return false
})

if err != nil {
    return err
}
```