### PR TITLE
Simplify json_import

### DIFF
--- a/samples/go/json-import/json_importer.go
+++ b/samples/go/json-import/json_importer.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -15,58 +14,48 @@ import (
 	"strings"
 	"time"
 
+	"github.com/attic-labs/kingpin"
 	"github.com/attic-labs/noms/go/config"
 	"github.com/attic-labs/noms/go/d"
-	"github.com/attic-labs/noms/go/datas"
-	"github.com/attic-labs/noms/go/spec"
 	"github.com/attic-labs/noms/go/util/jsontonoms"
 	"github.com/attic-labs/noms/go/util/progressreader"
 	"github.com/attic-labs/noms/go/util/status"
 	"github.com/attic-labs/noms/go/util/verbose"
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	flag "github.com/juju/gnuflag"
 )
 
 func main() {
-	performCommit := flag.Bool("commit", true, "commit the data to head of the dataset (otherwise only write the data to the dataset)")
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: %s <url> <dataset>\n", os.Args[0])
-		flag.PrintDefaults()
-	}
+	kingpin.CommandLine.HelpFlag.Short('h')
 
-	spec.RegisterCommitMetaFlags(flag.CommandLine)
+	source := kingpin.Arg("source", "file or url to import").Required().String()
+	destDB := kingpin.Arg("dest-db", "database to import to").Required().String()
+	quiet := kingpin.Flag("quiet", "don't print out import progress").Short('q').Bool()
+
 	verbose.RegisterVerboseFlags(flag.CommandLine)
-	flag.Parse(true)
 
-	if len(flag.Args()) != 2 {
-		d.CheckError(errors.New("expected url and dataset flags"))
-	}
+	kingpin.Parse()
 
 	cfg := config.NewResolver()
-	db, ds, err := cfg.GetDataset(flag.Arg(1))
+	db, err := cfg.GetDatabase(*destDB)
 	d.CheckError(err)
 	defer db.Close()
 
-	url := flag.Arg(0)
-	if url == "" {
-		flag.Usage()
-	}
-
 	var r io.Reader
-	if strings.HasPrefix(url, "http") {
-		res, err := http.Get(url)
+	if strings.HasPrefix(*source, "http") {
+		res, err := http.Get(*source)
 		if err != nil {
-			log.Fatalf("Error fetching %s: %+v\n", url, err)
+			log.Fatalf("Error fetching %s: %+v\n", *source, err)
 		} else if res.StatusCode != 200 {
-			log.Fatalf("Error fetching %s: %s\n", url, res.Status)
+			log.Fatalf("Error fetching %s: %s\n", *source, res.Status)
 		}
 		defer res.Body.Close()
 		r = res.Body
 	} else {
 		// assume it's a file
-		f, err := os.Open(url)
+		f, err := os.Open(*source)
 		if err != nil {
-			log.Fatalf("Invalid URL %s - does not start with 'http' and isn't local file either. fopen error: %s", url, err)
+			log.Fatalf("Invalid URL %s - does not start with 'http' and isn't local file either. fopen error: %s", *source, err)
 		}
 
 		r = f
@@ -77,22 +66,19 @@ func main() {
 	r = progressreader.New(r, func(seen uint64) {
 		elapsed := time.Since(start).Seconds()
 		rate := uint64(float64(seen) / elapsed)
-		status.Printf("%s decoded in %ds (%s/s)...", humanize.Bytes(seen), int(elapsed), humanize.Bytes(rate))
+		if !*quiet {
+			status.Printf("%s decoded in %ds (%s/s)...", humanize.Bytes(seen), int(elapsed), humanize.Bytes(rate))
+		}
 	})
 	err = json.NewDecoder(r).Decode(&jsonObject)
 	if err != nil {
 		log.Fatalln("Error decoding JSON: ", err)
 	}
-	status.Done()
-
-	if *performCommit {
-		additionalMetaInfo := map[string]string{"url": url}
-		meta, err := spec.CreateCommitMetaStruct(ds.Database(), "", "", additionalMetaInfo, nil)
-		d.CheckErrorNoUsage(err)
-		_, err = db.Commit(ds, jsontonoms.NomsValueFromDecodedJSON(db, jsonObject, true), datas.CommitOptions{Meta: meta})
-		d.PanicIfError(err)
-	} else {
-		ref := db.WriteValue(jsontonoms.NomsValueFromDecodedJSON(db, jsonObject, true))
-		fmt.Fprintf(os.Stdout, "#%s\n", ref.TargetHash().String())
+	if !*quiet {
+		status.Done()
 	}
+
+	ref := db.WriteValue(jsontonoms.NomsValueFromDecodedJSON(db, jsonObject, true))
+	db.Flush()
+	fmt.Fprintf(os.Stdout, "#%s\n", ref.TargetHash().String())
 }


### PR DESCRIPTION
Now that we have simple cli manipulation tools, we no longer need the import tools to support committing on their own. You can just import, get a hash, and use that to do what you want with.

Also updated json_import to use kingpin so the cli docs are better.