### PR TITLE
fix mapeditor bug

### DIFF
--- a/go/types/map_editor.go
+++ b/go/types/map_editor.go
@@ -150,10 +150,7 @@ func (me *MapEditor) Remove(k Value) *MapEditor {
 
 func (me *MapEditor) Get(k Value) Valuable {
 	if idx, found := me.findEdit(k); found {
-		v := me.edits[idx].value
-		if v != nil {
-			return v
-		}
+		return me.edits[idx].value
 	}
 
 	return me.m.Get(k)

--- a/go/types/map_test.go
+++ b/go/types/map_test.go
@@ -547,6 +547,17 @@ func TestMapHas(t *testing.T) {
 	doTest(getTestRefToValueOrderMap, 2)
 }
 
+func TestMapRemoveMasksUnderlyingMap(t *testing.T) {
+	assert := assert.New(t)
+	vrw := newTestValueStore()
+
+	k := String("foo")
+	me := NewMap(vrw, k, String("bar")).Edit()
+	me.Remove(k)
+	assert.False(me.Has(k))
+	assert.Nil(me.Get(k))
+}
+
 func TestMapHasRemove(t *testing.T) {
 	assert := assert.New(t)
 	vrw := newTestValueStore()


### PR DESCRIPTION
MapEditor was erroneously going to the underlying map if the edit value was nil. The edit value will be nil when it has been removed (and so we shouldn't go to the underlying map).