### PR TITLE
Simplify CLI output for value edits

### DIFF
--- a/cmd/noms/noms_struct.go
+++ b/cmd/noms/noms_struct.go
@@ -137,7 +137,5 @@ func appplyPatch(sp spec.Spec, rootVal types.Value, basePath types.Path, patch d
 		Hash: r.TargetHash(),
 		Path: basePath,
 	}
-	newSpec := sp
-	newSpec.Path = newAbsPath
-	fmt.Println(newSpec.String())
+	fmt.Println(newAbsPath.String())
 }


### PR DESCRIPTION
Print out only absolute path, not complete spec. Database is superfluous since the user specified it (or already knows which database they are working with).